### PR TITLE
chore: make crs ceremony tests serial since they're computation heavy

### DIFF
--- a/.github/workflows/global-common-workflow.yml
+++ b/.github/workflows/global-common-workflow.yml
@@ -470,7 +470,9 @@ jobs:
     uses: ./.github/workflows/common-testing-big-instance.yml
     with:
       working-directory: './core/threshold'
-      args-tests: '-F slow_tests --lib'
+      # with the rayon pool, each test uses more thread to run. We run those tests on a 16 core machine
+      # and limit the number of test ran in parallel to 4
+      args-tests: '-F slow_tests --lib -- --test-threads=4'
       package-name: 'threshold-fhe'
       app-cache-dir: 'threshold-fhe'
     secrets:
@@ -495,7 +497,9 @@ jobs:
     uses: ./.github/workflows/common-testing-big-instance.yml
     with:
       working-directory: './core/threshold'
-      args-tests: '-F slow_tests'
+      # with the rayon pool, each test uses more thread to run. We run those tests on a 16 core machine
+      # and limit the number of test ran in parallel to 4
+      args-tests: '-F slow_tests --lib -- --test-threads=4'
       run-redis: true
       package-name: 'threshold-fhe'
       app-cache-dir: 'threshold-fhe'

--- a/core/threshold/src/execution/zk/ceremony.rs
+++ b/core/threshold/src/execution/zk/ceremony.rs
@@ -1222,9 +1222,9 @@ mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     #[case(TestingParameters::init(4,1,&[1],&[],&[],false,None), 4)]
     #[case(TestingParameters::init(4,1,&[0],&[],&[],false,None), 4)]
