### PR TITLE
chore: properly increment failed requests metric

### DIFF
--- a/core/service/src/engine/centralized/central_kms.rs
+++ b/core/service/src/engine/centralized/central_kms.rs
@@ -478,20 +478,13 @@ pub fn central_public_decrypt<
     // run the decryption of each ct in the batch in parallel
     cts.par_iter()
         .map(|ct| {
-            let inner_timer = metrics::METRICS
+            let mut inner_timer = metrics::METRICS
                 .time_operation(OP_PUBLIC_DECRYPT_INNER)
-                .map_err(|e| tracing::warn!("Failed to create metric: {}", e))
-                .and_then(|b| {
-                    b.tags(metric_tags.clone()).map_err(|e| {
-                        tracing::warn!("Failed to a tag in party_id, key_id or request_id : {}", e)
-                    })
-                })
-                .map(|b| b.start())
-                .map_err(|e| tracing::warn!("Failed to start timer: {:?}", e))
-                .ok();
+                .tags(metric_tags.clone())
+                .start();
             let fhe_type = ct.fhe_type()?;
             let fhe_type_string = ct.fhe_type_string();
-            inner_timer.map(|mut b| b.tag(TAG_TFHE_TYPE, fhe_type_string));
+            inner_timer.tag(TAG_TFHE_TYPE, fhe_type_string);
             RealCentralizedKms::<PubS, PrivS>::public_decrypt(
                 keys,
                 &ct.ciphertext,
@@ -530,21 +523,14 @@ pub async fn async_user_decrypt<
 
     let mut all_signcrypted_cts = vec![];
     for typed_ciphertext in typed_ciphertexts {
-        let inner_timer = metrics::METRICS
+        let mut inner_timer = metrics::METRICS
             .time_operation(OP_USER_DECRYPT_INNER)
-            .map_err(|e| tracing::warn!("Failed to create metric: {}", e))
-            .and_then(|b| {
-                b.tags(metric_tags.clone()).map_err(|e| {
-                    tracing::warn!("Failed to a tag in party_id, key_id or request_id : {}", e)
-                })
-            })
-            .map(|b| b.start())
-            .map_err(|e| tracing::warn!("Failed to start timer: {:?}", e))
-            .ok();
+            .tags(metric_tags.clone())
+            .start();
         let high_level_ct = &typed_ciphertext.ciphertext;
         let fhe_type = typed_ciphertext.fhe_type()?;
         let fhe_type_string = typed_ciphertext.fhe_type_string();
-        inner_timer.map(|mut b| b.tag(TAG_TFHE_TYPE, fhe_type_string));
+        inner_timer.tag(TAG_TFHE_TYPE, fhe_type_string);
         let ct_format = typed_ciphertext.ciphertext_format();
         let external_handle = typed_ciphertext.external_handle.clone();
         let signcrypted_ciphertext = RealCentralizedKms::<PubS, PrivS>::user_decrypt(

--- a/core/service/src/engine/centralized/service/crs_gen.rs
+++ b/core/service/src/engine/centralized/service/crs_gen.rs
@@ -7,7 +7,7 @@ use kms_grpc::kms::v1::{CrsGenRequest, CrsGenResult, Empty};
 use kms_grpc::rpc_types::{optional_protobuf_to_alloy_domain, SignedPubDataHandleInternal};
 use kms_grpc::RequestId;
 use observability::metrics::METRICS;
-use observability::metrics_names::{ERR_CRS_GEN_FAILED, ERR_RATE_LIMIT_EXCEEDED, OP_CRS_GEN};
+use observability::metrics_names::{ERR_CRS_GEN_FAILED, OP_CRS_GEN_REQUEST};
 use threshold_fhe::execution::tfhe_internals::parameters::DKGParams;
 use threshold_fhe::session_id::SessionId;
 use tokio::sync::{OwnedSemaphorePermit, RwLock};
@@ -33,23 +33,9 @@ pub async fn crs_gen_impl<
     request: Request<CrsGenRequest>,
 ) -> Result<Response<Empty>, Status> {
     tracing::info!("Received CRS generation request");
-    let _timer = METRICS
-        .time_operation(OP_CRS_GEN)
-        .map_err(|e| Status::internal(format!("Failed to start metrics: {e}")))?
-        .start();
-    METRICS
-        .increment_request_counter(OP_CRS_GEN)
-        .map_err(|e| Status::internal(format!("Failed to increment counter: {e}")))?;
+    let _timer = METRICS.time_operation(OP_CRS_GEN_REQUEST).start();
 
-    let permit = service
-        .rate_limiter
-        .start_crsgen()
-        .await
-        .inspect_err(|_e| {
-            if let Err(e) = METRICS.increment_error_counter(OP_CRS_GEN, ERR_RATE_LIMIT_EXCEEDED) {
-                tracing::warn!("Failed to increment error counter: {:?}", e);
-            }
-        })?;
+    let permit = service.rate_limiter.start_crsgen().await?;
 
     let inner = request.into_inner();
     let req_id = tonic_some_or_err(
@@ -90,6 +76,7 @@ pub async fn crs_gen_impl<
             )
             .await
             {
+                METRICS.increment_error_counter(OP_CRS_GEN_REQUEST, ERR_CRS_GEN_FAILED);
                 tracing::error!("CRS generation of request {} failed: {}", req_id, e);
             } else {
                 tracing::info!(
@@ -160,9 +147,6 @@ pub(crate) async fn crs_gen_background<
                         "Failed CRS generation for CRS with ID {req_id}: {e}"
                     )),
                 );
-                METRICS
-                    .increment_error_counter(OP_CRS_GEN, ERR_CRS_GEN_FAILED)
-                    .ok();
                 return Err(anyhow::anyhow!("Failed CRS generation: {}", e));
             }
         };

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -6,9 +6,9 @@ use kms_grpc::kms::v1::{
 };
 use observability::metrics::METRICS;
 use observability::metrics_names::{
-    ERR_KEY_NOT_FOUND, ERR_PUBLIC_DECRYPTION_FAILED, ERR_RATE_LIMIT_EXCEEDED,
-    ERR_USER_DECRYPTION_FAILED, OP_PUBLIC_DECRYPT_REQUEST, OP_USER_DECRYPT_REQUEST, TAG_KEY_ID,
-    TAG_PARTY_ID, TAG_PUBLIC_DECRYPTION_KIND,
+    ERR_KEY_NOT_FOUND, ERR_PUBLIC_DECRYPTION_FAILED, ERR_USER_DECRYPTION_FAILED,
+    OP_PUBLIC_DECRYPT_REQUEST, OP_USER_DECRYPT_REQUEST, TAG_KEY_ID, TAG_PARTY_ID,
+    TAG_PUBLIC_DECRYPTION_KIND,
 };
 use tonic::{Request, Response, Status};
 use tracing::Instrument;
@@ -37,31 +37,11 @@ pub async fn user_decrypt_impl<
     // Start timing and counting before any operations
     let mut timer = METRICS
         .time_operation(OP_USER_DECRYPT_REQUEST)
-        .map_err(|e| tracing::warn!("Failed to create metric: {}", e))
-        .and_then(|b| {
-            // Use a constant party ID since this is the central KMS
-            b.tag(TAG_PARTY_ID, "central")
-                .map_err(|e| tracing::warn!("Failed to add party tag id: {}", e))
-        })
-        .map(|b| b.start())
-        .map_err(|e| tracing::warn!("Failed to start timer: {:?}", e))
-        .ok();
+        // Use a constant party ID since this is the central KMS
+        .tag(TAG_PARTY_ID, "central")
+        .start();
 
-    let _request_counter = METRICS
-        .increment_request_counter(OP_USER_DECRYPT_REQUEST)
-        .map_err(|e| tracing::warn!("Failed to increment request counter: {}", e));
-
-    let permit = service
-        .rate_limiter
-        .start_user_decrypt()
-        .await
-        .inspect_err(|_e| {
-            if let Err(e) =
-                METRICS.increment_error_counter(OP_USER_DECRYPT_REQUEST, ERR_RATE_LIMIT_EXCEEDED)
-            {
-                tracing::warn!("Failed to increment error counter: {:?}", e);
-            }
-        })?;
+    let permit = service.rate_limiter.start_user_decrypt().await?;
 
     let inner = request.into_inner();
 
@@ -71,12 +51,7 @@ pub async fn user_decrypt_impl<
             format!("Failed to validate user decryption request: {inner:?}"),
         )?;
 
-    if let Some(b) = timer.as_mut() {
-        //We log but we don't want to return early because timer failed
-        let _ = b
-            .tags([(TAG_KEY_ID, key_id.as_str())])
-            .map_err(|e| tracing::warn!("Failed to add tag key_id or request_id: {}", e));
-    }
+    timer.tags([(TAG_KEY_ID, key_id.as_str())]);
 
     {
         let mut guarded_meta_store = service.user_decrypt_meta_map.write().await;
@@ -116,11 +91,7 @@ pub async fn user_decrypt_impl<
                 Ok(k) => k,
                 Err(e) => {
                     let mut guarded_meta_store = meta_store.write().await;
-                    if let Err(e) =
-                        METRICS.increment_error_counter(OP_USER_DECRYPT_REQUEST, ERR_KEY_NOT_FOUND)
-                    {
-                        tracing::warn!("Failed to increment error counter: {:?}", e);
-                    }
+                    METRICS.increment_error_counter(OP_USER_DECRYPT_REQUEST, ERR_KEY_NOT_FOUND);
                     let _ = guarded_meta_store.update(
                         &request_id,
                         Err(format!("Failed to get key ID {key_id} with error {e:?}")),
@@ -160,12 +131,10 @@ pub async fn user_decrypt_impl<
                     let mut guarded_meta_store = meta_store.write().await;
                     let _ = guarded_meta_store
                         .update(&request_id, Err(format!("Failed user decryption: {e}")));
-                    METRICS
-                        .increment_error_counter(
-                            OP_USER_DECRYPT_REQUEST,
-                            ERR_USER_DECRYPTION_FAILED,
-                        )
-                        .ok();
+                    METRICS.increment_error_counter(
+                        OP_USER_DECRYPT_REQUEST,
+                        ERR_USER_DECRYPTION_FAILED,
+                    );
                 }
             }
         }
@@ -225,31 +194,11 @@ pub async fn public_decrypt_impl<
     // Start timing and counting before any operations
     let mut timer = METRICS
         .time_operation(OP_PUBLIC_DECRYPT_REQUEST)
-        .map_err(|e| tracing::warn!("Failed to create metric: {}", e))
-        .and_then(|b| {
-            // Use a constant party ID since this is the central KMS
-            b.tag(TAG_PARTY_ID, "central")
-                .map_err(|e| tracing::warn!("Failed to add party tag id: {}", e))
-        })
-        .map(|b| b.start())
-        .map_err(|e| tracing::warn!("Failed to start timer: {:?}", e))
-        .ok();
+        // Use a constant party ID since this is the central KMS
+        .tag(TAG_PARTY_ID, "central")
+        .start();
 
-    METRICS
-        .increment_request_counter(OP_PUBLIC_DECRYPT_REQUEST)
-        .map_err(|e| Status::internal(e.to_string()))?;
-
-    let permit = service
-        .rate_limiter
-        .start_pub_decrypt()
-        .await
-        .inspect_err(|_e| {
-            if let Err(e) =
-                METRICS.increment_error_counter(OP_PUBLIC_DECRYPT_REQUEST, ERR_RATE_LIMIT_EXCEEDED)
-            {
-                tracing::warn!("Failed to increment error counter: {:?}", e);
-            }
-        })?;
+    let permit = service.rate_limiter.start_pub_decrypt().await?;
 
     let start = tokio::time::Instant::now();
     let inner = request.into_inner();
@@ -259,12 +208,7 @@ pub async fn public_decrypt_impl<
         format!("Failed to validate decrypt request {inner:?}"),
     )?;
 
