### PR TITLE
chore: remove high-cardinality metric tags

### DIFF
--- a/core/service/src/engine/centralized/central_kms.rs
+++ b/core/service/src/engine/centralized/central_kms.rs
@@ -467,7 +467,6 @@ pub fn central_public_decrypt<
 >(
     keys: &KmsFheKeyHandles,
     cts: &[TypedCiphertext],
-    metric_tags: Vec<(&'static str, String)>,
 ) -> anyhow::Result<Vec<TypedPlaintext>> {
     use observability::{
         metrics,
@@ -481,7 +480,6 @@ pub fn central_public_decrypt<
         .map(|ct| {
             let mut inner_timer = metrics::METRICS
                 .time_operation(OP_PUBLIC_DECRYPT_INNER)
-                .tags(metric_tags.clone())
                 .start();
             let fhe_type = ct.fhe_type()?;
             let fhe_type_string = ct.fhe_type_string();
@@ -511,7 +509,6 @@ pub async fn async_user_decrypt<
     client_address: &alloy_primitives::Address,
     server_verf_key: Vec<u8>,
     domain: &alloy_sol_types::Eip712Domain,
-    metric_tags: Vec<(&'static str, String)>,
     extra_data: &[u8],
 ) -> anyhow::Result<(UserDecryptionResponsePayload, Vec<u8>)> {
     use observability::{
@@ -527,7 +524,6 @@ pub async fn async_user_decrypt<
     for typed_ciphertext in typed_ciphertexts {
         let mut inner_timer = metrics::METRICS
             .time_operation(OP_USER_DECRYPT_INNER)
-            .tags(metric_tags.clone())
             .start();
         let high_level_ct = &typed_ciphertext.ciphertext;
         let fhe_type = typed_ciphertext.fhe_type()?;

--- a/core/service/src/engine/centralized/service/crs_gen.rs
+++ b/core/service/src/engine/centralized/service/crs_gen.rs
@@ -7,8 +7,7 @@ use kms_grpc::kms::v1::{CrsGenRequest, CrsGenResult, Empty};
 use kms_grpc::{EpochId, RequestId};
 use observability::metrics::METRICS;
 use observability::metrics_names::{
-    CENTRAL_TAG, OP_CRS_GEN_REQUEST, OP_CRS_GEN_RESULT, OP_INSECURE_CRS_GEN_REQUEST,
-    TAG_CONTEXT_ID, TAG_CRS_ID, TAG_PARTY_ID,
+    CENTRAL_TAG, OP_CRS_GEN_REQUEST, OP_CRS_GEN_RESULT, OP_INSECURE_CRS_GEN_REQUEST, TAG_PARTY_ID,
 };
 use threshold_execution::tfhe_internals::parameters::DKGParams;
 
@@ -50,18 +49,13 @@ pub async fn crs_gen_impl<
     };
 
     let permit = service.rate_limiter.start_crsgen(op_tag).await?;
-    let mut timer = METRICS
+    let timer = METRICS
         .time_operation(op_tag)
         .tag(TAG_PARTY_ID, CENTRAL_TAG.to_string())
         .start();
     let inner = request.into_inner();
     let max_bits = inner.max_num_bits;
     let verified = validate_crs_gen_request(inner, op_tag)?;
-    let metric_tags = vec![
-        (TAG_CRS_ID, verified.req_id.to_string()),
-        (TAG_CONTEXT_ID, verified.context_id.to_string()),
-    ];
-    timer.tags(metric_tags.clone());
 
     if !service
         .context_manager

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -148,7 +148,6 @@ pub async fn user_decrypt_impl<
                 &client_address,
                 server_verf_key,
                 &domain,
-                vec![],
                 &extra_data,
             )
             .await;
@@ -345,7 +344,7 @@ pub async fn public_decrypt_impl<
         // run the computation in a separate rayon thread to avoid blocking the tokio runtime
         let (send, recv) = tokio::sync::oneshot::channel();
         rayon::spawn_fifo(move || {
-            let decryptions = central_public_decrypt::<PubS, PrivS>(&keys, &ciphertexts, vec![]);
+            let decryptions = central_public_decrypt::<PubS, PrivS>(&keys, &ciphertexts);
             let _ = send.send(decryptions);
         });
         let decryptions = recv.await;

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -21,7 +21,7 @@ use kms_grpc::kms::v1::{
 use observability::metrics::METRICS;
 use observability::metrics_names::{
     CENTRAL_TAG, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT, OP_USER_DECRYPT_REQUEST,
-    OP_USER_DECRYPT_RESULT, TAG_CONTEXT_ID, TAG_EPOCH_ID, TAG_KEY_ID, TAG_PARTY_ID,
+    OP_USER_DECRYPT_RESULT, TAG_PARTY_ID,
 };
 use std::sync::Arc;
 use tonic::{Request, Response};
@@ -38,7 +38,7 @@ pub async fn user_decrypt_impl<
     request: Request<UserDecryptionRequest>,
 ) -> Result<Response<Empty>, MetricedError> {
     let permit = service.rate_limiter.start_user_decrypt().await?;
-    let mut timer = METRICS
+    let timer = METRICS
         .time_operation(OP_USER_DECRYPT_REQUEST)
         .tag(TAG_PARTY_ID, CENTRAL_TAG.to_string())
         .start();
@@ -69,14 +69,6 @@ pub async fn user_decrypt_impl<
         ));
     }
     // Observe we accept any epoch ID
-
-    // Use a constant party ID since this is the central KMS
-    let metric_tags = vec![
-        (TAG_KEY_ID, key_id.to_string()),
-        (TAG_CONTEXT_ID, context_id.to_string()),
-        (TAG_EPOCH_ID, epoch_id.to_string()),
-    ];
-    timer.tags(metric_tags.clone());
 
     match service
         .crypto_storage
@@ -156,7 +148,7 @@ pub async fn user_decrypt_impl<
                 &client_address,
                 server_verf_key,
                 &domain,
-                metric_tags,
+                vec![],
                 &extra_data,
             )
             .await;
@@ -243,7 +235,7 @@ pub async fn public_decrypt_impl<
     request: Request<PublicDecryptionRequest>,
 ) -> Result<Response<Empty>, MetricedError> {
     let permit = service.rate_limiter.start_pub_decrypt().await?;
-    let mut timer = METRICS
+    let timer = METRICS
         .time_operation(OP_PUBLIC_DECRYPT_REQUEST)
         // Use a constant party ID since this is the central KMS
         .tag(TAG_PARTY_ID, CENTRAL_TAG.to_string())
@@ -265,13 +257,6 @@ pub async fn public_decrypt_impl<
         ));
     }
     // Observe we accept any epoch ID
