### PR TITLE
chore: allow docker build from Github UI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,11 @@ on:
   release:
     types: [published]
   #=======================================================
+  # Manual trigger from the GitHub UI. The "Use workflow from" dropdown lets
+  # users pick a branch or tag; commit SHAs can be passed via
+  # `gh workflow run docker-build.yml --ref <sha>`.
+  workflow_dispatch:
+  #=======================================================
   workflow_call:
     secrets:
       BLOCKCHAIN_ACTIONS_TOKEN:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,7 +8,25 @@ on:
   # Manual trigger from the GitHub UI. The "Use workflow from" dropdown lets
   # users pick a branch or tag; commit SHAs can be passed via
   # `gh workflow run docker-build.yml --ref <sha>`.
+  # Each image can be toggled; unticking a parent also skips its dependents.
   workflow_dispatch:
+    inputs:
+      build-golden-image:
+        description: 'Build rust-golden-image (parent of core-client, core-service, enclave)'
+        type: boolean
+        default: true
+      build-core-client:
+        description: 'Build core-client (needs golden-image)'
+        type: boolean
+        default: true
+      build-core-service:
+        description: 'Build core-service (needs golden-image; parent of enclave)'
+        type: boolean
+        default: true
+      build-enclave:
+        description: 'Build core-service-enclave (needs core-service)'
+        type: boolean
+        default: true
   #=======================================================
   workflow_call:
     secrets:
@@ -51,6 +69,7 @@ jobs:
   #
   golden-image:
     name: docker-build/golden-image (bpr)
+    if: github.event_name != 'workflow_dispatch' || inputs.build-golden-image
     # needs:
     #   - start-amd64-runner
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@478ee7de5baeab4fd49edfc42c9b81a56f6cfb03 # v1.0.5
@@ -84,6 +103,7 @@ jobs:
   #
   core-client:
     name: docker-build/core-client (bpr)
+    if: github.event_name != 'workflow_dispatch' || inputs.build-core-client
     needs:
       # - start-amd64-runner
       - golden-image
@@ -118,6 +138,7 @@ jobs:
   #
   core-service:
     name: docker-build/core-service (bpr)
+    if: github.event_name != 'workflow_dispatch' || inputs.build-core-service
     needs:
       # - start-amd64-runner
       - golden-image
@@ -152,6 +173,7 @@ jobs:
   #
   enclave:
     name: docker-build/core-service-enclave (bpr)
+    if: github.event_name != 'workflow_dispatch' || inputs.build-enclave
     needs:
       # - start-amd64-runner
       - core-service


### PR DESCRIPTION
## Description of changes
This adds `workflow_dispatch` to the `docker_build` workflow, in order to allow it to be triggered via the GitHub UI.
Previously this was only possible by adding the `docker` label to a PR or by waiting for the nightly pipeline to run.

## Checklist
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
