### PR TITLE
fix(ci): use correct pod name in performance-testing log collection

### DIFF
--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -389,7 +389,7 @@ jobs:
           echo "Collecting logs from KMS Core pods..."
           for i in {1..13}; do
             echo "Collecting logs from KMS Core pod ${i}/13..."
-            POD_NAME="kms-service-threshold-${i}-${PATH_SUFFIX}-core-${i}"
+            POD_NAME="${HELM_RELEASE_PREFIX:-kms-core}-${i}-core-${i}"
             LOG_FILE="kms-core-${i}-logs.txt"
 
             # Get pod logs and save to file


### PR DESCRIPTION
## Description of changes
The log-collection step in the performance-testing workflow used a pod name pattern that does not match the pods created by the deploy script, so `kubectl get pod` always failed and produced empty `kms-core-*-logs.txt` artifacts. 
After this change we use the actual helm-generated pattern instead.


## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
