### PR TITLE
chore: bump version to v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "backward-compatibility"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aes-prng",
  "bincode 1.3.3",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "cc-tests-utils"
-version = "0.11.0"
+version = "0.11.1"
 
 [[package]]
 name = "cexpr"
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "kms"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "kms-core-client"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aes-prng",
  "alloy-primitives",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "kms-grpc"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "kms-health-check"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -7319,7 +7319,7 @@ dependencies = [
 
 [[package]]
 name = "tests-utils"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7490,7 +7490,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-fhe"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aes",
  "aes-prng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Zama"]
 publish = true
 edition = "2021"
 license = "BSD-3-Clause-Clear"
-version = "0.11.0"
+version = "0.11.1"
 
 [workspace.dependencies]
 # ⚠️ WORKSPACE DEPENDENCY MANAGEMENT BEST PRACTICES ⚠️

--- a/backward-compatibility/Cargo.toml
+++ b/backward-compatibility/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backward-compatibility"
-version = "0.11.0"
+version = "0.11.1"
 publish = false
 authors = ["Zama"]
 edition = "2021"

--- a/backward-compatibility/src/data_0_11.rs
+++ b/backward-compatibility/src/data_0_11.rs
@@ -1,6 +1,6 @@
 //! Data generation for kms-core v0.11
 //! This file provides the code that is used to generate all the data to serialize and versionize
-//! for kms-core v0.11.
+//! for kms-core v0.11
 
 use aes_prng::AesRng;
 use kms_0_11::cryptography::internal_crypto_types::gen_sig_keys;


### PR DESCRIPTION
## Description of changes
This PR sets the version to `v0.11.1` to prepare for the next release.

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

