### PR TITLE
fix: remove duplicate metrics

### DIFF
--- a/observability/src/metrics.rs
+++ b/observability/src/metrics.rs
@@ -33,10 +33,10 @@ pub struct TaggedMetric<T> {
 }
 
 impl<T> TaggedMetric<T> {
-    fn new(metric: T, name: &'static str) -> Self {
+    fn new(metric: T) -> Self {
         Self {
             metric,
-            default_tags: vec![MetricTag::new("name", name)],
+            default_tags: vec![],
         }
     }
 
@@ -280,33 +280,24 @@ impl CoreMetrics {
         gauge.record(0, &[]);
 
         Self {
-            request_counter: TaggedMetric::new(request_counter, "operations"),
-            error_counter: TaggedMetric::new(error_counter, "errors"),
-            network_rx_counter: TaggedMetric::new(network_rx_counter, "network_rx"),
-            network_tx_counter: TaggedMetric::new(network_tx_counter, "network_tx"),
-            duration_histogram: TaggedMetric::new(duration_histogram, "duration"),
-            size_histogram: TaggedMetric::new(size_histogram, "size"),
-            cpu_load_gauge: TaggedMetric::new(cpu_gauge, "cpu_load"),
-            memory_usage_gauge: TaggedMetric::new(memory_gauge, "memory_usage"),
-            file_descriptor_gauge: TaggedMetric::new(file_descriptor_gauge, "file_descriptors"),
-            socat_file_descriptor_gauge: TaggedMetric::new(
-                socat_file_descriptor_gauge,
-                "socat_file_descriptors",
-            ),
-            socat_task_gauge: TaggedMetric::new(socat_task_gauge, "socat_tasks"),
-            task_gauge: TaggedMetric::new(task_gauge, "tasks"),
-            rate_limiter_gauge: TaggedMetric::new(rate_limiter_gauge, "rate_limit_usage"),
-            active_session_gauge: TaggedMetric::new(active_session_gauge, "active_sessions"),
-            inactive_session_gauge: TaggedMetric::new(inactive_session_gauge, "inactive_sessions"),
-            meta_storage_pub_dec_gauge: TaggedMetric::new(
-                meta_storage_pub_dec_gauge,
-                "public_decryptions",
-            ),
-            meta_storage_user_dec_gauge: TaggedMetric::new(
-                meta_storage_user_dec_gauge,
-                "user_decryptions",
-            ),
-            gauge: TaggedMetric::new(gauge, "active_operations"),
+            request_counter: TaggedMetric::new(request_counter),
+            error_counter: TaggedMetric::new(error_counter),
+            network_rx_counter: TaggedMetric::new(network_rx_counter),
+            network_tx_counter: TaggedMetric::new(network_tx_counter),
+            duration_histogram: TaggedMetric::new(duration_histogram),
+            size_histogram: TaggedMetric::new(size_histogram),
+            cpu_load_gauge: TaggedMetric::new(cpu_gauge),
+            memory_usage_gauge: TaggedMetric::new(memory_gauge),
+            file_descriptor_gauge: TaggedMetric::new(file_descriptor_gauge),
+            socat_file_descriptor_gauge: TaggedMetric::new(socat_file_descriptor_gauge),
+            socat_task_gauge: TaggedMetric::new(socat_task_gauge),
+            task_gauge: TaggedMetric::new(task_gauge),
+            rate_limiter_gauge: TaggedMetric::new(rate_limiter_gauge),
+            active_session_gauge: TaggedMetric::new(active_session_gauge),
+            inactive_session_gauge: TaggedMetric::new(inactive_session_gauge),
+            meta_storage_pub_dec_gauge: TaggedMetric::new(meta_storage_pub_dec_gauge),
+            meta_storage_user_dec_gauge: TaggedMetric::new(meta_storage_user_dec_gauge),
+            gauge: TaggedMetric::new(gauge),
             trace_guard: Arc::new(Mutex::new(None)),
         }
     }


### PR DESCRIPTION
## Description of changes
This PR fixes the issue that metrics were exported twice, by removing the unnecessary default `name` tag from the metrics.

Validated locally that things work as expected.

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

