### PR TITLE
chore: use release tag as version for npm release in workflow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -59,7 +59,7 @@ jobs:
           rm -rf pkg
           wasm-pack build --target nodejs . --no-default-features
           sed -i 's/"kms"/"node-tkms"/g' pkg/package.json
-          sed -i 's/\"version\": \".*\"/\"version\": \"${TAG_NAME}\"/' pkg/package.json
+          sed -i "s/\"version\": *\"[^\"]*\"/\"version\": \"${TAG_NAME}\"/" pkg/package.json
           echo "# node-tkms" > pkg/README.md
 
       - name: NPM publish Node package
@@ -80,7 +80,7 @@ jobs:
           rm -rf pkg
           wasm-pack build --target web . --no-default-features
           sed -i 's/"kms"/"tkms"/g' pkg/package.json
-          sed -i 's/\"version\": \".*\"/\"version\": \"${TAG_NAME}\"/' pkg/package.json
+          sed -i "s/\"version\": *\"[^\"]*\"/\"version\": \"${TAG_NAME}\"/" pkg/package.json
           echo "# tkms" > pkg/README.md
 
       - name: NPM publish web package


### PR DESCRIPTION
## Description of changes
This PR uses the `tag_name` of the release as version information when making a npm release.
Previously we would use the value from `Cargo.toml` but that might not always match, so we want to use what we provide during the release process.
This should be identical to the behavior of the docker release: https://github.com/zama-ai/ci-templates/blob/main/.github/workflows/common-docker.yml#L96-L100.


## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

