### PR TITLE
fix: default docker build to true, when wf is invoked from another one

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,7 +10,10 @@ on:
   # `gh workflow run docker-build.yml --ref <sha>`.
   # Each image can be toggled; unticking a parent also skips its dependents.
   workflow_dispatch:
-    inputs:
+    # Anchored so workflow_call below reuses the same input set; without
+    # workflow_call inputs, the per-image `if` gates evaluate `inputs.build-*`
+    # to null when invoked from another workflow and skip every image.
+    inputs: &build_inputs
       build-golden-image:
         description: 'Build rust-golden-image (parent of core-client, core-service, enclave)'
         type: boolean
@@ -29,23 +32,7 @@ on:
         default: true
   #=======================================================
   workflow_call:
-    inputs:
-      # Mirrored from workflow_dispatch so the per-image `if` gates below
-      # evaluate to `true` when this workflow is invoked from another one.
-      # Without these, `inputs.build-*` is null in workflow_call context and
-      # every image is skipped.
-      build-golden-image:
-        type: boolean
-        default: true
-      build-core-client:
-        type: boolean
-        default: true
-      build-core-service:
-        type: boolean
-        default: true
-      build-enclave:
-        type: boolean
-        default: true
+    inputs: *build_inputs
     secrets:
       BLOCKCHAIN_ACTIONS_TOKEN:
         required: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,6 +29,23 @@ on:
         default: true
   #=======================================================
   workflow_call:
+    inputs:
+      # Mirrored from workflow_dispatch so the per-image `if` gates below
+      # evaluate to `true` when this workflow is invoked from another one.
+      # Without these, `inputs.build-*` is null in workflow_call context and
+      # every image is skipped.
+      build-golden-image:
+        type: boolean
+        default: true
+      build-core-client:
+        type: boolean
+        default: true
+      build-core-service:
+        type: boolean
+        default: true
+      build-enclave:
+        type: boolean
+        default: true
     secrets:
       BLOCKCHAIN_ACTIONS_TOKEN:
         required: true


### PR DESCRIPTION
## Description of changes
Fixes an oversight from #549, which resulted in the docker build to be skipped, if it was invoked by another workflow and not through GitHub UI (`workflow_dispatch`).
Now these images are built by default if the workflow is called and parameters are not set.

## Issue ticket number and link
https://github.com/zama-ai/kms/actions/runs/25108364250

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

