### PR TITLE
fix: backward compatible context ID to support v0.12.7

### DIFF
--- a/core/service/src/consts.rs
+++ b/core/service/src/consts.rs
@@ -167,3 +167,20 @@ lazy_static::lazy_static! {
 lazy_static::lazy_static! {
     pub static ref MOCK_NITRO_SIGNING_KEY_BYTES: Vec<u8> = include_bytes!("../certs/mock_nitro_signing_key.der").into();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_session_id_from_context() {
+        let sid = DEFAULT_MPC_CONTEXT.derive_session_id().unwrap();
+        assert_eq!(
+            threshold_fhe::session_id::SessionId::from(
+                threshold_fhe::tls_certs::DEFAULT_SESSION_ID_FROM_CONTEXT
+            ),
+            sid,
+            "DEFAULT_SESSION_ID_FROM_CONTEXT must match DEFAULT_MPC_CONTEXT.derive_session_id()"
+        );
+    }
+}

--- a/core/service/src/cryptography/attestation/mod.rs
+++ b/core/service/src/cryptography/attestation/mod.rs
@@ -10,7 +10,8 @@ use nsm_nitro_enclave_utils::{driver::dev::DevNitro, pcr::Pcrs};
 use rcgen::{BasicConstraints, PKCS_ECDSA_P384_SHA384};
 use rcgen::{
     CertificateParams, CustomExtension, DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa,
-    KeyPair, KeyUsagePurpose, PublicKeyData, PKCS_ECDSA_P256K1_SHA256, PKCS_ECDSA_P256_SHA256,
+    KeyPair, KeyUsagePurpose, PublicKeyData, SerialNumber, PKCS_ECDSA_P256K1_SHA256,
+    PKCS_ECDSA_P256_SHA256,
 };
 use std::{sync::Arc, time::Duration};
 use threshold_fhe::networking::tls::extract_subject_from_cert;
@@ -113,6 +114,9 @@ pub trait SecurityModule {
         let mut distinguished_name = DistinguishedName::new();
         distinguished_name.push(DnType::CommonName, subject);
         tls_cp.distinguished_name = distinguished_name;
+        tls_cp.serial_number = Some(SerialNumber::from_slice(
+            &threshold_fhe::tls_certs::DEFAULT_SESSION_ID_FROM_CONTEXT.to_be_bytes(),
+        ));
 
         // Key usages
         tls_cp.key_usages = vec![

--- a/core/threshold/src/networking/health_check.rs
+++ b/core/threshold/src/networking/health_check.rs
@@ -7,7 +7,8 @@ use tonic::{service::interceptor::InterceptedService, transport::Channel, Status
 use crate::{
     error::error_handler::anyhow_error_and_log,
     execution::runtime::party::{Identity, RoleTrait},
-    networking::grpc::HealthTag,
+    networking::grpc::HealthTagWithContextId,
+    session_id::SessionId,
 };
 
 pub struct HealthCheckSession<R: RoleTrait> {
@@ -60,8 +61,9 @@ impl<R: RoleTrait> HealthCheckSession<R> {
     }
 
     pub async fn run_healthcheck(&self) -> anyhow::Result<HealthCheckResult<R>> {
-        let tag = HealthTag {
+        let tag = HealthTagWithContextId {
             sender: self.owner.mpc_identity(),
+            context_id: SessionId::from(crate::tls_certs::DEFAULT_SESSION_ID_FROM_CONTEXT),
         };
 
         let tag_serialized = bc2wrap::serialize(&tag)

--- a/core/threshold/src/networking/sending_service.rs
+++ b/core/threshold/src/networking/sending_service.rs
@@ -32,7 +32,7 @@ use crate::{execution::runtime::party::RoleAssignment, session_id::SessionId};
 
 #[cfg(feature = "choreographer")]
 use super::grpc::NETWORK_RECEIVED_MEASUREMENT;
-use super::grpc::{MessageQueueStore, OptionConfigWrapper, Tag};
+use super::grpc::{MessageQueueStore, OptionConfigWrapper, TagWithContextId};
 use super::{NetworkMode, Networking};
 use crate::thread_handles::ThreadHandleGroup;
 
@@ -424,9 +424,10 @@ impl<R: RoleTrait> Networking<R> for NetworkSession {
         // This may cause an error if someone tries to increase the round counter at the same time
         // however, this would imply incorrect use of the networking API and thus we want to fail fast.
         let round_counter = *self.round_counter.read().await;
-        let tagged_value = Tag {
+        let tagged_value = TagWithContextId {
             session_id: self.session_id,
             sender: self.owner.mpc_identity(),
+            context_id: SessionId::from(crate::tls_certs::DEFAULT_SESSION_ID_FROM_CONTEXT),
             round_counter,
         };
 

--- a/core/threshold/src/tls_certs.rs
+++ b/core/threshold/src/tls_certs.rs
@@ -1,3 +1,9 @@
+/// The default session ID derived from DEFAULT_MPC_CONTEXT.
+/// This equals `DEFAULT_MPC_CONTEXT.derive_session_id()` and is used for
+/// backward compatibility with v0.12.7, which embeds context_id in tags
+/// and TLS certificate serial numbers.
+pub const DEFAULT_SESSION_ID_FROM_CONTEXT: u128 = 75144625629816062620302474174838463545;
+
 use anyhow::anyhow;
 use clap::Parser;
 use k256::{ecdsa::SigningKey, pkcs8::EncodePrivateKey};


### PR DESCRIPTION
## Description of changes
In v0.12.7, the wire format contains a context_id in the tag for p2p communication and the ephemeral certificate contains the serial number field. But on 0.13.0 these are removed so running 0.12.7 and 0.13.0 does not work. This is a hotfix for 0.13.0 that always sends the default context_id in the tag, and the default context_id as the serial number. This change should be reverted later when all nodes are running 0.13.x.

## Issue ticket number and link
n/a

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new pub item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
