### PR TITLE
fix: do not delete images from PRs with label `docker`

### DIFF
--- a/.github/workflows/kind-testing.yml
+++ b/.github/workflows/kind-testing.yml
@@ -453,7 +453,8 @@ jobs:
     name: kind-testing/clean-up-build
     if: |
       always() &&
-      github.event_name != 'schedule'
+      github.event_name != 'schedule' &&
+      !contains(github.event.pull_request.labels.*.name, 'docker')
     needs:
       - docker-build
       - kind-testing


### PR DESCRIPTION
## Description of changes
Retains built docker images when PRs are tagged with `docker` label.
