### PR TITLE
feat(chart): add support for backup vault config

### DIFF
--- a/charts/kms-core/Chart.yaml
+++ b/charts/kms-core/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-service
 description: A helm chart to distribute and deploy the Zama KMS application stack
-version: 1.0.10
+version: 1.1.0
 apiVersion: v2
 keywords:
   - kms-service

--- a/charts/kms-core/templates/kms-core-client-cronjob.yaml
+++ b/charts/kms-core/templates/kms-core-client-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
                 value: "{{ .Values.minio.endpoint }}/{{ .Values.kmsCore.publicVault.s3.bucket }}/{{ .Values.kmsCore.publicVault.s3.path }}"
               {{ else }}
               - name: S3_ENDPOINT
-                value: "https://{{ .Values.kmsCore.publicVault.s3.bucket }}.s3.{{ .Values.kmsCore.aws.region }}.amazonaws.com{{ if .Values.kmsCore.publicVault.s3.path }}/{{ .Values.kmsCore.publicVault.s3.path }}{{ end }}"
+                value: "https://{{ .Values.kmsCore.publicVault.s3.bucket }}.s3.{{ .Values.kmsCore.aws.region }}.amazonaws.com{{ if .Values.kmsCore.publicVault.s3.prefix }}/{{ .Values.kmsCore.publicVault.s3.prefix }}{{ end }}"
               {{ end }}
               - name: OBJECT_FOLDER
                 {{- if .Values.kmsCore.thresholdMode.peersList }}

--- a/charts/kms-core/templates/kms-core-client-statefulset.yaml
+++ b/charts/kms-core/templates/kms-core-client-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
             value: "{{ .Values.minio.endpoint }}/{{ .Values.kmsCore.publicVault.s3.bucket }}/{{ .Values.kmsCore.publicVault.s3.path }}"
           {{- else }}
           - name: S3_ENDPOINT
-            value: "https://{{ .Values.kmsCore.publicVault.s3.bucket }}.s3.{{ .Values.kmsCore.aws.region }}.amazonaws.com{{ if .Values.kmsCore.publicVault.s3.path }}/{{ .Values.kmsCore.publicVault.s3.path }}{{ end }}"
+            value: "https://{{ .Values.kmsCore.publicVault.s3.bucket }}.s3.{{ .Values.kmsCore.aws.region }}.amazonaws.com{{ if .Values.kmsCore.publicVault.s3.prefix }}/{{ .Values.kmsCore.publicVault.s3.prefix }}{{ end }}"
           {{- end }}
           - name: OBJECT_FOLDER
             {{- if .Values.kmsCore.thresholdMode.peersList }}

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -64,7 +64,7 @@ data:
     prefix = "${KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX}"
       {{- end }}
     {{- end }}
-    {{- if .Values.kmsCore.nitroEnclave.enabled }}
+    {{- if .Values.kmsCore.backupVault.awskms.enabled }}
     [backup_vault.keychain.aws_kms]
     root_key_id = "${KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID}"
     root_key_spec = "${KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC}"

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -33,7 +33,7 @@ data:
     {{ if .Values.kmsCore.publicVault.s3.enabled }}
     [public_vault.storage.s3]
     bucket = "${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET}"
-      {{ if .Values.kmsCore.publicVault.s3.path }}
+      {{ if .Values.kmsCore.publicVault.s3.prefix }}
     prefix = "${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX}"
       {{ end }}
     {{ else }}
@@ -44,7 +44,7 @@ data:
     {{ if .Values.kmsCore.privateVault.s3.enabled }}
     [private_vault.storage.s3]
     bucket = "${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET}"
-      {{ if .Values.kmsCore.publicVault.s3.path }}
+      {{ if .Values.kmsCore.publicVault.s3.prefix }}
     prefix = "${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX}"
       {{ end }}
 
@@ -60,7 +60,7 @@ data:
     {{- if .Values.kmsCore.backupVault.s3.enabled }}
     [backup_vault.storage.s3]
     bucket = "${KMS_CORE__BACKUP_VAULT__STORAGE__S3__BUCKET}"
-      {{- if .Values.kmsCore.backupVault.s3.path }}
+      {{- if .Values.kmsCore.backupVault.s3.prefix }}
     prefix = "${KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX}"
       {{- end }}
     {{- else }}

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -41,7 +41,6 @@ data:
     path = "/keys"
     {{ end }}
 
