### PR TITLE
chore: fix non_local_effect_before_error_return dylint

### DIFF
--- a/core/threshold/src/execution/tfhe_internals/randomness.rs
+++ b/core/threshold/src/execution/tfhe_internals/randomness.rs
@@ -228,6 +228,10 @@ impl<Z: BaseRing, Gen: ParallelByteRandomGenerator, const EXTENSION_DEGREE: usiz
         }
     }
 
+    // We allow the following lints because we are fine with mutating the rng
+    // since we only care about the protocol state and reproducibility when it executes correctly.
+    #[allow(unknown_lints)]
+    #[allow(non_local_effect_before_error_return)]
     pub fn fork_bsk_to_ggsw(
         &mut self,
         lwe_dimension: LweDimension,
@@ -249,6 +253,10 @@ impl<Z: BaseRing, Gen: ParallelByteRandomGenerator, const EXTENSION_DEGREE: usiz
         Ok(map_to_encryption_generator(mask_iter, noise_iter))
     }
 
+    // We allow the following lints because we are fine with mutating the rng
+    // since we only care about the protocol state and reproducibility when it executes correctly.
+    #[allow(unknown_lints)]
+    #[allow(non_local_effect_before_error_return)]
     pub fn fork_lwe_list_to_lwe(
         &mut self,
         lwe_count: LweCiphertextCount,
@@ -262,6 +270,10 @@ impl<Z: BaseRing, Gen: ParallelByteRandomGenerator, const EXTENSION_DEGREE: usiz
         Ok(map_to_encryption_generator(mask_iter, noise_iter))
     }
 
+    // We allow the following lints because we are fine with mutating the rng
+    // since we only care about the protocol state and reproducibility when it executes correctly.
+    #[allow(unknown_lints)]
+    #[allow(non_local_effect_before_error_return)]
     pub fn fork_ggsw_level_to_glwe(
         &mut self,
         glwe_size: GlweSize,
@@ -278,6 +290,10 @@ impl<Z: BaseRing, Gen: ParallelByteRandomGenerator, const EXTENSION_DEGREE: usiz
         Ok(map_to_encryption_generator(mask_iter, noise_iter))
     }
 
+    // We allow the following lints because we are fine with mutating the rng
+    // since we only care about the protocol state and reproducibility when it executes correctly.
+    #[allow(unknown_lints)]
+    #[allow(non_local_effect_before_error_return)]
     pub fn fork_ggsw_to_ggsw_levels(
         &mut self,
         level: DecompositionLevelCount,


### PR DESCRIPTION
## Description of changes
It seems dylint got better and found some more `non_local_effect_before_error_return` issues. But they're all related to randomness so it's not a problem for us

## Issue ticket number and link
<!-- Add a reference to the issue fixed if available -->

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