+    #[serial_test::serial]
     async fn test_dropping_ceremony(#[case] params: TestingParameters, #[case] witness_dim: usize) {
         use crate::malicious_execution::zk::ceremony::DroppingCeremony;
 
@@ -1237,9 +1237,9 @@ mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     #[case(TestingParameters::init(4,1,&[1],&[],&[],false,None), 4)]
     #[case(TestingParameters::init(4,1,&[0],&[],&[],false,None), 4)]
+    #[serial_test::serial]
     async fn test_bad_proof_ceremony<BCast: Broadcast + Default + 'static>(
         #[case] params: TestingParameters,
         #[case] witness_dim: usize,
@@ -1256,9 +1256,9 @@ mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     #[case(TestingParameters::init(4,1,&[1],&[],&[],false,None), 4)]
     #[case(TestingParameters::init(4,1,&[0],&[],&[],false,None), 4)]
+    #[serial_test::serial]
     async fn test_rushing_ceremony<BCast: Broadcast + Default + 'static>(
         #[case] params: TestingParameters,
         #[case] witness_dim: usize,

--- a/core/threshold/src/execution/zk/ceremony.rs
+++ b/core/threshold/src/execution/zk/ceremony.rs
@@ -994,11 +994,13 @@ mod tests {
     use tokio::task::JoinSet;
 
     #[test]
+    #[serial_test::serial]
     fn test_honest_crs_ceremony_secure() {
         test_honest_crs_ceremony(SecureCeremony::default)
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_honest_crs_ceremony_insecure() {
         test_honest_crs_ceremony(InsecureCeremony::default)
     }
@@ -1220,6 +1222,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial_test::serial]
     #[case(TestingParameters::init(4,1,&[1],&[],&[],false,None), 4)]
     #[case(TestingParameters::init(4,1,&[0],&[],&[],false,None), 4)]
     async fn test_dropping_ceremony(#[case] params: TestingParameters, #[case] witness_dim: usize) {
@@ -1234,6 +1237,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial_test::serial]
     #[case(TestingParameters::init(4,1,&[1],&[],&[],false,None), 4)]
     #[case(TestingParameters::init(4,1,&[0],&[],&[],false,None), 4)]
     async fn test_bad_proof_ceremony<BCast: Broadcast + Default + 'static>(
@@ -1252,6 +1256,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial_test::serial]
     #[case(TestingParameters::init(4,1,&[1],&[],&[],false,None), 4)]
     #[case(TestingParameters::init(4,1,&[0],&[],&[],false,None), 4)]
     async fn test_rushing_ceremony<BCast: Broadcast + Default + 'static>(

--- a/core/threshold/src/execution/zk/ceremony.rs
+++ b/core/threshold/src/execution/zk/ceremony.rs
@@ -1222,6 +1222,7 @@ mod tests {
     }
 
     #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     #[case(TestingParameters::init(4,1,&[1],&[],&[],false,None), 4)]
     #[case(TestingParameters::init(4,1,&[0],&[],&[],false,None), 4)]
     #[serial_test::serial]
@@ -1237,6 +1238,7 @@ mod tests {
     }
 
     #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     #[case(TestingParameters::init(4,1,&[1],&[],&[],false,None), 4)]
     #[case(TestingParameters::init(4,1,&[0],&[],&[],false,None), 4)]
     #[serial_test::serial]
@@ -1256,6 +1258,7 @@ mod tests {
     }
 
     #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     #[case(TestingParameters::init(4,1,&[1],&[],&[],false,None), 4)]
     #[case(TestingParameters::init(4,1,&[0],&[],&[],false,None), 4)]
     #[serial_test::serial]


### PR DESCRIPTION
## Description of changes
Making crs ceremony tests serial to avoid flakyness on CI

## Issue ticket number and link
NA

## Checklist before requesting a review
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), e.g. "chore: made key gen consistent with tfhe-rs 1.4".
- [x] I have made sunshine tests for all new `pub` methods.
- [x] Code comments are in place for public methods along with tricky or non-obvious code segments.
- [x] I have performed a self-review of my code
- [x] Any unfinished business is documented with a `TODO(#issue_number)` comment and brief description what needs to be fixed.
- [x] I have only used `unwrap`, `expect` or `panic!` tests or in situations where it would imply that there is a bug in the code, and I have documented this.
- [x] My PR is _not_ updating _any_ dependencies (i.e. no changes to `Cargo.lock`). Or if it is, then it _only_ contains the dependency updates and any changes needed to fix compilation and tests (see [here](#Checklist-for-dependency-updates) for details.)
- [x] My changes do not affect the architecture of the protocol. Or if they do these steps must be taken:
    - [ ] A parallel PR or issue has been open in the [tech-spec repo](https://github.com/zama-ai/tech-spec) (add the link here).
- [x] My PR does not contain any breaking changes to the configuration and deployment files.
      (A change is _only_ considered breaking if a deployment configuration must be changed as part of an update. E.g. adding new fields, with default values is _not_ considered breaking). Or if it does then these steps must be taken:
    - [ ] My PR is labeled with `devops`.
    - [ ] I have pinged the infra team on Slack (in the MPC channel).
    - [ ] I have put a devops person on the PR as reviewer.
- [x] My PR does not contain breaking changes to the gRPC interface or data serialized into data in the service gRPC interface. In particular there are no changes to the `extraData` fields. Or if it does the following steps have been taken:
    - [ ] The PR is marked using `!` in accordance with conventional commits. E.g. `chore!: changed decryption format according to Q3 release`.
    - [ ] The Gateway and Connector teams have been notified about this change.
- [x] I have not changed existing `versionized` structs, nor added new `versionized` structs. Or if I have, these steps must be taken:
    - [ ] The backwards compatibility tests have been updated and/or new tests covering the changes have been added.
- [x] My PR does not contain changes to the critical business logic or cryptographic code. Or if it does then these steps must be taken:
    - [ ] At least two people must be assigned as reviewers (and eventually approve!) the PR.
- [x] I have not added new structs or modified struct to contain private or key data. Or if so then these steps must be taken:
    - [ ] The `zeroize` and `ZeroizeOnDrop` traits have been implemented to clean up private data.
- [x] I have not added data to the public storage. Or if I have, then these steps must be taken:
    - [ ] I have ensured that the data does _not_ need to be trusted. I.e. it can be validated through a signature or the existence of a digest in the private storage.

### Checklist for dependency updates
For dependency updates the following essay questions _must_ be also answered and comments where the import of the dependency happens must be updated if there is any changes in the answers since the last update.
If this is the first time a new dependency is added, then the questions must be answered in the `toml` where the new dependency is imported:
1. Did ownership change change significantly since last update. Is the owner suspicious? I.e. is it limited to one or a few people or small companies in "dangerous territories"?
2. Is the crate not particularly popular?
3. Is there an unusual jump in package versions?
4. Is documentation lacking?
5. Is there no CI enabled on the project's GitHub?
6. Do the owners not make any statements in relation to security and
responsible disclosure of vulnerabilities?
7. Is there a significant change in size of the crate?

Finally, observe that an update or addition of a dependency will cause an update to secondary imports in `Cargo.lock`. We currently consider this an acceptable risk. Hence there is no need to manually modify `Cargo.lock`.