-
     {{ if .Values.kmsCore.privateVault.s3.enabled }}
     [private_vault.storage.s3]
     bucket = "${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET}"
@@ -58,6 +57,21 @@ data:
     root_key_id = "${KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID}"
     root_key_spec = "${KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC}"
     {{ end }}
+    {{- if .Values.kmsCore.backupVault.s3.enabled }}
+    [backup_vault.storage.s3]
+    bucket = "${KMS_CORE__BACKUP_VAULT__STORAGE__S3__BUCKET}"
+      {{- if .Values.kmsCore.backupVault.s3.path }}
+    prefix = "${KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX}"
+      {{- end }}
+    {{- else }}
+    [backup_vault.storage.file]
+    path = "./backup-keys"
+    {{- end }}
+    {{- if .Values.kmsCore.nitroEnclave.enabled }}
+    [backup_vault.keychain.aws_kms]
+    root_key_id = "${KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID}"
+    root_key_spec = "${KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC}"
+    {{- end }}
   kms-gen-keys.toml: |
     [keygen]
     enabled = true

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kmsCore.enabled -}}
+{{- if or .Values.kmsCore.enabled .Values.kmsGenCertAndKeys.enabled -}}
 {{- $kmsCoreName := include "kmsCoreName" . }}
 {{- $peersIDList := untilStep (include "kmsPeersStartID" . | int) (.Values.kmsPeers.count | add1 | int) 1  }}
 apiVersion: v1

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -63,9 +63,6 @@ data:
       {{- if .Values.kmsCore.backupVault.s3.prefix }}
     prefix = "${KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX}"
       {{- end }}
-    {{- else }}
-    [backup_vault.storage.file]
-    path = "./backup-keys"
     {{- end }}
     {{- if .Values.kmsCore.nitroEnclave.enabled }}
     [backup_vault.keychain.aws_kms]

--- a/charts/kms-core/templates/kms-core-statefulset.yaml
+++ b/charts/kms-core/templates/kms-core-statefulset.yaml
@@ -387,14 +387,12 @@ spec:
           args:
             - -c
             - |
-              {{- if .Values.kmsCore.nitroEnclave.debug }}
               echo "### BEGIN - enclave.json ###"
               cat /var/lib/kms-core/config/enclave.json
               echo "### END - enclave.json ###"
               echo "### BEGIN - describe-eif ###"
               nitro-cli describe-eif --eif-path {{ .Values.kmsCore.nitroEnclave.eifPath }}
               echo "### END - describe-eif ###"
-              {{- end }}
               {{- if .Values.kmsCore.nitroEnclave.signed }}
               nitro-cli sign-eif --eif-path {{ .Values.kmsCore.nitroEnclave.eifPath }} --signing-certificate /var/lib/kms-core/config/party_cert.pem --private-key {{ .Values.kmsCore.nitroEnclave.eifSignKey }}
               {{- end }}

--- a/charts/kms-core/templates/kms-core-statefulset.yaml
+++ b/charts/kms-core/templates/kms-core-statefulset.yaml
@@ -57,20 +57,20 @@ spec:
               export AWS_ROLE_ARN="${AWS_ROLE_ARN:={{ .Values.kmsCore.aws.roleArn }}}"
               {{- if .Values.kmsCore.publicVault.s3.enabled }}
               export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.publicVault.s3.bucket }}}"
-              {{- if .Values.kmsCore.publicVault.s3.path }}
-              export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.publicVault.s3.path }}}"
+              {{- if .Values.kmsCore.publicVault.s3.prefix }}
+              export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.publicVault.s3.prefix }}}"
               {{- end }}
               {{- end }}
               {{- if .Values.kmsCore.privateVault.s3.enabled }}
               export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.privateVault.s3.bucket }}}"
-              {{- if .Values.kmsCore.privateVault.s3.path }}
-              export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.privateVault.s3.path }}}"
+              {{- if .Values.kmsCore.privateVault.s3.prefix }}
+              export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.privateVault.s3.prefix }}}"
               {{- end }}
               {{- end }}
               {{- if .Values.kmsCore.backupVault.s3.enabled }}
               export KMS_CORE__BACKUP_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__BACKUP_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.backupVault.s3.bucket }}}"
