### PR TITLE
chore: print information about tokio and rayon threads

### DIFF
--- a/core/service/src/bin/kms-server.rs
+++ b/core/service/src/bin/kms-server.rs
@@ -235,7 +235,7 @@ async fn main() -> anyhow::Result<()> {
         env::var_os("TOKIO_WORKER_THREADS"),
         env::var_os("RAYON_NUM_THREADS"),
         thread::available_parallelism()?.get(),
-        rayon::max_num_threads(),
+        rayon::current_num_threads(),
         tokio::runtime::Handle::current().metrics().num_workers()
     );
 

--- a/core/service/src/bin/kms-server.rs
+++ b/core/service/src/bin/kms-server.rs
@@ -231,12 +231,12 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("Starting KMS Server with core config: {:?}", &core_config);
 
     tracing::info!(
-        "Multi-threading ENV vars: Tokio {:?}; Rayon {:?}; available_parallelism: {}, rayon::max_num_threads: {}, tokio::num_workers: {}.",
-        env::var_os("TOKIO_WORKER_THREADS"),
-        env::var_os("RAYON_NUM_THREADS"),
-        thread::available_parallelism()?.get(),
+        "Multi-threading values: TOKIO_WORKER_THREADS: {:?}, tokio::num_workers: {}, RAYON_NUM_THREADS: {:?}, rayon::current_num_threads: {}, available_parallelism: {}.",
+        env::var_os("TOKIO_WORKER_THREADS").unwrap_or_else(|| "not set".into()),
+        tokio::runtime::Handle::current().metrics().num_workers(),
+        env::var_os("RAYON_NUM_THREADS").unwrap_or_else(||  "not set".into()),
         rayon::current_num_threads(),
-        tokio::runtime::Handle::current().metrics().num_workers()
+        thread::available_parallelism()?.get(),
     );
 
     let party_role = core_config

--- a/core/service/src/bin/kms-server.rs
+++ b/core/service/src/bin/kms-server.rs
@@ -28,7 +28,7 @@ use kms_lib::{
         Vault,
     },
 };
-use std::{net::ToSocketAddrs, sync::Arc};
+use std::{env, net::ToSocketAddrs, sync::Arc, thread};
 use threshold_fhe::{
     execution::runtime::party::Role,
     networking::tls::{build_ca_certs_map, AttestedVerifier},
@@ -229,6 +229,15 @@ async fn main() -> anyhow::Result<()> {
         init_conf_kms_core_telemetry::<CoreConfig>(&args.config_file).await?;
 
     tracing::info!("Starting KMS Server with core config: {:?}", &core_config);
+
+    tracing::info!(
+        "Multi-threading ENV vars: Tokio {:?}; Rayon {:?}; available_parallelism: {}, rayon::max_num_threads: {}, tokio::num_workers: {}.",
+        env::var_os("TOKIO_WORKER_THREADS"),
+        env::var_os("RAYON_NUM_THREADS"),
+        thread::available_parallelism()?.get(),
+        rayon::max_num_threads(),
+        tokio::runtime::Handle::current().metrics().num_workers()
+    );
 
     let party_role = core_config
         .threshold

--- a/core/threshold/src/thread_handles.rs
+++ b/core/threshold/src/thread_handles.rs
@@ -16,11 +16,6 @@ pub struct ThreadHandleGroup {
 impl ThreadHandleGroup {
     /// Create a new empty group of thread handles
     pub fn new() -> Self {
-        tracing::info!(
-            "Creating new ThreadHandleGroup. rayon::max_num_threads: {}, tokio::num_workers: {}.",
-            rayon::current_num_threads(),
-            tokio::runtime::Handle::current().metrics().num_workers()
-        );
         Self {
             handles: Vec::new(),
         }

--- a/core/threshold/src/thread_handles.rs
+++ b/core/threshold/src/thread_handles.rs
@@ -18,7 +18,7 @@ impl ThreadHandleGroup {
     pub fn new() -> Self {
         tracing::info!(
             "Creating new ThreadHandleGroup. rayon::max_num_threads: {}, tokio::num_workers: {}.",
-            rayon::max_num_threads(),
+            rayon::current_num_threads(),
             tokio::runtime::Handle::current().metrics().num_workers()
         );
         Self {

--- a/core/threshold/src/thread_handles.rs
+++ b/core/threshold/src/thread_handles.rs
@@ -16,6 +16,11 @@ pub struct ThreadHandleGroup {
 impl ThreadHandleGroup {
     /// Create a new empty group of thread handles
     pub fn new() -> Self {
+        tracing::info!(
+            "Creating new ThreadHandleGroup. rayon::max_num_threads: {}, tokio::num_workers: {}.",
+            rayon::max_num_threads(),
+            tokio::runtime::Handle::current().metrics().num_workers()
+        );
         Self {
             handles: Vec::new(),
         }


### PR DESCRIPTION
## Description of changes
This PR prints information about tokio and rayon thread pool sizes and ENV vars.

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.


