### PR TITLE
Flaky tests: tweak timeouts

### DIFF
--- a/core/threshold-networking/src/constants.rs
+++ b/core/threshold-networking/src/constants.rs
@@ -33,8 +33,10 @@ lazy_static! {
     /// The default maximum elapsed time before giving up on retrying
     pub(crate) static ref MAX_ELAPSED_TIME: Option<Duration> = Some(Duration::from_secs(60));
 
-    /// maximum number of seconds that a party waits for a network message during a protocol
-    pub(crate) static ref NETWORK_TIMEOUT: Duration = Duration::from_secs(5);
+    /// Maximum number of seconds that a party waits for a network message during a protocol.
+    /// This is only used by the local test networking (`LocalNetworking`), not in production.
+    /// The value must be large enough to tolerate CPU contention when many tests run in parallel.
+    pub(crate) static ref NETWORK_TIMEOUT: Duration = Duration::from_secs(10);
 
     /// maximum number of seconds that a party waits for a network message during a protocol
     pub static ref NETWORK_TIMEOUT_LONG: Duration = Duration::from_secs(120);

--- a/core/threshold-networking/src/local.rs
+++ b/core/threshold-networking/src/local.rs
@@ -203,7 +203,14 @@ impl<R: RoleTrait> Networking<R> for LocalNetworking<R> {
                 self.network_round.lock(),
             )
             .await;
-        *max_elapsed_time += *current_round_timeout;
+        // Advance the deadline by at least one round timeout, but also ensure
+        // it never falls behind actual wall-clock time. Without this, processing
+        // overhead (e.g., crypto operations, waiting for malicious party timeouts)
+        // can accumulate across rounds, causing the deadline to drift into the past
+        // and honest parties to spuriously timeout on each other.
+        let actual_elapsed = self.init_time.get_or_init(Instant::now).elapsed();
+        *max_elapsed_time =
+            std::cmp::max(*max_elapsed_time + *current_round_timeout, actual_elapsed);
 
         //Update next round timeout
         *current_round_timeout = *next_round_timeout;


### PR DESCRIPTION
Two changes to "local" networking (tests).

The [first,](https://github.com/zama-ai/kms/pull/519/commits/5c46390d612cd1382390056aadd1e6dbbbc009c9) ensures that the deadline is never in the past.  This addresses intermittent local failures in `test_large_offline_malicious_subprotocols_caught` — specifically the DroppingVssFromStart + DroppingCoinflipAfterVss + DroppingShareDispute combination. Error: "The number of parties 1 is less or equal to the threshold 1".

See internal discussion [here](https://zama-ai.slack.com/archives/C05UD8KC0UD/p1776066329842939).

The  [second](https://github.com/zama-ai/kms/pull/519/commits/5c46390d612cd1382390056aadd1e6dbbbc009c9) commit fixes intermittent failures in `test_reshare_malicious_subprotocols` – specifically all MaliciousRobustOpenDrop variants. Error: "Input shares and masks are required for parties in set 1" / syndrome assertion failures.

Both commits are the result of having Claude spend the weekend re-running tests over and over again. With these commits I do not see any test failures over ~40 complete runs, so that's good. That doesn't mean we want to merge this as-is though and this PR needs careful analysis.
