### PR TITLE
chore: bump kms version to v0.13.20-0 and chart to v1.6.0-0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "backward-compatibility"
-version = "0.13.10"
+version = "0.13.20"
 dependencies = [
  "bincode 1.3.3",
  "ron 0.10.1",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "cc-tests-utils"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 
 [[package]]
 name = "cfg-if"
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "error-utils"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "anyhow",
  "tracing",
@@ -3396,7 +3396,7 @@ checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
 
 [[package]]
 name = "generate-test-material"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4234,7 +4234,7 @@ dependencies = [
 
 [[package]]
 name = "kms"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "kms-core-client"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "aes-prng",
  "alloy-primitives",
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "kms-grpc"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "kms-health-check"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "anyhow",
  "axum",
@@ -7485,7 +7485,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -7494,7 +7494,7 @@ dependencies = [
 
 [[package]]
 name = "tests-utils"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -7650,7 +7650,7 @@ dependencies = [
 
 [[package]]
 name = "thread-handles"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "anyhow",
  "error-utils",
@@ -7680,7 +7680,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-algebra"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "aes-prng",
  "anyhow",
@@ -7708,7 +7708,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-execution"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "aes",
  "aes-prng",
@@ -7758,7 +7758,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-experimental"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "aes-prng",
  "anyhow",
@@ -7796,7 +7796,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-fhe"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "aes",
  "aes-prng",
@@ -7857,7 +7857,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-hashing"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -7867,7 +7867,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-networking"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7904,7 +7904,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-types"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 dependencies = [
  "aes-prng",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ authors = ["Zama"]
 publish = true
 edition = "2021"
 license = "BSD-3-Clause-Clear"
-version = "0.13.10-rc.0"
+version = "0.13.20-0"
 repository = "https://github.com/zama-ai/kms"
 description = "Key Management System for the Zama Protocol."
 

--- a/backward-compatibility/Cargo.toml
+++ b/backward-compatibility/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backward-compatibility"
-version = "0.13.10"
+version = "0.13.20"
 publish = false
 authors = ["Zama"]
 edition = "2021"

--- a/charts/kms-core/Chart.yaml
+++ b/charts/kms-core/Chart.yaml
@@ -1,7 +1,7 @@
 name: kms-core
 description: A helm chart to distribute and deploy the Zama KMS core service.
-version: 1.5.0-beta.13
-appVersion: 0.13.0   # Minimum kms version to run this chart
+version: 1.6.0-0
+appVersion: 0.13.20   # Minimum kms version to run this chart
 apiVersion: v2
 keywords:
   - kms-service


### PR DESCRIPTION
## Description of changes
This is a simple version bump to kms v0.13.20-0 to clearly distinguish the latest release v0.13.10 from what's on `main`.
Also bump the chart version to v1.6.0-0 to avoid confusion with older versions.


## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
