### PR TITLE
chore: upgrade slab as it is vulnerable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6661,9 +6661,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
This is done using `cargo update slab`

Reference: https://rustsec.org/advisories/RUSTSEC-2025-0047