-              {{- if .Values.kmsCore.backupVault.s3.path }}
-              export KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.backupVault.s3.path }}}"
+              {{- if .Values.kmsCore.backupVault.s3.prefix }}
+              export KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.backupVault.s3.prefix }}}"
               {{- end }}
               {{- end }}
               {{- if .Values.kmsCore.nitroEnclave.enabled }}
@@ -326,8 +326,8 @@ spec:
               {{- if .Values.kmsCore.publicVault.s3.enabled -}}
               --public-storage s3 \
               --public-s3-bucket "${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.publicVault.s3.bucket }}}" \
-                {{- if .Values.kmsCore.publicVault.s3.path }}
-              --public-s3-prefix = "${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.publicVault.s3.path }}}" \
+                {{- if .Values.kmsCore.publicVault.s3.prefix }}
+              --public-s3-prefix = "${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.publicVault.s3.prefix }}}" \
                 {{- end }}
               {{- else }}
               --public-storage file \
@@ -336,8 +336,8 @@ spec:
               {{- if .Values.kmsCore.privateVault.s3.enabled -}}
               --private-storage s3 \
               --private-s3-bucket "${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.privateVault.s3.bucket }}}" \
-                {{- if .Values.kmsCore.privateVault.s3.path }}
-              --private-s3-prefix = "${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.privateVault.s3.path }}}" \
+                {{- if .Values.kmsCore.privateVault.s3.prefix }}
+              --private-s3-prefix = "${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX:=={{ .Values.kmsCore.privateVault.s3.prefix }}}" \
                 {{- end }}
               {{- else }}
               --private-storage file \

--- a/charts/kms-core/templates/kms-core-statefulset.yaml
+++ b/charts/kms-core/templates/kms-core-statefulset.yaml
@@ -55,22 +55,32 @@ spec:
               apk add curl
               export AWS_REGION="${AWS_REGION:={{ .Values.kmsCore.aws.region }}}"
               export AWS_ROLE_ARN="${AWS_ROLE_ARN:={{ .Values.kmsCore.aws.roleArn }}}"
-              {{ if .Values.kmsCore.publicVault.s3.enabled }}
+              {{- if .Values.kmsCore.publicVault.s3.enabled }}
               export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.publicVault.s3.bucket }}}"
-              {{ if .Values.kmsCore.publicVault.s3.path }}
+              {{- if .Values.kmsCore.publicVault.s3.path }}
               export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.publicVault.s3.path }}}"
-              {{ end }}
-              {{ end }}
-              {{ if .Values.kmsCore.privateVault.s3.enabled }}
+              {{- end }}
+              {{- end }}
+              {{- if .Values.kmsCore.privateVault.s3.enabled }}
               export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.privateVault.s3.bucket }}}"
-              {{ if .Values.kmsCore.privateVault.s3.path }}
+              {{- if .Values.kmsCore.privateVault.s3.path }}
               export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.privateVault.s3.path }}}"
-              {{ end }}
-              {{ end }}
-              {{ if .Values.kmsCore.nitroEnclave.enabled }}
+              {{- end }}
+              {{- end }}
+              {{- if .Values.kmsCore.backupVault.s3.enabled }}
+              export KMS_CORE__BACKUP_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__BACKUP_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.backupVault.s3.bucket }}}"
+              {{- if .Values.kmsCore.backupVault.s3.path }}
+              export KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.backupVault.s3.path }}}"
+              {{- end }}
+              {{- end }}
+              {{- if .Values.kmsCore.nitroEnclave.enabled }}
               export KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID="${KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID:={{ .Values.kmsCore.privateVault.awskms.rootKeyId }}}"
               export KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC="${KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC:={{ .Values.kmsCore.privateVault.awskms.rootKeySpec }}}"
-              {{ end }}
+              {{- if .Values.kmsCore.backupVault.awskms.enabled }}
+              export KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID="${KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID:={{ .Values.kmsCore.backupVault.awskms.rootKeyId }}}"
+              export KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC="${KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC:={{ .Values.kmsCore.backupVault.awskms.rootKeySpec }}}"
+              {{- end }}
+              {{- end }}
               for i in $(seq 1 {{ len .Values.kmsCore.thresholdMode.peersList }}); do
                 BUCKET_PATH=$(curl -s "${CORE_CLIENT__S3_ENDPOINT}/?list-type=2&prefix=PUB-p${i}/CACert/" | grep -o "<Key>[^<]*</Key>" | sed "s/<Key>//;s/<\/Key>//")
                 curl -s -o ./ca_pem "${CORE_CLIENT__S3_ENDPOINT}/${BUCKET_PATH}"
