### PR TITLE
fix: correctly check whether rerand ksk reuses pksk

### DIFF
--- a/core/threshold-execution/src/endpoints/keygen.rs
+++ b/core/threshold-execution/src/endpoints/keygen.rs
@@ -737,10 +737,8 @@ where
         params_basics_handle.get_pksk_params(),
         params_basics_handle.get_rerand_ksk_params(),
     ) {
-        (Some(pksk_params), Some(cpk_re_randomization_ksk_params)) => {
-            // If these are equal, we already have the KSK from the LWE sk of the PK
-            // and the glwe sk that's necessary for rerand
-            if pksk_params == cpk_re_randomization_ksk_params {
+        (Some(_pksk_params), Some(cpk_re_randomization_ksk_params)) => {
+            if params_basics_handle.rerand_ksk_reuses_pksk() {
                 Some(CompressedReRandomizationRawKeySwitchingKey::UseCPKEncryptionKSK)
             } else {
                 Some(CompressedReRandomizationRawKeySwitchingKey::DedicatedKSK(

--- a/core/threshold-execution/src/online/preprocessing/dummy.rs
+++ b/core/threshold-execution/src/online/preprocessing/dummy.rs
@@ -53,6 +53,9 @@ pub struct DummyPreprocessing {
     parameters: SessionParameters,
     pub rnd_ctr: u64,
     pub trip_ctr: u64,
+    // Note: Important for DKG that we don't always produce the same bit sequence
+    // otherwise we may never be able to sample the expected Hamming weight for our secret keys.
+    pub bit_ctr: u64,
 }
 
 impl DummyPreprocessing {
@@ -63,6 +66,7 @@ impl DummyPreprocessing {
             parameters: session.to_parameters(),
             rnd_ctr: 0,
             trip_ctr: 0,
+            bit_ctr: 0,
         }
     }
 
@@ -112,6 +116,7 @@ impl Default for DummyPreprocessing {
             .unwrap(),
             rnd_ctr: 0,
             trip_ctr: 0,
+            bit_ctr: 0,
         }
     }
 }
@@ -264,7 +269,8 @@ where
 
     fn next_bit_vec(&mut self, amount: usize) -> anyhow::Result<Vec<Share<Z>>> {
         const BIT_FLAG: u64 = 0xB542074E84A9D88E;
-        let mut rng = AesRng::seed_from_u64(BIT_FLAG ^ self.seed);
+        let mut rng = AesRng::seed_from_u64(BIT_FLAG ^ self.seed ^ self.bit_ctr);
+        self.bit_ctr += amount as u64;
         let mut res = Vec::with_capacity(amount);
         let my_role = self.parameters.my_role();
         let my_share_zero = DummyPreprocessing::share(

--- a/core/threshold-execution/src/online/preprocessing/dummy.rs
+++ b/core/threshold-execution/src/online/preprocessing/dummy.rs
@@ -270,7 +270,6 @@ where
     fn next_bit_vec(&mut self, amount: usize) -> anyhow::Result<Vec<Share<Z>>> {
         const BIT_FLAG: u64 = 0xB542074E84A9D88E;
         let mut rng = AesRng::seed_from_u64(BIT_FLAG ^ self.seed ^ self.bit_ctr);
-        self.bit_ctr += amount as u64;
         let mut res = Vec::with_capacity(amount);
         let my_role = self.parameters.my_role();
         let my_share_zero = DummyPreprocessing::share(
@@ -290,6 +289,7 @@ where
             let secret = if bit { my_share_one } else { my_share_zero };
             res.push(secret);
         }
+        self.bit_ctr += amount as u64;
         Ok(res)
     }
 

--- a/core/threshold-execution/src/tfhe_internals/parameters.rs
+++ b/core/threshold-execution/src/tfhe_internals/parameters.rs
@@ -2162,7 +2162,7 @@ mod tests {
         },
     };
 
-    use super::{BC_PARAMS_NO_SNS, DkgParamsAvailable};
+    use super::{BC_PARAMS_NO_SNS, DKGParams, DkgParamsAvailable};
     use strum::IntoEnumIterator;
 
     #[test]
@@ -2348,6 +2348,57 @@ mod tests {
                          noise budgeted",
                     );
                 }
+            }
+        }
+    }
+
+    // Best effort test to catch any panics from the various `unwrap()` and `assert!()`
+    #[test]
+    fn check_no_panic() {
+        for param in DkgParamsAvailable::iter() {
+            let p = param.to_param();
+            let h = p.get_params_basics_handle();
+
+            // `unwrap()` inside serialization.
+            let _ = h.get_prefix_path();
+
+            // `panic!` if the noise distribution is not TUniform.
+            let _ = h.lwe_tuniform_bound();
+            let _ = h.lwe_hat_tuniform_bound();
+            let _ = h.glwe_tuniform_bound();
+
+            // `panic!` if compression key noise distribution is not TUniform.
+            let _ = h.compression_key_tuniform_bound();
+
+            // Multiple `unwrap()` from `compute_min_trials`.
+            let _ = h.lwe_sk_num_bits_to_sample();
+            let _ = h.lwe_hat_sk_num_bits_to_sample();
+            let _ = h.glwe_sk_num_bits_to_sample();
+            let _ = h.compression_sk_num_bits_to_sample();
+
+            // `assert!` inside this function can panic if destination key is invalid.
+            let _ = h.get_rerand_params();
+            let _ = h.get_rerand_ksk_params();
+
+            // `unwrap()` when converting to compact public key parameters.
+            let _ = h.get_compact_pk_enc_params();
+
+            // `panic!` if compression params are present but not `Classic`.
+            let _ = h.get_compression_decompression_params();
+
+            if let DKGParams::WithSnS(sns_params) = p {
+                // `panic!` if SnS GLWE noise distribution is not TUniform.
+                let _ = sns_params.glwe_tuniform_bound_sns();
+
+                // `unwrap()` from `compute_min_trials`.
+                let _ = sns_params.glwe_sk_num_bits_sns_to_sample();
+                let _ = sns_params.sns_compression_sk_num_bits_to_sample();
+
+                // `panic!` if SnS compression key noise is not TUniform.
+                let _ = sns_params.num_needed_noise_sns_compression_key();
+
+                // `panic!` if SnS params are MultiBit (currently unsupported).
+                let _ = sns_params.get_msnrk_configuration_sns();
             }
         }
     }

--- a/core/threshold-execution/src/tfhe_internals/parameters.rs
+++ b/core/threshold-execution/src/tfhe_internals/parameters.rs
@@ -436,6 +436,20 @@ pub trait DKGParamsBasics: Sync {
     fn get_pmax(&self) -> Option<f64> {
         self.get_sk_deviations().map(|dev| dev.pmax)
     }
+
+    /// Returns `true` when the CPK re-randomization KSK has the same crypto
+    /// parameters as the PKSK (the keyswitching key bundled with the dedicated
+    /// compact public key parameters) and can therefore reuse it instead of
+    /// being generated as a dedicated key.
+    fn rerand_ksk_reuses_pksk(&self) -> bool {
+        match (
+            self.get_rerand_params(),
+            self.get_dedicated_pk_params().map(|(_, p)| p),
+        ) {
+            (Some(rerand), Some(pksk)) => rerand == pksk,
+            _ => false,
+        }
+    }
 }
 
 fn combine_noise_info(target_bound: NoiseBounds, list: &[NoiseInfo]) -> NoiseInfo {
@@ -724,11 +738,9 @@ impl DKGParamsBasics for DKGParamsRegular {
     }
 
     fn num_needed_noise_rerand_ksk(&self) -> NoiseInfo {
-        // If there's a dedicated compact key with same parameter,
-        // we won't need to generate a new rerand key.
-        let amount = if self.cpk_re_randomization_ksk_params
-            == self.dedicated_compact_public_key_parameters.map(|(_, p)| p)
-        {
+        // If the dedicated PKSK can be reused as the rerand KSK we don't need
+        // any new noise for it; keep this in sync with `rerand_ksk_reuses_pksk`.
+        let amount = if self.rerand_ksk_reuses_pksk() {
             0
         } else {
             self.lwe_hat_dimension().0 * self.decomposition_level_count_rerand_ksk().0
@@ -2144,7 +2156,9 @@ mod tests {
     use crate::{
         keyset_config::{KeySetConfig, StandardKeySetConfig},
         tfhe_internals::parameters::{
-            BC_PARAMS_SNS, compute_min_trials, compute_prob_hw_within_range,
+            BC_PARAMS_SNS, NIST_PARAMS_P8_NO_SNS_FGLWE, NIST_PARAMS_P8_SNS_FGLWE,
+            NIST_PARAMS_P32_NO_SNS_FGLWE, NIST_PARAMS_P32_SNS_FGLWE, compute_min_trials,
+            compute_prob_hw_within_range,
         },
     };
 
@@ -2303,5 +2317,69 @@ mod tests {
         let log2_p_failure = -20;
         let result = compute_min_trials(p, log2_p_failure).unwrap();
         assert_eq!(result, 49);
+    }
+
+    /// Guards the invariant that the "reuse PKSK as rerand KSK" decision is
+    /// consistent across `rerand_ksk_reuses_pksk` (which the keygen pipeline
+    /// branches on) and `num_needed_noise_rerand_ksk` (which the noise budget
+    /// is sized from).
+    ///
+    /// Regression for the panic at
+    /// `MPCNoiseRandomGenerator::fork` during compressed key generation with
+    /// `NIST_PARAMS_P*_SNS_FGLWE`: the two functions disagreed and the keygen
+    /// would generate a "dedicated" rerand KSK with a zero-length noise vector.
+    #[test]
+    fn rerand_ksk_reuse_decision_is_consistent_with_noise_budget() {
+        for param in DkgParamsAvailable::iter() {
+            let p = param.to_param();
+            let h = p.get_params_basics_handle();
+            if h.rerand_ksk_reuses_pksk() {
+                assert_eq!(
+                    h.num_needed_noise_rerand_ksk().amount,
+                    0,
+                    "{param:?}: rerand_ksk_reuses_pksk() == true but \
+                     num_needed_noise_rerand_ksk().amount != 0; this drove \
+                     keygen into the dedicated-KSK branch with an empty noise \
+                     vec, causing a fork panic during the first LWE encryption.",
+                );
+            } else {
+                // When rerand can't reuse PKSK, the rerand KSK is generated as
+                // a dedicated key and must have a non-zero noise budget iff
+                // rerand params are configured at all.
+                if h.get_rerand_params().is_some() {
+                    assert!(
+                        h.num_needed_noise_rerand_ksk().amount > 0,
+                        "{param:?}: dedicated rerand KSK requested but no \
+                         noise budgeted",
+                    );
+                }
+            }
+        }
+    }
+
+    /// The `NIST_PARAMS_P*_FGLWE` parameter sets configure
+    /// `cpk_re_randomization_ksk_params` to the same
+    /// `ShortintKeySwitchingParameters` value as the PKSK ksk component, so
+    /// the rerand KSK must reuse PKSK on these. The blockchain parameter
+    /// sets use distinct values and must NOT reuse PKSK.
+    #[test]
+    fn rerand_ksk_reuse_decision_matches_known_parameter_sets() {
+        for p in [
+            NIST_PARAMS_P8_NO_SNS_FGLWE,
+            NIST_PARAMS_P8_SNS_FGLWE,
+            NIST_PARAMS_P32_NO_SNS_FGLWE,
+            NIST_PARAMS_P32_SNS_FGLWE,
+        ] {
+            assert!(
+                p.get_params_basics_handle().rerand_ksk_reuses_pksk(),
+                "expected rerand KSK to reuse PKSK on {p:?}",
+            );
+        }
+        for p in [BC_PARAMS_NO_SNS, BC_PARAMS_SNS] {
+            assert!(
+                !p.get_params_basics_handle().rerand_ksk_reuses_pksk(),
+                "expected dedicated rerand KSK on {p:?}",
+            );
+        }
     }
 }

--- a/core/threshold-execution/src/tfhe_internals/parameters.rs
+++ b/core/threshold-execution/src/tfhe_internals/parameters.rs
@@ -838,7 +838,10 @@ impl DKGParamsBasics for DKGParamsRegular {
             self.cpk_re_randomization_ksk_params,
             self.dedicated_compact_public_key_parameters,
         ) {
-            (Some(cpk_re_randomization_ksk_params), Some(_)) => {
+            // Note: Having rerand params without pk parameter would be unusual,
+            // but with transciphering we might someday need it
+            // (since the pk would become useless, even though we'd still technically have a public key scheme)
+            (Some(cpk_re_randomization_ksk_params), _) => {
                 assert!(
                     matches!(
                         cpk_re_randomization_ksk_params.destination_key,
@@ -854,8 +857,7 @@ impl DKGParamsBasics for DKGParamsRegular {
                     decomposition_level_count: self.decomposition_level_count_rerand_ksk(),
                 })
             }
-            (_, None) => None,
-            _ => panic!("Inconsistent ClientKey set-up for CompactPublicKey re-randomization."),
+            (None, _) => None,
         }
     }
 
@@ -2156,9 +2158,7 @@ mod tests {
     use crate::{
         keyset_config::{KeySetConfig, StandardKeySetConfig},
         tfhe_internals::parameters::{
-            BC_PARAMS_SNS, NIST_PARAMS_P8_NO_SNS_FGLWE, NIST_PARAMS_P8_SNS_FGLWE,
-            NIST_PARAMS_P32_NO_SNS_FGLWE, NIST_PARAMS_P32_SNS_FGLWE, compute_min_trials,
-            compute_prob_hw_within_range,
+            BC_PARAMS_SNS, compute_min_trials, compute_prob_hw_within_range,
         },
     };
 

--- a/core/threshold-execution/src/tfhe_internals/parameters.rs
+++ b/core/threshold-execution/src/tfhe_internals/parameters.rs
@@ -2323,11 +2323,6 @@ mod tests {
     /// consistent across `rerand_ksk_reuses_pksk` (which the keygen pipeline
     /// branches on) and `num_needed_noise_rerand_ksk` (which the noise budget
     /// is sized from).
-    ///
-    /// Regression for the panic at
-    /// `MPCNoiseRandomGenerator::fork` during compressed key generation with
-    /// `NIST_PARAMS_P*_SNS_FGLWE`: the two functions disagreed and the keygen
-    /// would generate a "dedicated" rerand KSK with a zero-length noise vector.
     #[test]
     fn rerand_ksk_reuse_decision_is_consistent_with_noise_budget() {
         for param in DkgParamsAvailable::iter() {
@@ -2354,32 +2349,6 @@ mod tests {
                     );
                 }
             }
-        }
-    }
-
-    /// The `NIST_PARAMS_P*_FGLWE` parameter sets configure
-    /// `cpk_re_randomization_ksk_params` to the same
-    /// `ShortintKeySwitchingParameters` value as the PKSK ksk component, so
-    /// the rerand KSK must reuse PKSK on these. The blockchain parameter
-    /// sets use distinct values and must NOT reuse PKSK.
-    #[test]
-    fn rerand_ksk_reuse_decision_matches_known_parameter_sets() {
-        for p in [
-            NIST_PARAMS_P8_NO_SNS_FGLWE,
-            NIST_PARAMS_P8_SNS_FGLWE,
-            NIST_PARAMS_P32_NO_SNS_FGLWE,
-            NIST_PARAMS_P32_SNS_FGLWE,
-        ] {
-            assert!(
-                p.get_params_basics_handle().rerand_ksk_reuses_pksk(),
-                "expected rerand KSK to reuse PKSK on {p:?}",
-            );
-        }
-        for p in [BC_PARAMS_NO_SNS, BC_PARAMS_SNS] {
-            assert!(
-                !p.get_params_basics_handle().rerand_ksk_reuses_pksk(),
-                "expected dedicated rerand KSK on {p:?}",
-            );
         }
     }
 }


### PR DESCRIPTION
## Description of changes
<!-- Please explain the changes you made -->
The way we checked whether or not to reuse the KSK was wrong, which lead to issues during DKG for some NIST params. 
In short, we were checking whether the derive KSKParams were identical, but when generating those KSKParams, if we knew the rerand key would re-use the pksk we'd set the num needed noise to 0, effectively artificially making those non-equal.
This is now using a dedicated function for this check instead of trying to use the derived KSKParams as a proxy for this information.

## Issue ticket number and link
<!-- Add a reference to the issue fixed if available -->

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new pub item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