-
-    let metric_tags = vec![
-        (TAG_KEY_ID, key_id.to_string()),
-        (TAG_CONTEXT_ID, context_id.to_string()),
-        (TAG_EPOCH_ID, epoch_id.to_string()),
-    ];
-    timer.tags(metric_tags.clone());
 
     let keys_exist = match service
         .crypto_storage
@@ -360,8 +345,7 @@ pub async fn public_decrypt_impl<
         // run the computation in a separate rayon thread to avoid blocking the tokio runtime
         let (send, recv) = tokio::sync::oneshot::channel();
         rayon::spawn_fifo(move || {
-            let decryptions =
-                central_public_decrypt::<PubS, PrivS>(&keys, &ciphertexts, metric_tags);
+            let decryptions = central_public_decrypt::<PubS, PrivS>(&keys, &ciphertexts, vec![]);
             let _ = send.send(decryptions);
         });
         let decryptions = recv.await;

--- a/core/service/src/engine/centralized/service/key_gen.rs
+++ b/core/service/src/engine/centralized/service/key_gen.rs
@@ -24,7 +24,7 @@ use kms_grpc::{EpochId, RequestId};
 use observability::metrics::METRICS;
 use observability::metrics_names::{
     CENTRAL_TAG, OP_INSECURE_KEYGEN_REQUEST, OP_INSECURE_KEYGEN_RESULT, OP_KEYGEN_REQUEST,
-    OP_KEYGEN_RESULT, TAG_CONTEXT_ID, TAG_EPOCH_ID, TAG_KEY_ID, TAG_PARTY_ID,
+    OP_KEYGEN_RESULT, TAG_PARTY_ID,
 };
 use std::sync::Arc;
 use threshold_execution::keyset_config::KeySetConfig;