@@ -105,32 +115,66 @@ spec:
             - name: RUST_LOG
               value: {{ .Values.rustLog }}
           {{- if .Values.kmsCore.envFrom.configmap.name }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.coreClientS3Endpoint }}
+            - name: CORE_CLIENT__S3_ENDPOINT
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.coreClientS3Endpoint }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultStorageBucket }}
+            - name: KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultStorageBucket }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.publicVaultStorageBucket }}
+            - name: KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.kmsCore.envFrom.configmap.name }}
+                  key: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultStoragePrefix }}
+            - name: KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.publicVaultStorageBucket }}
+            - name: KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.kmsCore.envFrom.configmap.name }}
+                  key: {{ .Values.kmsCore.envFrom.configmap.key.publicVaultStoragePrefix }}
             {{- if .Values.kmsCore.privateVault.awskms.enabled }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeySpec }}
+            - name: KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeySpec }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeyID }}
+            - name: KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeyID }}
+            {{- end }}
+            {{- if .Values.kmsCore.backupVault.s3.enabled }}
+            - name: KMS_CORE__BACKUP_VAULT__STORAGE__S3__BUCKET
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.kmsCore.envFrom.configmap.name }}
+                  key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultStorageBucket }}
+            - name: KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.kmsCore.envFrom.configmap.name }}
+                  key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultStoragePrefix }}
+            {{- end }}
+            {{- if .Values.kmsCore.backupVault.awskms.enabled }}
+            - name: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.kmsCore.envFrom.configmap.name }}
+                  key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultKeychainAWSKMSRootKeyID }}
+            - name: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.kmsCore.envFrom.configmap.name }}
+                  key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultKeychainAWSKMSRootKeySpec }}
             {{- end }}
           {{- end }}
           workingDir: {{ .Values.kmsCore.workdir }}
@@ -337,23 +381,23 @@ spec:
             - name: RUST_LOG
               value: {{ .Values.rustLog }}
           {{- if .Values.kmsCore.envFrom.configmap.name }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultStorageBucket }}
+            - name: KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultStorageBucket }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.publicVaultStorageBucket }}
+            - name: KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.publicVaultStorageBucket }}
             {{- if .Values.kmsCore.privateVault.awskms.enabled }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeySpec }}
+            - name: KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeySpec }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeyID }}
+            - name: KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
@@ -437,27 +481,39 @@ spec:
               value: {{ .Values.minio.password}}
             {{- end }}
           {{- if .Values.kmsCore.envFrom.configmap.name }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultStorageBucket }}
+            - name: KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultStorageBucket }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.publicVaultStorageBucket }}
+            - name: KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.publicVaultStorageBucket }}
             {{- if .Values.kmsCore.privateVault.awskms.enabled }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeySpec }}
+            - name: KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeySpec }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeyID }}
+            - name: KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeyID }}
+            {{- end }}
+            {{- if .Values.kmsCore.backupVault.awskms.enabled }}
+            - name: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.kmsCore.envFrom.configmap.name }}
+                  key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultKeychainAWSKMSRootKeySpec }}
+            - name: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.kmsCore.envFrom.configmap.name }}
+                  key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultKeychainAWSKMSRootKeyID }}
             {{- end }}
           {{- end }}
           workingDir: {{ .Values.kmsCore.workdir }}

--- a/charts/kms-core/templates/kms-core-statefulset.yaml
+++ b/charts/kms-core/templates/kms-core-statefulset.yaml
@@ -52,7 +52,6 @@ spec:
           args:
             - -c
             - |
-              apk add curl
               export AWS_REGION="${AWS_REGION:={{ .Values.kmsCore.aws.region }}}"
               export AWS_ROLE_ARN="${AWS_ROLE_ARN:={{ .Values.kmsCore.aws.roleArn }}}"
               {{- if .Values.kmsCore.publicVault.s3.enabled }}

