### PR TITLE
fix: respect attest_private_vault_root_key in cert resolver

### DIFF
--- a/core/service/src/bin/kms-server.rs
+++ b/core/service/src/bin/kms-server.rs
@@ -272,12 +272,19 @@ async fn build_tls_config(
                 }
             };
 
+            let attest_private_vault_root_key_flag =
+                attest_private_vault_root_key.is_some_and(|m| m);
+
             let cert_resolver = Arc::new(CertResolver::AutoRefresh(
                 AutoRefreshCertResolver::new(
                     sk,
                     ca_cert,
                     security_module.clone(),
-                    private_vault_root_key_measurements,
+                    if attest_private_vault_root_key_flag {
+                        private_vault_root_key_measurements
+                    } else {
+                        None
+                    },
                     renew_slack_after_expiration.unwrap_or(5),
                     renew_fail_retry_timeout.unwrap_or(60),
                 )
@@ -289,7 +296,7 @@ async fn build_tls_config(
                 Some(trusted_releases.iter().cloned().collect()),
                 eif_signing_cert.is_some(),
                 ignore_aws_ca_chain.is_some_and(|m| m),
-                attest_private_vault_root_key.is_some_and(|m| m),
+                attest_private_vault_root_key_flag,
             )
         }
     };

--- a/core/service/src/cryptography/attestation/mod.rs
+++ b/core/service/src/cryptography/attestation/mod.rs
@@ -292,7 +292,12 @@ impl AutoRefreshCertResolver {
             security_module.clone(),
             private_vault_root_key_measurements.clone(),
         )
-        .await?;
+        .await
+        .map_err(|e| anyhow::anyhow!("Could not issue initial TLS certificate: {e}"))?;
+        tracing::info!(
+            "Issued initial TLS certificate valid for {} s",
+            expiration.as_secs()
+        );
         let certified_key_with_expiration = Arc::new(RwLock::new((certified_key, expiration)));
         let resolver = Self {
             certified_key_with_expiration: certified_key_with_expiration.clone(),
@@ -336,7 +341,7 @@ impl AutoRefreshCertResolver {
                 {
                     Ok((certified_key, expiration)) => {
                         tracing::info!(
-                            "Issued new TLS certificate valid for {} s",
+                            "Issued renewed TLS certificate valid for {} s",
                             expiration.as_secs()
                         );
 


### PR DESCRIPTION
## Description of changes
The autorefreshing certificate resolver added in https://github.com/zama-ai/kms/pull/326 doesn't respect the key policy attestation feature flag. While that feature isn't yet stable, we should be able to switch it off entirely, not only on the verifier side but also on certificate generation side, which is what this PR does.


## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
