### PR TITLE
chore: do not drop receiver when peer has completed

### DIFF
--- a/core/threshold-networking/src/sending_service.rs
+++ b/core/threshold-networking/src/sending_service.rs
@@ -656,7 +656,7 @@ mod tests {
     use std::time::Duration;
     use threshold_types::network::{NetworkMode, Networking};
     use threshold_types::party::{Identity, RoleAssignment};
-    use threshold_types::role::{Role, TwoSetsRole};
+    use threshold_types::role::{Role, RoleTrait, TwoSetsRole};
     use threshold_types::session_id::SessionId;
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1086,8 +1086,8 @@ mod tests {
     async fn test_run_network_task_does_not_drop_receiver_on_completed() {
         use super::ArcSendValueRequest;
         use super::GrpcSendingService;
-        use crate::networking::ggen::gnetworking_server::{Gnetworking, GnetworkingServer};
-        use crate::networking::ggen::{
+        use crate::ggen::gnetworking_server::{Gnetworking, GnetworkingServer};
+        use crate::ggen::{
             HealthCheckRequest, HealthCheckResponse, SendValueRequest, SendValueResponse, Status,
         };
         use backoff::ExponentialBackoff;
@@ -1154,16 +1154,15 @@ mod tests {
             }
         };
 
-        let client =
-            crate::networking::ggen::gnetworking_client::GnetworkingClient::with_interceptor(
-                channel,
-                observability::telemetry::ContextPropagator,
-            );
+        let client = crate::ggen::gnetworking_client::GnetworkingClient::with_interceptor(
+            channel,
+            observability::telemetry::ContextPropagator,
+        );
 
         // Create channel and shared state
         let (sender, receiver) = unbounded_channel::<ArcSendValueRequest>();
         let completed_parties = Arc::new(DashSet::new());
-        let role_kind = algebra::role::Role::indexed_from_one(1).get_role_kind();
+        let role_kind = threshold_types::role::Role::indexed_from_one(1).get_role_kind();
 
         let backoff = ExponentialBackoff {
             max_elapsed_time: Some(Duration::from_secs(5)),


### PR DESCRIPTION
## Description of changes
This PR attempts to fix flaky tests and situations in which some cores are slower than others and might accidentally drop sessions of faster peers that report the session as being completed.

## Issue ticket number and link
closes https://github.com/zama-ai/kms-internal/issues/2948

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