--- a/charts/kms-core/templates/kms-core-statefulset.yaml
+++ b/charts/kms-core/templates/kms-core-statefulset.yaml
@@ -114,11 +114,13 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultStorageBucket }}
+                  optional: true
             - name: KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultStoragePrefix }}
+                  optional: true
             {{- end }}
             {{- if .Values.kmsCore.backupVault.awskms.enabled }}
             - name: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
@@ -126,11 +128,13 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultKeychainAWSKMSRootKeyID }}
+                  optional: true
             - name: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultKeychainAWSKMSRootKeySpec }}
+                  optional: true
             {{- end }}
           {{- end }}
           workingDir: {{ .Values.kmsCore.workdir }}
@@ -465,11 +469,13 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultKeychainAWSKMSRootKeySpec }}
+                  optional: true
             - name: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.backupVaultKeychainAWSKMSRootKeyID }}
+                  optional: true
             {{- end }}
           {{- end }}
           workingDir: {{ .Values.kmsCore.workdir }}

--- a/charts/kms-core/templates/kms-core-statefulset.yaml
+++ b/charts/kms-core/templates/kms-core-statefulset.yaml
@@ -52,56 +52,13 @@ spec:
           args:
             - -c
             - |
-              export AWS_REGION="${AWS_REGION:={{ .Values.kmsCore.aws.region }}}"
-              export AWS_ROLE_ARN="${AWS_ROLE_ARN:={{ .Values.kmsCore.aws.roleArn }}}"
-              {{- if .Values.kmsCore.publicVault.s3.enabled }}
-              export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.publicVault.s3.bucket }}}"
-              {{- if .Values.kmsCore.publicVault.s3.prefix }}
-              export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.publicVault.s3.prefix }}}"
-              {{- end }}
-              {{- end }}
-              {{- if .Values.kmsCore.privateVault.s3.enabled }}
-              export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.privateVault.s3.bucket }}}"
-              {{- if .Values.kmsCore.privateVault.s3.prefix }}
-              export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.privateVault.s3.prefix }}}"
-              {{- end }}
-              {{- end }}
-              {{- if .Values.kmsCore.backupVault.s3.enabled }}
-              export KMS_CORE__BACKUP_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__BACKUP_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.backupVault.s3.bucket }}}"
-              {{- if .Values.kmsCore.backupVault.s3.prefix }}
-              export KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.backupVault.s3.prefix }}}"
-              {{- end }}
-              {{- end }}
-              {{- if .Values.kmsCore.nitroEnclave.enabled }}
-              export KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID="${KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID:={{ .Values.kmsCore.privateVault.awskms.rootKeyId }}}"
-              export KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC="${KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC:={{ .Values.kmsCore.privateVault.awskms.rootKeySpec }}}"
-              {{- if .Values.kmsCore.backupVault.awskms.enabled }}
-              export KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID="${KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID:={{ .Values.kmsCore.backupVault.awskms.rootKeyId }}}"
-              export KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC="${KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC:={{ .Values.kmsCore.backupVault.awskms.rootKeySpec }}}"
-              {{- end }}
-              {{- end }}
-              for i in $(seq 1 {{ len .Values.kmsCore.thresholdMode.peersList }}); do
-                BUCKET_PATH=$(curl -s "${CORE_CLIENT__S3_ENDPOINT}/?list-type=2&prefix=PUB-p${i}/CACert/" | grep -o "<Key>[^<]*</Key>" | sed "s/<Key>//;s/<\/Key>//")
-                curl -s -o ./ca_pem "${CORE_CLIENT__S3_ENDPOINT}/${BUCKET_PATH}"
-                export KMS_CA_PEM_${i}="\"\"\"$(cat ./ca_pem)\"\"\""
-              done
-              envsubst < /var/lib/kms-core/config/aws.toml > aws.toml
-              envsubst < /var/lib/kms-core/config/vaults.toml > vaults.toml
-              envsubst < /var/lib/kms-core/config/kms-gen-keys.toml > kms-gen-keys.toml
+              {{ include "kmsCoreInitEnvVars" . | indent 14 | trim }}
               envsubst < /var/lib/kms-core/config/kms-server.toml > kms-server.toml
