### PR TITLE
chore: upgrade `rasn` and `rasn-cms` to v0.28.11 (latest).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,15 +2336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_panic"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
-dependencies = [
- "typewit",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3537,9 +3528,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4392,26 +4380,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "konst"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4381b9b00c55f251f2ebe9473aef7c117e96828def1a7cb3bd3f0f903c6894e9"
-dependencies = [
- "const_panic",
- "konst_kernel",
- "typewit",
-]
-
-[[package]]
-name = "konst_kernel"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b1eb7788f3824c629b1116a7a9060d6e898c358ebff59070093d51103dcc3c"
-dependencies = [
- "typewit",
 ]
 
 [[package]]
@@ -5950,18 +5918,16 @@ dependencies = [
 
 [[package]]
 name = "rasn"
-version = "0.20.2"
+version = "0.28.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e442690f86da40561d5548e7ffb4a18af90d1c1b3536090de847ca2d5a3a6426"
+checksum = "1c00672f0ebff31e31b6d7e8db8b7c639b4a8ee9ae6afa206bc4e6acd706e6b2"
 dependencies = [
- "arrayvec",
  "bitvec",
  "bitvec-nom2",
  "bytes",
+ "cfg-if",
  "chrono",
  "either",
- "hashbrown 0.14.5",
- "konst",
  "nom 7.1.3",
  "num-bigint",
  "num-integer",
@@ -5970,13 +5936,14 @@ dependencies = [
  "rasn-derive",
  "serde_json",
  "snafu",
+ "xml-no-std",
 ]
 
 [[package]]
 name = "rasn-cms"
-version = "0.20.2"
+version = "0.28.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede8eba1e2dd8a472aff4568af9f598e218d8e45f3f1a092a3c40ed9ebd4fb15"
+checksum = "b062f8fd7cd3f3273c923c79b326d4cae2c20df17536feb522d8720de415fbb6"
 dependencies = [
  "rasn",
  "rasn-pkix",
@@ -5984,24 +5951,34 @@ dependencies = [
 
 [[package]]
 name = "rasn-derive"
-version = "0.20.2"
+version = "0.28.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0d374c7e4e985e6bc97ca7e7ad1d9642a8415db2017777d6e383002edaab2"
+checksum = "e6eaf3291a7744ab19ddd7eb12610859e73b804fa642e56b4b04b902a4a5d0ad"
+dependencies = [
+ "proc-macro2",
+ "rasn-derive-impl",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "rasn-derive-impl"
+version = "0.28.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1676f3d82e9a8899f157366cd2b0890d9baf55240e8f0e8d78559e8325595014"
 dependencies = [
  "either",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "rayon",
  "syn 2.0.114",
  "uuid",
 ]
 
 [[package]]
 name = "rasn-pkix"
-version = "0.20.2"
+version = "0.28.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8497305b8eaf88c93968ad7ebb404d8dba6c8980b89ca536d3567ffec604a61b"
+checksum = "b0ef60fdd14a70643442e46b45f99e878c454c67354f122017b4630f4f766cac"
 dependencies = [
  "rasn",
 ]
@@ -8334,21 +8311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "typewit"
-version = "1.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
-dependencies = [
- "typewit_proc_macros",
-]
-
-[[package]]
-name = "typewit_proc_macros"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
-
-[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9081,6 +9043,12 @@ dependencies = [
  "thiserror 2.0.12",
  "time",
 ]
+
+[[package]]
+name = "xml-no-std"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd223bc94c615fc02bf2f4bbc22a4a9bfe489c2add3ec10b1038df3aca44cac7"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,8 +173,8 @@ proptest = "=1.6.0"  # Property-based testing - MEDIUM RISK: Individual maintain
 prost = "=0.14.3"  # Protocol Buffers - LOW RISK: tokio-rs team, 10M+ downloads
 quote = "=1.0.40"  # Quote macro utilities - MEDIUM RISK: Reputable individual maintainer (dtolnay), 722M downloads
 rand = "=0.8.5"  # Random number generation - LOW RISK: rust-random, 100M+ downloads
-rasn = "=0.20.2"  # ASN.1 encoding/decoding - HIGH RISK: Individual maintainer (XAMPPRocky), security-critical ASN.1 handling
-rasn-cms = "=0.20.2"  # CMS (Cryptographic Message Syntax) - HIGH RISK: Individual maintainer (XAMPPRocky), security-critical
+rasn = "=0.28.11"  # ASN.1 encoding/decoding - HIGH RISK: Individual maintainer (XAMPPRocky), security-critical ASN.1 handling
+rasn-cms = "=0.28.11"  # CMS (Cryptographic Message Syntax) - HIGH RISK: Individual maintainer (XAMPPRocky), security-critical
 rayon = "=1.11.0"  # Data parallelism - LOW RISK: rayon-rs team
 rcgen = { version = "=0.14.7", default-features = false, features = ["aws_lc_rs", "crypto", "pem", "x509-parser"] }  # X.509 certificate generation - MEDIUM RISK: Using custom fork (see patch section), needs verification
 redis = { version = "=0.29.5" }  # Redis client - LOW RISK: redis-rs team

--- a/core/service/src/vault/keychain/awskms.rs
+++ b/core/service/src/vault/keychain/awskms.rs
@@ -482,7 +482,7 @@ pub fn decrypt_ciphertext_for_recipient(
 
     // validate the PKCS7 envelope
     ensure!(
-        envelope.version == Integer::Primitive(AWS_KMS_ENVELOPED_DATA_VERSION),
+        envelope.version == Integer::from(AWS_KMS_ENVELOPED_DATA_VERSION),
         "User decrypted ciphertext envelope must have version {}, actual version: {}",
         AWS_KMS_ENVELOPED_DATA_VERSION,
         envelope.version
@@ -497,7 +497,7 @@ pub fn decrypt_ciphertext_for_recipient(
         bail!("User decrypted ciphertext envelope does not contain a recipient");
     };
     ensure!(
-        ktri.version == Integer::Primitive(AWS_KMS_ENVELOPED_DATA_RECIPIENT_VERSION),
+        ktri.version == Integer::from(AWS_KMS_ENVELOPED_DATA_RECIPIENT_VERSION),
         "User decrypted ciphertext envelope recipient info must have version {}, actual version: {}",
         AWS_KMS_ENVELOPED_DATA_RECIPIENT_VERSION,
         ktri.version


### PR DESCRIPTION
Upgrade two crates to their latest versions, 0.28.11: `rasn` and `rasn-cms`. These are two security critical crates.

The motivation for the upgrade was the use of a sketchy dependency (`konst`) with unsound `unsafe` usage that will break with the next Rustc release. Recent versions of `rasn*` removes this dependency (and several others).

I asked the bot to assess the changes between 0.20.2 and 0.28.11:

---

Upgrade Assessment: rasn 0.20.2 → 0.28.11

### Security-relevant fixes (strongest justification)

1. **Integer decode panic (PR #257)** — Decoding integers with byte lengths greater than `{integer}::BITS / 8` caused a subtraction underflow and index panic. This is a **DoS vector**: a crafted ASN.1 payload can crash the process. Your KMS decodes CMS envelopes from AWS KMS (externally-influenced ASN.1 data), so defense-in-depth demands the decoder not panic on malformed input.

2. **OID comparison stack overflow (Issue #223)** — `ObjectIdentifier::PartialEq` could trigger a stack overflow. Your code at line 506 compares OIDs directly (`ktri.key_encryption_algorithm.algorithm == Oid::...`), making this directly relevant.

3. **BER decoder correctness for OPTIONAL ANY in SEQUENCE (PR #504)** — Explicit errors instead of silently mishandling. CMS `EnvelopedData` contains OPTIONAL and ANY fields.

4. **BitString truncation (Issue #111)** and **empty BIT STRING handling (PR #458)** — Encoding/decoding correctness fixes.

5. **Constrained length encoding fix (PR #493)** — Incorrect encoding for `SIZE(0..65535)`.

### No formal RUSTSEC advisory exists
The bugs are real but weren't reported through the advisory database. `cargo audit` won't flag the old version — this is a reporting gap, not evidence of safety.

### Performance improvements

- **Integer decoding (PR #256)** — No longer heap-allocates a BigInt for every decoded integer. Small integers (like your version numbers) stay on the stack.
- **OID parsing (PR #263)** — Eliminated 2+N BigInt allocations per OID parse.

### Breaking API changes

| Change | PR | Impact on this codebase |
|---|---|---|
| Integer type redesign (enum, no more `Primitive`) | #289 | **Fixed above** — `Integer::Primitive(v)` → `Integer::from(v)` |
| OctetString wrapped in newtype | #469 | No impact — code uses `OctetString::decode()` which still works |
| BER decoder stricter error handling | #504 | Positive — previously-accepted malformed inputs now rejected |

### Dependency surface reduction

- **Packages removed**: `konst`, `const_panic`, `konst_kernel`, `typewit`, `typewit_proc_macros`, `hashbrown 0.14`, `arrayvec`
- **Packages added**: `rasn-derive-impl`, `xml-no-std`
- **Net change**: 823 → 820 packages (-3)

### Sustainability note
The project has EU/NLnet funding through the NGI Assure Fund and RE-ROUTE project, providing some sustainability assurance despite the single-maintainer risk.

---

**Bottom line**: The upgrade is well-justified. The two DoS vectors (integer decode panic, OID comparison stack overflow) alone warrant it for a security-critical KMS. The reduced dependency surface and performance improvements are bonuses. The only code change needed was the two-line `Integer::Primitive` → `Integer::from` fix, and `rasn` is confined to a single file (`core/service/src/vault/keychain/awskms.rs`).

