### PR TITLE
Fix: properly check certificate for authentication in moby

### DIFF
--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -21,7 +21,7 @@ use threshold_fhe::{
         runtime::party::{Role, RoleAssignment},
     },
     networking::{
-        grpc::{GrpcNetworkingManager, GrpcServer},
+        grpc::{GrpcNetworkingManager, GrpcServer, TlsExtensionGetter},
         tls::{
             build_ca_certs_map, AttestedClientVerifier, BasicTLSConfig, SendingServiceTLSConfig,
         },
@@ -287,7 +287,10 @@ where
         config.core_to_core_net,
     )?));
     let manager_clone = Arc::clone(&networking_manager);
-    let networking_server = networking_manager.write().await.new_server();
+    let networking_server = networking_manager
+        .write()
+        .await
+        .new_server(TlsExtensionGetter::SslConnectInfo);
     // we won't be setting TLS configuration through tonic::transport knobs here
     // since it doesn't permit setting rustls configuration directly, and we
     // need to supply a custom certificate verifier to enable AWS Nitro

--- a/core/threshold/src/grpc/server.rs
+++ b/core/threshold/src/grpc/server.rs
@@ -11,7 +11,7 @@ use crate::experimental::choreography::grpc::ExperimentalGrpcChoreography;
 #[cfg(not(feature = "experimental"))]
 use crate::malicious_execution::malicious_moby::add_strategy_to_router;
 use crate::networking::constants::NETWORK_TIMEOUT_LONG;
-use crate::networking::grpc::{GrpcNetworkingManager, GrpcServer};
+use crate::networking::grpc::{GrpcNetworkingManager, GrpcServer, TlsExtensionGetter};
 use crate::networking::Networking;
 use observability::telemetry::make_span;
 use std::sync::Arc;
@@ -51,7 +51,7 @@ where
         tls_conf,
         settings.net_conf,
     )?);
-    let networking_server = networking.new_server();
+    let networking_server = networking.new_server(TlsExtensionGetter::TlsConnectInfo);
 
     let factory = match &settings.redis {
         None => create_memory_factory::<EXTENSION_DEGREE>(),

--- a/core/threshold/src/networking/grpc.rs
+++ b/core/threshold/src/networking/grpc.rs
@@ -285,10 +285,11 @@ impl GrpcNetworkingManager {
         let force_tls = tls_conf.is_some();
 
         #[cfg(not(feature = "testing"))]
-        assert!(
-            tls_conf.is_some(),
-            "TLS configuration must be provided in non-testing environments",
-        );
+        if tls_conf.is_none() {
+            return Err(crate::error::error_handler::anyhow_error_and_log(
+                "TLS configuration must be provided in non-testing environments",
+            ));
+        }
 
         let conf = OptionConfigWrapper { conf };
         let session_store = Arc::new(SessionStore::default());

--- a/core/threshold/src/networking/grpc.rs
+++ b/core/threshold/src/networking/grpc.rs
@@ -709,7 +709,7 @@ impl Gnetworking for NetworkingImpl {
                     format!("wrong sender: expected {host:?} to be in {sender:?}"),
                 ));
             }
-            tracing::warn!("TLS Check went fine for sender: {:?}", sender);
+            tracing::debug!("TLS Check went fine for sender: {:?}", sender);
         } else {
             tracing::warn!(
                 "Could not find a TLS certificate in the request to verify user's identity."

--- a/core/threshold/src/networking/grpc.rs
+++ b/core/threshold/src/networking/grpc.rs
@@ -276,6 +276,15 @@ impl GrpcNetworkingManager {
         tls_conf: Option<SendingServiceTLSConfig>,
         conf: Option<CoreToCoreNetworkConfig>,
     ) -> anyhow::Result<Self> {
+        #[cfg(feature = "testing")]
+        let force_tls = tls_conf.is_some();
+
+        #[cfg(not(feature = "testing"))]
+        assert!(
+            tls_conf.is_some(),
+            "TLS configuration must be provided in non-testing environments",
+        );
+
         let conf = OptionConfigWrapper { conf };
         let session_store = Arc::new(SessionStore::default());
 
@@ -290,9 +299,6 @@ impl GrpcNetworkingManager {
             cleanup_interval,
             discard_inactive_interval,
         );
-
-        #[cfg(feature = "testing")]
-        let force_tls = tls_conf.is_some();
 
         Ok(GrpcNetworkingManager {
             session_store,

--- a/core/threshold/src/networking/sending_service.rs
+++ b/core/threshold/src/networking/sending_service.rs
@@ -614,6 +614,7 @@ impl Networking for NetworkSession {
 
 #[cfg(test)]
 mod tests {
+    use crate::networking::grpc::TlsExtensionGetter;
     use crate::thread_handles::OsThreadGroup;
     use crate::{
         execution::runtime::party::{Identity, Role, RoleAssignment},
@@ -648,7 +649,7 @@ mod tests {
                 let runtime = tokio::runtime::Runtime::new().unwrap();
                 let _guard = runtime.enter();
                 let networking = GrpcNetworkingManager::new(id.clone(), None, None).unwrap();
-                let networking_server = networking.new_server();
+                let networking_server = networking.new_server(TlsExtensionGetter::default());
 
                 let core_grpc_layer = tower::ServiceBuilder::new().timeout(Duration::from_secs(3));
 
@@ -703,7 +704,7 @@ mod tests {
             let runtime = tokio::runtime::Runtime::new().unwrap();
             let _guard = runtime.enter();
             let networking = GrpcNetworkingManager::new(id.clone(), None, None).unwrap();
-            let networking_server = networking.new_server();
+            let networking_server = networking.new_server(TlsExtensionGetter::default());
 
             let core_grpc_layer = tower::ServiceBuilder::new().timeout(Duration::from_secs(3));
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->
The authenticity of the sender's indentity wasn't properly checked in moby due to recent changes.

We now explicitly specify the extension to get to fetch the certificate, this is because the custom TlsIncoming we use for the enclave workaround uses this extension:

```rust
#[derive(Debug, Clone)]
pub struct SslConnectInfo<T> {
    inner: T,
    certs: Option<Arc<Vec<CertificateDer<'static>>>>,
}
```
 
 which is actually a duplicate of the extension used by tonic by default
 
 ```rust
 #[cfg(feature = "_tls-any")]
#[derive(Debug, Clone)]
pub struct TlsConnectInfo<T> {
    inner: T,
    certs: Option<Arc<Vec<CertificateDer<'static>>>>,
}
```
 except it's a different struct, so the extension getter can't be the exact same.
 
This PR fixes it, makes it mandatory to have TLS if we have the testing feature disabled and allows to enforce TLS if we have testing feature enabled.
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/zama-ai/kms/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/zama-ai/kms/blob/main/CHANGELOG.md
-->
