### PR TITLE
chore: Remove the CoW-reflinks verification step

### DIFF
--- a/.github/workflows/common-testing.yml
+++ b/.github/workflows/common-testing.yml
@@ -283,19 +283,6 @@ jobs:
           # shellcheck disable=SC2086
           env ${CMD_ENV} cargo nextest run --profile "${NEXTEST_PROFILE}" --no-fail-fast ${CRATE_NAMES} ${ARGS_TESTS:+$ARGS_TESTS}
 
-      # TODO(dp): keep?
-      # Did reflinks actually happen? Compare the logical size of all per-test
-      # tempdirs (apparent) against the disk blocks used on the btrfs mount.
-      # If reflinks worked, apparent >> used (e.g., 200 GB logical / 25 GB used).
-      # If they didn't, apparent ≈ used and we got byte copies for nothing.
-      - name: Verify CoW reflinks
-        if: ${{ always() && ! inputs.skip-test-material }}
-        run: |
-          echo "--- logical size of per-test tempdirs (apparent) ---"
-          du -sh --apparent-size /mnt/cow-scratch/tmp 2>/dev/null || echo "no tempdirs (tests didn't run?)"
-          echo "--- actual blocks used on the btrfs mount ---"
-          df -h /mnt/cow-scratch
-
       - name: Copy Test Results
         if: (!cancelled() || !failure() && github.event_name == 'pull_request')
         env:


### PR DESCRIPTION
Pretty much what it says on the tin: added a while back to check that CoW is working. Now we know that it does, so no need to keep it I think.
