### PR TITLE
chore: Change to using NIST compatible XOF in DKG

### DIFF
--- a/core/threshold/src/execution/endpoints/keygen.rs
+++ b/core/threshold/src/execution/endpoints/keygen.rs
@@ -80,6 +80,7 @@ struct RawPubKeySet {
     pub compression_keys: Option<(CompressionKey, DecompressionKey)>,
     pub msnrk: ModulusSwitchConfiguration<u64>,
     pub msnrk_sns: Option<ModulusSwitchConfiguration<u64>>,
+    pub seed: u128,
     pub sns_compression_key: Option<NoiseSquashingCompressionKey>,
 }
 
@@ -1252,6 +1253,7 @@ where
         compression_keys,
         msnrk,
         msnrk_sns,
+        seed,
         sns_compression_key,
     };
 
@@ -1518,6 +1520,8 @@ pub mod tests {
         },
         tests::helper::tests_and_benches::execute_protocol_small,
     };
+
+    const DUMMY_PREPROC_SEED: u64 = 42;
 
     #[cfg(not(target_arch = "aarch64"))]
     #[test]
@@ -2517,7 +2521,10 @@ pub mod tests {
                 // we use dummy preprocessing to generate the existing compression sk
                 // because it won't consume our preprocessing materials
                 let mut dummy_preproc =
-                    DummyPreprocessing::<ResiduePoly<Z128, EXTENSION_DEGREE>>::new(0_u64, &session);
+                    DummyPreprocessing::<ResiduePoly<Z128, EXTENSION_DEGREE>>::new(
+                        DUMMY_PREPROC_SEED,
+                        &session,
+                    );
                 let params_basics_handles = params.get_params_basics_handle();
                 Some(
                     CompressionPrivateKeyShares::new_from_preprocessing(
@@ -2643,7 +2650,7 @@ pub mod tests {
     {
         let mut task = |mut session: LargeSession| async move {
             let my_role = session.my_role();
-            let mut large_preproc = DummyPreprocessing::new(0_u64, &session);
+            let mut large_preproc = DummyPreprocessing::new(DUMMY_PREPROC_SEED, &session);
 
             let (pk, sk) = super::distributed_keygen::<Z128, _, _, EXTENSION_DEGREE>(
                 &mut session,

--- a/core/threshold/src/execution/tfhe_internals/ggsw_ciphertext.rs
+++ b/core/threshold/src/execution/tfhe_internals/ggsw_ciphertext.rs
@@ -247,7 +247,12 @@ pub fn encrypt_constant_ggsw_ciphertext<Z, Gen, const EXTENSION_DEGREE: usize>(
 {
     let max_level = output.decomposition_level_count();
     let gen_iter = generator
-        .fork_ggsw_to_ggsw_levels(max_level, output.glwe_size(), output.polynomial_size())
+        .fork_ggsw_to_ggsw_levels(
+            max_level,
+            output.glwe_size(),
+            output.polynomial_size(),
+            encryption_type,
+        )
         .expect("Failed to split generator into ggsw levels");
 
     let output_glwe_size = output.glwe_size();
@@ -270,7 +275,7 @@ pub fn encrypt_constant_ggsw_ciphertext<Z, Gen, const EXTENSION_DEGREE: usize>(
         };
 
         let gen_iter = generator
-            .fork_ggsw_level_to_glwe(output_glwe_size, output_polynomial_size)
+            .fork_ggsw_level_to_glwe(output_glwe_size, output_polynomial_size, encryption_type)
             .expect("Failed to split generator into glwe");
 
         let last_row_index = level_matrix.glwe_size().0 - 1;

--- a/core/threshold/src/execution/tfhe_internals/lwe_bootstrap_key_generation.rs
+++ b/core/threshold/src/execution/tfhe_internals/lwe_bootstrap_key_generation.rs
@@ -43,6 +43,7 @@ where
         output.decomposition_level_count(),
         output.glwe_size(),
         output.polynomial_size(),
+        encryption_type,
     )?;
 
     let encoded_input_key_elements = ggsw_encode_messages(

--- a/core/threshold/src/execution/tfhe_internals/lwe_ciphertext.rs
+++ b/core/threshold/src/execution/tfhe_internals/lwe_ciphertext.rs
@@ -176,8 +176,11 @@ where
         encoded.len()
     );
 
-    let gen_iter =
-        generator.fork_lwe_list_to_lwe(LweCiphertextCount(output.len()), output[0].lwe_size())?;
+    let gen_iter = generator.fork_lwe_list_to_lwe(
+        LweCiphertextCount(output.len()),
+        output[0].lwe_size(),
+        EncryptionType::Bits64,
+    )?;
 
     for ((encoded_plaintext, ciphertext), mut loop_generator) in
         encoded.iter().zip_eq(output.iter_mut()).zip_eq(gen_iter)

--- a/core/threshold/src/execution/tfhe_internals/randomness.rs
+++ b/core/threshold/src/execution/tfhe_internals/randomness.rs
@@ -353,12 +353,6 @@ fn mask_bytes_per_polynomial(poly_size: PolynomialSize, encryption_type: Encrypt
     poly_size.0 * mask_bytes_per_coef(encryption_type)
 }
 
-//WARNING: IDK yet if it's a big deal, but we may be asking more bytes from our XOF than we actually need
-//as we ask enough bytes to fill up a full element from the ring even if we actually require less
-//e.g. if the sharing domain is Z128 but we are generating the Z64 key material.
-//ANSWER: Turned out to be a big deal for compatibility with tfhe-rs when generating seeded struct.
-//Fixed now.
-
 ///How many bytes to fill an element in Z
 fn mask_bytes_per_coef(encryption_type: EncryptionType) -> usize {
     match encryption_type {

--- a/core/threshold/src/execution/tfhe_internals/randomness.rs
+++ b/core/threshold/src/execution/tfhe_internals/randomness.rs
@@ -1,18 +1,23 @@
-use crate::algebra::{galois_rings::common::ResiduePoly, structure_traits::BaseRing};
+use crate::{
+    algebra::{galois_rings::common::ResiduePoly, structure_traits::BaseRing},
+    hashing::DomainSep,
+};
 
 use itertools::Itertools;
 use tfhe::{
     core_crypto::commons::{
-        math::random::RandomGenerator,
+        math::random::{RandomGenerable, RandomGenerator, Uniform},
         parameters::{GlweSize, LweCiphertextCount, LweSize},
         traits::ByteRandomGenerator,
     },
     shortint::parameters::{DecompositionLevelCount, GlweDimension, LweDimension, PolynomialSize},
-    Seed,
 };
-use tfhe_csprng::generators::ForkError;
+use tfhe_csprng::{generators::ForkError, seeders::XofSeed};
 
 use super::parameters::EncryptionType;
+
+const KG_DSEP: DomainSep = *b"TFHE_GEN";
+
 //Question:
 //For now there's a single noise vector which should be filled with the values we want
 //however different parts of the protocol require different noise distribution
@@ -107,7 +112,7 @@ impl<Z: BaseRing, const EXTENSION_DEGREE: usize> MPCNoiseRandomGenerator<Z, EXTE
 impl<Gen: ByteRandomGenerator> MPCMaskRandomGenerator<Gen> {
     pub fn new_from_seed(seed: u128) -> Self {
         Self {
-            gen: RandomGenerator::<Gen>::new(Seed(seed)),
+            gen: RandomGenerator::<Gen>::new(XofSeed::new_u128(seed, KG_DSEP)),
         }
     }
     pub fn fill_slice_with_random_mask_custom_mod<Z: BaseRing>(
@@ -115,54 +120,59 @@ impl<Gen: ByteRandomGenerator> MPCMaskRandomGenerator<Gen> {
         output_mask: &mut [Z],
         randomness_type: EncryptionType,
     ) {
-        let num_bytes_needed = match randomness_type {
-            EncryptionType::Bits64 => 8,
-            EncryptionType::Bits128 => 16,
-        };
-
         for element in output_mask.iter_mut() {
-            for _ in 0..num_bytes_needed {
-                *element = (*element << 8) + (Z::from_u128(self.gen.generate_next() as u128));
-            }
+            let randomness = match randomness_type {
+                EncryptionType::Bits64 => u64::generate_one(&mut self.gen, Uniform) as u128,
+                EncryptionType::Bits128 => u128::generate_one(&mut self.gen, Uniform),
+            };
+            *element = Z::from_u128(randomness);
         }
     }
 
-    pub(crate) fn fork_bsk_to_ggsw<Z: BaseRing>(
+    pub(crate) fn fork_bsk_to_ggsw(
         &mut self,
         lwe_dimension: LweDimension,
         level: DecompositionLevelCount,
         glwe_size: GlweSize,
         polynomial_size: PolynomialSize,
+        encryption_type: EncryptionType,
     ) -> Result<impl Iterator<Item = Self>, ForkError> {
-        let mask_bytes = mask_bytes_per_ggsw::<Z>(level, glwe_size, polynomial_size);
+        let mask_bytes = mask_bytes_per_ggsw(level, glwe_size, polynomial_size, encryption_type);
         self.try_fork(lwe_dimension.0, mask_bytes)
     }
 
-    pub(crate) fn fork_lwe_list_to_lwe<Z: BaseRing>(
+    pub(crate) fn fork_lwe_list_to_lwe(
         &mut self,
         lwe_count: LweCiphertextCount,
         lwe_size: LweSize,
+        encryption_type: EncryptionType,
     ) -> Result<impl Iterator<Item = Self>, ForkError> {
-        let mask_bytes = mask_bytes_per_lwe::<Z>(lwe_size.to_lwe_dimension());
+        let mask_bytes = mask_bytes_per_lwe(lwe_size.to_lwe_dimension(), encryption_type);
         self.try_fork(lwe_count.0, mask_bytes)
     }
 
-    pub(crate) fn fork_ggsw_level_to_glwe<Z: BaseRing>(
+    pub(crate) fn fork_ggsw_level_to_glwe(
         &mut self,
         glwe_size: GlweSize,
         polynomial_size: PolynomialSize,
+        encryption_type: EncryptionType,
     ) -> Result<impl Iterator<Item = Self>, ForkError> {
-        let mask_bytes = mask_bytes_per_glwe::<Z>(glwe_size.to_glwe_dimension(), polynomial_size);
+        let mask_bytes = mask_bytes_per_glwe(
+            glwe_size.to_glwe_dimension(),
+            polynomial_size,
+            encryption_type,
+        );
         self.try_fork(glwe_size.0, mask_bytes)
     }
 
-    pub(crate) fn fork_ggsw_to_ggsw_levels<Z: BaseRing>(
+    pub(crate) fn fork_ggsw_to_ggsw_levels(
         &mut self,
         level: DecompositionLevelCount,
         glwe_size: GlweSize,
         polynomial_size: PolynomialSize,
+        encryption_type: EncryptionType,
     ) -> Result<impl Iterator<Item = Self>, ForkError> {
-        let mask_bytes = mask_bytes_per_ggsw_level::<Z>(glwe_size, polynomial_size);
+        let mask_bytes = mask_bytes_per_ggsw_level(glwe_size, polynomial_size, encryption_type);
         self.try_fork(level.0, mask_bytes)
     }
 
@@ -225,10 +235,15 @@ impl<Z: BaseRing, Gen: ByteRandomGenerator, const EXTENSION_DEGREE: usize>
         level: DecompositionLevelCount,
         glwe_size: GlweSize,
         polynomial_size: PolynomialSize,
+        encryption_type: EncryptionType,
     ) -> Result<impl Iterator<Item = Self>, ForkError> {
-        let mask_iter =
-            self.mask
-                .fork_bsk_to_ggsw::<Z>(lwe_dimension, level, glwe_size, polynomial_size)?;
+        let mask_iter = self.mask.fork_bsk_to_ggsw(
+            lwe_dimension,
+            level,
+            glwe_size,
+            polynomial_size,
+            encryption_type,
+        )?;
         let noise_iter =
             self.noise
                 .fork_bsk_to_ggsw(lwe_dimension, level, glwe_size, polynomial_size);
@@ -239,8 +254,11 @@ impl<Z: BaseRing, Gen: ByteRandomGenerator, const EXTENSION_DEGREE: usize>
         &mut self,
         lwe_count: LweCiphertextCount,
         lwe_size: LweSize,
+        encryption_type: EncryptionType,
     ) -> Result<impl Iterator<Item = Self>, ForkError> {
-        let mask_iter = self.mask.fork_lwe_list_to_lwe::<Z>(lwe_count, lwe_size)?;
+        let mask_iter = self
+            .mask
+            .fork_lwe_list_to_lwe(lwe_count, lwe_size, encryption_type)?;
         let noise_iter = self.noise.fork_lwe_list_to_lwe(lwe_count);
         Ok(map_to_encryption_generator(mask_iter, noise_iter))
     }
@@ -249,10 +267,11 @@ impl<Z: BaseRing, Gen: ByteRandomGenerator, const EXTENSION_DEGREE: usize>
         &mut self,
         glwe_size: GlweSize,
         polynomial_size: PolynomialSize,
+        encryption_type: EncryptionType,
     ) -> Result<impl Iterator<Item = Self>, ForkError> {
-        let mask_iter = self
-            .mask
-            .fork_ggsw_level_to_glwe::<Z>(glwe_size, polynomial_size)?;
+        let mask_iter =
+            self.mask
+                .fork_ggsw_level_to_glwe(glwe_size, polynomial_size, encryption_type)?;
 
         let noise_iter = self
             .noise
@@ -265,10 +284,14 @@ impl<Z: BaseRing, Gen: ByteRandomGenerator, const EXTENSION_DEGREE: usize>
         level: DecompositionLevelCount,
         glwe_size: GlweSize,
         polynomial_size: PolynomialSize,
+        encryption_type: EncryptionType,
     ) -> Result<impl Iterator<Item = Self>, ForkError> {
-        let mask_iter =
-            self.mask
-                .fork_ggsw_to_ggsw_levels::<Z>(level, glwe_size, polynomial_size)?;
+        let mask_iter = self.mask.fork_ggsw_to_ggsw_levels(
+            level,
+            glwe_size,
+            polynomial_size,
+            encryption_type,
+        )?;
 
         let noise_iter = self
             .noise
@@ -293,45 +316,57 @@ fn map_to_encryption_generator<
         .map(|(mask, noise)| MPCEncryptionRandomGenerator { mask, noise })
 }
 
-fn mask_bytes_per_ggsw<Z: BaseRing>(
+fn mask_bytes_per_ggsw(
     level: DecompositionLevelCount,
     glwe_size: GlweSize,
     poly_size: PolynomialSize,
+    encryption_type: EncryptionType,
 ) -> usize {
-    level.0 * mask_bytes_per_ggsw_level::<Z>(glwe_size, poly_size)
+    level.0 * mask_bytes_per_ggsw_level(glwe_size, poly_size, encryption_type)
 }
 
 ///How many bytes to fill the mask part of a ggsw row
-fn mask_bytes_per_ggsw_level<Z: BaseRing>(glwe_size: GlweSize, poly_size: PolynomialSize) -> usize {
-    glwe_size.0 * mask_bytes_per_glwe::<Z>(glwe_size.to_glwe_dimension(), poly_size)
+fn mask_bytes_per_ggsw_level(
+    glwe_size: GlweSize,
+    poly_size: PolynomialSize,
+    encryption_type: EncryptionType,
+) -> usize {
+    glwe_size.0 * mask_bytes_per_glwe(glwe_size.to_glwe_dimension(), poly_size, encryption_type)
 }
 
 ///How many bytes to fill the mask part of an lwe encryption
-fn mask_bytes_per_lwe<Z: BaseRing>(lwe_dimension: LweDimension) -> usize {
-    lwe_dimension.0 * mask_bytes_per_coef::<Z>()
+fn mask_bytes_per_lwe(lwe_dimension: LweDimension, encryption_type: EncryptionType) -> usize {
+    lwe_dimension.0 * mask_bytes_per_coef(encryption_type)
 }
 
 ///How many bytes to fill the mask part of a glwe encryption
-fn mask_bytes_per_glwe<Z: BaseRing>(
+fn mask_bytes_per_glwe(
     glwe_dimension: GlweDimension,
     poly_size: PolynomialSize,
+    encryption_type: EncryptionType,
 ) -> usize {
-    glwe_dimension.0 * mask_bytes_per_polynomial::<Z>(poly_size)
+    glwe_dimension.0 * mask_bytes_per_polynomial(poly_size, encryption_type)
 }
 
 ///How many bytes to fill a polynomial with coefs in Z
-fn mask_bytes_per_polynomial<Z: BaseRing>(poly_size: PolynomialSize) -> usize {
-    poly_size.0 * mask_bytes_per_coef::<Z>()
+fn mask_bytes_per_polynomial(poly_size: PolynomialSize, encryption_type: EncryptionType) -> usize {
+    poly_size.0 * mask_bytes_per_coef(encryption_type)
 }
 
 //WARNING: IDK yet if it's a big deal, but we may be asking more bytes from our XOF than we actually need
 //as we ask enough bytes to fill up a full element from the ring even if we actually require less
 //e.g. if the sharing domain is Z128 but we are generating the Z64 key material.
+//ANSWER: Turned out to be a big deal for compatibility with tfhe-rs when generating seeded struct.
+//Fixed now.
 
 ///How many bytes to fill an element in Z
-fn mask_bytes_per_coef<Z: BaseRing>() -> usize {
-    Z::BIT_LENGTH / 8
+fn mask_bytes_per_coef(encryption_type: EncryptionType) -> usize {
+    match encryption_type {
+        EncryptionType::Bits64 => 8,
+        EncryptionType::Bits128 => 16,
+    }
 }
+
 fn noise_elements_per_ggsw(
     level: DecompositionLevelCount,
     glwe_size: GlweSize,


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Properly uses the NIST XOF.
Also, first step towards https://github.com/zama-ai/kms-internal/issues/146 as tfhe-rs should provide us with a way to expand the XOF seed onto the masks required for the public keys.
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/zama-ai/kms-core/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/zama-ai/kms-core/blob/main/CHANGELOG.md
-->
