### PR TITLE
chore: update test param to use v2 crs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7105,9 +7105,9 @@ dependencies = [
 
 [[package]]
 name = "tfhe-zk-pok"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869be339aa0b2a67a66eaf58905127fc0456eb1cb824427d3248f915d9e41c70"
+checksum = "e73edceedf380f2c28a42f5f6e25ca5cce7721fcf18cc17a3e248ea490ec03ec"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ tower-http = "=0.6.6"
 tfhe = "=1.3.3"
 tfhe-csprng = "=0.6.0"
 tfhe-versionable = "=0.6.1"
-tfhe-zk-pok = "=0.7.1"
+tfhe-zk-pok = "=0.7.2"
 tokio = { version = "=1.46.1", features = ["full"] }
 tokio-rustls = { version = "=0.26.2", default-features = false, features = [
     "ring",

--- a/core/service/src/client/crs_gen.rs
+++ b/core/service/src/client/crs_gen.rs
@@ -221,6 +221,8 @@ pub(crate) mod tests {
     use tfhe::Tag;
     use threshold_fhe::execution::tfhe_internals::parameters::DKGParams;
 
+    use crate::consts::TEST_PARAM;
+
     pub(crate) fn verify_pp(dkg_params: &DKGParams, pp: &CompactPkeCrs) {
         let dkg_params_handle = dkg_params.get_params_basics_handle();
 
@@ -252,11 +254,32 @@ pub(crate) mod tests {
         let metadata = vec![23_u8, 42];
         let mut compact_list_builder = ProvenCompactCiphertextList::builder(&pk);
         for msg in msgs {
-            compact_list_builder.push_with_num_bits(msg, 64).unwrap();
+            compact_list_builder.push(msg);
+            // .push_with_num_bits(
+            //     msg,
+            //     dkg_params_handle.get_message_modulus().0.ilog2() as usize,
+            // )
+            // .unwrap();
         }
         let proven_ct = compact_list_builder
             .build_with_proof_packed(pp, &metadata, tfhe::zk::ZkComputeLoad::Proof)
             .unwrap();
         assert!(proven_ct.verify(pp, &pk, &metadata).is_valid());
+    }
+
+    #[test]
+    fn verify_pp_with_tfhers() {
+        let dkg_params = TEST_PARAM;
+        let params_h = dkg_params.get_params_basics_handle();
+
+        let config =
+            tfhe::ConfigBuilder::with_custom_parameters(params_h.to_classic_pbs_parameters())
+                .use_dedicated_compact_public_key_parameters(
+                    params_h.get_dedicated_pk_params().unwrap(),
+                )
+                .build();
+
+        let crs = CompactPkeCrs::from_config(config, 2048).unwrap();
+        verify_pp(&dkg_params, &crs);
     }
 }

--- a/core/service/src/client/crs_gen.rs
+++ b/core/service/src/client/crs_gen.rs
@@ -255,11 +255,6 @@ pub(crate) mod tests {
         let mut compact_list_builder = ProvenCompactCiphertextList::builder(&pk);
         for msg in msgs {
             compact_list_builder.push(msg);
-            // .push_with_num_bits(
-            //     msg,
-            //     dkg_params_handle.get_message_modulus().0.ilog2() as usize,
-            // )
-            // .unwrap();
         }
         let proven_ct = compact_list_builder
             .build_with_proof_packed(pp, &metadata, tfhe::zk::ZkComputeLoad::Proof)
@@ -269,6 +264,8 @@ pub(crate) mod tests {
 
     #[test]
     fn verify_pp_with_tfhers() {
+        // We're using test parameters because they're unique to KMS
+        // and have more constraints. The normal parameters should always be tested by tfhe-rs.
         let dkg_params = TEST_PARAM;
         let params_h = dkg_params.get_params_basics_handle();
 

--- a/core/service/src/client/tests/centralized/crs_gen_tests.rs
+++ b/core/service/src/client/tests/centralized/crs_gen_tests.rs
@@ -148,12 +148,7 @@ pub(crate) async fn crs_gen_centralized(
     let (kms_server, mut kms_client, internal_client) =
         crate::client::test_tools::centralized_handles(&dkg_param, Some(rate_limiter_conf)).await;
 
-    let max_num_bits = if params == FheParameter::Test {
-        Some(1)
-    } else {
-        // The default is 2048 which is too slow for tests, so we switch to 256
-        Some(256)
-    };
+    let max_num_bits = Some(2048);
     let domain = dummy_domain();
     let gen_req = internal_client
         .crs_gen_request(crs_req_id, max_num_bits, Some(params), &domain)

--- a/core/service/src/client/tests/threshold/crs_gen_tests.rs
+++ b/core/service/src/client/tests/threshold/crs_gen_tests.rs
@@ -40,14 +40,14 @@ async fn test_insecure_crs_gen_threshold() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn secure_threshold_crs() {
-    crs_gen(4, FheParameter::Default, Some(16), false, 1, false).await;
+    crs_gen(4, FheParameter::Default, Some(2048), false, 1, false).await;
 }
 
 #[cfg(feature = "slow_tests")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn test_crs_gen_threshold() {
-    crs_gen(4, FheParameter::Test, Some(1), false, 1, false).await;
+    crs_gen(4, FheParameter::Test, Some(2048), false, 1, false).await;
 }
 
 #[cfg(any(feature = "slow_tests", feature = "insecure"))]
@@ -140,7 +140,7 @@ pub(crate) async fn run_crs(
 
     let responses = launch_crs(&vec![crs_req.clone()], kms_clients, insecure).await;
     for response in responses {
-        assert!(response.is_ok());
+        response.unwrap();
     }
     wait_for_crsgen_result(&vec![crs_req], kms_clients, internal_client, &dkg_param).await;
 }

--- a/core/threshold/src/execution/tfhe_internals/parameters.rs
+++ b/core/threshold/src/execution/tfhe_internals/parameters.rs
@@ -1586,13 +1586,13 @@ pub const PARAMS_TEST_BK_SNS: DKGParams = DKGParams::WithSnS(DKGParamsSnS {
         }),
         dedicated_compact_public_key_parameters: Some((
             CompactPublicKeyEncryptionParameters {
-                encryption_lwe_dimension: LweDimension(256),
+                encryption_lwe_dimension: LweDimension(512),
                 encryption_noise_distribution: DynamicDistribution::new_t_uniform(0),
                 message_modulus: MessageModulus(4),
                 carry_modulus: CarryModulus(4),
                 ciphertext_modulus: CiphertextModulus::new_native(),
                 expansion_kind: CompactCiphertextListExpansionKind::RequiresCasting,
-                zk_scheme: SupportedCompactPkeZkScheme::V1,
+                zk_scheme: SupportedCompactPkeZkScheme::V2,
             },
             ShortintKeySwitchingParameters {
                 ks_level: DecompositionLevelCount(1),


### PR DESCRIPTION
## Describe your changes
Update test param to use v2 crs

## Issue ticket number and link
NA

## Checklist before requesting a review
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), e.g. "chore: made key gen consistent with tfhe-rs 1.4".
- [x] I have made sunshine tests for all new `pub` methods.
- [x] Code comments are in place for public methods along with tricky or non-obvious code segments.
- [x] I have performed a self-review of my code
- [x] Any unfinished business is documented with a `TODO(#issue_number)` comment and brief description what needs to be fixed.
- [x] I have only used `unwrap`, `expect` or `panic!` tests or in situations where it would imply that there is a bug in the code, and I have documented this.
- [ ] My PR is _not_ updating _any_ dependencies (i.e. no changes to `cargo.lock`). Or if it is, then it _only_ contains the dependency updates and any changes needed to fix compilation and tests (see [here](#Checklist-for-dependency-updates) for details.)
- [x] My changes do not affect the architecture of the protocol. Or if they do these steps must be taken:
    - [ ] A parallel PR or issue has been open in the [tech-spec repo](https://github.com/zama-ai/tech-spec) (add the link here).
- [x] My PR does not contain any breaking changes to the configuration and deployment files.
      (A change is _only_ considered breaking if a deployment configuration must be changed as part of an update. E.g. adding new fields, with default values is _not_ considered breaking). Or if it does then these steps must be taken:
    - [ ] My PR is labeled with `devops`.
    - [ ] I have pinged the infra team on Slack (in the MPC channel).
    - [ ] I have put a devops person on the PR as reviewer.
- [x] My PR does not contain breaking changes to the gRPC interface or data serialized into data in the service gRPC interface. In particular there are no changes to the `extraData` fields. Or if it does the following steps have been taken:
    - [ ] The PR is marked using `!` in accordance with conventional commits. E.g. `chore!: changed decryption format according to Q3 release`. 
    - [ ] The Gateway and Connector teams have been notified about this change. 
- [x] I have not changed existing `versionized` structs, nor added new `versionized` structs. Or if I have, these steps must be taken:
    - [ ] The backwards compatibility tests have been updated and/or new tests covering the changes have been added. 
- [x] My PR does not contain changes to the critical business logic or cryptographic code. Or if it does then these steps must be taken:
    - [ ] At least two people must be assigned as reviewers (and eventually approve!) the PR.
- [x] I have not added new structs or modified struct to contain private or key data. Or if so then these steps must be taken:
    - [ ] The `zeroize` and `ZeroizeOnDrop` traits have been implemented to clean up private data.
- [x] I have not added data to the public storage. Or if I have, then these steps must be taken:
    - [ ] I have ensured that the data does _not_ need to be trusted. I.e. it can be validated through a signature or the existence of a digest in the private storage. 

### Checklist for dependency updates
For dependency updates the following essay questions _must_ be also answered and comments where the import of the dependency happens must be updated if there is any changes in the answers since the last update.
If this is the first time a new dependency is added, then the questions must be answered in the `toml` where the new dependency is imported:
1. Did ownership change change significantly since last update. Is the owner suspicious? I.e. is it limited to one or a few people or small companies in "dangerous territories"?
2. Is the crate not particularly popular?
3. Is there an unusual jump in package versions?
4. Is documentation lacking?
5. Is there no CI enabled on the project's GitHub?
6. Do the owners not make any statements in relation to security and
responsible disclosure of vulnerabilities?
7. Is there a significant change in size of the crate?

Finally, observe that an update or addition of a dependency will cause an update to secondary imports in `Cargo.lock`. We currently consider this an acceptable risk. Hence there is no need to manually modify `Cargo.lock`.