### PR TITLE
fix: performance testing workflow fixes and improvements

### DIFF
--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -76,6 +76,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: performance-testing-kms-ci
+  cancel-in-progress: false
+
 jobs:
   ############################################################################
   # Docker Build Job (Conditional)

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -213,7 +213,6 @@ jobs:
           NAMESPACE: 'kms-ci'
           KMS_CHART_VERSION: ${{ inputs.kms_chart_version || 'repository' }}
           TKMS_INFRA_CHART_VERSION: ${{ inputs.tkms_infra_chart_version || '0.3.2' }}
-          SYNC_SECRETS_CHART_VERSION: '0.2.1'
         run: |
           {
             echo "DEPLOYMENT_TYPE=${DEPLOYMENT_TYPE}"
@@ -223,7 +222,6 @@ jobs:
             echo "NAMESPACE=${NAMESPACE}"
             echo "KMS_CHART_VERSION=${KMS_CHART_VERSION}"
             echo "TKMS_INFRA_CHART_VERSION=${TKMS_INFRA_CHART_VERSION}"
-            echo "SYNC_SECRETS_CHART_VERSION=${SYNC_SECRETS_CHART_VERSION}"
           } >> "$GITHUB_ENV"
 
       - name: Login to zws GitHub Container Registry

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -229,6 +229,43 @@ jobs:
             echo "PATH_SUFFIX=kms-ci" >> "$GITHUB_ENV"
           fi
 
+      # VERIFY IMAGE TAGS EXIST IN REGISTRY
+      # Fail fast if requested tags are missing, instead of waiting ~40min for
+      # helm pre-install hooks to time out on ImagePullBackOff.
+      # ======================================================================
+      - name: Verify image tags exist in registry
+        env:
+          IMAGE_REPO: hub.zama.org/ghcr/zama-ai/kms
+        run: |
+          if [[ "${DEPLOYMENT_TYPE}" == *"Enclave"* ]]; then
+            CORE_IMAGE_NAME="core-service-enclave"
+          else
+            CORE_IMAGE_NAME="core-service"
+          fi
+
+          images=(
+            "${IMAGE_REPO}/${CORE_IMAGE_NAME}:${KMS_CORE_IMAGE_TAG}"
+            "${IMAGE_REPO}/core-client:${KMS_CORE_CLIENT_IMAGE_TAG}"
+          )
+
+          missing=0
+          for img in "${images[@]}"; do
+            echo "Checking ${img}..."
+            if docker manifest inspect "${img}" > /dev/null 2>&1; then
+              echo "  ✅ found"
+            else
+              echo "  ❌ not found in registry"
+              missing=1
+            fi
+          done
+
+          if [[ "${missing}" -eq 1 ]]; then
+            echo "ERROR: One or more required image tags are missing from the registry."
+            echo "If you dispatched manually with build=false, check that the provided"
+            echo "image tags were actually pushed; otherwise re-run with build=true."
+            exit 1
+          fi
+
       # ======================================================================
       # TOOLING SETUP
       # ======================================================================

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Configure deployment parameters
         env:
           DEPLOYMENT_TYPE: ${{ inputs.deployment_type || 'thresholdWithEnclave' }}
-          TLS: ${{ inputs.tls || 'true' }}
+          TLS: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.tls) || 'true' }}
           FHE_PARAMS: ${{ inputs.fhe_params || 'Test' }}
           KMS_BRANCH: ${{ inputs.kms_branch || github.ref }}
           NAMESPACE: 'kms-ci'

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -112,12 +112,18 @@ jobs:
 
   ############################################################################
   # Start AMD64 Runner
-  # Waits for docker-build if it's running, but always executes
+  # Waits for docker-build if required, then starts the test runner
   ############################################################################
   start-amd64-runner:
     name: performance-testing/start-amd64-runner
     needs: [docker-build]
-    if: always()
+    if: |
+      always() &&
+      !cancelled() &&
+      (
+        needs.docker-build.result == 'success' ||
+        (github.event_name == 'workflow_dispatch' && inputs.build == false)
+      )
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner-amd64.outputs.label }}
@@ -139,7 +145,14 @@ jobs:
   ############################################################################
   performance-testing:
     needs: [docker-build, start-amd64-runner]
-    if: always() && needs.start-amd64-runner.result == 'success' && !cancelled()
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.start-amd64-runner.result == 'success' &&
+      (
+        needs.docker-build.result == 'success' ||
+        (github.event_name == 'workflow_dispatch' && inputs.build == false)
+      )
     name: performance-testing
     runs-on: ${{ needs.start-amd64-runner.outputs.label }}
     timeout-minutes: 1800
@@ -498,7 +511,7 @@ jobs:
     name: performance-testing/stop-amd64-runner
     needs: [start-amd64-runner, performance-testing]
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.start-amd64-runner.result == 'success'
     steps:
       - name: Stop AMD64 runner
         uses: zama-ai/slab-github-runner@5aee5d157f4a0201e5eaefc9cc648e5f9f5472a5 # v1.6.0

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -291,7 +291,7 @@ jobs:
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:${NAMESPACE}
+          tags: tag:kms-ci
 
       - name: Setup helm
         run: |


### PR DESCRIPTION
## Description of changes

Several independent fixes to `.github/workflows/performance-testing.yml`:

- **Fail fast on missing image tags.** New step runs `docker manifest inspect` against the resolved core / core-client tags before allocating cluster resources. Previously, a missing tag was only discovered ~40 min later when helm pre-install hooks timed out on `ImagePullBackOff`.
- **Gate runner allocation on the build flag.** `start-amd64-runner` and `performance-testing` previously had `if: always()` and only checked `start-amd64-runner.result == 'success'`, so a failed `docker-build` would still spin up an EC2 runner and run perf tests against missing/stale images. They now require either `docker-build` success or an explicit `workflow_dispatch` with `build=false`.
- **Stop the runner only if it started.** `stop-amd64-runner` now requires `start-amd64-runner.result == 'success'`, so we don't call slab-stop with no label when the start step is skipped.
- **Preserve manual `tls=false` input.** The previous expression `${{ inputs.tls || 'true' }}` silently coerced a dispatched `tls: false` to `'true'` because the boolean `false` is falsy in GHA expressions. Replaced with a `format('{0}', inputs.tls)` form that produces the string `"false"` (truthy → preserved through `||`) on dispatch and falls back to `'true'` on schedule.
- **Hardcode the Tailscale tag.** `tags: tag:${NAMESPACE}` was a latent bug — the `with:` block isn't a shell context, so the action received the literal `tag:${NAMESPACE}`. Replaced with `tag:kms-ci`, matching `pr-preview-deploy.yml` and `pr-preview-destroy.yml`.
- **Serialize concurrent runs.** Added `concurrency: { group: performance-testing-kms-ci, cancel-in-progress: false }` so two runs targeting the shared `kms-ci` namespace queue rather than collide.
- **Drop unused `SYNC_SECRETS_CHART_VERSION`.** The variable was set and exported but never consumed by `deploy.sh` or anything downstream of this workflow. (It is still set in `pr-preview-deploy.yml` and `rolling-upgrade-testing.yml`; if it is dead there too, follow-up PR.)

Co-authored by Claude

## Issue ticket number and link

N/A — observed during recent perf runs.

## PR Checklist
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased. _(N/A — CI workflow only)_
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present). _(N/A)_
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.