### PR TITLE
chore: depend on protected branches of rcgen, rustls-webpki, rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "rcgen"
 version = "0.14.7"
-source = "git+https://github.com/zama-ai/rcgen.git?branch=k256#f8582f243899a7eff1a6524b42da60faaec73f15"
+source = "git+https://github.com/zama-ai/rcgen.git#17504e6dd9c430784dd83a81db7a865b0db38e5d"
 dependencies = [
  "aws-lc-rs",
  "pem",
@@ -6519,7 +6519,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.37"
-source = "git+https://github.com/zama-ai/rustls.git?branch=rel-0.23-k256#b459952c88fc64c0a1352447cd5e10284670166f"
+source = "git+https://github.com/zama-ai/rustls.git?branch=rel-0.23#49aa4091eae6a73f575bebeae28d370acd74f8b6"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6587,7 +6587,7 @@ dependencies = [
 [[package]]
 name = "rustls-webpki"
 version = "0.103.9"
-source = "git+https://github.com/zama-ai/webpki.git?branch=rel-0.103-k256#0b5ee7b1de0b2d87457c0bf1cc93f8e442f3a3c1"
+source = "git+https://github.com/zama-ai/webpki.git?branch=rel-0.103#9558707f39b97060b527966de76943e7ed40a022"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,6 +246,6 @@ lto = "off"
 [patch.crates-io]
 # MEDIUM RISK: Using fork instead of upstream - verify changes, consider upstreaming
 attestation-doc-validation = { git = 'https://github.com/mkmks/attestation-doc-validation.git', branch = 'timestamps' }
-rcgen = { git = 'https://github.com/zama-ai/rcgen.git', branch = 'k256' }
-rustls = { git = 'https://github.com/zama-ai/rustls.git', branch = 'rel-0.23-k256' }
-rustls-webpki = { git = 'https://github.com/zama-ai/webpki.git', branch = 'rel-0.103-k256' }
+rcgen = { git = 'https://github.com/zama-ai/rcgen.git' }
+rustls = { git = 'https://github.com/zama-ai/rustls.git', branch = 'rel-0.23' }
+rustls-webpki = { git = 'https://github.com/zama-ai/webpki.git', branch = 'rel-0.103' }


### PR DESCRIPTION
## Description of changes
This is a followup to #437. Instead of depending on feature branches of `rcgen`, `webpki` and `rustls`, we should depend on the protected branches (`rcgen/main`, `webpki/rel-0.103`, `rustls/rel-0.23`). 

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
