### PR TITLE
fix: add missing build of kms-custodian to core/service Dockerfile

### DIFF
--- a/docker/core/service/Dockerfile
+++ b/docker/core/service/Dockerfile
@@ -20,17 +20,13 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
 RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/${APP_CACHE_DIR}/target,sharing=locked \
     cargo build  --locked --profile=${LTO_RELEASE} -p kms --bin kms-server --bin kms-gen-tls-certs --bin kms-init -F insecure && \
-    cargo build --locked --profile=${LTO_RELEASE} -p kms --bin kms-gen-keys -F testing -F insecure && \
+    cargo build --locked --profile=${LTO_RELEASE} -p kms --bin kms-gen-keys --bin kms-custodian -F testing -F insecure && \
     cp /app/kms/target/${LTO_RELEASE}/kms-server \
        /app/kms/target/${LTO_RELEASE}/kms-gen-tls-certs \
        /app/kms/target/${LTO_RELEASE}/kms-init \
        /app/kms/target/${LTO_RELEASE}/kms-gen-keys \
+       /app/kms/target/${LTO_RELEASE}/kms-custodian \
     ./core/service/bin
-
-ARG YQ_VERSION=v4.47.2
-# Overridable arg to allow building for different architectures
-ARG TARGETARCH=amd64
-RUN wget -qO/usr/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH}
 
 ################################################################
 ## Third stage: Copy the binaries from preceding stages

--- a/docker/core/service/Dockerfile
+++ b/docker/core/service/Dockerfile
@@ -98,15 +98,10 @@ RUN apk update && apk add --no-cache git && \
 
 
 ################################################################
-## Fourth stage: Build and install yq-go -- For development only with extra tools
+## Fourth stage: Build and install grpc_health_probe -- For development only with extra tools
 FROM --platform=$BUILDPLATFORM prod AS dev
-
-ARG YQ_VERSION=v4.47.2
-ARG TARGETARCH=amd64
 
 USER root
 COPY --from=go-builder /out/grpc_health_probe /bin/grpc_health_probe
-RUN wget -qO/usr/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH} && \
-    chmod +x /usr/bin/yq
 
 CMD ["kms-server", "centralized"]


### PR DESCRIPTION
## Description of changes
This fixes the missing `kms-custodian` binary used in the integration tests.


## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

