### PR TITLE
fix(s3): cleared and improved store/update/delete logic

### DIFF
--- a/core-client/tests-utils/src/lib.rs
+++ b/core-client/tests-utils/src/lib.rs
@@ -32,7 +32,7 @@ impl fmt::Display for OutputWrapper<'_> {
 }
 
 // Helper function to create the wrapper
-pub fn format_output(output: &Output) -> OutputWrapper {
+pub fn format_output(output: &Output) -> OutputWrapper<'_> {
     OutputWrapper(output)
 }
 

--- a/core/service/src/vault/storage/mod.rs
+++ b/core/service/src/vault/storage/mod.rs
@@ -419,6 +419,10 @@ impl StorageCache {
         // do we have to use to_string()?
         self.cache.get(&(key.to_string(), subkey.to_string()))
     }
+
+    pub(crate) fn remove(&mut self, key: &str, subkey: &str) -> Option<Vec<u8>> {
+        self.cache.remove(&(key.to_string(), subkey.to_string()))
+    }
 }
 
 #[cfg(test)]

--- a/core/service/src/vault/storage/s3.rs
+++ b/core/service/src/vault/storage/s3.rs
@@ -65,6 +65,50 @@ impl S3Storage {
     fn item_key(&self, data_id: &RequestId, data_type: &str) -> String {
         format!("{}/{}/{}", self.prefix, data_type, data_id)
     }
+
+    /// Helper to update cache after successful S3 operation
+    async fn update_cache(&self, key: &str, data: &[u8]) {
+        if let Some(cache) = &self.cache {
+            let cache = Arc::clone(cache);
+            let mut guarded_cache = cache.lock().await;
+            guarded_cache.insert(&self.bucket, key, data);
+        }
+    }
+
+    /// Helper to invalidate cache entry (using poison approach)
+    async fn invalidate_cache(&self, key: &str) {
+        if let Some(cache) = &self.cache {
+            let cache = Arc::clone(cache);
+            let mut guarded_cache = cache.lock().await;
+            guarded_cache.insert(&self.bucket, key, &[]); // Poison with empty data
+        }
+    }
+
+    /// Helper to get data from cache or S3 with cache population
+    async fn get_with_cache(&self, key: &str) -> anyhow::Result<Vec<u8>> {
+        match &self.cache {
+            Some(cache) => {
+                let cache = Arc::clone(cache);
+                let mut guarded_cache = cache.lock().await;
+                match guarded_cache.get(&self.bucket, key) {
+                    Some(buf) => {
+                        tracing::info!(
+                            "found bucket={}, path={} in storage cache",
+                            &self.bucket,
+                            key
+                        );
+                        Ok(buf.clone())
+                    }
+                    None => {
+                        let data = s3_get_blob(&self.s3_client, &self.bucket, key).await?;
+                        guarded_cache.insert(&self.bucket, key, &data);
+                        Ok(data)
+                    }
+                }
+            }
+            None => s3_get_blob(&self.s3_client, &self.bucket, key).await,
+        }
+    }
 }
 
 impl StorageReader for S3Storage {
@@ -106,28 +150,7 @@ impl StorageReader for S3Storage {
             key
         );
 
-        let buf = match &self.cache {
-            Some(cache) => {
-                let cache = Arc::clone(cache);
-                let mut guarded_cache = cache.lock().await;
-                match guarded_cache.get(&self.bucket, key) {
-                    Some(buf) => {
-                        tracing::info!(
-                            "found bucket={}, path={} in storage cache",
-                            &self.bucket,
-                            key
-                        );
-                        buf.clone()
-                    }
-                    None => {
-                        let data = s3_get_blob(&self.s3_client, &self.bucket, key).await?;
-                        guarded_cache.insert(&self.bucket, key, &data);
-                        data
-                    }
-                }
-            }
-            None => s3_get_blob(&self.s3_client, &self.bucket, key).await?,
-        };
+        let buf = self.get_with_cache(key).await?;
         safe_deserialize(&mut std::io::Cursor::new(buf), SAFE_SER_SIZE_LIMIT)
             .map_err(|e| anyhow::anyhow!(e))
     }
