### PR TITLE
chore: update switch and squash benchmark to test more bit lengths

### DIFF
--- a/core/threshold/benches/bench_switch_and_squash.rs
+++ b/core/threshold/benches/bench_switch_and_squash.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use tfhe::{set_server_key, FheUint16, FheUint8};
+use tfhe::{set_server_key, FheUint16, FheUint2, FheUint32, FheUint64, FheUint8};
 use threshold_fhe::execution::{
     random::get_rng,
     tfhe_internals::{
@@ -17,14 +17,8 @@ fn bench_switch_and_squash(c: &mut Criterion) {
 
     let params: DKGParams = BC_PARAMS_SNS;
     let keyset = gen_key_set(params, tfhe::Tag::default(), &mut get_rng());
-
-    let msg8 = 5_u8;
-    let msg16 = 5_u16;
-
     set_server_key(keyset.public_keys.server_key.clone());
 
-    let ct8: FheUint8 = expanded_encrypt(&keyset.public_keys.public_key, msg8, 8).unwrap();
-    let ct16: FheUint16 = expanded_encrypt(&keyset.public_keys.public_key, msg16, 16).unwrap();
     let public_key = bc2wrap::serialize(&(keyset.public_keys.public_key)).unwrap();
     let server_key = bc2wrap::serialize(&(keyset.public_keys.server_key)).unwrap();
     let conversion_key =
@@ -39,8 +33,30 @@ fn bench_switch_and_squash(c: &mut Criterion) {
         conversion_key.len() / 1024
     );
 
-    // benchmark s&s for a single ct block
-    group.bench_function(BenchmarkId::new("s+s", "single_block"), |b| {
+    // generate ciphertexts to be used in benchmarks
+    let msg8 = 5_u8;
+    let msg16 = 5_u16;
+    let msg32 = 5_u32;
+    let msg64 = 5_u64;
+
+    let ct2: FheUint2 = expanded_encrypt(&keyset.public_keys.public_key, msg8, 2).unwrap();
+    let ct8: FheUint8 = expanded_encrypt(&keyset.public_keys.public_key, msg8, 8).unwrap();
+    let ct16: FheUint16 = expanded_encrypt(&keyset.public_keys.public_key, msg16, 16).unwrap();
+    let ct32: FheUint32 = expanded_encrypt(&keyset.public_keys.public_key, msg32, 32).unwrap();
+    let ct64: FheUint64 = expanded_encrypt(&keyset.public_keys.public_key, msg64, 64).unwrap();
+
+    // benchmark s&s for the blocks that make up a u2
+    group.bench_function(BenchmarkId::new("s&s", "u2"), |b| {
+        b.iter(|| {
+            let (raw_ct, _id, _tag, _rerand_metadata) = ct2.clone().into_raw_parts();
+            let server_key = keyset.public_keys.server_key.as_ref();
+            let sns_key = keyset.public_keys.server_key.noise_squashing_key().unwrap();
+            let _ = black_box(sns_key.squash_radix_ciphertext_noise(server_key, &raw_ct));
+        });
+    });
+
+    // benchmark s&s for the blocks that make up a u8
+    group.bench_function(BenchmarkId::new("s&s", "u8"), |b| {
         b.iter(|| {
             let (raw_ct, _id, _tag, _rerand_metadata) = ct8.clone().into_raw_parts();
             let server_key = keyset.public_keys.server_key.as_ref();
@@ -49,20 +65,30 @@ fn bench_switch_and_squash(c: &mut Criterion) {
         });
     });
 
-    // benchmark s&s for the blocks that make up a u8 sequentially
-    group.bench_function(BenchmarkId::new("s+s", "u8_sequential"), |b| {
-        b.iter(|| {
-            let (raw_ct, _id, _tag, _rerand_metadata) = ct8.clone().into_raw_parts();
-            let server_key = keyset.public_keys.server_key.as_ref();
-            let sns_key = keyset.public_keys.server_key.noise_squashing_key().unwrap();
-            let _ = black_box(sns_key.squash_radix_ciphertext_noise(server_key, &raw_ct));
-        });
-    });
-
-    // benchmark s&s for the blocks that make up a u16 sequentially
-    group.bench_function(BenchmarkId::new("s+s", "u16_sequential"), |b| {
+    // benchmark s&s for the blocks that make up a u16
+    group.bench_function(BenchmarkId::new("s&s", "u16"), |b| {
         b.iter(|| {
             let (raw_ct, _id, _tag, _rerand_metadata) = ct16.clone().into_raw_parts();
+            let server_key = keyset.public_keys.server_key.as_ref();
+            let sns_key = keyset.public_keys.server_key.noise_squashing_key().unwrap();
+            let _ = black_box(sns_key.squash_radix_ciphertext_noise(server_key, &raw_ct));
+        });
+    });
+
+    // benchmark s&s for the blocks that make up a u32
+    group.bench_function(BenchmarkId::new("s&s", "u32"), |b| {
+        b.iter(|| {
+            let (raw_ct, _id, _tag, _rerand_metadata) = ct32.clone().into_raw_parts();
+            let server_key = keyset.public_keys.server_key.as_ref();
+            let sns_key = keyset.public_keys.server_key.noise_squashing_key().unwrap();
+            let _ = black_box(sns_key.squash_radix_ciphertext_noise(server_key, &raw_ct));
+        });
+    });
+
+    // benchmark s&s for the blocks that make up a u64
+    group.bench_function(BenchmarkId::new("s&s", "u64"), |b| {
+        b.iter(|| {
+            let (raw_ct, _id, _tag, _rerand_metadata) = ct64.clone().into_raw_parts();
             let server_key = keyset.public_keys.server_key.as_ref();
             let sns_key = keyset.public_keys.server_key.noise_squashing_key().unwrap();
             let _ = black_box(sns_key.squash_radix_ciphertext_noise(server_key, &raw_ct));


### PR DESCRIPTION
## Description of changes
Minor updates to the slightly outdated switch&squash benchmarks to cover more bit lengths.

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.


