### PR TITLE
chore: ensure centralized CRS gen does not use tau=0

### DIFF
--- a/core/threshold/src/execution/zk/ceremony.rs
+++ b/core/threshold/src/execution/zk/ceremony.rs
@@ -596,9 +596,15 @@ pub fn public_parameters_by_trusted_setup<R: Rng + CryptoRng>(
     let pparam = InternalPublicParameter::new_from_tfhe_param(params, max_num_bits)?;
 
     let mut tau = curve::ZeroizeZp::ZERO;
-    tau.rand_in_place(rng);
+    // ensure tau is random and non-zero
+    while tau == curve::ZeroizeZp::ZERO {
+        tau.rand_in_place(rng);
+    }
     let mut r = curve::ZeroizeZp::ZERO;
-    r.rand_in_place(rng);
+    // ensure r is random and non-zero
+    while r == curve::ZeroizeZp::ZERO {
+        r.rand_in_place(rng);
+    }
 
     let pproof = make_partial_proof_deterministic(&pparam, &tau, 1, &r, sid);
 


### PR DESCRIPTION
This PR ensures that a CRS generated by a centralized KMS is not created with $\tau=0$, by simply sampling again in the unlikely case a zero was chosen initially.

The threshold setup handles this case by checking for zero here: https://github.com/zama-ai/kms/blob/main/core/threshold/src/execution/zk/ceremony.rs#L646-L652

Closes https://github.com/zama-ai/kms-internal/issues/2726