@@ -179,13 +202,14 @@ impl Storage for S3Storage {
         );
         let mut buf = Vec::new();
         safe_serialize(data, &mut buf, SAFE_SER_SIZE_LIMIT)?;
-        self.cache.as_ref().map(|cache| async {
-            Arc::clone(cache)
-                .lock()
-                .await
-                .insert(&self.bucket, key, &buf);
-        });
-        s3_put_blob(&self.s3_client, &self.bucket, key, buf).await
+
+        // Store in S3 FIRST - only update cache if S3 operation succeeds
+        s3_put_blob(&self.s3_client, &self.bucket, key, buf.clone()).await?;
+
+        // Update cache ONLY after successful S3 storage
+        self.update_cache(key, &buf).await;
+
+        Ok(())
     }
 
     async fn delete_data(&mut self, data_id: &RequestId, data_type: &str) -> anyhow::Result<()> {
@@ -197,13 +221,21 @@ impl Storage for S3Storage {
             key
         );
 
-        let _ = self
+        // Remove from cache BEFORE deleting from S3 to prevent stale cache reads
+        self.invalidate_cache(key).await;
+
+        // Attempt S3 deletion but don't fail on errors
+        if let Err(e) = self
             .s3_client
             .delete_object()
             .bucket(&self.bucket)
             .key(key)
             .send()
-            .await;
+            .await
+        {
+            tracing::error!("S3 delete failed: {:?}", e);
+        }
+
         Ok(())
     }
 }
@@ -219,7 +251,13 @@ impl StorageForBytes for S3Storage {
 
         tracing::info!("Storing text in bucket {} under key {}", &self.bucket, key);
 
-        s3_put_blob(&self.s3_client, &self.bucket, key, bytes.to_vec()).await
+        // Store in S3 FIRST - only update cache if S3 operation succeeds
+        s3_put_blob(&self.s3_client, &self.bucket, key, bytes.to_vec()).await?;
+
+        // Update cache ONLY after successful S3 storage
+        self.update_cache(key, bytes).await;
+
+        Ok(())
     }
 
     async fn load_bytes(&self, data_id: &RequestId, data_type: &str) -> anyhow::Result<Vec<u8>> {
@@ -231,7 +269,8 @@ impl StorageForBytes for S3Storage {
             key
         );
 
-        s3_get_blob(&self.s3_client, &self.bucket, key).await
+        // Check cache first, then S3 if not found
+        self.get_with_cache(key).await
     }
 }
 

--- a/core/service/src/vault/storage/s3.rs
+++ b/core/service/src/vault/storage/s3.rs
@@ -75,12 +75,12 @@ impl S3Storage {
         }
     }
 
-    /// Helper to invalidate cache entry (using poison approach)
+    /// Helper to invalidate cache entry (remove from cache)
     async fn invalidate_cache(&self, key: &str) {
         if let Some(cache) = &self.cache {
             let cache = Arc::clone(cache);
             let mut guarded_cache = cache.lock().await;
-            guarded_cache.insert(&self.bucket, key, &[]); // Poison with empty data
+            guarded_cache.remove(&self.bucket, key);
         }
     }
 


### PR DESCRIPTION
### This PR brings critical security fixes to S3-related operations:

- Cache invalidation in `delete_data()`: Fixes cache not being cleared on deletion
- Cache consistency in `store_data()`: Fixes cache updated before S3 success
- Cache bypass in `StorageForBytes`: Adds cache support to `store_bytes()` / `load_bytes()`

Closes [Cache is not updated after deleting data in S3 #4](https://github.com/zenith-security/2025-07-zama/issues/4) and interrelated [Cache is updated before the data is stored in AWS S3 #5 ](https://github.com/zenith-security/2025-07-zama/issues/5)