### PR TITLE
fix: deadlock

### DIFF
--- a/core/threshold/src/networking/grpc.rs
+++ b/core/threshold/src/networking/grpc.rs
@@ -411,6 +411,8 @@ impl GrpcNetworkingManager {
             NetworkMode::Sync => self.conf.get_network_timeout(),
         };
 
+        let connection_channel = self.sending_service.add_connections(&others).await?;
+
         let session = match self.session_store.entry(session_id) {
             // Turn an inactive session into an active one
             dashmap::Entry::Occupied(mut status) => {
@@ -431,8 +433,6 @@ impl GrpcNetworkingManager {
                         owner
                     ));
                 };
-
-                let connection_channel = self.sending_service.add_connections(&others).await?;
 
                 let session = Arc::new(NetworkSession {
                     owner: owner.clone(),
@@ -455,8 +455,6 @@ impl GrpcNetworkingManager {
                 session
             }
             dashmap::Entry::Vacant(vacant) => {
-                let connection_channel = self.sending_service.add_connections(&others).await?;
-
                 let message_queue = MessageQueueStore::new_initialized(
                     self.conf.get_message_limit(),
                     &others,


### PR DESCRIPTION
## Description of changes
<!-- Please explain the changes you made -->
Fix a deadlock

The `session_store` is a `DashMap` and calling `entry()` on it basically holds a write lock on a `sync::RwLock` , it is thus blocking.
The issue is that whilst holding that lock I do an `async` call to `add_connections` which can lead to the tokio task holding the lock to go to sleep. If that happens, and another tokio task wakes up and tries to take the write lock to entry it'll block. If all my tokio threads are stuck on tasks trying to acquire entry lock that's game over as the task which holds the lock will never make progress again.

Fixed by moving the async task before locking the lock.

## Issue ticket number and link
<!-- Add a reference to the issue fixed if available -->

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new pub item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
