### PR TITLE
chore: rename global-common-workflow to main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 .github/workflows/common-testing.yml                @zama-ai/mpc-devops
 .github/workflows/common-update-argocd.yml         @zama-ai/mpc-devops
 .github/workflows/dependencies_analysis.yml         @zama-ai/mpc-devops
-.github/workflows/global-common-workflow.yml        @zama-ai/mpc-devops
+.github/workflows/main.yml                          @zama-ai/mpc-devops
 .github/workflows/helm-lint.yml                     @zama-ai/mpc-devops
 .github/workflows/helm-release.yml                  @zama-ai/mpc-devops
 .github/workflows/helm-test.yml                     @zama-ai/mpc-devops

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ This document describes the CI/CD workflow structure for the KMS Core project. O
 
 ## 🔄 Main Workflow File
 
-[`.github/workflows/global-common-workflow.yml`](global-common-workflow.yml)
+[`.github/workflows/main.yml`](main.yml)
 
 ### Trigger Types
 
@@ -27,19 +27,19 @@ This document describes the CI/CD workflow structure for the KMS Core project. O
 <details>
 <summary><b>View Component Details</b></summary>
 
-#### 🧪 Test Job [`test-helm-chart`](global-common-workflow.yml)
+#### 🧪 Test Job [`test-helm-chart`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🔍 PR | ✅ | On chart changes |
 | 🎯 Main | ✅ | On chart changes |
 
-#### 🔍 Lint Job [`lint-helm-chart`](global-common-workflow.yml)
+#### 🔍 Lint Job [`lint-helm-chart`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🔍 PR | ✅ | On chart changes |
 | 🎯 Main | ✅ | On chart changes |
 
-#### 📦 Release Job [`release-helm-chart`](global-common-workflow.yml)
+#### 📦 Release Job [`release-helm-chart`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🎯 Main | ✅ | On chart changes |
@@ -49,7 +49,7 @@ This document describes the CI/CD workflow structure for the KMS Core project. O
 <details>
 <summary><b>View Component Details</b></summary>
 
-#### 🔍 Check Job [`check-docs`](global-common-workflow.yml)
+#### 🔍 Check Job [`check-docs`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🔍 PR | ✅ | On docs changes |
@@ -62,13 +62,13 @@ This document describes the CI/CD workflow structure for the KMS Core project. O
 <details>
 <summary><b>View Component Details</b></summary>
 
-#### 🧪 Test Job [`test-core-client`](global-common-workflow.yml)
+#### 🧪 Test Job [`test-core-client`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🔍 PR | ✅ | On core-client/service/threshold/grpc changes |
 | 🎯 Main | ✅ | Always |
 
-#### 🐳 Docker Job [`docker-core-client`](global-common-workflow.yml)
+#### 🐳 Docker Job [`docker-core-client`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🌙 Nightly | ✅ | On main/release branch |
@@ -80,7 +80,7 @@ This document describes the CI/CD workflow structure for the KMS Core project. O
 <details>
 <summary><b>View Component Details</b></summary>
 
-#### 🧪 Test Job [`test-grpc`](global-common-workflow.yml)
+#### 🧪 Test Job [`test-grpc`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🌙 Nightly | ✅ | Always runs |
@@ -92,7 +92,7 @@ This document describes the CI/CD workflow structure for the KMS Core project. O
 <details>
 <summary><b>View Component Details</b></summary>
 
-#### 🧪 Test Job [`test-core-service`](global-common-workflow.yml)
+#### 🧪 Test Job [`test-core-service`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🌙 Nightly | ✅ | Comprehensive suite |
@@ -115,14 +115,14 @@ This document describes the CI/CD workflow structure for the KMS Core project. O
      - Features: `slow_tests`, `s3_tests`, `insecure`
      - Excludes: Threshold tests
 
-#### 🐳 Docker Job [`docker-core-service`](global-common-workflow.yml)
+#### 🐳 Docker Job [`docker-core-service`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🌙 Nightly | ✅ | On main/release branch |
 | 🔍 PR | ✅ | When labeled with "docker" |
 | 🎯 Main | ✅ | After successful tests |
 
-#### 🛡️ Nitro Enclave [`docker-nitro-enclave`](global-common-workflow.yml)
+#### 🛡️ Nitro Enclave [`docker-nitro-enclave`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🌙 Nightly | ✅ | On main/release branch |
@@ -134,7 +134,7 @@ This document describes the CI/CD workflow structure for the KMS Core project. O
 <details>
 <summary><b>View Component Details</b></summary>
 
-#### 🧪 Test Job [`test-core-threshold-main`](global-common-workflow.yml)
+#### 🧪 Test Job [`test-core-threshold-main`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🌙 Nightly | ✅ | On main/release branch |
@@ -148,7 +148,7 @@ This document describes the CI/CD workflow structure for the KMS Core project. O
 <details>
 <summary><b>View Component Details</b></summary>
 