-              cat aws.toml vaults.toml >> kms-gen-keys.toml
-              cat aws.toml vaults.toml >> kms-server.toml
-              {{- if .Values.kmsCore.nitroEnclave.debug }}
-              echo "### BEGIN - env ###"
-              env
-              echo "### END - env ###"
-              echo "### BEGIN - kms-gen-keys.toml ###"
-              cat kms-gen-keys.toml
-              echo "### END - kms-gen-keys.toml ###"
+              envsubst < /var/lib/kms-core/config/aws.toml >> kms-server.toml
+              envsubst < /var/lib/kms-core/config/vaults.toml >> kms-server.toml
               echo "### BEGIN - kms-server.toml ###"
               cat kms-server.toml
               echo "### END - kms-server.toml ###"
-              {{- end }}
           env:
             - name: KMS_CORE__THRESHOLD__MY_ID
               valueFrom:

--- a/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
+++ b/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
@@ -219,10 +219,6 @@ spec:
               memory: 4Gi
               aws.ec2.nitro/nitro_enclaves: "1"
               hugepages-1Gi: {{ .Values.kmsCore.nitroEnclave.memoryGiB }}Gi
-          # lifecycle:
-          #   preStop:
-          #     exec:
-          #       command: [ "nitro-cli", "terminate-enclave", "--all" ]
       imagePullSecrets:
         - name: registry-credentials
       nodeSelector:

--- a/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
+++ b/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
@@ -76,22 +76,22 @@ spec:
               value: {{ .Values.runMode }}
             - name: RUST_LOG
               value: {{ .Values.rustLog }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultStorageBucket }}
+            - name: KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultStorageBucket }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.publicVaultStorageBucket }}
+            - name: KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.publicVaultStorageBucket }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeySpec }}
+            - name: KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}
                   key: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeySpec }}
-            - name: {{ .Values.kmsCore.envFrom.configmap.key.privateVaultKeychainAWSKMSRootKeyID }}
+            - name: KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.kmsCore.envFrom.configmap.name }}

--- a/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
+++ b/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
@@ -35,14 +35,14 @@ spec:
               export AWS_ROLE_ARN="${AWS_ROLE_ARN:={{ .Values.kmsCore.aws.roleArn }}}"
               {{ if .Values.kmsCore.publicVault.s3.enabled }}
               export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.publicVault.s3.bucket }}}"
-              {{ if .Values.kmsCore.publicVault.s3.path }}
-              export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.publicVault.s3.path }}}"
+              {{ if .Values.kmsCore.publicVault.s3.prefix }}
+              export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.publicVault.s3.prefix }}}"
               {{ end }}
               {{ end }}
               {{ if .Values.kmsCore.privateVault.s3.enabled }}
               export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.privateVault.s3.bucket }}}"
-              {{ if .Values.kmsCore.privateVault.s3.path }}
-              export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.privateVault.s3.path }}}"
+              {{ if .Values.kmsCore.privateVault.s3.prefix }}
+              export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.privateVault.s3.prefix }}}"
               {{ end }}
               {{ end }}
               export KMS_CORE__THRESHOLD__MY_ID="${KMS_CORE__THRESHOLD__MY_ID:={{ .Values.kmsPeers.id }}}"

--- a/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
+++ b/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
@@ -9,6 +9,7 @@ metadata:
     app: kms-core
     app.kubernetes.io/name: {{ $kmsGenCertAndKeysName }}
   annotations:
+    "helm.sh/hook": post-install
     "helm.sh/hook-weight": "-2"
   name: {{ $kmsGenCertAndKeysName }}
 spec:

--- a/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
+++ b/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
@@ -140,14 +140,12 @@ spec:
           args:
             - -c
             - |
-              {{- if .Values.kmsCore.nitroEnclave.debug }}
               echo "### BEGIN - enclave.json ###"
               cat /var/lib/kms-core/config/enclave.json
               echo "### END - enclave.json ###"
               echo "### BEGIN - describe-eif ###"
               nitro-cli describe-eif --eif-path {{ .Values.kmsCore.nitroEnclave.eifPath }}
               echo "### END - describe-eif ###"
-              {{- end }}
               # enclave config vsock is hardcoded to 4000 in init_enclave.sh
               # it can't be a separate container
               # because we need to serve kms-gen-keys.toml on the same port later

--- a/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
+++ b/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
@@ -31,42 +31,13 @@ spec:
           args:
             - -c
             - |