-    if let Some(b) = timer.as_mut() {
-        //We log but we don't want to return early because timer failed
-        let _ = b
-            .tags([(TAG_KEY_ID, key_id.as_str())])
-            .map_err(|e| tracing::warn!("Failed to add tag key_id or request_id: {}", e));
-    }
+    timer.tags([(TAG_KEY_ID, key_id.as_str())]);
 
     tracing::info!(
         "Decrypting {} ciphertexts using key {} with request id {}",
@@ -307,11 +251,7 @@ pub async fn public_decrypt_impl<
                 Ok(k) => k,
                 Err(e) => {
                     let mut guarded_meta_store = meta_store.write().await;
-                    if let Err(e) = METRICS
-                        .increment_error_counter(OP_PUBLIC_DECRYPT_REQUEST, ERR_KEY_NOT_FOUND)
-                    {
-                        tracing::warn!("Failed to increment error counter: {:?}", e);
-                    }
+                    METRICS.increment_error_counter(OP_PUBLIC_DECRYPT_REQUEST, ERR_KEY_NOT_FOUND);
                     let _ = guarded_meta_store.update(
                         &request_id,
                         Err(format!("Failed to get key ID {key_id} with error {e:?}")),
@@ -368,12 +308,10 @@ pub async fn public_decrypt_impl<
                 }
                 Ok(Err(e)) => {
                     let mut guarded_meta_store = meta_store.write().await;
-                    if let Err(e) = METRICS.increment_error_counter(
+                    METRICS.increment_error_counter(
                         OP_PUBLIC_DECRYPT_REQUEST,
                         ERR_PUBLIC_DECRYPTION_FAILED,
-                    ) {
-                        tracing::warn!("Failed to increment error counter: {:?}", e);
-                    }
+                    );
                     let _ = guarded_meta_store.update(
                         &request_id,
                         Err(format!("Error during decryption computation: {e}")),

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -10,9 +10,9 @@ use kms_grpc::{
 use observability::{
     metrics,
     metrics_names::{
-        ERR_RATE_LIMIT_EXCEEDED, OP_DECOMPRESSION_KEYGEN, OP_INSECURE_DECOMPRESSION_KEYGEN,
-        OP_INSECURE_KEYGEN, OP_INSECURE_SNS_COMPRESSION_KEYGEN, OP_KEYGEN,
-        OP_SNS_COMPRESSION_KEYGEN, TAG_PARTY_ID,
+        ERR_CANCELLED, ERR_KEYGEN_FAILED, OP_DECOMPRESSION_KEYGEN,
+        OP_INSECURE_DECOMPRESSION_KEYGEN, OP_INSECURE_KEYGEN, OP_INSECURE_SNS_COMPRESSION_KEYGEN,
+        OP_KEYGEN, OP_SNS_COMPRESSION_KEYGEN, TAG_PARTY_ID,
     },
 };
 use tfhe::{
@@ -237,19 +237,16 @@ impl<
             ) => OP_INSECURE_SNS_COMPRESSION_KEYGEN,
         };
 
-        let _request_counter = metrics::METRICS
-            .increment_request_counter(op_tag)
-            .map_err(|e| tracing::warn!("Failed to increment request counter: {}", e));
+        // On top of the global KG request counter, we also increment the specific operation counter
+        // as such, the sum of the specific operation counter is supposed to be equal the global KG
+        // counter
+        metrics::METRICS.increment_request_counter(op_tag);
 
         // Prepare the timer before giving it to the tokio task
         // that runs the computation
         let timer = metrics::METRICS
             .time_operation(op_tag)
-            .map_err(|e| tracing::warn!("Failed to create metric: {}", e))
-            .and_then(|b| {
-                b.tag(TAG_PARTY_ID, self.session_preparer.my_id.to_string())
-                    .map_err(|e| tracing::warn!("Failed to add party tag id: {}", e))
-            });
+            .tag(TAG_PARTY_ID, self.session_preparer.my_id.to_string());
         // Update status
         {
             let mut guarded_meta_store = self.dkg_pubinfo_meta_store.write().await;
@@ -335,9 +332,13 @@ impl<
         self.tracker
             .spawn(async move {
                 //Start the metric timer, it will end on drop
-                let _timer = timer.map(|b| b.start());
+                let _timer = timer.start();
                 tokio::select! {
-                    () = keygen_background => {
+                    res = keygen_background => {
+                        if res.is_err() {
+                            // We use the more specific tag to increment the error counter
+                            metrics::METRICS.increment_error_counter(op_tag, ERR_KEYGEN_FAILED);
+                        }
                         // Remove cancellation token since generation is now done.
                         ongoing.lock().await.remove(&req_id);
                         tracing::info!("Key generation of request {} exiting normally.", req_id);
@@ -347,6 +348,8 @@ impl<
                         // Delete any persistant data. Since we only cancel during shutdown we can ignore cleaning up the meta store since it is only in RAM
                         let guarded_meta_store = meta_store_cancelled.write().await;
                         crypto_storage_cancelled.purge_key_material(&req_id, guarded_meta_store).await;
+                        // We use the more specific tag to increment the error counter
+                        metrics::METRICS.increment_error_counter(op_tag, ERR_CANCELLED);
                         tracing::info!("Trying to clean up any already written material.")
                     },
                 }
@@ -359,13 +362,9 @@ impl<
         request: Request<KeyGenRequest>,
         insecure: bool,
     ) -> Result<Response<Empty>, Status> {
-        let permit = self.rate_limiter.start_keygen().await.inspect_err(|_e| {
-            if let Err(e) =
-                metrics::METRICS.increment_error_counter(OP_KEYGEN, ERR_RATE_LIMIT_EXCEEDED)
-            {
-                tracing::warn!("Failed to increment error counter: {:?}", e);
-            }
-        })?;
+        // Note: We increase the request counter only in launch_dkg
+        // so we don't increase the error counter here either
+        let permit = self.rate_limiter.start_keygen().await?;
 
         let inner = request.into_inner();
         tracing::info!(
@@ -800,7 +799,7 @@ impl<
         keyset_added_info: KeySetAddedInfo,
         eip712_domain: alloy_sol_types::Eip712Domain,
         permit: OwnedSemaphorePermit,
-    ) {
+    ) -> Result<(), ()> {
         let _permit = permit;
         let start = Instant::now();
         let dkg_res = match preproc_handle_w_mode {
@@ -852,7 +851,7 @@ impl<
                 let mut guarded_meta_storage = meta_store.write().await;
                 // We cannot do much if updating the storage fails at this point...
                 let _ = guarded_meta_storage.update(req_id, Err(e.to_string()));
-                return;
+                return Err(());
             }
         };
 
@@ -864,10 +863,12 @@ impl<
                 // We cannot do much if updating the storage fails at this point...
                 let _ = guarded_meta_storage
                     .update(req_id, Err("Failed to compute key info".to_string()));
-                return;
+                return Err(());
             }
         };
 
+        //Note: We can't easily check here whether we succeeded writing to the meta store
+        //thus we can't increment the error counter if it fails
         crypto_storage
             .write_decompression_key_with_meta_store(req_id, decompression_key, info, meta_store)
             .await;
@@ -876,6 +877,7 @@ impl<
             "Decompression DKG protocol took {} ms to complete for request {req_id}",
             start.elapsed().as_millis()
         );
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -890,7 +892,7 @@ impl<
         keyset_added_info: KeySetAddedInfo,
         eip712_domain: alloy_sol_types::Eip712Domain,
         permit: OwnedSemaphorePermit,
-    ) {
+    ) -> Result<(), ()> {
         let _permit = permit;
         let start = Instant::now();
         tracing::info!("Starting SNS compression key generation for request {req_id}");
@@ -905,7 +907,7 @@ impl<
                 let mut guarded_meta_storage = meta_store.write().await;
                 // We cannot do much if updating the storage fails at this point...
                 let _ = guarded_meta_storage.update(req_id, Err(e.to_string()));
-                return;
+                return Err(());
             }
         };
 
@@ -959,7 +961,7 @@ impl<
                 let mut guarded_meta_storage = meta_store.write().await;
                 // We cannot do much if updating the storage fails at this point...
                 let _ = guarded_meta_storage.update(req_id, Err(e.to_string()));
-                return;
+                return Err(());
             }
         };
 
@@ -979,7 +981,7 @@ impl<
                     req_id,
                     Err(format!("Failed to add sns compression key due to {e}")),
                 );