-#### 📦 Deploy Job [`update-argocd-staging`](global-common-workflow.yml)
+#### 📦 Deploy Job [`update-argocd-staging`](main.yml)
 | Trigger | Status | Condition |
 |---------|--------|-----------|
 | 🌙 Nightly | ✅ | Always runs |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@
 # 2. Pull requests: For validation before merging
 # 3. Pushes: On main and release/* branches for building images
 # IMPORTANT NOTES: The tests are only executed for components that have been changed
-name: global-common-workflow
+name: main
 
 on:
   schedule:
@@ -30,7 +30,7 @@ jobs:
   # Initial job that determines which components have changed
   # Used by subsequent jobs to decide whether they need to run
   check-changes:
-    name: global-common-workflow/check-changes
+    name: main/check-changes
     permissions:
       actions: 'read'
       contents: 'read'
@@ -94,7 +94,7 @@ jobs:
   # - Changes to charts/**'
   ############################################################################
   test-helm-chart:
-    name: global-common-workflow/test-helm-chart
+    name: main/test-helm-chart
     permissions:
       actions: 'read'
       contents: 'read'
@@ -104,7 +104,7 @@ jobs:
     uses: ./.github/workflows/helm-test.yml
 
   lint-helm-chart:
-    name: global-common-workflow/lint-helm-chart
+    name: main/lint-helm-chart
     permissions:
       actions: 'read'
       contents: 'read'
@@ -114,7 +114,7 @@ jobs:
     uses: ./.github/workflows/helm-lint.yml
 
   release-helm-chart:
-    name: global-common-workflow/release-helm-chart
+    name: main/release-helm-chart
     permissions:
       actions: 'read'
       contents: 'read'
@@ -131,7 +131,7 @@ jobs:
   # - Changes to workflow file itself
   ############################################################################
   check-docs:
-    name: global-common-workflow/check-docs
+    name: main/check-docs
     permissions:
       actions: 'read'
       contents: 'read'
@@ -157,7 +157,7 @@ jobs:
   # - Changes to workflow file itself
   ############################################################################
   test-backward-compatibility:
-    name: global-common-workflow/test-backward-compatibility
+    name: main/test-backward-compatibility
     needs: check-changes
     if: >-
       needs.check-changes.outputs.changes-backward-compatibility == 'true' ||
@@ -193,7 +193,7 @@ jobs:
   # - Changes to workflow file
   ############################################################################
   prepare-core-client-matrix:
-    name: global-common-workflow/prepare-core-client-matrix
+    name: main/prepare-core-client-matrix
     needs: check-changes
     if: >-
       needs.check-changes.outputs.changes-core-client == 'true' ||
@@ -217,7 +217,7 @@ jobs:
 
 
   test-core-client:
-    name: global-common-workflow/test-core-client
+    name: main/test-core-client
     needs:
       - prepare-core-client-matrix
       - check-changes
@@ -252,7 +252,7 @@ jobs:
   # Only runs on main/release branches after successful tests
   # Also runs on pull requests targeting main/release branches with the docker label
   docker-core-client:
-    name: global-common-workflow/docker-core-client
+    name: main/docker-core-client
     permissions:
       actions: 'write'
       attestations: 'write'
@@ -285,7 +285,7 @@ jobs:
   # - Changes to workflow file
   ############################################################################
   test-grpc:
-    name: global-common-workflow/test-grpc
+    name: main/test-grpc
     needs: check-changes
     if: needs.check-changes.outputs.changes-core-grpc == 'true' || github.ref == 'refs/heads/main'
     uses: ./.github/workflows/common-testing-big-instance.yml
@@ -326,7 +326,7 @@ jobs:
   # - For scheduled runs: Runs comprehensive nightly tests in release mode
   # - For other events: Runs multiple test suites in parallel with specific features
   prepare-matrix:
-    name: global-common-workflow/prepare-matrix
+    name: main/prepare-matrix
     needs: check-changes
     if: >-
       needs.check-changes.outputs.changes-core-service == 'true' ||
@@ -357,7 +357,7 @@ jobs:
   # - MinIO for object storage testing
   # - WASM runtime for WebAssembly tests
   test-core-service:
-    name: global-common-workflow/test-core-service
+    name: main/test-core-service
     needs:
       - check-changes
       - prepare-matrix
@@ -392,7 +392,7 @@ jobs:
   # Only runs on main/release branches after successful tests
   # Uses a custom Dockerfile optimized for production
   docker-core-service:
-    name: global-common-workflow/docker-core-service
+    name: main/docker-core-service
     permissions:
       actions: read
       contents: read
@@ -425,7 +425,7 @@ jobs:
   # Only runs on main/release branches after core service image is built
   # Creates both regular container and enclave-specific images
   docker-nitro-enclave:
-    name: global-common-workflow/docker-nitro-enclave
+    name: main/docker-nitro-enclave
     permissions:
       actions: read
       contents: write
@@ -464,7 +464,7 @@ jobs:
   # Runs basic threshold tests for pull requests
   # Includes slow tests but runs only library tests
   test-core-threshold-pr:
-    name: global-common-workflow/test-core-threshold-pr
+    name: main/test-core-threshold-pr
     needs: check-changes
     if: needs.check-changes.outputs.changes-core-threshold == 'true'
     uses: ./.github/workflows/common-testing-big-instance.yml
@@ -491,7 +491,7 @@ jobs:
   # Includes Redis integration and all test suites
   # Only runs when threshold-related changes are detected
   test-core-threshold-main:
-    name: global-common-workflow/test-core-threshold-main
+    name: main/test-core-threshold-main
     needs: check-changes
     if: needs.check-changes.outputs.changes-core-threshold == 'true' && contains(fromJSON('["release/", "main"]'), github.ref) || github.ref == 'refs/heads/main'
     uses: ./.github/workflows/common-testing-big-instance.yml
@@ -519,7 +519,7 @@ jobs:
   # Only runs library tests without integration components
   # Helps validate dependency updates quickly
   build-dependabot:
-    name: global-common-workflow/build-dependabot
+    name: main/build-dependabot
     needs: check-changes
     if: needs.check-changes.outputs.changes-core-threshold == 'true' && startsWith(github.head_ref, 'dependabot/')
     uses: ./.github/workflows/common-testing.yml
@@ -544,7 +544,7 @@ jobs:
   # Provides dependencies for building rust kms-core images
   ############################################################################
   docker-golden-image:
-    name: global-common-workflow/docker-golden-image
+    name: main/docker-golden-image
     permissions:
       actions: read
       contents: read
@@ -581,7 +581,7 @@ jobs:
   # Deploys to kms-threshold-staging namespace
   ############################################################################
   # update-kms-core-client-argocd-staging:
-  #   name: global-common-workflow/update-kms-core-client-argocd-staging
+  #   name: main/update-kms-core-client-argocd-staging
   #   if: github.event_name == 'schedule'
   #   needs:
   #     - test-core-client
@@ -597,7 +597,7 @@ jobs:
   #     ZWS_BOT_TOKEN: ${{ secrets.ZWS_BOT_TOKEN }}
 
   # update-kms-core-argocd-staging:
-  #   name: global-common-workflow/update-kms-core-argocd-staging
+  #   name: main/update-kms-core-argocd-staging
   #   if: github.event_name == 'schedule'
   #   needs:
   #     - test-core-service
@@ -615,7 +615,7 @@ jobs:
   #     ZWS_BOT_TOKEN: ${{ secrets.ZWS_BOT_TOKEN }}
 
   # update-kms-core-client-argocd-staging-with-enclave:
-  #   name: global-common-workflow/update-kms-core-client-argocd-staging-with-enclave
+  #   name: main/update-kms-core-client-argocd-staging-with-enclave
   #   if: github.event_name == 'schedule'
   #   needs:
   #     - test-core-client
@@ -632,7 +632,7 @@ jobs:
   #     ZWS_BOT_TOKEN: ${{ secrets.ZWS_BOT_TOKEN }}
 
   # update-kms-core-argocd-staging-with-enclave:
-  #   name: global-common-workflow/update-kms-core-argocd-staging-with-enclave
+  #   name: main/update-kms-core-argocd-staging-with-enclave
   #   if: github.event_name == 'schedule'
   #   needs:
   #     - test-core-service
@@ -652,4 +652,3 @@ jobs:
   #     image-tag: ${{ needs.docker-nitro-enclave.outputs.image_tag }}
   #   secrets:
   #     ZWS_BOT_TOKEN: ${{ secrets.ZWS_BOT_TOKEN }}
-

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-BSD--3--Clause--Clear-%23ffb243?style=flat-square"></a>
   <a href="https://github.com/zama-ai/bounty-program"><img src="https://img.shields.io/badge/Contribute-Zama%20Bounty%20Program-%23ffd208?style=flat-square"></a>
-  <a href="https://github.com/zama-ai/kms/pkgs/container/kms-service"><img src="https://github.com/zama-ai/kms/actions/workflows/global-common-workflow.yml/badge.svg?branch=main"></a>
+  <a href="https://github.com/zama-ai/kms/pkgs/container/kms-service"><img src="https://github.com/zama-ai/kms/actions/workflows/main.yml/badge.svg?branch=main"></a>
   <!-- TODO: add release badge once we made a public release -->
 </p>
 


### PR DESCRIPTION
## Description of changes
This PR renames the existing `global-common-workflow` to `main`, so CI runs are easier to follow on the Github website.
The old name was too long, so the UI would truncate the actual workflow name in may places.

## Issue ticket number and link


## PR Checklist
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.


