### PR TITLE
chore: crs public storage validation

### DIFF
--- a/core/service/src/engine/centralized/central_kms.rs
+++ b/core/service/src/engine/centralized/central_kms.rs
@@ -19,7 +19,7 @@ use crate::engine::context_manager::CentralizedContextManager;
 use crate::engine::traits::{BackupOperator, ContextManager};
 use crate::engine::traits::{BaseKms, Kms};
 #[cfg(feature = "non-wasm")]
-use crate::engine::utils::sanity_check_public_materials;
+use crate::engine::utils::{sanity_check_crs_materials, sanity_check_public_materials};
 use crate::engine::validation::DSEP_USER_DECRYPTION;
 use crate::engine::Shutdown;
 use crate::grpc::metastore_status_service::CustodianMetaStore;
@@ -891,6 +891,9 @@ impl<
             .collect();
         let crs_info: HashMap<RequestId, CrsGenMetadata> =
             read_all_data_versioned(&private_storage, &PrivDataType::CrsInfo.to_string()).await?;
+
+        sanity_check_crs_materials(&public_storage, &crs_info).await?;
+
         let validation_material: HashMap<RequestId, RecoveryValidationMaterial> =
             read_all_data_versioned(&public_storage, &PubDataType::RecoveryMaterial.to_string())
                 .await?;

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -67,7 +67,7 @@ use crate::{
             threshold_kms::ThresholdKms,
         },
         traits::PrivateKeyMaterialMetadata,
-        utils::sanity_check_public_materials,
+        utils::{sanity_check_crs_materials, sanity_check_public_materials},
     },
     grpc::metastore_status_service::MetaStoreStatusServiceImpl,
     util::{meta_store::MetaStore, rate_limiter::RateLimiter},
@@ -402,6 +402,8 @@ where
     // load crs_info (roughly hashes of CRS) from storage
     let crs_info: HashMap<RequestId, CrsGenMetadata> =
         read_all_data_versioned(&private_storage, &PrivDataType::CrsInfo.to_string()).await?;
