### PR TITLE
chore: update slab in backward compatibility crate

### DIFF
--- a/backward-compatibility/Cargo.lock
+++ b/backward-compatibility/Cargo.lock
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "backward-compatibility"
-version = "0.11.0-22"
+version = "0.11.0-24"
 dependencies = [
  "aes-prng",
  "alloy-primitives",
@@ -6068,9 +6068,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
Follow up of https://github.com/zama-ai/kms/pull/59
