### PR TITLE
fix: backward compatibility of NetworkValue

### DIFF
--- a/core/threshold/src/networking/value.rs
+++ b/core/threshold/src/networking/value.rs
@@ -100,7 +100,11 @@ pub enum AgreeRandomValue {
     KeyValue(Vec<PrfKey>),
 }
 
-/// a value that is sent via network
+/// A value that is sent via network.
+///
+/// IMPORTANT: when adding new variants, they must be added to the *end*
+/// of the enum for bincode to behave in a backward compatible way.
+/// Otherwise we will have issues when performing a rolling upgrade.
 #[derive(Serialize, Deserialize, Clone)]
 pub enum NetworkValue<Z: Eq + Zero> {
     #[cfg(any(test, feature = "testing"))]
@@ -113,8 +117,6 @@ pub enum NetworkValue<Z: Eq + Zero> {
     DecompressionKey(Box<tfhe::integer::compression_keys::DecompressionKey>),
     #[cfg(any(test, feature = "testing"))]
     SnsCompressionKey(Box<tfhe::shortint::list_compression::NoiseSquashingCompressionKey>),
-    #[cfg(any(test, feature = "testing"))]
-    CompressedXofKeySet(Box<tfhe::xof_key_set::CompressedXofKeySet>),
     RingValue(Z),
     VecRingValue(Vec<Z>),
     VecPairRingValue(Vec<(Z, Z)>),
@@ -125,6 +127,8 @@ pub enum NetworkValue<Z: Eq + Zero> {
     Bot,
     Empty,
     Round1VSS(ExchangedDataRound1<Z>),
+    #[cfg(any(test, feature = "testing"))]
+    CompressedXofKeySet(Box<tfhe::xof_key_set::CompressedXofKeySet>),
 }
 
 impl<Z: Eq + Zero + std::fmt::Debug> std::fmt::Debug for NetworkValue<Z> {
@@ -155,11 +159,6 @@ impl<Z: Eq + Zero + std::fmt::Debug> std::fmt::Debug for NetworkValue<Z> {
                 .debug_tuple(self.network_type_name())
                 .field(&"...")
                 .finish(),
-            #[cfg(any(test, feature = "testing"))]
-            NetworkValue::CompressedXofKeySet(_) => f
-                .debug_tuple(self.network_type_name())
-                .field(&"...")
-                .finish(),
             NetworkValue::RingValue(v) => f.debug_tuple(self.network_type_name()).field(v).finish(),
             NetworkValue::VecRingValue(v) => {
                 f.debug_tuple(self.network_type_name()).field(v).finish()
@@ -176,6 +175,11 @@ impl<Z: Eq + Zero + std::fmt::Debug> std::fmt::Debug for NetworkValue<Z> {
             NetworkValue::Bot => f.write_str(self.network_type_name()),
             NetworkValue::Empty => f.write_str(self.network_type_name()),
             NetworkValue::Round1VSS(v) => f.debug_tuple(self.network_type_name()).field(v).finish(),
+            #[cfg(any(test, feature = "testing"))]
+            NetworkValue::CompressedXofKeySet(_) => f
+                .debug_tuple(self.network_type_name())
+                .field(&"...")
+                .finish(),
         }
     }
 }
@@ -226,8 +230,6 @@ impl<Z: Eq + Zero> NetworkValue<Z> {
             NetworkValue::DecompressionKey(_) => "DecompressionKey",
             #[cfg(any(test, feature = "testing"))]
             NetworkValue::SnsCompressionKey(_) => "SnsCompressionKey",
-            #[cfg(any(test, feature = "testing"))]
-            NetworkValue::CompressedXofKeySet(_) => "CompressedXofKeySet",
             NetworkValue::RingValue(_) => "RingValue",
             NetworkValue::VecRingValue(_) => "VecRingValue",
             NetworkValue::VecPairRingValue(_) => "VecPairRingValue",
@@ -238,6 +240,8 @@ impl<Z: Eq + Zero> NetworkValue<Z> {
             NetworkValue::Bot => "Bot",
             NetworkValue::Empty => "Empty",
             NetworkValue::Round1VSS(_) => "Round1VSS",
+            #[cfg(any(test, feature = "testing"))]
+            NetworkValue::CompressedXofKeySet(_) => "CompressedXofKeySet",
         }
     }
 }


### PR DESCRIPTION
## Description of changes
NetworkValue is not backward compatible since CompressedXofKeySet was not added to the end, this PR fixes that.

## Issue ticket number and link
Closes zama-ai/kms-internal#2898

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new pub item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