@@ -55,7 +55,7 @@ pub async fn key_gen_impl<
     // TODO add serial lock to have similar flow to threshold case
     // Acquire the serial lock to make sure no other keygen is running concurrently
     // let _guard = service.serial_lock.lock().await;
-    let mut timer = METRICS
+    let timer = METRICS
         .time_operation(op_tag)
         // Use a constant party ID since this is the central KMS
         .tag(TAG_PARTY_ID, CENTRAL_TAG.to_string())
@@ -73,12 +73,7 @@ pub async fn key_gen_impl<
         eip712_domain,
         extra_data,
     ) = validate_key_gen_request(inner, op_tag)?;
-    let metric_tags = vec![
-        (TAG_KEY_ID, req_id.to_string()),
-        (TAG_CONTEXT_ID, context_id.to_string()),
-        (TAG_EPOCH_ID, epoch_id.to_string()),
-    ];
-    timer.tags(metric_tags.clone());
+
     tracing::info!("centralized key-gen with request id: {:?}", req_id);
 
     if !service

--- a/core/service/src/engine/centralized/service/key_gen.rs
+++ b/core/service/src/engine/centralized/service/key_gen.rs
@@ -89,7 +89,7 @@ pub async fn key_gen_impl<
         ));
     }
 
-    // Check for existance of request preprocessing ID
+    // Check for existence of request preprocessing ID
     // also check that the request ID is not used yet
     // If all is ok write the request ID to the meta store
     // All validation must be done before inserting the request ID

--- a/core/service/src/engine/centralized/service/preprocessing.rs
+++ b/core/service/src/engine/centralized/service/preprocessing.rs
@@ -13,8 +13,7 @@ use kms_grpc::kms::v1::{self, Empty, KeyGenPreprocRequest, KeyGenPreprocResult};
 use observability::{
     metrics::METRICS,
     metrics_names::{
-        CENTRAL_TAG, OP_KEYGEN_PREPROC_REQUEST, OP_KEYGEN_PREPROC_RESULT, TAG_CONTEXT_ID,
-        TAG_EPOCH_ID, TAG_PARTY_ID,
+        CENTRAL_TAG, OP_KEYGEN_PREPROC_REQUEST, OP_KEYGEN_PREPROC_RESULT, TAG_PARTY_ID,
     },
 };
 use tonic::{Request, Response};
