### PR TITLE
feat: enable regenerating CA certs from existing signing keys

### DIFF
--- a/core/service/src/util/key_setup/mod.rs
+++ b/core/service/src/util/key_setup/mod.rs
@@ -779,6 +779,7 @@ async fn ensure_ca_cert_exists<PubS: StorageForBytes>(
     let (ca_cert_ki, ca_cert) = threshold_fhe::tls_certs::create_ca_cert_from_signing_key(
         subject.as_str(),
         tls_wildcard,
+        #[allow(deprecated)]
         sk.sk(),
     )?;
 


### PR DESCRIPTION
## Description of changes
`kms-gen-keys` generates CA certificates based on the party signing keys but sometimes we need to regenerate these certificates, for example, if we want certificates with a different subject but the same public key. This PR makes `kms-gen-keys` regenerate CA certificates from the existing party signing keys if they're not already present in the public storage.

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
