### PR TITLE
chore: Don't load FHE pubkeys on startup

### DIFF
--- a/core/service/src/engine/threshold/service/crs_generator.rs
+++ b/core/service/src/engine/threshold/service/crs_generator.rs
@@ -549,12 +549,8 @@ mod tests {
             priv_storage: PrivS,
             session_maker: ImmutableSessionMaker,
         ) -> Self {
-            let crypto_storage = ThresholdCryptoMaterialStorage::new(
-                pub_storage,
-                priv_storage,
-                None,
-                HashMap::new(),
-            );
+            let crypto_storage =
+                ThresholdCryptoMaterialStorage::new(pub_storage, priv_storage, None);
 
             let tracker = Arc::new(TaskTracker::new());
             let ongoing = Arc::new(Mutex::new(HashMap::new()));

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1457,7 +1457,6 @@ pub(crate) mod tests {
                     RamStorage::new(),
                     RamStorage::new(),
                     None,
-                    HashMap::new(),
                 ),
                 reshare_pubinfo_meta_store: Arc::new(RwLock::new(MetaStore::new(10, 10))),
                 tracker: Arc::new(TaskTracker::new()),

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -1507,12 +1507,8 @@ mod tests {
             priv_storage: PrivS,
             session_maker: ImmutableSessionMaker,
         ) -> Self {
-            let crypto_storage = ThresholdCryptoMaterialStorage::new(
-                pub_storage,
-                priv_storage,
-                None,
-                HashMap::new(),
-            );
+            let crypto_storage =
+                ThresholdCryptoMaterialStorage::new(pub_storage, priv_storage, None);
 
             let tracker = Arc::new(TaskTracker::new());
             let rate_limiter = RateLimiter::default();

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -499,7 +499,7 @@ where
     let preproc_buckets = Arc::new(RwLock::new(MetaStore::new_unlimited()));
     let preproc_factory = Arc::new(Mutex::new(preproc_factory));
     let crs_meta_store = Arc::new(RwLock::new(MetaStore::new_from_map(crs_info)));
-    let dkg_pubinfo_meta_store = Arc::new(RwLock::new(MetaStore::new_from_map(HashMap::new())));
+    let dkg_pubinfo_meta_store = Arc::new(RwLock::new(MetaStore::new_unlimited()));
     let pub_dec_meta_store = Arc::new(RwLock::new(MetaStore::new(
         threshold_config.dec_capacity,
         threshold_config.min_dec_cache,
@@ -521,12 +521,8 @@ where
     .await?;
 
     let private_storage_info = private_storage.info();
-    let crypto_storage = ThresholdCryptoMaterialStorage::new(
-        public_storage,
-        private_storage,
-        backup_storage,
-        HashMap::new(),
-    );
+    let crypto_storage =
+        ThresholdCryptoMaterialStorage::new(public_storage, private_storage, backup_storage);
 
     let metastore_status_service = MetaStoreStatusServiceImpl::new(
         Some(dkg_pubinfo_meta_store.clone()),  // key_gen_store
@@ -576,7 +572,7 @@ where
         session_maker: session_maker.clone(),
         base_kms: base_kms.new_instance().await,
         reshare_pubinfo_meta_store: Arc::new(RwLock::new(MetaStore::new_unlimited())),
-        tracker: tracker.clone(),
+        tracker: Arc::clone(&tracker),
         rate_limiter: rate_limiter.clone(),
         _init: PhantomData,
         _reshare: PhantomData,

--- a/core/service/src/engine/threshold/service/public_decryptor.rs
+++ b/core/service/src/engine/threshold/service/public_decryptor.rs
@@ -776,12 +776,8 @@ mod tests {
             priv_storage: PrivS,
             session_maker: ImmutableSessionMaker,
         ) -> Self {
-            let crypto_storage = ThresholdCryptoMaterialStorage::new(
-                pub_storage,
-                priv_storage,
-                None,
-                HashMap::new(),
-            );
+            let crypto_storage =
+                ThresholdCryptoMaterialStorage::new(pub_storage, priv_storage, None);
 
             let tracker = Arc::new(TaskTracker::new());
             let rate_limiter = RateLimiter::default();

--- a/core/service/src/engine/threshold/service/reshare_utils.rs
+++ b/core/service/src/engine/threshold/service/reshare_utils.rs
@@ -763,12 +763,8 @@ mod tests {
         .unwrap();
 
         // create dummy crypto storage
-        let crypto_storage = ThresholdCryptoMaterialStorage::new(
-            RamStorage::new(),
-            RamStorage::new(),
-            None,
-            HashMap::new(),
-        );
+        let crypto_storage =
+            ThresholdCryptoMaterialStorage::new(RamStorage::new(), RamStorage::new(), None);
 
         let context_info = ContextInfo {
             mpc_nodes: [
@@ -1116,12 +1112,8 @@ mod tests {
         .unwrap();
 
         // create dummy crypto storage
-        let crypto_storage = ThresholdCryptoMaterialStorage::new(
-            RamStorage::new(),
-            RamStorage::new(),
-            None,
-            HashMap::new(),
-        );
+        let crypto_storage =
+            ThresholdCryptoMaterialStorage::new(RamStorage::new(), RamStorage::new(), None);
 
         let context_info = ContextInfo {
             mpc_nodes: [

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -396,8 +396,7 @@ impl<
         priv_storage: PrivS,
         session_maker: ImmutableSessionMaker,
     ) -> Self {
-        let crypto_storage =
-            ThresholdCryptoMaterialStorage::new(pub_storage, priv_storage, None, HashMap::new());
+        let crypto_storage = ThresholdCryptoMaterialStorage::new(pub_storage, priv_storage, None);
 
         let tracker = Arc::new(TaskTracker::new());
         let rate_limiter = RateLimiter::default();

--- a/core/service/src/vault/storage/crypto_material/tests.rs
+++ b/core/service/src/vault/storage/crypto_material/tests.rs
@@ -469,12 +469,8 @@ async fn read_guarded_threshold_fhe_keys_not_found() {
         .into();
 
     // Create a threshold storage with no keys in the cache and no keys in storage
-    let crypto_storage = ThresholdCryptoMaterialStorage::new(
-        FailingRamStorage::new(100),
-        RamStorage::new(),
-        None,
-        HashMap::new(),
-    );
+    let crypto_storage =
+        ThresholdCryptoMaterialStorage::new(FailingRamStorage::new(100), RamStorage::new(), None);
 
     // Try to read a non-existent key - should return an error
     let result = crypto_storage
@@ -535,12 +531,8 @@ fn setup_threshold_store(
     ThresholdFheKeys,
     FhePubKeySet,
 ) {
-    let crypto_storage = ThresholdCryptoMaterialStorage::new(
-        FailingRamStorage::new(100),
-        RamStorage::new(),
-        None,
-        HashMap::new(),
-    );
+    let crypto_storage =
+        ThresholdCryptoMaterialStorage::new(FailingRamStorage::new(100), RamStorage::new(), None);
 
     let pbs_params: ClassicPBSParameters = TEST_PARAM
         .get_params_basics_handle()

--- a/core/service/src/vault/storage/crypto_material/threshold.rs
+++ b/core/service/src/vault/storage/crypto_material/threshold.rs
@@ -49,19 +49,14 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
     ThresholdCryptoMaterialStorage<PubS, PrivS>
 {
     /// Create a new cached storage device for threshold KMS.
-    pub fn new(
-        public_storage: PubS,
-        private_storage: PrivS,
-        backup_vault: Option<Vault>,
-        fhe_keys: HashMap<(RequestId, EpochId), ThresholdFheKeys>,
-    ) -> Self {
+    pub fn new(public_storage: PubS, private_storage: PrivS, backup_vault: Option<Vault>) -> Self {
         Self {
             inner: CryptoMaterialStorage {
                 public_storage: Arc::new(Mutex::new(public_storage)),
                 private_storage: Arc::new(Mutex::new(private_storage)),
                 backup_vault: backup_vault.map(|x| Arc::new(Mutex::new(x))),
             },
-            fhe_keys: Arc::new(RwLock::new(fhe_keys)),
+            fhe_keys: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 


### PR DESCRIPTION
Refactors the `new_real_threshold_kms` to avoid loading and validating the big FHE public keys at start up, essentially switching to lazy-loading.

Also restructures this big method so that core-to-core networking starts before we do the heavy disk IO; also do more disk IO and validation in parallel.

In my local tests with ~114Gb worth of on-disk data I see some tests run ~15-20% faster. The more cores a test spins up the bigger the gain.

This is a fairly conservative and light touch refactor that keeps semantics essentially untouched. We could opt to do more invasive changes, e.g. removing more things from the critical path (backup update, PRSS init, default MPC context) but I think the low hanging fruit is in this PR. 