-                return;
+                return Err(());
             }
         };
 
@@ -991,10 +993,12 @@ impl<
                 // We cannot do much if updating the storage fails at this point...
                 let _ = guarded_meta_storage
                     .update(req_id, Err("Failed to compute key info".to_string()));
-                return;
+                return Err(());
             }
         };
 
+        // Note: We can't easily check here whether we succeeded writing to the meta store
+        // thus we can't increment the error counter if it fails
         crypto_storage
             .write_threshold_keys_with_meta_store(
                 req_id,
@@ -1009,6 +1013,7 @@ impl<
             "Sns compression DKG protocol took {} ms to complete for request {req_id}",
             start.elapsed().as_millis()
         );
+        Ok(())
     }
 
     // TODO(2674)
@@ -1118,7 +1123,7 @@ impl<
         compression_key_id: Option<RequestId>,
         eip712_domain: alloy_sol_types::Eip712Domain,
         permit: OwnedSemaphorePermit,
-    ) {
+    ) -> Result<(), ()> {
         let _permit = permit;
         let start = Instant::now();
         let dkg_res = match preproc_handle_w_mode {
@@ -1150,7 +1155,7 @@ impl<
                                     .to_string(),
                             ),
                         );
-                            return;
+                            return Err(());
                         }
                     }
                 }
