### PR TITLE
fix: use deserialize_safe in js-api

### DIFF
--- a/core/service/src/client/js_api.rs
+++ b/core/service/src/client/js_api.rs
@@ -80,7 +80,6 @@ use crate::cryptography::encryption::{
 use crate::cryptography::hybrid_ml_kem;
 use crate::cryptography::signatures::{PrivateSigKey, PublicSigKey};
 use aes_prng::AesRng;
-use bc2wrap::{deserialize_safe, serialize};
 use kms_grpc::kms::v1::FheParameter;
 use kms_grpc::kms::v1::UserDecryptionResponse;
 use kms_grpc::kms::v1::{Eip712DomainMsg, TypedPlaintext, UserDecryptionResponsePayload};
@@ -126,12 +125,12 @@ pub fn u8vec_to_public_sig_key(v: &[u8]) -> Result<PublicSigKey, JsError> {
 
 #[wasm_bindgen]
 pub fn private_sig_key_to_u8vec(sk: &PrivateSigKey) -> Result<Vec<u8>, JsError> {
-    serialize(sk).map_err(|e| JsError::new(&e.to_string()))
+    bc2wrap::serialize(sk).map_err(|e| JsError::new(&e.to_string()))
 }
 
 #[wasm_bindgen]
 pub fn u8vec_to_private_sig_key(v: &[u8]) -> Result<PrivateSigKey, JsError> {
-    deserialize_safe(v).map_err(|e| JsError::new(&e.to_string()))
+    bc2wrap::deserialize_safe(v).map_err(|e| JsError::new(&e.to_string()))
 }
 
 // We cannot use a hashmap so use this struct as an alternative
@@ -351,7 +350,7 @@ pub fn ml_kem_pke_pk_to_u8vec(pk: &PublicEncKeyMlKem512) -> Result<Vec<u8>, JsEr
 
 #[wasm_bindgen]
 pub fn ml_kem_pke_sk_to_u8vec(sk: &PrivateEncKeyMlKem512) -> Result<Vec<u8>, JsError> {
-    serialize(&sk.0).map_err(|e| JsError::new(&e.to_string()))
+    bc2wrap::serialize(&sk.0).map_err(|e| JsError::new(&e.to_string()))
 }
 
 #[wasm_bindgen]
@@ -366,7 +365,7 @@ pub fn u8vec_to_ml_kem_pke_pk(v: &[u8]) -> Result<PublicEncKeyMlKem512, JsError>
 
 #[wasm_bindgen]
 pub fn u8vec_to_ml_kem_pke_sk(v: &[u8]) -> Result<PrivateEncKeyMlKem512, JsError> {
-    deserialize_safe::<PrivateEncKey<ml_kem::MlKem512>>(v)
+    bc2wrap::deserialize_safe::<PrivateEncKey<ml_kem::MlKem512>>(v)
         .map(PrivateEncKeyMlKem512)
         .map_err(|e| JsError::new(&e.to_string()))
 }
@@ -376,8 +375,10 @@ pub fn u8vec_to_ml_kem_pke_sk(v: &[u8]) -> Result<PrivateEncKeyMlKem512, JsError
 #[wasm_bindgen]
 pub fn ml_kem_pke_encrypt(msg: &[u8], their_pk: &PublicEncKeyMlKem512) -> Vec<u8> {
     let mut rng = AesRng::from_entropy();
-    serialize(&hybrid_ml_kem::enc::<ml_kem::MlKem512, _>(&mut rng, msg, &their_pk.0 .0).unwrap())
-        .unwrap()
+    bc2wrap::serialize(
+        &hybrid_ml_kem::enc::<ml_kem::MlKem512, _>(&mut rng, msg, &their_pk.0 .0).unwrap(),
+    )
+    .unwrap()
 }
 
 /// This function is *not* used by relayer-sdk because the decryption
@@ -385,7 +386,7 @@ pub fn ml_kem_pke_encrypt(msg: &[u8], their_pk: &PublicEncKeyMlKem512) -> Vec<u8
 /// It's just here for completeness and tests.
 #[wasm_bindgen]
 pub fn ml_kem_pke_decrypt(ct: &[u8], my_sk: &PrivateEncKeyMlKem512) -> Vec<u8> {
-    let ct: hybrid_ml_kem::HybridKemCt = deserialize_safe(ct).unwrap();
+    let ct: hybrid_ml_kem::HybridKemCt = bc2wrap::deserialize_safe(ct).unwrap();
     hybrid_ml_kem::dec::<ml_kem::MlKem512>(ct, &my_sk.0 .0).unwrap()
 }
 
@@ -404,7 +405,7 @@ fn resp_to_js(agg_resp: Vec<UserDecryptionResponse>) -> JsValue {
         let r = UserDecryptionResponseHex {
             signature: hex::encode(&resp.external_signature),
             payload: match resp.payload {
-                Some(inner) => Some(hex::encode(serialize(&inner).unwrap())),
+                Some(inner) => Some(hex::encode(bc2wrap::serialize(&inner).unwrap())),
                 None => None,
             },
             extra_data: Some(hex::encode(&resp.extra_data)),
@@ -433,7 +434,9 @@ fn js_to_resp(json: JsValue) -> anyhow::Result<Vec<UserDecryptionResponse>> {
             payload: match hex_resp.payload {
                 Some(inner) => {
                     let buf = hex::decode(&inner)?;
-                    Some(deserialize_safe::<UserDecryptionResponsePayload>(&buf)?)
+                    Some(bc2wrap::deserialize_safe::<UserDecryptionResponsePayload>(
+                        &buf,
+                    )?)
                 }
                 None => None,
             },


### PR DESCRIPTION
## Description of changes
fixes an oversight in the js-api to fix failing wasm build.

## Issue ticket number and link
<!-- Add a reference to the issue fixed if available -->

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