@@ -51,19 +50,14 @@ pub async fn preprocessing_impl<
     request: Request<KeyGenPreprocRequest>,
 ) -> Result<Response<Empty>, MetricedError> {
     let _permit = service.rate_limiter.start_preproc().await?;
-    let mut timer = METRICS
+    let _timer = METRICS
         .time_operation(OP_KEYGEN_PREPROC_REQUEST)
         .tag(TAG_PARTY_ID, CENTRAL_TAG)
         .start();
     let inner = request.into_inner();
 
-    let (req_id, context_id, epoch_id, dkg_param, _key_set_config, eip712_domain) =
+    let (req_id, _context_id, _epoch_id, dkg_param, _key_set_config, eip712_domain) =
         validate_preproc_request(inner)?;
-    let metric_tags = vec![
-        (TAG_CONTEXT_ID, context_id.as_str()),
-        (TAG_EPOCH_ID, epoch_id.as_str()),
-    ];
-    timer.tags(metric_tags.clone());
 
     add_req_to_meta_store(
         &mut service.preprocessing_meta_store.write().await,

--- a/core/service/src/engine/context_manager.rs
+++ b/core/service/src/engine/context_manager.rs
@@ -931,7 +931,7 @@ where
         let exists_in_storage = self.inner.mpc_context_exists_in_storage(context_id).await?;
         if exists_in_storage != exsits_in_session_maker {
             anyhow::bail!(
-                "inconsistent context state for context while checking existance, exists_in_storage={exists_in_storage}, exsits_in_session_maker={exsits_in_session_maker}"
+                "inconsistent context state for context while checking existence, exists_in_storage={exists_in_storage}, exsits_in_session_maker={exsits_in_session_maker}"
             )
         } else {
             Ok(exsits_in_session_maker && exists_in_storage)

--- a/core/service/src/engine/threshold/service/crs_generator.rs
+++ b/core/service/src/engine/threshold/service/crs_generator.rs
@@ -13,8 +13,7 @@ use kms_grpc::{
 use observability::{
     metrics::{self, DurationGuard},
     metrics_names::{
-        OP_CRS_GEN_REQUEST, OP_CRS_GEN_RESULT, OP_INSECURE_CRS_GEN_REQUEST, TAG_CONTEXT_ID,
-        TAG_CRS_ID, TAG_PARTY_ID,
+        OP_CRS_GEN_REQUEST, OP_CRS_GEN_RESULT, OP_INSECURE_CRS_GEN_REQUEST, TAG_PARTY_ID,
     },
 };
 use threshold_execution::{
@@ -108,11 +107,7 @@ impl<
             .map_err(|e| {
                 MetricedError::new(op_tag, Some(verified.req_id), e, tonic::Code::NotFound)
             })?;
-        let metric_tags = vec![
-            (TAG_PARTY_ID, my_role.to_string()),
-            (TAG_CRS_ID, verified.req_id.as_str()),
-            (TAG_CONTEXT_ID, verified.context_id.as_str()),
-        ];
+        let metric_tags = vec![(TAG_PARTY_ID, my_role.to_string())];
         timer.tags(metric_tags.clone());
 
         // Validate the request ID before proceeding

--- a/core/service/src/engine/threshold/service/crs_generator.rs
+++ b/core/service/src/engine/threshold/service/crs_generator.rs
@@ -108,7 +108,7 @@ impl<
                 MetricedError::new(op_tag, Some(verified.req_id), e, tonic::Code::NotFound)
             })?;
         let metric_tags = vec![(TAG_PARTY_ID, my_role.to_string())];
-        timer.tags(metric_tags.clone());
+        timer.tags(metric_tags);
 
         // Validate the request ID before proceeding
         self.crypto_storage
@@ -118,7 +118,7 @@ impl<
                 MetricedError::new(
                     op_tag,
                     None,
-                    format!("Could not check crs existance in storage: {e}"),
+                    format!("Could not check crs existence in storage: {e}"),
                     tonic::Code::AlreadyExists,
                 )
             })?;

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -21,8 +21,7 @@ use observability::{
         OP_DECOMPRESSION_KEYGEN, OP_INSECURE_DECOMPRESSION_KEYGEN, OP_INSECURE_KEYGEN_REQUEST,
         OP_INSECURE_KEYGEN_RESULT, OP_INSECURE_STANDARD_COMPRESSED_KEYGEN,
         OP_INSECURE_STANDARD_KEYGEN, OP_KEYGEN_REQUEST, OP_KEYGEN_RESULT,
-        OP_STANDARD_COMPRESSED_KEYGEN, OP_STANDARD_KEYGEN, TAG_CONTEXT_ID, TAG_EPOCH_ID,
-        TAG_KEY_ID, TAG_PARTY_ID,
+        OP_STANDARD_COMPRESSED_KEYGEN, OP_STANDARD_KEYGEN, TAG_PARTY_ID,
     },
 };
 use tfhe::integer::compression_keys::DecompressionKey;
@@ -483,12 +482,7 @@ impl<
             &epoch_id,
         )
         .await?;
