### PR TITLE
Ensure Rust cache is updated

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -2,6 +2,10 @@ name: rust-lint
 
 on:
   pull_request:
+  # Run on main pushes too so the rust-cache `save-if` condition in the "Setup Rust cache"-step evaluates to true and
+  # populates the workspace cache. PR runs only use the cache for reading.
+  push:
+    branches: [main]
 
 concurrency:
   group: rust-lint-${{ github.ref }}


### PR DESCRIPTION
Our CI is setup so that the workflows that run on PRs only read from the workspace cache. This PR makes the `rust-lint` job run when a PR is merged to `main`, which in turn makes the `save-if ${{ github.ref == 'refs/heads/main' }}`-condition evaluate to true, and update the cache.

The `save-if` clause is [here](https://github.com/zama-ai/kms/pull/558/changes#diff-ab0021448c8fedbcb76ed1d696974011f26211d4333fd3d37f8ff431cb619f46R53).


