### PR TITLE
chore: user decrypt key log improvement

### DIFF
--- a/core/service/src/cryptography/internal_crypto_types.rs
+++ b/core/service/src/cryptography/internal_crypto_types.rs
@@ -188,7 +188,6 @@ impl<C: KemCore> Visitor<'_> for PublicEncKeyVisitor<C> {
             Ok(array) => array,
             Err(_) => {
                 let msg = "ML-KEM Public Enc Key Byte array of incorrect length";
-                tracing::error!(msg);
                 return Err(serde::de::Error::custom(msg));
             }
         };
@@ -266,7 +265,6 @@ impl<C: KemCore> Visitor<'_> for PrivateEncKeyVisitor<C> {
             Ok(array) => array,
             Err(_) => {
                 let msg = "ML-KEM Private Enc Key Byte array of incorrect length";
-                tracing::warn!(msg);
                 return Err(serde::de::Error::custom(msg));
             }
         };

--- a/core/service/src/engine/validation_non_wasm.rs
+++ b/core/service/src/engine/validation_non_wasm.rs
@@ -203,18 +203,23 @@ pub fn validate_user_decrypt_req(
         ))
     })?;
     // NOTE: we need to do some backward compatibility support here so
-    // first try to deserialize it using the old format
+    // first try to deserialize it using the old format (ML-KEM1024 encoded with bincode)
     let client_enc_key = match bc2wrap::deserialize::<PublicEncKey<ml_kem::MlKem1024>>(&req.enc_key)
     {
         Ok(inner) => {
+            // we got an old MlKem1024 public key, wrap it in the enum
             tracing::warn!("🔒 Using MlKem1024 public encryption key");
             UnifiedPublicEncKey::MlKem1024(inner)
         }
+        // in case the old deserialization fails, try the new format
         Err(_) => tfhe::safe_serialization::safe_deserialize::<UnifiedPublicEncKey>(
             std::io::Cursor::new(&req.enc_key),
             crate::consts::SAFE_SER_SIZE_LIMIT,
         )
         .map_err(|e| {
+            tracing::error!(
+                "Error deserializing UnifiedPublicEncKey from UserDecryptionRequest: {e}"
+            );
             BoxedStatus::from(tonic::Status::new(
                 tonic::Code::InvalidArgument,
                 format!("Error deserializing UnifiedPublicEncKey from UserDecryptionRequest: {e}"),


### PR DESCRIPTION
## Description of changes
This PR removes the log of a failed public key deserialization and instead ensures that the calling functions logs the error.

This removes wrong log entries that currently happen since we try to deserialize an old format for backward compat. reasons.


## PR Checklist
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
