### PR TITLE
chore: purge redis on drop

### DIFF
--- a/core/service/src/engine/threshold/service/preprocessor.rs
+++ b/core/service/src/engine/threshold/service/preprocessor.rs
@@ -133,7 +133,7 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
                         tracing::info!("Preprocessing of request {} exiting normally.", &request_id);
                     },
                     () = token.cancelled() => {
-                        // NOTE: Any correlated randomness that was already generated will still exist in the Redis db (if we use Redis).
+                        // NOTE: Any correlated randomness that was already generated should be cleaned up from Redis on drop.
                         tracing::error!("Preprocessing of request {} exiting before completion because of a cancellation event.", &request_id);
                         let mut guarded_bucket_store = bucket_store_cancellation.write().await;
                         let _ = guarded_bucket_store.update(&request_id, Result::Err("Preprocessing was cancelled".to_string()));

--- a/core/threshold/tests/integration_redis.rs
+++ b/core/threshold/tests/integration_redis.rs
@@ -40,8 +40,8 @@ macro_rules! test_triples {
         paste! {
 
 
-            #[test]
-            fn [<test_redis_preprocessing $z:lower>]() {
+            #[tokio::test]
+            async fn [<test_redis_preprocessing $z:lower>]() {
                 let test_key_prefix = format!("test_redis_preprocessing_{}",stringify!($z));
                 let redis_conf = RedisConf::default();
                 let mut redis_factory = create_redis_factory(test_key_prefix.clone(), &redis_conf);
@@ -81,8 +81,8 @@ macro_rules! test_triples {
     };
 }
 
-#[test]
-fn test_store_fetch_100_triples() {
+#[tokio::test]
+async fn test_store_fetch_100_triples() {
     let test_key_prefix = "test_store_fetch_100_triples".to_string();
     let redis_conf = RedisConf::default();
     let mut redis_factory = create_redis_factory(test_key_prefix.clone(), &redis_conf);
@@ -118,8 +118,8 @@ fn test_store_fetch_100_triples() {
     assert_eq!(triples, fetched_triples);
 }
 
-#[test]
-fn test_store_fetch_100_randoms() {
+#[tokio::test]
+async fn test_store_fetch_100_randoms() {
     let test_key_prefix = "test_store_fetch_100_randoms".to_string();
     let redis_conf = RedisConf::default();
     let mut redis_factory = create_redis_factory(test_key_prefix.clone(), &redis_conf);
@@ -141,8 +141,8 @@ fn test_store_fetch_100_randoms() {
     assert_eq!(randoms, fetched_shares);
 }
 
-#[test]
-fn test_store_fetch_100_bits() {
+#[tokio::test]
+async fn test_store_fetch_100_bits() {
     let test_key_prefix = "test_store_fetch_100_bits".to_string();
     let redis_conf = RedisConf::default();
     let mut redis_factory = create_redis_factory(test_key_prefix.clone(), &redis_conf);
@@ -164,8 +164,8 @@ fn test_store_fetch_100_bits() {
     assert_eq!(bits, fetched_bits);
 }
 
-#[test]
-fn test_fetch_more_than_stored() {
+#[tokio::test]
+async fn test_fetch_more_than_stored() {
     let store_count = 100;
     let fetch_count = 101;
 
@@ -191,8 +191,8 @@ fn test_fetch_more_than_stored() {
         .contains("Pop length error."));
 }
 
-#[test]
-fn test_cleanup_on_drop() {
+#[tokio::test]
+async fn test_cleanup_on_drop() {
     let test_key_prefix = "test_cleanup_on_drop".to_string();
     let redis_conf = RedisConf::default();
     let mut redis_factory = create_redis_factory(test_key_prefix.clone(), &redis_conf);
@@ -216,6 +216,10 @@ fn test_cleanup_on_drop() {
     assert_eq!(bit_redis_preprocessing_bis.bits_len(), 1);
     // Drop the preprocessing instance
     drop(bit_redis_preprocessing);
+
+    // Sleep for a while because drop of the Redis preproc is
+    // sent to a tokio blocking thread so drop might return early
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // Check that the shares have been cleaned up
     assert_eq!(bit_redis_preprocessing_bis.bits_len(), 0);
@@ -360,8 +364,8 @@ fn test_dkg_orchestrator_params8_small_no_sns() {
 }
 
 #[cfg(feature = "testing")]
-#[test]
-fn test_cast_fail_memory_bit_dec_preprocessing() {
+#[tokio::test]
+async fn test_cast_fail_memory_bit_dec_preprocessing() {
     use threshold_fhe::{
         algebra::galois_rings::degree_4::ResiduePolyF4Z64,
         execution::online::preprocessing::{

--- a/core/threshold/tests/integration_redis.rs
+++ b/core/threshold/tests/integration_redis.rs
@@ -197,6 +197,7 @@ fn test_cleanup_on_drop() {
     let redis_conf = RedisConf::default();
     let mut redis_factory = create_redis_factory(test_key_prefix.clone(), &redis_conf);
     let mut bit_redis_preprocessing = redis_factory.create_bit_preprocessing_residue_64();
+    let mut random_redis_preprocessing = redis_factory.create_base_preprocessing_residue_64();
 
     // Create a new factory because we want to have the exact same key prefix (i.e. no counter increase)
     let mut redis_factory_bis: Box<dyn PreprocessorFactory<4>> =
@@ -209,6 +210,7 @@ fn test_cleanup_on_drop() {
     );
 
     bit_redis_preprocessing.append_bits(vec![share]);
+    random_redis_preprocessing.append_randoms(vec![share]);
 
     // Make sure we can actually see the "bit" from the other preprocessing
     assert_eq!(bit_redis_preprocessing_bis.bits_len(), 1);
@@ -217,6 +219,9 @@ fn test_cleanup_on_drop() {
 
     // Check that the shares have been cleaned up
     assert_eq!(bit_redis_preprocessing_bis.bits_len(), 0);
+
+    // But not these ones
+    assert_eq!(random_redis_preprocessing.randoms_len(), 1)
 }
 
 test_triples![create_base_preprocessing_residue_64 Z64];


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Closes https://github.com/zama-ai/kms-internal/issues/2715 
I couldn't find a way to do secure erasure of stuff inside Redis.

NOTE: Currently the keys into redis are made unique by having a local counter, wondering if we shouldn't use the `session_id` instead, such that even if we ever have 2 cores sharing the same redis db they wont have key collision.
(otoh, tbh, I am not sure when it'd be best to use Redis vs the InMemory struct)
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/zama-ai/kms/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/zama-ai/kms/blob/main/CHANGELOG.md
-->
