### PR TITLE
chore: fix inconsistency in crs ceremony

### DIFF
--- a/core/threshold/src/execution/zk/constants.rs
+++ b/core/threshold/src/execution/zk/constants.rs
@@ -18,3 +18,4 @@ pub const ZK_DSEP_PHI: DomainSep = *b"ZKHA_PHI";
 pub const ZK_DSEP_XI: DomainSep = *b"ZKHAS_XI";
 pub const ZK_DSEP_CHI: DomainSep = *b"ZKHA_CHI";
 pub const ZK_DSEP_GAMMA: DomainSep = *b"VCProve2";
+pub const ZK_DSEP_CRS_UPDA: DomainSep = *b"CRS_UPDA";


### PR DESCRIPTION
NIST uses one XOF to generate \tau and r in the ceremony, we need to do it this way.

Also, NIST does not hash the punctured point to rho_0 rho_1

Closes https://github.com/zama-ai/kms-internal/issues/2581