### PR TITLE
chore: ignore RUSTSEC-2026-0099 and RUSTSEC-2026-0098 temporarily

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -12,6 +12,9 @@
 # when socat proxies are used, the connection goes to localhost and if we don't
 # overload the server names, the handshake would fail because localhost isn't
 # `sts.*.amazonaws.com`).
+# RUSTSEC-2026-0098 and RUSTSEC-2026-0099 can be ignored for now, as they could only be exploited by AWS itself.
+# We are currently in the process of removing code that is affected by RUSTSEC-2026-0049, RUSTSEC-2026-0098
+#and RUSTSEC-2026-0099, and we will remove the ignores below for them once that is done.
 ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2026-0049", "RUSTSEC-2026-0098", "RUSTSEC-2026-0099"]
 informational_warnings = ["unmaintained"]
 severity_threshold = "medium"

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -12,7 +12,7 @@
 # when socat proxies are used, the connection goes to localhost and if we don't
 # overload the server names, the handshake would fail because localhost isn't
 # `sts.*.amazonaws.com`).
-ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2026-0049"]
+ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2026-0049", "RUSTSEC-2026-0098", "RUSTSEC-2026-0099"]
 informational_warnings = ["unmaintained"]
 severity_threshold = "medium"
 


### PR DESCRIPTION
## Description of changes
ignore RUSTSEC-2026-0099 and RUSTSEC-2026-0098 temporarily until we have removed the affected code parts.
This should unblock CI for the moment.

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

