### PR TITLE
chore: v0.13.0-rc.2 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "backward-compatibility"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 dependencies = [
  "bincode 1.3.3",
  "ron 0.10.1",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "cc-tests-utils"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 
 [[package]]
 name = "cexpr"
@@ -3354,7 +3354,7 @@ checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
 
 [[package]]
 name = "generate-test-material"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "kms"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "kms-core-client"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 dependencies = [
  "aes-prng",
  "alloy-primitives",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "kms-grpc"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "kms-health-check"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -7427,7 +7427,7 @@ dependencies = [
 
 [[package]]
 name = "tests-utils"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7602,7 +7602,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-fhe"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 dependencies = [
  "aes",
  "aes-prng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ authors = ["Zama"]
 publish = true
 edition = "2021"
 license = "BSD-3-Clause-Clear"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 repository = "https://github.com/zama-ai/kms"
 description = "Key Management System for the Zama Protocol."
 

--- a/backward-compatibility/Cargo.toml
+++ b/backward-compatibility/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backward-compatibility"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.2"
 publish = false
 authors = ["Zama"]
 edition = "2021"


### PR DESCRIPTION
## Description of changes
Bumps the KMS version to `v0.13.0-rc.2` for the next pre-release.

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

