### PR TITLE
fix: fix compile warning about duplicate bench files

### DIFF
--- a/core/threshold/Cargo.toml
+++ b/core/threshold/Cargo.toml
@@ -177,23 +177,23 @@ required-features = ["testing", "extension_degree_8"]
 
 [[bench]]
 name = "non-threshold_erc20"
-path = "benches/non-threshold/erc20.rs"
+path = "benches/non-threshold/erc20_plain.rs"
 harness = false
 
 [[bench]]
 name = "non-threshold_erc20_memory"
-path = "benches/non-threshold/erc20.rs"
+path = "benches/non-threshold/erc20_memory.rs"
 harness = false
 required-features = ["non-wasm", "measure_memory"]
 
 [[bench]]
 name = "non-threshold_basic-ops"
-path = "benches/non-threshold/basic_ops.rs"
+path = "benches/non-threshold/basic_ops_plain.rs"
 harness = false
 
 [[bench]]
 name = "non-threshold_basic-ops_memory"
-path = "benches/non-threshold/basic_ops.rs"
+path = "benches/non-threshold/basic_ops_memory.rs"
 harness = false
 required-features = ["non-wasm", "measure_memory"]
 

--- a/core/threshold/benches/non-threshold/basic_ops_common.rs
+++ b/core/threshold/benches/non-threshold/basic_ops_common.rs
@@ -166,7 +166,7 @@ bench_type!(FheUint128);
 #[global_allocator]
 pub static PEAK_ALLOC: peak_alloc::PeakAlloc = peak_alloc::PeakAlloc;
 
-fn main() {
+pub(crate) fn run_bench() {
     #[cfg(feature = "measure_memory")]
     threshold_fhe::allocator::MEM_ALLOCATOR.get_or_init(|| PEAK_ALLOC);
 

--- a/core/threshold/benches/non-threshold/basic_ops_memory.rs
+++ b/core/threshold/benches/non-threshold/basic_ops_memory.rs
@@ -1,0 +1,5 @@
+mod basic_ops_common;
+
+fn main() {
+    basic_ops_common::run_bench();
+}

--- a/core/threshold/benches/non-threshold/basic_ops_plain.rs
+++ b/core/threshold/benches/non-threshold/basic_ops_plain.rs
@@ -1,0 +1,5 @@
+mod basic_ops_common;
+
+fn main() {
+    basic_ops_common::run_bench();
+}

--- a/core/threshold/benches/non-threshold/erc20_common.rs
+++ b/core/threshold/benches/non-threshold/erc20_common.rs
@@ -117,7 +117,7 @@ fn bench_transfer_throughput<FheType, F>(
 pub static PEAK_ALLOC: peak_alloc::PeakAlloc = peak_alloc::PeakAlloc;
 
 #[allow(unused_mut)]
-fn main() {
+pub(crate) fn run_bench() {
     #[cfg(feature = "measure_memory")]
     threshold_fhe::allocator::MEM_ALLOCATOR.get_or_init(|| PEAK_ALLOC);
 

--- a/core/threshold/benches/non-threshold/erc20_memory.rs
+++ b/core/threshold/benches/non-threshold/erc20_memory.rs
@@ -1,0 +1,5 @@
+mod erc20_common;
+
+fn main() {
+    erc20_common::run_bench();
+}

--- a/core/threshold/benches/non-threshold/erc20_plain.rs
+++ b/core/threshold/benches/non-threshold/erc20_plain.rs
@@ -1,0 +1,5 @@
+mod erc20_common;
+
+fn main() {
+    erc20_common::run_bench();
+}


### PR DESCRIPTION
## Description of changes
This fixes a compile warning about benchmark files being used for 2 binaries.

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