@@ -1192,7 +1197,7 @@ impl<
                 let mut guarded_meta_storage = meta_store.write().await;
                 // We cannot do much if updating the storage fails at this point...
                 let _ = guarded_meta_storage.update(req_id, Err(e.to_string()));
-                return;
+                return Err(());
             }
         };
 
@@ -1204,7 +1209,7 @@ impl<
                 // We cannot do much if updating the storage fails at this point...
                 let _ = guarded_meta_storage
                     .update(req_id, Err("Failed to compute key info".to_string()));
-                return;
+                return Err(());
             }
         };
 
@@ -1232,6 +1237,9 @@ impl<
             decompression_key,
             pk_meta_data: info.clone(),
         };
+
+        //Note: We can't easily check here whether we succeeded writing to the meta store
+        //thus we can't increment the error counter if it fails
         crypto_storage
             .write_threshold_keys_with_meta_store(
                 req_id,
@@ -1246,6 +1254,7 @@ impl<
             "DKG protocol took {} ms to complete for request {req_id}",
             start.elapsed().as_millis()
         );
+        Ok(())
     }
 }
 

--- a/core/service/src/engine/threshold/service/preprocessor.rs
+++ b/core/service/src/engine/threshold/service/preprocessor.rs
@@ -9,7 +9,9 @@ use kms_grpc::{
 };
 use observability::{
     metrics,
-    metrics_names::{ERR_RATE_LIMIT_EXCEEDED, OP_KEYGEN_PREPROC, TAG_PARTY_ID},
+    metrics_names::{
+        ERR_CANCELLED, ERR_USER_PREPROC_FAILED, OP_KEYGEN_PREPROC_REQUEST, TAG_PARTY_ID,
+    },
 };
 use threshold_fhe::{
     algebra::{galois_rings::degree_4::ResiduePolyF4Z128, structure_traits::Ring},
@@ -74,19 +76,11 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
         request_id: RequestId,
         permit: OwnedSemaphorePermit,
     ) -> anyhow::Result<()> {
-        let _request_counter = metrics::METRICS
-            .increment_request_counter(OP_KEYGEN_PREPROC)
-            .map_err(|e| tracing::warn!("Failed to increment request counter: {}", e));
-
         // Prepare the timer before giving it to the tokio task
         // that runs the computation
         let timer = metrics::METRICS
-            .time_operation(OP_KEYGEN_PREPROC)
-            .map_err(|e| tracing::warn!("Failed to create metric: {}", e))
-            .and_then(|b| {
-                b.tag(TAG_PARTY_ID, self.session_preparer.my_id.to_string())
-                    .map_err(|e| tracing::warn!("Failed to add party tag id: {}", e))
-            });
+            .time_operation(OP_KEYGEN_PREPROC_REQUEST)
+            .tag(TAG_PARTY_ID, self.session_preparer.my_id.to_string());
         {
             let mut guarded_meta_store = self.preproc_buckets.write().await;
             guarded_meta_store.insert(&request_id)?;
@@ -97,6 +91,7 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
         let sids = (0..self.num_sessions_preproc)
             .map(|ctr| request_id.derive_session_id_with_counter(ctr as u64))
             .collect::<anyhow::Result<Vec<_>>>()?;
+
         let base_sessions = {
             let mut res = Vec::with_capacity(sids.len());
             for sid in sids {
@@ -117,6 +112,7 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
             (*self.prss_setup.read().await).clone(),
             "No PRSS setup exists".to_string(),
         )?;
+
         let token = CancellationToken::new();
         {
             self.ongoing.lock().await.insert(request_id, token.clone());
@@ -125,9 +121,12 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
         self.tracker.spawn(
             async move {
                 //Start the metric timer, it will end on drop
-                let _timer = timer.map(|b| b.start());
+                let _timer = timer.start();
                  tokio::select! {
-                    () = Self::preprocessing_background(&request_id, base_sessions, bucket_store, prss_setup, own_identity, dkg_params, keyset_config, factory, permit) => {
+                    res = Self::preprocessing_background(&request_id, base_sessions, bucket_store, prss_setup, own_identity, dkg_params, keyset_config, factory, permit) => {
+                        if res.is_err() {
+                            metrics::METRICS.increment_error_counter(OP_KEYGEN_PREPROC_REQUEST, ERR_USER_PREPROC_FAILED);
+                        }
                         // Remove cancellation token since generation is now done.
                         ongoing.lock().await.remove(&request_id);
                         tracing::info!("Preprocessing of request {} exiting normally.", &request_id);
@@ -137,6 +136,7 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
                         tracing::error!("Preprocessing of request {} exiting before completion because of a cancellation event.", &request_id);
                         let mut guarded_bucket_store = bucket_store_cancellation.write().await;
                         let _ = guarded_bucket_store.update(&request_id, Result::Err("Preprocessing was cancelled".to_string()));
+                        metrics::METRICS.increment_error_counter(OP_KEYGEN_PREPROC_REQUEST, ERR_CANCELLED);
                     },
                 }
             }
@@ -156,7 +156,7 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
         keyset_config: ddec_keyset_config::KeySetConfig,
         factory: Arc<Mutex<Box<dyn PreprocessorFactory<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>>>>,
         permit: OwnedSemaphorePermit,
-    ) {
+    ) -> Result<(), ()> {
         let _permit = permit; // dropped at the end of the function
         fn create_sessions(
             base_sessions: Vec<BaseSession>,
@@ -206,17 +206,28 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
             }
         };
 
-        // Update the bucket store with the result (success or error)
         let mut guarded_meta_store = bucket_store.write().await;
+
         // We cannot do much if updating the storage fails at this point...
-        let _ = guarded_meta_store.update(req_id, handle_update.clone());
+        let meta_store_write = guarded_meta_store.update(req_id, handle_update.clone());
 
         // Log completion status
-        if handle_update.is_ok() {
-            tracing::info!("Preproc Finished Successfully P[{:?}]", own_identity);
-        } else {
-            tracing::info!("Preproc Failed P[{:?}]", own_identity);
+        match (handle_update, meta_store_write) {
+            (Ok(_), Ok(_)) => tracing::info!("Preproc Finished Successfully P[{:?}]", own_identity),
+            (Err(e), _) => {
+                tracing::error!("Preproc Failed P[{:?}] with error: {}", own_identity, e);
+                return Err(());
+            }
+            (_, Err(e)) => {
+                tracing::info!(
+                    "Preproc Failed due to meta store issue P[{:?}] with error: {}",
+                    own_identity,
+                    e
+                );
+                return Err(());
+            }
         }
+        Ok(())
     }
 }
 
@@ -228,13 +239,7 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>> + Se
         &self,
         request: Request<KeyGenPreprocRequest>,
     ) -> Result<Response<Empty>, Status> {
-        let permit = self.rate_limiter.start_preproc().await.inspect_err(|_e| {
-            if let Err(e) =
-                metrics::METRICS.increment_error_counter(OP_KEYGEN_PREPROC, ERR_RATE_LIMIT_EXCEEDED)
-            {
-                tracing::warn!("Failed to increment error counter: {:?}", e);
-            }
-        })?;
+        let permit = self.rate_limiter.start_preproc().await?;
 
         let inner = request.into_inner();
         let request_id: RequestId = tonic_some_or_err(
@@ -258,9 +263,11 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>> + Se
             "Failed to process keyset config".to_string(),
         )?;
 
-        //If the entry did not exist before, start the preproc
+        // If the entry did not exist before, start the preproc
+        // NOTE: We currently consider an existing entry is NOT an error
         if !entry_exists {
             tracing::info!("Starting preproc generation for Request ID {}", request_id);
+            // We don't increment the error counter here but rather in launch_dkg_preproc
             tonic_handle_potential_err(self.launch_dkg_preproc(dkg_params, keyset_config, request_id, permit).await, format!("Error launching dkg preprocessing for Request ID {request_id} and parameters {dkg_params:?}"))?;
         } else {
             tracing::warn!(

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -13,8 +13,9 @@ use kms_grpc::{
 use observability::{
     metrics,
     metrics_names::{
-        ERR_RATE_LIMIT_EXCEEDED, OP_USER_DECRYPT_INNER, OP_USER_DECRYPT_REQUEST, TAG_KEY_ID,
-        TAG_PARTY_ID, TAG_PUBLIC_DECRYPTION_KIND, TAG_TFHE_TYPE,
+        ERR_USER_DECRYPTION_FAILED, ERR_WITH_META_STORAGE, OP_USER_DECRYPT_INNER,
+        OP_USER_DECRYPT_REQUEST, TAG_KEY_ID, TAG_PARTY_ID, TAG_PUBLIC_DECRYPTION_KIND,
+        TAG_TFHE_TYPE,
     },
 };
 use rand::{CryptoRng, RngCore};
@@ -184,20 +185,11 @@ impl<
             // exported at the end of the iteration
             let mut inner_timer = metrics::METRICS
                 .time_operation(OP_USER_DECRYPT_INNER)
-                .map_err(|e| tracing::warn!("Failed to create metric: {}", e))
-                .and_then(|b| {
-                    b.tags(metric_tags.clone()).map_err(|e| {
-                        tracing::warn!("Failed to a tag in party_id, key_id or request_id : {}", e)
-                    })
-                })
-                .map(|b| b.start())
-                .map_err(|e| tracing::warn!("Failed to start timer: {:?}", e))
-                .ok();
+                .tags(metric_tags.clone())
+                .start();
             let fhe_type = typed_ciphertext.fhe_type()?;
             let fhe_type_str = typed_ciphertext.fhe_type_string();
-            inner_timer
-                .as_mut()
-                .map(|b| b.tag(TAG_TFHE_TYPE, fhe_type_str));
+            inner_timer.tag(TAG_TFHE_TYPE, fhe_type_str);
             let ct_format = typed_ciphertext.ciphertext_format();
             let ct = &typed_ciphertext.ciphertext;
             let external_handle = typed_ciphertext.external_handle.clone();
@@ -428,30 +420,10 @@ impl<
         // Start timing and counting before any operations
         let mut timer = metrics::METRICS
             .time_operation(OP_USER_DECRYPT_REQUEST)
-            .map_err(|e| tracing::warn!("Failed to create metric: {}", e))
-            .and_then(|b| {
-                b.tag(TAG_PARTY_ID, self.session_preparer.my_id.to_string())
-                    .map_err(|e| tracing::warn!("Failed to add party tag id: {}", e))
-            })
-            .map(|b| b.start())
-            .map_err(|e| tracing::warn!("Failed to start timer: {:?}", e))
-            .ok();
+            .tag(TAG_PARTY_ID, self.session_preparer.my_id.to_string())
+            .start();
 
-        let _request_counter = metrics::METRICS
-            .increment_request_counter(OP_USER_DECRYPT_REQUEST)
-            .map_err(|e| tracing::warn!("Failed to increment request counter: {}", e));
-
-        let permit = self
-            .rate_limiter
-            .start_user_decrypt()
-            .await
-            .inspect_err(|_e| {
-                if let Err(e) = metrics::METRICS
-                    .increment_error_counter(OP_USER_DECRYPT_REQUEST, ERR_RATE_LIMIT_EXCEEDED)
-                {
-                    tracing::warn!("Failed to increment error counter: {:?}", e);
-                }
-            })?;
+        let permit = self.rate_limiter.start_user_decrypt().await?;
 
         let inner = request.into_inner();
         tracing::info!(
@@ -468,12 +440,7 @@ impl<
                 ),
             )?;
 
-        if let Some(b) = timer.as_mut() {
-            //We log but we don't want to return early because timer failed
-            let _ = b
-                .tags([(TAG_KEY_ID, key_id.as_str())])
-                .map_err(|e| tracing::warn!("Failed to add tag key_id or request_id: {}", e));
-        }
+        timer.tags([(TAG_KEY_ID, key_id.as_str())]);
 
         let meta_store = Arc::clone(&self.user_decrypt_meta_store);
         let crypto_storage = self.crypto_storage.clone();
@@ -550,9 +517,20 @@ impl<
                 match tmp {
                     Ok((payload, sig, extra_data)) => {
                         // We cannot do much if updating the storage fails at this point...
-                        let _ = guarded_meta_store.update(&req_id, Ok((payload, sig, extra_data)));
+                        let _ = guarded_meta_store
+                            .update(&req_id, Ok((payload, sig, extra_data)))
+                            .inspect_err(|_| {
+                                metrics::METRICS.increment_error_counter(
+                                    OP_USER_DECRYPT_REQUEST,
+                                    ERR_WITH_META_STORAGE,
+                                );
+                            });
                     }
                     Result::Err(e) => {
+                        metrics::METRICS.increment_error_counter(
+                            OP_USER_DECRYPT_REQUEST,
+                            ERR_USER_DECRYPTION_FAILED,
+                        );
                         // We cannot do much if updating the storage fails at this point...
                         let _ = guarded_meta_store
                             .update(&req_id, Err(format!("Failed decryption: {e}")));

--- a/observability/src/metrics_names.rs
+++ b/observability/src/metrics_names.rs
@@ -2,26 +2,48 @@
 /// These match the gRPC method names for better correlation
 //
 // Key Generation Operations
+pub const OP_KEYGEN_REQUEST: &str = "keygen_request";
+pub const OP_KEYGEN_RESULT: &str = "keygen_result";
+pub const OP_INSECURE_KEYGEN_REQUEST: &str = "insecure_keygen_request";
+pub const OP_INSECURE_KEYGEN_RESULT: &str = "insecure_keygen_result";
 pub const OP_INSECURE_KEYGEN: &str = "insecure_keygen";
 pub const OP_INSECURE_DECOMPRESSION_KEYGEN: &str = "insecure_decompression_keygen";
 pub const OP_INSECURE_SNS_COMPRESSION_KEYGEN: &str = "insecure_sns_compression_keygen";
 pub const OP_KEYGEN: &str = "keygen";
 pub const OP_DECOMPRESSION_KEYGEN: &str = "decompression_keygen";
 pub const OP_SNS_COMPRESSION_KEYGEN: &str = "sns_compression_keygen";
-pub const OP_KEYGEN_PREPROC: &str = "keygen_preproc";
+pub const OP_KEYGEN_PREPROC_REQUEST: &str = "keygen_preproc_request";
+pub const OP_KEYGEN_PREPROC_RESULT: &str = "keygen_preproc_result";
 
 // Public/User decryption Operations
 // Corresponds to a request, a request may contain several ciphertexts
 pub const OP_PUBLIC_DECRYPT_REQUEST: &str = "public_decrypt_request";
+pub const OP_PUBLIC_DECRYPT_RESULT: &str = "public_decrypt_result";
 pub const OP_USER_DECRYPT_REQUEST: &str = "user_decrypt_request";
+pub const OP_USER_DECRYPT_RESULT: &str = "user_decrypt_result";
 // Inner variants of the OP
 // Corresponds to a single ciphertext
 pub const OP_PUBLIC_DECRYPT_INNER: &str = "public_decrypt_inner";
 pub const OP_USER_DECRYPT_INNER: &str = "user_decrypt_inner";
 
 // CRS Operations
-pub const OP_CRS_GEN: &str = "crs_gen";
-pub const OP_INSECURE_CRS_GEN: &str = "insecure_crs_gen";
+pub const OP_CRS_GEN_REQUEST: &str = "crs_gen_request";
+pub const OP_CRS_GEN_RESULT: &str = "crs_gen_result";
+pub const OP_INSECURE_CRS_GEN_REQUEST: &str = "insecure_crs_gen_request";
+pub const OP_INSECURE_CRS_GEN_RESULT: &str = "insecure_crs_gen_result";
+
+// PRSS init
+pub const OP_INIT: &str = "init";
+
+// Context operations
+pub const OP_NEW_KMS_CONTEXT: &str = "new_kms_context";
+pub const OP_DESTROY_KMS_CONTEXT: &str = "destroy_kms_context";
+pub const OP_NEW_CUSTODIAN_CONTEXT: &str = "new_custodian_context";
+pub const OP_DESTROY_CUSTODIAN_CONTEXT: &str = "destroy_custodian_context";
+pub const OP_CUSTODIAN_CONTEXT_RESTORE: &str = "custodian_context_restore";
+
+// PK fetch
+pub const OP_FETCH_PK: &str = "fetch_pk";
 
 // Common metric tag keys
 pub const TAG_OPERATION: &str = "operation";
@@ -40,11 +62,36 @@ pub const ERR_KEY_EXISTS: &str = "key_already_exists";
 pub const ERR_KEY_NOT_FOUND: &str = "key_not_found";
 pub const ERR_PUBLIC_DECRYPTION_FAILED: &str = "public_decryption_failed";
 pub const ERR_USER_DECRYPTION_FAILED: &str = "user_decryption_failed";
+pub const ERR_USER_PREPROC_FAILED: &str = "preproc_failed";
+pub const ERR_PREPROC_NOT_FOUND: &str = "preproc_not_found";
+pub const ERR_KEYGEN_FAILED: &str = "keygen_failed";
 pub const ERR_VERIFICATION_FAILED: &str = "verification_failed";
 pub const ERR_CRS_GEN_FAILED: &str = "crs_gen_failed";
+pub const ERR_WITH_META_STORAGE: &str = "meta_storage_error";
+pub const ERR_INVALID_REQUEST: &str = "invalid_request";
+pub const ERR_CANCELLED: &str = "cancelled";
+pub const ERR_INVALID_ARGUMENT: &str = "invalid_argument";
+pub const ERR_ABORTED: &str = "aborted";
+pub const ERR_ALREADY_EXISTS: &str = "already_exists";
+pub const ERR_NOT_FOUND: &str = "not_found";
+pub const ERR_INTERNAL: &str = "internal_error";
+pub const ERR_UNAVAILABLE: &str = "unavailable";
+pub const ERR_OTHER: &str = "other";
 
 // Common operation type values
 pub const OP_TYPE_TOTAL: &str = "total";
 pub const OP_TYPE_LOAD_CRS_PK: &str = "load_crs_pk";
 pub const OP_TYPE_PROOF_VERIFICATION: &str = "proof_verification";
 pub const OP_TYPE_CT_PROOF: &str = "ct_proof";
+
+pub fn map_tonic_code_to_metric_tag(code: tonic::Code) -> &'static str {
+    match code {
+        tonic::Code::InvalidArgument => ERR_INVALID_ARGUMENT,
+        tonic::Code::NotFound => ERR_NOT_FOUND,
+        tonic::Code::Internal => ERR_INTERNAL,
+        tonic::Code::Unavailable => ERR_UNAVAILABLE,
+        tonic::Code::Aborted => ERR_ABORTED,
+        tonic::Code::AlreadyExists => ERR_ALREADY_EXISTS,
+        _ => ERR_OTHER,
+    }
+}

--- a/observability/src/telemetry.rs
+++ b/observability/src/telemetry.rs
@@ -148,9 +148,7 @@ pub fn init_metrics(settings: &TelemetryConfig) -> Result<SdkMeterProvider, anyh
     let state = MetricsState::new(registry);
 
     // Use the global METRICS instance also as a sanity check that metrics are working
-    METRICS
-        .increment_request_counter("system_startup")
-        .context("Failed to increment system startup counter")?;
+    METRICS.increment_request_counter("system_startup");
 
     // Get the current runtime handle
     let rt = tokio::runtime::Handle::current();


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Closes https://github.com/zama-ai/kms-internal/issues/2669

Current design decision:
- For all request we increment the counter directly in the endpoint, only exception is DKG where we increment it in the endpoint with a global KG tag and once again in the logic with a more specific tag that relates to the exact kind of KG we are doing.
- For all request we handle the error counter directly in the endpoint for the part that isn't async
- For request with an async part, we make the task return `Result<(),()>` and handle the error counter in a single place.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/zama-ai/kms-core/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/zama-ai/kms-core/blob/main/CHANGELOG.md
-->
