### PR TITLE
fix: test_keygen_backup_presence_central

### DIFF
--- a/core/service/src/client/tests/centralized/custodian_backup_tests.rs
+++ b/core/service/src/client/tests/centralized/custodian_backup_tests.rs
@@ -168,7 +168,8 @@ async fn backup_after_crs(amount_custodians: usize, threshold: u32) {
         Some(env.temp_dir.path()),
     )
     .await;
-
+    // Sleep briefly to allow backup to be written (since backup is done asynchronously after generation)
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     // Check that the new CRS was backed up
     let crss = read_custodian_backup_files_with_epoch(
         env.test_path(),

--- a/core/service/src/client/tests/centralized/custodian_backup_tests.rs
+++ b/core/service/src/client/tests/centralized/custodian_backup_tests.rs
@@ -429,7 +429,8 @@ async fn test_keygen_backup_presence_central() {
         Some(env.temp_dir.path()),
     )
     .await;
-
+    // Sleep briefly to allow backup to be written (since backup is done asynchronously after keygen)
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     // Verify FHE key material appears in backup immediately after keygen
     let key_backup: Vec<BackupCiphertext> = read_custodian_backup_files_with_epoch(
         env.test_path(),

--- a/core/service/src/client/tests/threshold/custodian_backup_tests.rs
+++ b/core/service/src/client/tests/threshold/custodian_backup_tests.rs
@@ -229,6 +229,8 @@ async fn backup_after_crs(amount_custodians: usize, threshold: u32) {
     )
     .await;
 
+    // Sleep briefly to allow backup to be written (since backup is done asynchronously after generation)
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     // Check that the new CRS was backed up
     let crss: Vec<BackupCiphertext> = read_custodian_backup_files_with_epoch(
         env.test_path(),
@@ -589,7 +591,8 @@ async fn test_custodian_reencryption_with_existing_data_threshold() {
         0,
     )
     .await;
-
+    // Sleep briefly to allow backup to be written (since backup is done asynchronously after generation)
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     // Read backup under first custodian context
     let backup_a: Vec<BackupCiphertext> = read_custodian_backup_files_with_epoch(
         env.test_path(),
@@ -781,7 +784,8 @@ async fn test_backup_after_reshare_threshold() {
     .await;
     assert_eq!(crs_info_vec.len(), 1);
     let crs_info_item = &crs_info_vec[0];
-
+    // Sleep briefly to allow backup to be written (since backup is done asynchronously after generation)
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     // Verify initial backup exists at default epoch before reshare
     let initial_key_backup: Vec<BackupCiphertext> = read_custodian_backup_files_with_epoch(
         env.test_path(),

--- a/core/service/src/client/tests/threshold/custodian_backup_tests.rs
+++ b/core/service/src/client/tests/threshold/custodian_backup_tests.rs
@@ -537,7 +537,8 @@ async fn test_keygen_backup_presence_threshold() {
         0,
     )
     .await;
-
+    // Sleep briefly to allow backup to be written (since backup is done asynchronously after keygen)
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     // Verify FHE key material appears in backup immediately after keygen
     let key_backup: Vec<BackupCiphertext> = read_custodian_backup_files_with_epoch(
         env.test_path(),


### PR DESCRIPTION
## Description of changes
<!-- Please explain the changes you made -->
With the merge of 521, the storage logic changed slightly such that backup happens _after_ the the result of the request has been stored and the meta store updated. 
Thus may lead to a race conditions in the test that checks the existence of the backup as soon as the initial requests has finished (i.e. meta store updated).  
The simple fix is to sleep for a little bit to ensure that the backup has been completed before checking if it exists. 
We do not want to revert the logic, since the backup (in particular failure) should not have an affect on the actual key/crs generation call. The backup should be considered something extra that is conceptually independent of the key/crs gen calls.

## Issue ticket number and link
<!-- Add a reference to the issue fixed if available -->
Issue came from this PR https://github.com/zama-ai/kms/pull/521
Things will be more streamlined with the completion of this issue https://github.com/zama-ai/kms-internal/issues/2983

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