-        let metric_tags = vec![
-            (TAG_PARTY_ID, my_role.to_string()),
-            (TAG_KEY_ID, req_id.to_string()),
-            (TAG_CONTEXT_ID, context_id.to_string()),
-            (TAG_EPOCH_ID, epoch_id.to_string()),
-        ];
+        let metric_tags = vec![(TAG_PARTY_ID, my_role.to_string())];
         timer.tags(metric_tags.clone());
 
         let (preproc_handle, dkg_params) =

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -483,7 +483,7 @@ impl<
         )
         .await?;
         let metric_tags = vec![(TAG_PARTY_ID, my_role.to_string())];
-        timer.tags(metric_tags.clone());
+        timer.tags(metric_tags);
 
         let (preproc_handle, dkg_params) =
             // Processes the bucket meta information. This is a slightly funky as in certain situations it may override the DKGParams sepcified in the request

--- a/core/service/src/engine/threshold/service/preprocessor.rs
+++ b/core/service/src/engine/threshold/service/preprocessor.rs
@@ -11,8 +11,7 @@ use kms_grpc::{
 use observability::{
     metrics::{self, DurationGuard, METRICS},
     metrics_names::{
-        ERR_CANCELLED, OP_KEYGEN_PREPROC_REQUEST, OP_KEYGEN_PREPROC_RESULT, TAG_CONTEXT_ID,
-        TAG_EPOCH_ID, TAG_PARTY_ID,
+        ERR_CANCELLED, OP_KEYGEN_PREPROC_REQUEST, OP_KEYGEN_PREPROC_RESULT, TAG_PARTY_ID,
     },
 };
 use threshold_execution::{
@@ -380,11 +379,7 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
             &epoch_id,
         )
         .await?;
-        let metric_tags = vec![
-            (TAG_PARTY_ID, my_role.to_string()),
-            (TAG_CONTEXT_ID, context_id.as_str()),
-            (TAG_EPOCH_ID, epoch_id.as_str()),
-        ];
+        let metric_tags = vec![(TAG_PARTY_ID, my_role.to_string())];
         timer.tags(metric_tags);
 
         // Add preprocessing to metastore and fail in case it is already present

--- a/core/service/src/engine/threshold/service/public_decryptor.rs
+++ b/core/service/src/engine/threshold/service/public_decryptor.rs
@@ -881,7 +881,7 @@ mod tests {
             )
             .await;
         {
-            // check existance
+            // check existence
             let _guard = public_decryptor
                 .crypto_storage
                 .read_guarded_threshold_fhe_keys(&key_id, &epoch_id)

--- a/core/service/src/engine/threshold/service/public_decryptor.rs
+++ b/core/service/src/engine/threshold/service/public_decryptor.rs
@@ -20,9 +20,8 @@ use kms_grpc::{
 use observability::{
     metrics::{self},
     metrics_names::{
-        OP_PUBLIC_DECRYPT_INNER, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT,
-        TAG_CONTEXT_ID, TAG_EPOCH_ID, TAG_KEY_ID, TAG_PARTY_ID, TAG_PUBLIC_DECRYPTION_KIND,
-        TAG_TFHE_TYPE,
+        OP_PUBLIC_DECRYPT_INNER, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT, TAG_PARTY_ID,
+        TAG_PUBLIC_DECRYPTION_KIND, TAG_TFHE_TYPE,
     },
 };
 use tfhe::FheTypes;
@@ -301,9 +300,6 @@ impl<
         let dec_mode = self.decryption_mode;
         let metric_tags = vec![
             (TAG_PARTY_ID, my_role.to_string()),
-            (TAG_KEY_ID, key_id.as_str()),
-            (TAG_CONTEXT_ID, context_id.as_str()),
-            (TAG_EPOCH_ID, epoch_id.as_str()),
             (
                 TAG_PUBLIC_DECRYPTION_KIND,
                 dec_mode.as_str_name().to_string(),

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -27,8 +27,8 @@ use kms_grpc::{
 use observability::{
     metrics,
     metrics_names::{
-        OP_USER_DECRYPT_INNER, OP_USER_DECRYPT_REQUEST, OP_USER_DECRYPT_RESULT, TAG_CONTEXT_ID,
-        TAG_EPOCH_ID, TAG_KEY_ID, TAG_PARTY_ID, TAG_TFHE_TYPE, TAG_USER_DECRYPTION_KIND,
+        OP_USER_DECRYPT_INNER, OP_USER_DECRYPT_REQUEST, OP_USER_DECRYPT_RESULT, TAG_PARTY_ID,
+        TAG_TFHE_TYPE, TAG_USER_DECRYPTION_KIND,
     },
 };
 use rand::{CryptoRng, RngCore};
@@ -484,9 +484,6 @@ impl<
         let dec_mode = self.decryption_mode;
         let metric_tags = vec![
             (TAG_PARTY_ID, my_role.to_string()),
-            (TAG_KEY_ID, key_id.as_str()), // TODO will this be too many labels or does it make sense to keep key, context and epoch
-            (TAG_CONTEXT_ID, context_id.as_str()),
-            (TAG_EPOCH_ID, epoch_id.as_str()),
             (TAG_USER_DECRYPTION_KIND, dec_mode.as_str_name().to_string()),
         ];
         timer.tags(metric_tags.clone());

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -785,7 +785,7 @@ mod tests {
             .await;
 
         {
-            // check existance
+            // check existence
             let _guard = user_decryptor
                 .crypto_storage
                 .read_guarded_threshold_fhe_keys(&key_id, &epoch_id)

--- a/core/service/src/vault/storage/crypto_material/base.rs
+++ b/core/service/src/vault/storage/crypto_material/base.rs
@@ -1103,7 +1103,7 @@ where
         T: PrivateCryptoMaterialReader + PrivateMaterialUnderEpoch,
     {
         // This function does not need to be atomic, so we take a read lock
-        // on the cache first and check for existance, then release it.
+        // on the cache first and check for existence, then release it.
         // We do this because we want to avoid write locks unless necessary.
         let exists = {
             let guarded_fhe_keys = cache.read().await;

--- a/core/service/src/vault/storage/crypto_material/tests.rs
+++ b/core/service/src/vault/storage/crypto_material/tests.rs
@@ -298,7 +298,7 @@ async fn write_threshold_empty_update() {
         "PK already exists in pk_cache for {req_id}"
     )));
     assert!(!logs_contain(&format!(
-        "Failed to ensure existance of threshold key material for {req_id}."
+        "Failed to ensure existence of threshold key material for {req_id}."
     )));
     // write to an empty meta store should fail
     crypto_storage

--- a/observability/src/metrics.rs
+++ b/observability/src/metrics.rs
@@ -603,6 +603,7 @@ impl Default for MetricsConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
 
     #[test]
     fn metric_families_match_allowlist() {
@@ -663,5 +664,60 @@ mod tests {
             names, expected_metrics,
             "Metric families changed. If intentional, update the allowlist in this test."
         );
+    }
+
+    #[test]
+    fn duration_histogram_uses_only_low_cardinality_labels() {
+        let _ = &*METRICS;
+
+        METRICS.observe_duration_with_tags(
+            "_test_cardinality",
+            Duration::from_millis(1),
+            &[
+                (TAG_PARTY_ID, "1".to_string()),
+                (TAG_TFHE_TYPE, "fhe_uint8".to_string()),
+                (TAG_PUBLIC_DECRYPTION_KIND, "test".to_string()),
+            ],
+        );
+
+        let duration_family = prometheus::gather()
+            .into_iter()
+            .find(|family| family.name() == "kms_operation_duration_ms")
+            .expect("duration histogram should be registered");
+        let observed_metric = duration_family
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                metric.get_label().iter().any(|label| {
+                    label.name() == TAG_OPERATION_TYPE && label.value() == "_test_cardinality"
+                })
+            })
+            .expect("seeded duration sample should be present");
+
+        let actual_labels: BTreeSet<&str> = observed_metric
+            .get_label()
+            .iter()
+            .map(|label| label.name())
+            .collect();
+        let expected_labels: BTreeSet<&str> = DURATION_LABEL_KEYS.iter().copied().collect();
+
+        assert_eq!(
+            actual_labels, expected_labels,
+            "duration histogram labels should stay low-cardinality"
+        );
+
+        println!("Actual labels: {actual_labels:#?}");
+
+        assert!(
+            actual_labels.len() <= 5,
+            "duration histogram should have at most 5 labels to avoid high cardinality"
+        );
+
+        for disallowed_label in ["key_id", "context_id", "epoch_id", "crs_id"] {
+            assert!(
+                !actual_labels.contains(disallowed_label),
+                "high-cardinality label {disallowed_label} should not be exported"
+            );
+        }
     }
 }

--- a/observability/src/metrics.rs
+++ b/observability/src/metrics.rs
@@ -1,11 +1,20 @@
-use crate::metrics_names::{TAG_OPERATION_TYPE, TAG_PARTY_ID, TAG_TFHE_TYPE};
+use crate::metrics_names::{
+    TAG_OPERATION_TYPE, TAG_PARTY_ID, TAG_PUBLIC_DECRYPTION_KIND, TAG_TFHE_TYPE,
+    TAG_USER_DECRYPTION_KIND,
+};
 use prometheus::{Gauge, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, Opts};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use tracing::warn;
 
 /// Label keys for the duration histogram (must match all tag keys used by callers)
-const DURATION_LABEL_KEYS: &[&str] = &[TAG_OPERATION_TYPE, TAG_PARTY_ID, TAG_TFHE_TYPE];
+const DURATION_LABEL_KEYS: &[&str] = &[
+    TAG_OPERATION_TYPE,
+    TAG_PARTY_ID,
+    TAG_TFHE_TYPE,
+    TAG_PUBLIC_DECRYPTION_KIND,
+    TAG_USER_DECRYPTION_KIND,
+];
 
 /// Core metrics for tracking KMS operations
 #[derive(Debug, Clone)]

--- a/observability/src/metrics_names.rs
+++ b/observability/src/metrics_names.rs
@@ -58,10 +58,6 @@ pub const OP_FETCH_PK: &str = "fetch_pk";
 // Common metric tag keys
 pub const TAG_OPERATION: &str = "operation";
 pub const TAG_ERROR: &str = "error";
-pub const TAG_KEY_ID: &str = "key_id";
-pub const TAG_CRS_ID: &str = "crs_id";
-pub const TAG_CONTEXT_ID: &str = "context_id";
-pub const TAG_EPOCH_ID: &str = "epoch_id";
 pub const TAG_ALGORITHM: &str = "algorithm"; // TODO not used yet
 pub const TAG_OPERATION_TYPE: &str = "operation_type"; // TODO not used yet
 pub const TAG_PARTY_ID: &str = "party_id";


### PR DESCRIPTION
## Description of changes

Remove high-cardinality metric labels (`key_id`, `context_id`, `epoch_id`, `crs_id`) from duration histograms and register low-cardinality decryption mode labels that were defined but unused.

### Problem

Duration histogram tags `key_id`, `context_id`, `epoch_id`, and `crs_id` were passed by callers but silently dropped at recording time because they weren't in `DURATION_LABEL_KEYS`. This produced `WARN ignoring unknown duration metric tag key` on every request. Meanwhile, `public_decryption_mode` and `user_decryption_mode` — intentional low-cardinality labels — were also dropped for the same reason.

### Changes

- Add `public_decryption_mode` and `user_decryption_mode` to `DURATION_LABEL_KEYS` in `observability/src/metrics.rs`
- Remove `TAG_KEY_ID`, `TAG_CRS_ID`, `TAG_CONTEXT_ID`, `TAG_EPOCH_ID` constants from `observability/src/metrics_names.rs`
- Remove all usages of these high-cardinality tags from duration timers in both centralized and threshold core
- Clean up resulting unused imports, variables, and no-op `timer.tags(vec![])` calls


## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.