### PR TITLE
fix: use safe_serialization for hashing as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "backward-compatibility"
-version = "0.11.0-23"
+version = "0.11.0-24"
 dependencies = [
  "aes-prng",
  "bincode 1.3.3",
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "cc-tests-utils"
-version = "0.11.0-23"
+version = "0.11.0-24"
 
 [[package]]
 name = "cexpr"
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "kms"
-version = "0.11.0-23"
+version = "0.11.0-24"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "kms-core-client"
-version = "0.11.0-23"
+version = "0.11.0-24"
 dependencies = [
  "aes-prng",
  "alloy-primitives",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "kms-grpc"
-version = "0.11.0-23"
+version = "0.11.0-24"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.11.0-23"
+version = "0.11.0-24"
 dependencies = [
  "anyhow",
  "axum",
@@ -6952,7 +6952,7 @@ dependencies = [
 
 [[package]]
 name = "tests-utils"
-version = "0.11.0-23"
+version = "0.11.0-24"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7123,7 +7123,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-fhe"
-version = "0.11.0-23"
+version = "0.11.0-24"
 dependencies = [
  "aes",
  "aes-prng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ authors = ["Zama"]
 publish = true
 edition = "2021"
 license = "BSD-3-Clause-Clear"
-version = "0.11.0-23"
+version = "0.11.0-24"
 
 [workspace.dependencies]
 aes = "=0.8.4"

--- a/backward-compatibility/Cargo.toml
+++ b/backward-compatibility/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backward-compatibility"
-version = "0.11.0-23"
+version = "0.11.0-24"
 publish = false
 authors = ["Zama"]
 edition = "2021"

--- a/core/service/src/cryptography/internal_crypto_types.rs
+++ b/core/service/src/cryptography/internal_crypto_types.rs
@@ -78,17 +78,12 @@ impl UnifiedPublicEncKey {
                 )?;
                 Ok(enc_key_buf)
             }
-            UnifiedPublicEncKey::MlKem1024(user_pk) => {
-                let mut enc_key_buf = Vec::new();
-                tfhe::safe_serialization::safe_serialize(
-                    &UnifiedPublicEncKey::MlKem1024(user_pk.clone()),
-                    &mut enc_key_buf,
-                    SAFE_SER_SIZE_LIMIT,
-                )?;
-                Ok(enc_key_buf)
-            }
+            // TODO: The following bincode serialization is done to be backward compatible
+            // with the old serialization format, used in relayer-sdk v0.2.0-0 and older (tkms v0.11.0-rc20 and older).
+            // It should be replaced with safe serialization (as above) in the future.
+            UnifiedPublicEncKey::MlKem1024(user_pk) => bc2wrap::serialize(user_pk),
         }
-        .map_err(|e: anyhow::Error| anyhow::anyhow!("serialization error: {e}"))
+        .map_err(|e| anyhow::anyhow!("serialization error: {e}"))
     }
 }
 

--- a/core/service/src/cryptography/internal_crypto_types.rs
+++ b/core/service/src/cryptography/internal_crypto_types.rs
@@ -1,4 +1,4 @@
-use crate::consts::{DEFAULT_PARAM, SIG_SIZE, TEST_PARAM};
+use crate::consts::{DEFAULT_PARAM, SAFE_SER_SIZE_LIMIT, SIG_SIZE, TEST_PARAM};
 use crate::cryptography::hybrid_ml_kem::{self};
 use k256::ecdsa::{SigningKey, VerifyingKey};
 use kms_grpc::kms::v1::FheParameter;
@@ -69,10 +69,26 @@ impl UnifiedPublicEncKey {
     /// Do not use this for serialization, but use safe_serialize instead.
     pub fn bytes_for_hashing(&self) -> anyhow::Result<Vec<u8>> {
         match self {
-            UnifiedPublicEncKey::MlKem512(user_pk) => bc2wrap::serialize(user_pk),
-            UnifiedPublicEncKey::MlKem1024(user_pk) => bc2wrap::serialize(user_pk),
+            UnifiedPublicEncKey::MlKem512(user_pk) => {
+                let mut enc_key_buf = Vec::new();
+                tfhe::safe_serialization::safe_serialize(
+                    &UnifiedPublicEncKey::MlKem512(user_pk.clone()),
+                    &mut enc_key_buf,
+                    SAFE_SER_SIZE_LIMIT,
+                )?;
+                Ok(enc_key_buf)
+            }
+            UnifiedPublicEncKey::MlKem1024(user_pk) => {
+                let mut enc_key_buf = Vec::new();
+                tfhe::safe_serialization::safe_serialize(
+                    &UnifiedPublicEncKey::MlKem1024(user_pk.clone()),
+                    &mut enc_key_buf,
+                    SAFE_SER_SIZE_LIMIT,
+                )?;
+                Ok(enc_key_buf)
+            }
         }
-        .map_err(|e| anyhow::anyhow!("bincode2 error: {e}"))
+        .map_err(|e: anyhow::Error| anyhow::anyhow!("serialization error: {e}"))
     }
 }
 

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -115,7 +115,7 @@ pub fn compute_user_decrypt_message_hash(
     Ok(message_hash)
 }
 
-// ree-export DecryptionMode
+// re-export DecryptionMode
 pub use threshold_fhe::execution::endpoints::decryption::DecryptionMode;
 
 use crate::cryptography::internal_crypto_types::UnifiedPublicEncKey;


### PR DESCRIPTION
This ensures to use the same serialization for hashing the public key as is used in the kms-core and in the js client (via `tkms`/`node-tkms`)

This is also backward-compatible `relayer-sdk` versions `0.2.0-0` (`tkms v.0.11.0-rc20`) and older.