-              export AWS_REGION="${AWS_REGION:={{ .Values.kmsCore.aws.region }}}"
-              export AWS_ROLE_ARN="${AWS_ROLE_ARN:={{ .Values.kmsCore.aws.roleArn }}}"
-              {{ if .Values.kmsCore.publicVault.s3.enabled }}
-              export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.publicVault.s3.bucket }}}"
-              {{ if .Values.kmsCore.publicVault.s3.prefix }}
-              export KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.publicVault.s3.prefix }}}"
-              {{ end }}
-              {{ end }}
-              {{ if .Values.kmsCore.privateVault.s3.enabled }}
-              export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.privateVault.s3.bucket }}}"
-              {{ if .Values.kmsCore.privateVault.s3.prefix }}
-              export KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX="${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.privateVault.s3.prefix }}}"
-              {{ end }}
-              {{ end }}
-              export KMS_CORE__THRESHOLD__MY_ID="${KMS_CORE__THRESHOLD__MY_ID:={{ .Values.kmsPeers.id }}}"
-              {{ if .Values.kmsCore.nitroEnclave.enabled }}
-              export KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID="${KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID:={{ .Values.kmsCore.privateVault.awskms.rootKeyId }}}"
-              export KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC="${KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC:={{ .Values.kmsCore.privateVault.awskms.rootKeySpec }}}"
-              {{ end }}
-              envsubst < /var/lib/kms-core/config/aws.toml > aws.toml
-              envsubst < /var/lib/kms-core/config/vaults.toml > vaults.toml
+              {{ include "kmsCoreInitEnvVars" . | indent 14 | trim }}
               envsubst < /var/lib/kms-core/config/kms-gen-keys.toml > kms-gen-keys.toml
-              envsubst < /var/lib/kms-core/config/kms-server.toml > kms-server.toml
-              cat aws.toml vaults.toml >> kms-gen-keys.toml
-              cat aws.toml vaults.toml >> kms-server.toml
-              {{- if .Values.kmsCore.nitroEnclave.debug }}
-              echo "### BEGIN - env ###"
-              env
-              echo "### END - env ###"
+              envsubst < /var/lib/kms-core/config/aws.toml >> kms-gen-keys.toml
+              envsubst < /var/lib/kms-core/config/vaults.toml >> kms-gen-keys.toml
               echo "### BEGIN - kms-gen-keys.toml ###"
               cat kms-gen-keys.toml
               echo "### END - kms-gen-keys.toml ###"
-              echo "### BEGIN - kms-server.toml ###"
-              cat kms-server.toml
-              echo "### END - kms-server.toml ###"
-              {{- end }}
           env:
             - name: KMS_CORE__THRESHOLD__MY_ID
               value: "{{ .Values.kmsPeers.id }}"

--- a/charts/kms-core/values-example-local.yaml
+++ b/charts/kms-core/values-example-local.yaml
@@ -26,7 +26,7 @@ kmsCore:
     s3:
       enabled: true
       bucket: kms-public
-      path: ""
+      prefix: ""
   thresholdMode:
     enabled: true
     initializationScript:

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -105,7 +105,6 @@ kmsCore:
   nitroEnclave:
     enabled: false
     signed: false
-    debug: true
     # Enclave CPU count, must be a multiple of 2 since whole cores (not hyperthreads) are sliced off and dedicated to the enclave
     cpuCount: 6
     # Enclave Memory in GiB

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -86,19 +86,20 @@ kmsCore:
           pcr1: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
           pcr2: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
     # This value appears in the config file as `threshold`.
-    multiplier: 2
-    maxInterval: 1
+    multiplier: 2.0
+    maxInterval: 60
     maxElapsedTime: 300
     networkTimeout: 300
     initialIntervalMs: 100
     enableSysMetrics: true
     refreshIntervalMs: 5000
     # Threshold value is the number of corruptions that the protocol handles.
-    thresholdValue: 1
+    # 1 for 4 parties, 4 for 13 parties
+    thresholdValue: 4
     decCapacity: 10000
     minDecCache: 6000
     # Number of sessions to pre-process should be equal to number of vCPUs
-    numSessionsPreproc: 2
+    numSessionsPreproc: 64
     decryptionMode: "NoiseFloodSmall"
   # Add the following to enable nitro enclave:
   # Nitro enclave needs specific instance types
