### PR TITLE
fix: copy custodian binary for core-client image

### DIFF
--- a/docker/core-client/Dockerfile
+++ b/docker/core-client/Dockerfile
@@ -38,6 +38,7 @@ WORKDIR /app/kms-core-client
 # Copy binaries
 COPY --from=builder /app/kms-core-client/core-client/bin/ /app/kms-core-client/bin/
 COPY --from=builder /app/kms-core-client/tools/kms-health-check/bin/ /app/kms-core-client/bin/
+COPY --from=builder /app/kms-core-client/tools/service/bin/ /app/kms-core-client/bin/
 
 # Change user to limit root access
 RUN addgroup -S kms --gid 10002 && \


### PR DESCRIPTION
## Description of changes
Adds missing custodian binary to core-client docker image.

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.


