### PR TITLE
chore: use ZeroizeOnDrop for zk ceremony

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5639,9 +5639,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -5649,9 +5649,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -7040,9 +7040,9 @@ dependencies = [
 
 [[package]]
 name = "tfhe-versionable"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d853f69b5e95332fa76424525cc403f34645838927212609776e26f8beab52c5"
+checksum = "d41b22104d3cfb329a012fdbd9764decc31efd1d71289c74df913be1f7051dac"
 dependencies = [
  "aligned-vec",
  "num-complex",
@@ -7052,9 +7052,9 @@ dependencies = [
 
 [[package]]
 name = "tfhe-versionable-derive"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d916462cab867a9d95fe6097ed20ed491fc37cdac766e8c736b84b09859d4afd"
+checksum = "f5a8431efbbcda5c501d6573928ebbc9c99f4d0ffd34b228395cf948e33f443a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7063,9 +7063,9 @@ dependencies = [
 
 [[package]]
 name = "tfhe-zk-pok"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ed6d29772b0f7e6021b7d2c3fe789cad26e3e8e49ef6f8a18887f16a6a5bfa7"
+checksum = "869be339aa0b2a67a66eaf58905127fc0456eb1cb824427d3248f915d9e41c70"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ prost = "=0.13.5"
 prost-build = "=0.13.5"
 prost-types = "=0.13.5"
 rand = "=0.8.5"
-rayon = "=1.10.0"
+rayon = "=1.11.0"
 rcgen = { version = "=0.14.0", default-features = false, features = [
     "aws_lc_rs",
     "crypto",
@@ -85,8 +85,8 @@ tower = "=0.5.2"
 tower-http = "=0.6.6"
 tfhe = "=1.3.3"
 tfhe-csprng = "=0.6.0"
-tfhe-versionable = "=0.6.0"
-tfhe-zk-pok = "=0.7.0"
+tfhe-versionable = "=0.6.1"
+tfhe-zk-pok = "=0.7.1"
 tokio = { version = "=1.46.1", features = ["full"] }
 tokio-rustls = { version = "=0.26.2", default-features = false, features = [
     "ring",

--- a/core/threshold/src/malicious_execution/zk/ceremony.rs
+++ b/core/threshold/src/malicious_execution/zk/ceremony.rs
@@ -97,9 +97,12 @@ impl<BCast: Broadcast + Default> Ceremony for RushingCeremony<BCast> {
         let sid = session.session_id();
         for (round, role) in all_roles_sorted.iter().enumerate() {
             let round = round as u64;
-            let tau = curve::Zp::rand(&mut session.rng());
-            let r = curve::Zp::rand(&mut session.rng());
-            let proof: PartialProof = make_partial_proof_deterministic(&pp, tau, round + 1, r, sid);
+            let mut tau = curve::ZeroizeZp::ZERO;
+            tau.rand_in_place(&mut session.rng());
+            let mut r = curve::ZeroizeZp::ZERO;
+            r.rand_in_place(&mut session.rng());
+            let proof: PartialProof =
+                make_partial_proof_deterministic(&pp, &tau, round + 1, &r, sid);
             let vi = BroadcastValue::PartialProof::<Z>(proof);
             if role == &my_role {
                 let _ = self


### PR DESCRIPTION
closes: https://github.com/zama-ai/kms-internal/issues/2483

### PR content/description
Use the ZeroizeZp type that derives ZeroizeOnDrop for the crs generation ceremony.

ZeroizeOnDrop is not a silver bullet and is not a guarantee that the values won't be present in memory. In particular:
- "moves" create memory copies, so data must be passed by reference
- ZeroizeZp is still a wrapper of a type from arkworks, so upstream code might create copies
- the compiler is still free to create copies, for example through register spills. In the end ZeroizeZp is just a wrapper for a `[u64; 5]`.

This means that these values should be used with extreme care (even if compiler optimizations are often an ally as they tend to reduce the number of copies).

A more definitive (but unsafe!) solution would be to zeroize the stack below rsp after the `make_partial_proof_deterministic` function returns.

### Test bench
I did some tests here: https://github.com/zama-ai/test_zeroize. The idea is to run the `make_partial_proof_deterministic` function and scan the stack to try to find traces of toxic values. `tau`, `powers of tau` and `r` are the variables that should be zeroized. `tau_unreduced` is an intermediate value from tau generation that can be used to recover tau.

#### Debug mode
```
[000] 0x7ffc4eb370d0 (pad_stack_and_run)
[001] 0x7ffc4ea370b0 (pad_stack)
[002] 0x7ffc4ea37090 (run)
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0xa0a7a660701aa434 (tau_unreduced)
magic found 0 times
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0xcd7c17eb4cacfc2f (tau)
found value at 0x7ffc4ea359f8
found value at 0x7ffc4ea359d0
found value at 0x7ffc4ea35978
found value at 0x7ffc4ea35950
magic found 4 times
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0xf1746b4f08981e (tau_power_2)
magic found 0 times
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0xbdfc01e6906b13a6 (tau_power_1)
magic found 0 times
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0x1a3e7868d156d48 (tau_power_0)
magic found 0 times
=====
scanning memory between 0x7ffc4ea370b0 and 0x7ffc4e9370b0 for 0xe4c9521cc8306815 (r)
magic found 0 times
```

#### Release mode
```
[000] 0x7fff8740b940 (pad_stack_and_run)
[001] 0x7fff8730b940 (pad_stack)
[002] 0x7fff8730b920 (run)
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0xa0a7a660701aa434 (tau_unreduced)
magic found 0 times
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0xcd7c17eb4cacfc2f (tau)
magic found 0 times
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0xf1746b4f08981e (tau_power_2)
magic found 0 times
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0xbdfc01e6906b13a6 (tau_power_1)
magic found 0 times
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0x1a3e7868d156d48 (tau_power_0)
magic found 0 times
=====
scanning memory between 0x7fff8730b940 and 0x7fff8720b940 for 0xe4c9521cc8306815 (r)
magic found 0 times
```

#### Comments
in debug mode, `tau` is found 4 times in memory. Using a gdb watchpoint I found that these are all written by this line:
```rust
    let s_pok = h_pok * tau + r;
```
The copies are added by the multiplication generated from an arkworks macro in tfhe-rs (**tfhe-zk-pok/src/curve_446/mod.rs**):
```rust
#[derive(MontConfig)]
#[modulus = "645383785691237230677916041525710377746967055506026847120930304831624105190538527824412673"]
#[generator = "7"]
#[small_subgroup_base = "3"]
#[small_subgroup_power = "1"]
pub struct FrConfig;
```
These copies are removed by the compiler when building in release mode.
