### PR TITLE
fix: use locked dependencies in Dockerfiles

### DIFF
--- a/core/service/Dockerfile
+++ b/core/service/Dockerfile
@@ -21,7 +21,7 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked \
-    cargo install --path . --bin kms-server
+    cargo install --locked --path . --bin kms-server
 
 # Runtime stage
 FROM debian:bookworm-slim

--- a/core/threshold/docker/local.dockerfile
+++ b/core/threshold/docker/local.dockerfile
@@ -12,7 +12,7 @@ COPY . .
 ARG FEATURES
 
 RUN mkdir -p /app/ddec/bin
-RUN cargo install --path core/threshold --root . --bins --no-default-features --features=${FEATURES}
+RUN cargo install --locked --path core/threshold --root . --bins --no-default-features --features=${FEATURES}
     # cargo install --path . --root . --bins --no-default-features --features=${FEATURES}
     # NOTE: if we're in a workspace then we need to set a different path
 

--- a/docker/core-client/Dockerfile
+++ b/docker/core-client/Dockerfile
@@ -16,9 +16,9 @@ COPY . .
 RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/${APP_CACHE_DIR}/target,sharing=locked \
     mkdir -p /app/kms-core-client/bin && \
-    cargo install --path core/service --root tools/service --bin kms-custodian && \
-    cargo install --path core-client --root core-client --bins && \
-    cargo install --path tools/kms-health-check --root tools/kms-health-check --bins
+    cargo install --locked --path core/service --root tools/service --bin kms-custodian && \
+    cargo install --locked --path core-client --root core-client --bins && \
+    cargo install --locked --path tools/kms-health-check --root tools/kms-health-check --bins
 
 
 ################################################################

--- a/docker/core/service/local.dockerfile
+++ b/docker/core/service/local.dockerfile
@@ -9,7 +9,7 @@ COPY . .
 
 # Install the binary leaving it in the WORKDIR/bin folder
 RUN mkdir -p /app/kms/bin
-RUN cargo install --path core/service --root . --bin kms-server -F insecure
+RUN cargo install --locked --path core/service --root . --bin kms-server -F insecure
 
 
 ################################################################


### PR DESCRIPTION
## Description of changes
This PR locks the dependencies when installing them in the Docker files by passing `--locked` to `cargo install`.
This ensures the `Cargo.lock` is used and no indirect dependencies get updated (potentially causing [compilation](https://github.com/zama-ai/kms/actions/runs/18825852767/job/53782758252) or security issues).

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