+
+    sanity_check_crs_materials(&public_storage, &crs_info).await?;
 
     let networking_manager = Arc::new(RwLock::new(GrpcNetworkingManager::new(
         tls_config

--- a/core/service/src/engine/utils.rs
+++ b/core/service/src/engine/utils.rs
@@ -1,4 +1,4 @@
-use crate::engine::base::{KeyGenMetadata, DSEP_PUBDATA_KEY};
+use crate::engine::base::{CrsGenMetadata, KeyGenMetadata, DSEP_PUBDATA_CRS, DSEP_PUBDATA_KEY};
 use crate::vault::storage::{read_versioned_at_request_id, StorageExt, StorageReader};
 use kms_grpc::kms::v1::KeyMaterialAvailabilityResponse;
 use kms_grpc::rpc_types::{KMSType, PrivDataType, PubDataType};
@@ -17,6 +17,7 @@ pub(crate) const ERR_SERVER_KEY_DIGEST_MISMATCH: &str = "Server key digest misma
 pub(crate) const ERR_PUBLIC_KEY_DIGEST_MISMATCH: &str = "Public key digest mismatch";
 pub(crate) const ERR_COMPRESSED_KEYSET_DIGEST_MISMATCH: &str =
     "Compressed xof keyset digest mismatch";
+pub(crate) const ERR_CRS_DIGEST_MISMATCH: &str = "CRS digest mismatch";
 
 /// Verify key digests using raw bytes from storage.
 /// This avoids re-serializing the keys, which would produce different bytes
@@ -50,6 +51,20 @@ pub(crate) fn verify_compressed_key_digest_from_bytes(
     let actual_digest = hash_element(&DSEP_PUBDATA_KEY, compressed_keyset_bytes);
     if actual_digest != expected_digest {
         anyhow::bail!(ERR_COMPRESSED_KEYSET_DIGEST_MISMATCH);
+    }
+    Ok(())
+}
+
+/// Verify CRS digest using raw bytes from storage.
+/// This avoids re-serializing the CRS, which would produce different bytes
+/// if there was a version upgrade since the original digest was computed.
+pub(crate) fn verify_crs_digest_from_bytes(
+    crs_bytes: &[u8],
+    expected_digest: &[u8],
+) -> anyhow::Result<()> {
+    let actual_digest = hash_element(&DSEP_PUBDATA_CRS, crs_bytes);
+    if actual_digest != expected_digest {
+        anyhow::bail!(ERR_CRS_DIGEST_MISMATCH);
     }
     Ok(())
 }
@@ -162,6 +177,43 @@ where
                 );
                 let pub_data_types: HashSet<PubDataType> = hash_map.keys().cloned().collect();
                 check_readability(public_storage, id, &pub_data_types).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Sanity check that CRS materials can be read from storage and verify their integrity.
+///
+/// For each entry, verifies that the CRS can be successfully retrieved from public storage.
+/// When `CrsGenMetadata::Current` metadata is available, also verifies the integrity of the
+/// loaded data by comparing digests. For `CrsGenMetadata::LegacyV0` entries (which lack digest
+/// information), only readability is checked.
+pub async fn sanity_check_crs_materials<S>(
+    public_storage: &S,
+    crs_entries: &HashMap<RequestId, CrsGenMetadata>,
+) -> anyhow::Result<()>
+where
+    S: StorageReader + Sync,
+{
+    for (id, metadata) in crs_entries {
+        match metadata {
+            CrsGenMetadata::Current(inner) => {
+                let crs_bytes = public_storage
+                    .load_bytes(id, &PubDataType::CRS.to_string())
+                    .await?;
+                verify_crs_digest_from_bytes(&crs_bytes, &inner.crs_digest)?;
+            }
+            CrsGenMetadata::LegacyV0(_) => {
+                tracing::info!(
+                    "Legacy CRS metadata for id={id}, performing readability check only (no digest verification)"
+                );
+                read_versioned_at_request_id::<_, tfhe::zk::CompactPkeCrs>(
+                    public_storage,
+                    id,
+                    &PubDataType::CRS.to_string(),
+                )
+                .await?;
             }
         }
     }
@@ -391,14 +443,18 @@ impl From<MetricedError> for Status {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cryptography::signatures::gen_sig_keys;
     use crate::engine::base::{safe_serialize_hash_element_versioned, KeyGenMetadataInner};
+    use crate::engine::centralized::central_kms::gen_centralized_crs;
     use crate::vault::storage::ram::RamStorage;
     use crate::vault::storage::store_versioned_at_request_id;
     use aes_prng::AesRng;
     use kms_grpc::rpc_types::PubDataType;
     use rand::SeedableRng;
     use std::collections::HashMap;
+    use tfhe::core_crypto::prelude::NormalizedHammingWeightBound;
     use tfhe::shortint::ClassicPBSParameters;
+    use tfhe::xof_key_set::CompressedXofKeySet;
 
     #[test]
     #[tracing_test::traced_test]
@@ -587,6 +643,77 @@ mod tests {
         assert!(logs_contain("readability check only"));
     }
 
+    #[tokio::test]
+    async fn sanity_check_crs_valid_digest() {
+        let mut rng = AesRng::seed_from_u64(70);
+        let crs_id = RequestId::new_random(&mut rng);
+        let mut storage = RamStorage::new();
+
+        let (_crs, digest) = setup_crs(&mut storage, &crs_id).await;
+
+        let metadata = CrsGenMetadata::Current(crate::engine::base::CrsGenMetadataInner {
+            crs_id,
+            crs_digest: digest,
+            max_num_bits: 64,
+            external_signature: vec![],
+        });
+
+        let entries = HashMap::from_iter([(crs_id, metadata)]);
+        sanity_check_crs_materials(&storage, &entries)
+            .await
+            .expect("valid CRS digest should pass");
+    }
+
+    #[tokio::test]
+    async fn sanity_check_crs_invalid_digest() {
+        let mut rng = AesRng::seed_from_u64(71);
+        let crs_id = RequestId::new_random(&mut rng);
+        let mut storage = RamStorage::new();
+
+        let (_crs, mut digest) = setup_crs(&mut storage, &crs_id).await;
+        // Corrupt the digest
+        digest[0] ^= 0xFF;
+
+        let metadata = CrsGenMetadata::Current(crate::engine::base::CrsGenMetadataInner {
+            crs_id,
+            crs_digest: digest,
+            max_num_bits: 64,
+            external_signature: vec![],
+        });
+
+        let entries = HashMap::from_iter([(crs_id, metadata)]);
+        let err = sanity_check_crs_materials(&storage, &entries)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains(ERR_CRS_DIGEST_MISMATCH),
+            "expected CRS digest mismatch, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn sanity_check_crs_legacy_readability_only() {
+        let mut rng = AesRng::seed_from_u64(72);
+        let crs_id = RequestId::new_random(&mut rng);
+        let mut storage = RamStorage::new();
+
+        // Set up CRS in storage (we won't use the digest — legacy has no digest info)
+        let _crs_and_digest = setup_crs(&mut storage, &crs_id).await;
+
+        use kms_grpc::rpc_types::SignedPubDataHandleInternal;
+        let legacy_handle = SignedPubDataHandleInternal::new(String::new(), vec![], vec![]);
+        let metadata = CrsGenMetadata::LegacyV0(legacy_handle);
+
+        let entries = HashMap::from_iter([(crs_id, metadata)]);
+        sanity_check_crs_materials(&storage, &entries)
+            .await
+            .expect("legacy CRS readability check should pass");
+
+        assert!(logs_contain("Legacy CRS metadata"));
+        assert!(logs_contain("readability check only"));
+    }
+
     async fn setup_standard_keys(
         storage: &mut RamStorage,
         key_id: &RequestId,
@@ -639,9 +766,6 @@ mod tests {
         storage: &mut RamStorage,
         key_id: &RequestId,
     ) -> HashMap<PubDataType, Vec<u8>> {
-        use tfhe::core_crypto::prelude::NormalizedHammingWeightBound;
-        use tfhe::xof_key_set::CompressedXofKeySet;
-
         let params = crate::consts::TEST_PARAM;
         let config = params.to_tfhe_config();
         let max_norm_hwt = params
@@ -677,5 +801,31 @@ mod tests {
         .unwrap();
 
         HashMap::from_iter([(PubDataType::CompressedXofKeySet, digest)])
+    }
+
+    async fn setup_crs(
+        storage: &mut RamStorage,
+        crs_id: &RequestId,
+    ) -> (tfhe::zk::CompactPkeCrs, Vec<u8>) {
+        let mut rng = AesRng::seed_from_u64(42);
+        let (_pk, sk) = gen_sig_keys(&mut rng);
+        let params = crate::consts::TEST_PARAM;
+        let domain = crate::dummy_domain();
+        let max_num_bits = 64u32;
+
+        let (crs, metadata) =
+            gen_centralized_crs(&sk, &params, Some(max_num_bits), &domain, crs_id, &mut rng)
+                .unwrap();
+
+        let digest = match &metadata {
+            CrsGenMetadata::Current(inner) => inner.crs_digest.clone(),
+            _ => panic!("expected Current metadata"),
+        };
+
+        store_versioned_at_request_id(storage, crs_id, &crs, &PubDataType::CRS.to_string())
+            .await
+            .unwrap();
+
+        (crs, digest)
     }
 }


### PR DESCRIPTION
## Description of changes
PR #443 introduced startup-time validation for FHE keys and recovery materials loaded from public storage. CRS (Common Reference String) data was the only remaining unvalidated material, despite CrsGenMetadata in private storage already containing the crs_digest needed for verification.
                                                                                      
Changes:                                                                                                                                                                                                 
- utils.rs — Add verify_crs_digest_from_bytes and sanity_check_crs_materials, mirroring the existing FHE key validation pattern. Current metadata entries get full digest verification; LegacyV0 entries fall back to a readability check.
- kms_impl.rs / central_kms.rs — Call sanity_check_crs_materials after loading crs_info in both Threshold and Centralized KMS startup paths.
- Tests — 3 new unit tests: valid digest, corrupted digest (expects ERR_CRS_DIGEST_MISMATCH), and legacy metadata readability-only check.

## Issue ticket number and link
Closes https://github.com/zama-ai/kms-internal/issues/2923

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
