### PR TITLE
chore: bump version to v0.11.0-23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "backward-compatibility"
-version = "0.11.0-22"
+version = "0.11.0-23"
 dependencies = [
  "aes-prng",
  "bincode 1.3.3",
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "cc-tests-utils"
-version = "0.11.0-22"
+version = "0.11.0-23"
 
 [[package]]
 name = "cexpr"
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "kms"
-version = "0.11.0-22"
+version = "0.11.0-23"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "kms-core-client"
-version = "0.11.0-22"
+version = "0.11.0-23"
 dependencies = [
  "aes-prng",
  "alloy-primitives",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "kms-grpc"
-version = "0.11.0-22"
+version = "0.11.0-23"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.11.0-22"
+version = "0.11.0-23"
 dependencies = [
  "anyhow",
  "axum",
@@ -6952,7 +6952,7 @@ dependencies = [
 
 [[package]]
 name = "tests-utils"
-version = "0.11.0-22"
+version = "0.11.0-23"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7123,7 +7123,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-fhe"
-version = "0.11.0-22"
+version = "0.11.0-23"
 dependencies = [
  "aes",
  "aes-prng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ authors = ["Zama"]
 publish = true
 edition = "2021"
 license = "BSD-3-Clause-Clear"
-version = "0.11.0-22"
+version = "0.11.0-23"
 
 [workspace.dependencies]
 aes = "=0.8.4"

--- a/backward-compatibility/Cargo.toml
+++ b/backward-compatibility/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backward-compatibility"
-version = "0.11.0-22"
+version = "0.11.0-23"
 publish = false
 authors = ["Zama"]
 edition = "2021"


### PR DESCRIPTION
Bump the version for a new `tkms` npm release.