### PR TITLE
Handle issue with missing `continue

### DIFF
--- a/core/service/src/client/mod.rs
+++ b/core/service/src/client/mod.rs
@@ -690,6 +690,7 @@ impl Client {
                 None => {
                     tracing::warn!("Signature could not be verified for a CRS");
                     // do not insert
+                    continue;
                 }
             }
 


### PR DESCRIPTION
Fixes an issue where a `continue` was missing in the client code, this could allow unsigned responses to be counted when trying to find out which CRS to use after construction.