### PR TITLE
fix: ensure shutdown actually gets executed on drop

### DIFF
--- a/core/service/src/client/mod.rs
+++ b/core/service/src/client/mod.rs
@@ -2260,10 +2260,13 @@ pub mod test_tools {
 
         pub async fn assert_shutdown(self) {
             // Call shutdown so we can await the server to shut down even though sending the shutdown signal already calls this
-            self.server
+            let shutdown_handle = self
+                .server
                 .shutdown()
+                .expect("Failed to execute core service server shutdown");
+            shutdown_handle
                 .await
-                .expect("Failed to await core service server shutdown");
+                .expect("Failed to await core service server shutdown completion");
             // Shut down the core server
             // The receiver should not be closed, that's why we unwrap
             self.service_shutdown_tx
@@ -2926,7 +2929,8 @@ pub(crate) mod tests {
             ServingStatus::NotServing as i32,
             "Service is not in NOT SERVING status. Got status: {status}"
         );
-        let _ = server_handle.server.shutdown().await;
+        let shutdown_handle = server_handle.server.shutdown().unwrap();
+        shutdown_handle.await.unwrap();
         check_port_is_closed(mpc_port).await;
         check_port_is_closed(service_port).await;
     }

--- a/core/service/src/engine/threshold/threshold_kms.rs
+++ b/core/service/src/engine/threshold/threshold_kms.rs
@@ -99,31 +99,43 @@ impl<
         BO: Sync,
     > Shutdown for ThresholdKms<IN, UD, PD, KG, IKG, PP, CG, ICG, CM, BO>
 {
-    async fn shutdown(&self) -> anyhow::Result<()> {
-        self.health_reporter
-            .write()
-            .await
-            .set_not_serving::<CoreServiceEndpointServer<Self>>()
-            .await;
-        tracing::info!("Sat not serving");
-        self.tracker.close();
-        self.tracker.wait().await;
-        self.mpc_abort_handle.abort();
-        let res: anyhow::Result<()> = retry_loop!(
-            || async move {
-                if !self.mpc_abort_handle.is_finished() {
-                    return Err(anyhow::anyhow!("MPC server not done"));
+    fn shutdown(&self) -> anyhow::Result<JoinHandle<()>> {
+        let health_reporter = Arc::clone(&self.health_reporter);
+        let tracker = Arc::clone(&self.tracker);
+        let mpc_abort_handle = self.mpc_abort_handle.abort_handle();
+        let handle = {
+            let new_handle_clone = mpc_abort_handle.clone();
+            tokio::task::spawn(async move {
+                health_reporter
+                    .write()
+                    .await
+                    .set_not_serving::<CoreServiceEndpointServer<Self>>()
+                    .await;
+                tracing::info!("Sat not serving");
+                tracker.close();
+                tracker.wait().await;
+                mpc_abort_handle.abort();
+                let res: anyhow::Result<()> = retry_loop!(
+                    || {
+                        let new_handle_clone = new_handle_clone.clone();
+                        async move {
+                            if !new_handle_clone.is_finished() {
+                                return Err(anyhow::anyhow!("MPC server not done"));
+                            }
+                            Ok(())
+                        }
+                    },
+                    100,
+                    200
+                );
+                if let Err(e) = res {
+                    tracing::error!("Error waiting for MPC server to finish: {:?}", e);
                 }
-                Ok(())
-            },
-            100,
-            200
-        );
-        if let Err(e) = res {
-            tracing::error!("Error waiting for MPC server to finish: {:?}", e);
-        }
-        tracing::info!("Threshold Core service endpoint server shutdown complete.");
-        Ok(())
+                tracing::info!("Threshold Core service endpoint server shutdown complete.");
+            })
+        };
+
+        Ok(handle)
     }
 }
 
@@ -143,6 +155,7 @@ impl<
     > Drop for ThresholdKms<IN, UD, PD, KG, IKG, PP, CG, ICG, CM, BO>
 {
     fn drop(&mut self) {
+        // Start the shutdown and let it finish in the background
         let _ = self.shutdown();
     }
 }


### PR DESCRIPTION
This closes an issue where shutdown is not awaited on drop, since drop is not async. 
This is fixed by refactoring the shutdown mechanism