### PR TITLE
chore: Revert "fix: delay dkg start time (#223)"

### DIFF
--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -12,11 +12,7 @@ use threshold_fhe::{
         },
         small_execution::prss::{DerivePRSSState, PRSSSetup},
     },
-    networking::{
-        grpc::{GrpcNetworkingManager, OptionConfigWrapper},
-        health_check::HealthCheckSession,
-        NetworkMode,
-    },
+    networking::{grpc::GrpcNetworkingManager, health_check::HealthCheckSession, NetworkMode},
     session_id::SessionId,
     thread_handles::spawn_compute_bound,
 };
@@ -299,17 +295,6 @@ impl SessionPreparer {
                 inner: Some(inner.new_instance().await),
             },
         }
-    }
-
-    pub(crate) async fn get_core_to_core_config(&self) -> anyhow::Result<OptionConfigWrapper> {
-        let manager = self
-            .inner
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!(ERR_SESSION_NOT_INITIALIZED))?
-            .networking_manager
-            .read()
-            .await;
-        Ok(manager.sending_service.get_config())
     }
 
     #[cfg(test)]

--- a/core/threshold/src/networking/sending_service.rs
+++ b/core/threshold/src/networking/sending_service.rs
@@ -263,10 +263,6 @@ impl GrpcSendingService {
         }
         tracing::info!("dropped grpc sending service");
     }
-
-    pub fn get_config(&self) -> OptionConfigWrapper {
-        self.config
-    }
 }
 
 #[async_trait]


### PR DESCRIPTION
This reverts commit 494cb67c4adac76dc3e806a1485cd48fe2d47e57.

## Description of changes
Revert PR 223.

When a party tries to do keygen just before preproc is done cannot happen. This is because in this chunk of the code:
https://github.com/zama-ai/kms/blob/main/core/service/src/engine/threshold/service/key_generator.rs#L472-L476
the delete method won't error, it will just return None if preproc does not exist. That is impossible if preproc started.
Then we call `handle_res_mapping` which will block for 60 seconds to wait for preproc to finish if it's not already done. This is a much longer time than the round timeout that we're using in PR 223. So if I understood correctly, it will error only if it
- the preproc is still not done after 60 seconds
- the preproc finished with an error or
- preproc never started.

In other words the artificial delay we introduced doesn't do anything useful.


## Issue ticket number and link
Closes https://github.com/zama-ai/kms-internal/issues/2802

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