@@ -106,9 +107,9 @@ kmsCore:
     enabled: false
     signed: false
     # Enclave CPU count, must be a multiple of 2 since whole cores (not hyperthreads) are sliced off and dedicated to the enclave
-    cpuCount: 6
+    cpuCount: 48
     # Enclave Memory in GiB
-    memoryGiB: 20
+    memoryGiB: 96
     grpcPeerProxy:
       resources: {}
         # requests:
@@ -204,13 +205,10 @@ kmsCoreClient:
       name:
       privateVaultStorageKey:
       publicVaultStorageKey:
-  num_majority: 2
-  num_reconstruct: 3
-  decryption_mode: "NoiseFloodSmall"
-  fhe_parameter: Test
-  storage:
-    # storageClassName: gp3
-    capacity: 1Gi
+  num_majority: 5
+  num_reconstruct: 9
+  decryption_mode: NoiseFloodSmall
+  fhe_parameter: Default
   resources:
     requests: {}
       # memory: 1Gi

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -250,8 +250,8 @@ kmsGenKeys:
 
 kubeUtils:
   image:
-    name: ghcr.io/zama-ai/kube-utils
-    tag: 0.2.0
+    name: ghcr.io/zama-ai/security-hub/infra/kube-utils
+    tag: 0.4.0-safe
     pullPolicy: Always
 
 runMode: dev

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -144,12 +144,12 @@ kmsCore:
     s3:
       enabled: true
       bucket: kms-public
-      prefix: kms
+      prefix: ""
   privateVault:
     s3:
       enabled: false
       bucket: kms-private
-      prefix: kms
+      prefix: ""
     awskms:
       enabled: false
       rootKeyId: 00000000-0000-0000-0000-000000000000

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -145,12 +145,12 @@ kmsCore:
     s3:
       enabled: true
       bucket: kms-public
-      path: kms
+      prefix: kms
   privateVault:
     s3:
       enabled: false
       bucket: kms-private
-      path: kms
+      prefix: kms
     awskms:
       enabled: false
       rootKeyId: 00000000-0000-0000-0000-000000000000
@@ -159,7 +159,7 @@ kmsCore:
     s3:
       enabled: false
       bucket: kms-private
-      path: ""
+      prefix: ""
     awskms:
       enabled: false
       rootKeyId: 00000000-0000-0000-0000-000000000000

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -30,10 +30,15 @@ kmsCore:
       key:
         coreClientS3Endpoint: CORE_CLIENT__S3_ENDPOINT
         privateVaultStorageBucket: KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET
-        publicVaultStorageBucket: KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET
+        privateVaultStoragePrefix: KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX
         privateVaultKeychainAWSKMSRootKeySpec: KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC
         privateVaultKeychainAWSKMSRootKeyID: KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
-
+        publicVaultStorageBucket: KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET
+        publicVaultStoragePrefix: KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX
+        backupVaultStorageBucket: KMS_CORE__BACKUP_VAULT__STORAGE__S3__BUCKET
+        backupVaultStoragePrefix: KMS_CORE__BACKUP_VAULT__STORAGE__S3__PREFIX
+        backupVaultKeychainAWSKMSRootKeySpec: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC
+        backupVaultKeychainAWSKMSRootKeyID: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
   rateLimiter:
     bucketSize: 50000
   # Add the following to enable threshold mode:
@@ -146,6 +151,15 @@ kmsCore:
       enabled: false
       bucket: kms-private
       path: kms
+    awskms:
+      enabled: false
+      rootKeyId: 00000000-0000-0000-0000-000000000000
+      rootKeySpec: symm
+  backupVault:
+    s3:
+      enabled: false
+      bucket: kms-private
+      path: ""
     awskms:
       enabled: false
       rootKeyId: 00000000-0000-0000-0000-000000000000

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -157,7 +157,7 @@ kmsCore:
   backupVault:
     s3:
       enabled: false
-      bucket: kms-private
+      bucket: kms-private-backup
       prefix: ""
     awskms:
       enabled: false


### PR DESCRIPTION
* Add backup vault configuration
* Rename `path` key to `prefix` and set default value to `""` to match common usage
* Refactor enclave environment configuration between kms-server and kms-gen-key
* Fix loading environment variables from configmap with different name
* Update kube-util docker image to the new secure version