### PR TITLE
chore: bump npm-publish action to 4.1.1

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -63,7 +63,7 @@ jobs:
           echo "# node-tkms" > pkg/README.md
 
       - name: NPM publish Node package
-        uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
+        uses: JS-DevTools/npm-publish@7f8fe47b3bea1be0c3aec2b717c5ec1f3e03410b # v4.1.1
         with:
           package: ./core/service/pkg/package.json
           dry-run: false
@@ -80,7 +80,7 @@ jobs:
           echo "# tkms" > pkg/README.md
 
       - name: NPM publish web package
-        uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
+        uses: JS-DevTools/npm-publish@7f8fe47b3bea1be0c3aec2b717c5ec1f3e03410b # v4.1.1
         with:
           package: ./core/service/pkg/package.json
           dry-run: false

--- a/.github/workflows/wasm-testing.yml
+++ b/.github/workflows/wasm-testing.yml
@@ -107,7 +107,7 @@ jobs:
           echo "# node-tkms" > pkg/README.md
 
       - name: NPM publish Node package
-        uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
+        uses: JS-DevTools/npm-publish@7f8fe47b3bea1be0c3aec2b717c5ec1f3e03410b # v4.1.1
         with:
           package: ./core/service/pkg/package.json
           dry-run: true
@@ -124,7 +124,7 @@ jobs:
           echo "# tkms" > pkg/README.md
 
       - name: NPM publish web package
-        uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
+        uses: JS-DevTools/npm-publish@7f8fe47b3bea1be0c3aec2b717c5ec1f3e03410b # v4.1.1
         with:
           package: ./core/service/pkg/package.json
           dry-run: true


### PR DESCRIPTION
## Description of changes
bumps npm-release action to 4.1.1 to allow optional token
