### PR TITLE
chore: attempt to fix CI by pinning the revision of our dylint fetch

### DIFF
--- a/dylint.toml
+++ b/dylint.toml
@@ -1,6 +1,6 @@
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/trailofbits/dylint", pattern = "examples/general/non_local_effect_before_error_return" },
+    { git = "https://github.com/trailofbits/dylint", rev = "2c20d164e06c446de2cecadff0c55e16a877c006", pattern = "examples/general/non_local_effect_before_error_return" },
 ]
 
 [non_local_effect_before_error_return]


### PR DESCRIPTION
Ci has been failing fro a few days and it seems like ToB has updated the example lint that we're using. It is now named differently and, I think, also behaves differently.

This PR pins the git revision to what we were using before.

After this revision the lint has  changed behaviour and name. It is unclear to me why we noticed just the last few days. Perhaps some cache expired somewhere?