### PR TITLE
fix: add missing checkout to signing wf

### DIFF
--- a/.github/workflows/common-nitro-enclave.yml
+++ b/.github/workflows/common-nitro-enclave.yml
@@ -258,6 +258,13 @@ jobs:
     name: common-nitro-enclave/sign-image
     runs-on: 'ubuntu-latest'
     steps:
+      # docker-login below is a local composite action under .github/actions/,
+      # so the repo must be on disk before it is referenced.
+      - name: Checkout Project
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
       # Needed to be able to pull some docker images for the simulator test
       - name: Login to GitHub Container Registry
         uses: ./.github/actions/docker-login


### PR DESCRIPTION
## Description of changes
Image signing failed since apparently the checkout step was removed in #520 :
https://github.com/zama-ai/kms/actions/runs/25162613356

This PR brings it back.

## Issue ticket number and link
https://github.com/zama-ai/kms/actions/runs/25162613356

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.


