### PR TITLE
chore: downgrade rustc back to 1.94.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,7 @@ jobs:
           filters: |
             ci:
               - '.github/workflows/**'
+              - 'rust-toolchain.toml'
             core-client:
               - 'core-client/src/**'
               - 'core-client/config/**'
@@ -72,12 +73,15 @@ jobs:
               - 'core/thread-handles/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
             core-client-k8s-tests:
               - 'core-client/tests/**'
+              - 'rust-toolchain.toml'
             core-grpc:
               - 'core/grpc/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
             core-service:
               - 'backward-compatibility/**'
               - 'core/grpc/**'
@@ -88,12 +92,14 @@ jobs:
               - 'observability/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
             core-threshold:
               - 'core/threshold*/**'
               - 'core/thread-handles/**'
               - 'observability/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
             # Workspace crates that have no dedicated CI job of their own.
             # Used by `test-workspace-crates` to run their unit tests grouped
             # across a few runners.
@@ -106,10 +112,13 @@ jobs:
               - 'observability/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
             docs:
               - 'docs/**'
+              - 'rust-toolchain.toml'
             helm-chart:
               - 'charts/**'
+              - 'rust-toolchain.toml'
 
   ############################################################################
   # Docker build pipeline

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.94.0"


### PR DESCRIPTION
Attempt to "fix" CI compilation times by downgrading to 1.94 again.
