### PR TITLE
fix(security): replace unsafe zeroize impls with ZeroizeOnDrop

### DIFF
--- a/core/service/src/cryptography/encryption.rs
+++ b/core/service/src/cryptography/encryption.rs
@@ -314,7 +314,13 @@ impl<C: KemCore> Zeroize for PrivateEncKey<C> {
     }
 }
 
-impl<C: KemCore> zeroize::ZeroizeOnDrop for PrivateEncKey<C> {}
+// Only valid where the inner `DecapsulationKey` itself impls `ZeroizeOnDrop`.
+// Satisfied by `ml_kem::MlKem{512,1024}` with the workspace `zeroize` feature;
+// any other `KemCore` impl without that guarantee simply won't qualify.
+impl<C: KemCore> zeroize::ZeroizeOnDrop for PrivateEncKey<C> where
+    C::DecapsulationKey: zeroize::ZeroizeOnDrop
+{
+}
 
 impl<C: KemCore> Clone for PrivateEncKey<C> {
     fn clone(&self) -> Self {

--- a/core/service/src/cryptography/encryption.rs
+++ b/core/service/src/cryptography/encryption.rs
@@ -298,17 +298,27 @@ impl HasPkeScheme for UnifiedPrivateEncKey {
 }
 
 // Alias wrapping the ephemeral private decryption key the user's wallet constructs to receive the
-// server's encrypted payload
-// The only reason this format is not private is that it is needed to handle the legacy case, as we do this by distinguishing between 512 and 1024 bit keys
-pub struct PrivateEncKey<C: KemCore>(pub(crate) C::DecapsulationKey);
+// server's encrypted payload.
+// The only reason this format is not private is that it is needed to handle the legacy case, as we do this by distinguishing between 512 and 1024 bit keys.
+//
+// The `where C::DecapsulationKey: zeroize::ZeroizeOnDrop` clause on the
+// struct itself makes `PrivateEncKey<C>` un-instantiable for any `KemCore`
+// whose inner key doesn't wipe on drop — the wipe-on-drop guarantee is
+// enforced at type construction rather than only at `.zeroize()` call sites.
+// `#[derive(zeroize::ZeroizeOnDrop)]` then expands to a `Drop` impl calling
+// `self.zeroize()` plus the marker; the constraint propagates because every
+// impl block below repeats it.
+#[derive(zeroize::ZeroizeOnDrop)]
+pub struct PrivateEncKey<C>(pub(crate) C::DecapsulationKey)
+where
+    C: KemCore,
+    C::DecapsulationKey: zeroize::ZeroizeOnDrop;
 
-// Both `Zeroize` and `ZeroizeOnDrop` are bounded on the inner
-// `DecapsulationKey` actually wiping on drop: `mem::replace` here only
-// produces a real wipe if the dropped original's `Drop` zeroes its secret
-// state. Satisfied by `ml_kem::MlKem{512,1024}` with the workspace
-// `zeroize` feature; any other `KemCore` impl without that guarantee
-// simply won't get either trait, so callers can't accidentally rely on a
-// wipe that wouldn't happen.
+// `Zeroize` provides the wipe primitive called from the derived `Drop`.
+// The inner `DecapsulationKey` only impls `ZeroizeOnDrop` (marker) — not
+// `Zeroize` (method) — so we can't call `self.0.zeroize()`; instead, the
+// `mem::replace`-then-drop pattern lets the inner's `Drop` do the actual
+// zeroing.
 impl<C: KemCore> Zeroize for PrivateEncKey<C>
 where
     C::DecapsulationKey: zeroize::ZeroizeOnDrop,
@@ -319,19 +329,20 @@ where
     }
 }
 
-impl<C: KemCore> zeroize::ZeroizeOnDrop for PrivateEncKey<C> where
-    C::DecapsulationKey: zeroize::ZeroizeOnDrop
+impl<C: KemCore> Clone for PrivateEncKey<C>
+where
+    C::DecapsulationKey: zeroize::ZeroizeOnDrop,
 {
-}
-
-impl<C: KemCore> Clone for PrivateEncKey<C> {
     fn clone(&self) -> Self {
         let buf = self.0.as_bytes();
         PrivateEncKey(C::DecapsulationKey::from_bytes(&buf))
     }
 }
 
-impl<C: KemCore> std::fmt::Debug for PrivateEncKey<C> {
+impl<C: KemCore> std::fmt::Debug for PrivateEncKey<C>
+where
+    C::DecapsulationKey: zeroize::ZeroizeOnDrop,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PrivateEncKey")
             .field("decapsulation_key", &"ommitted")
@@ -339,7 +350,10 @@ impl<C: KemCore> std::fmt::Debug for PrivateEncKey<C> {
     }
 }
 
-impl<C: KemCore> tfhe_versionable::Versionize for PrivateEncKey<C> {
+impl<C: KemCore> tfhe_versionable::Versionize for PrivateEncKey<C>
+where
+    C::DecapsulationKey: zeroize::ZeroizeOnDrop,
+{
     type Versioned<'vers>
         = &'vers PrivateEncKey<C>
     where
@@ -350,14 +364,20 @@ impl<C: KemCore> tfhe_versionable::Versionize for PrivateEncKey<C> {
     }
 }
 
-impl<C: KemCore> tfhe_versionable::VersionizeOwned for PrivateEncKey<C> {
+impl<C: KemCore> tfhe_versionable::VersionizeOwned for PrivateEncKey<C>
+where
+    C::DecapsulationKey: zeroize::ZeroizeOnDrop,
+{
     type VersionedOwned = PrivateEncKey<C>;
     fn versionize_owned(self) -> Self::VersionedOwned {
         self
     }
 }
 
-impl<C: KemCore> tfhe_versionable::Unversionize for PrivateEncKey<C> {
+impl<C: KemCore> tfhe_versionable::Unversionize for PrivateEncKey<C>
+where
+    C::DecapsulationKey: zeroize::ZeroizeOnDrop,
+{
     fn unversionize(
         versioned: Self::VersionedOwned,
     ) -> Result<Self, tfhe_versionable::UnversionizeError> {
@@ -365,7 +385,10 @@ impl<C: KemCore> tfhe_versionable::Unversionize for PrivateEncKey<C> {
     }
 }
 
-impl<C: KemCore> Serialize for PrivateEncKey<C> {
+impl<C: KemCore> Serialize for PrivateEncKey<C>
+where
+    C::DecapsulationKey: zeroize::ZeroizeOnDrop,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -374,7 +397,10 @@ impl<C: KemCore> Serialize for PrivateEncKey<C> {
     }
 }
 
-impl<'de, C: KemCore> Deserialize<'de> for PrivateEncKey<C> {
+impl<'de, C: KemCore> Deserialize<'de> for PrivateEncKey<C>
+where
+    C::DecapsulationKey: zeroize::ZeroizeOnDrop,
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -384,7 +410,10 @@ impl<'de, C: KemCore> Deserialize<'de> for PrivateEncKey<C> {
 }
 
 struct PrivateEncKeyVisitor<C: KemCore>(std::marker::PhantomData<C>);
-impl<C: KemCore> Visitor<'_> for PrivateEncKeyVisitor<C> {
+impl<C: KemCore> Visitor<'_> for PrivateEncKeyVisitor<C>
+where
+    C::DecapsulationKey: zeroize::ZeroizeOnDrop,
+{
     type Value = PrivateEncKey<C>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/core/service/src/cryptography/encryption.rs
+++ b/core/service/src/cryptography/encryption.rs
@@ -302,21 +302,23 @@ impl HasPkeScheme for UnifiedPrivateEncKey {
 // The only reason this format is not private is that it is needed to handle the legacy case, as we do this by distinguishing between 512 and 1024 bit keys
 pub struct PrivateEncKey<C: KemCore>(pub(crate) C::DecapsulationKey);
 
-// Swap in a dummy and let the original drop —
-// `ml_kem::DecapsulationKey: ZeroizeOnDrop` (workspace `zeroize` feature)
-// wipes `dk_pke` and `z` on the replaced value. The dummy is built from
-// zero `Encoded<DecapsulationKey>` bytes; `from_bytes` is infallible
-// (it only splits the input into the key's structural fields).
-impl<C: KemCore> Zeroize for PrivateEncKey<C> {
+// Both `Zeroize` and `ZeroizeOnDrop` are bounded on the inner
+// `DecapsulationKey` actually wiping on drop: `mem::replace` here only
+// produces a real wipe if the dropped original's `Drop` zeroes its secret
+// state. Satisfied by `ml_kem::MlKem{512,1024}` with the workspace
+// `zeroize` feature; any other `KemCore` impl without that guarantee
+// simply won't get either trait, so callers can't accidentally rely on a
+// wipe that wouldn't happen.
+impl<C: KemCore> Zeroize for PrivateEncKey<C>
+where
+    C::DecapsulationKey: zeroize::ZeroizeOnDrop,
+{
     fn zeroize(&mut self) {
         let dummy = C::DecapsulationKey::from_bytes(&Default::default());
         let _wiped = std::mem::replace(&mut self.0, dummy);
     }
 }
 
-// Only valid where the inner `DecapsulationKey` itself impls `ZeroizeOnDrop`.
-// Satisfied by `ml_kem::MlKem{512,1024}` with the workspace `zeroize` feature;
-// any other `KemCore` impl without that guarantee simply won't qualify.
 impl<C: KemCore> zeroize::ZeroizeOnDrop for PrivateEncKey<C> where
     C::DecapsulationKey: zeroize::ZeroizeOnDrop
 {

--- a/core/service/src/cryptography/encryption.rs
+++ b/core/service/src/cryptography/encryption.rs
@@ -302,26 +302,19 @@ impl HasPkeScheme for UnifiedPrivateEncKey {
 // The only reason this format is not private is that it is needed to handle the legacy case, as we do this by distinguishing between 512 and 1024 bit keys
 pub struct PrivateEncKey<C: KemCore>(pub(crate) C::DecapsulationKey);
 
+// Swap in a dummy and let the original drop —
+// `ml_kem::DecapsulationKey: ZeroizeOnDrop` (workspace `zeroize` feature)
+// wipes `dk_pke` and `z` on the replaced value. The dummy is built from
+// zero `Encoded<DecapsulationKey>` bytes; `from_bytes` is infallible
+// (it only splits the input into the key's structural fields).
 impl<C: KemCore> Zeroize for PrivateEncKey<C> {
     fn zeroize(&mut self) {
-        // Directly zeroize the underlying key bytes without creating copies
-        // This is more secure as it avoids temporary allocations of sensitive data
-        let key_bytes_ptr = self.0.as_bytes().as_ptr() as *mut u8;
-        let key_len = self.0.as_bytes().len();
-
-        // SAFETY: We're zeroizing the memory that belongs to this struct
-        // The pointer is valid and the length is correct from as_bytes()
-        unsafe {
-            std::ptr::write_bytes(key_bytes_ptr, 0, key_len);
-        }
+        let dummy = C::DecapsulationKey::from_bytes(&Default::default());
+        let _wiped = std::mem::replace(&mut self.0, dummy);
     }
 }
 
-impl<C: KemCore> Drop for PrivateEncKey<C> {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
+impl<C: KemCore> zeroize::ZeroizeOnDrop for PrivateEncKey<C> {}
 
 impl<C: KemCore> Clone for PrivateEncKey<C> {
     fn clone(&self) -> Self {

--- a/core/service/src/cryptography/signatures.rs
+++ b/core/service/src/cryptography/signatures.rs
@@ -267,11 +267,19 @@ impl Zeroize for WrappedSigningKey {
     fn zeroize(&mut self) {
         // Swap in a known-valid dummy and let the original drop —
         // `SigningKey<Secp256k1>: ZeroizeOnDrop` wipes its scalar.
-        // `[1u8; 32]` is `0x0101…01` ≪ secp256k1 order `n`, so
-        // `from_slice` accepts it (rejects only len ≠ 32, scalar = 0,
-        // or scalar ≥ n; length is fixed by `FieldBytesSize = U32`).
-        let dummy = SigningKey::from_slice(&[1u8; 32]).expect("0x0101…01 < secp256k1 n");
-        let _wiped = std::mem::replace(&mut self.0, dummy);
+        // `[1u8; 32]` is `0x0101…01` ≪ secp256k1 order `n`, so the
+        // constructor is in practice infallible; `if let Ok` keeps the
+        // Drop path panic-free at the type level — future edits to the
+        // constant or to the underlying type can't introduce a panic
+        // surface inside `Drop` (this method is called from the
+        // `#[derive(ZeroizeOnDrop)]`-generated `Drop` impl).
+        if let Ok(dummy) = SigningKey::from_slice(&[1u8; 32]) {
+            let _wiped = std::mem::replace(&mut self.0, dummy);
+        }
+        // If construction ever failed (unreachable today), `self.0` would
+        // be untouched here — and Rust's drop glue still wipes the
+        // original via `SigningKey<Secp256k1>: ZeroizeOnDrop` when the
+        // generated `Drop` returns. No security loss.
     }
 }
 

--- a/core/service/src/cryptography/signatures.rs
+++ b/core/service/src/cryptography/signatures.rs
@@ -16,7 +16,7 @@ use strum_macros::Display;
 use tfhe::named::Named;
 use tfhe_versionable::{Versionize, VersionsDispatch};
 use wasm_bindgen::prelude::wasm_bindgen;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub const SIG_SIZE: usize = 64; // a 32 byte r value and a 32 byte s value
 
@@ -259,7 +259,7 @@ impl HasSigningScheme for PrivateSigKey {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, ZeroizeOnDrop)]
 struct WrappedSigningKey(k256::ecdsa::SigningKey);
 impl_generic_versionize!(WrappedSigningKey);
 
@@ -274,12 +274,6 @@ impl Zeroize for WrappedSigningKey {
         let _wiped = std::mem::replace(&mut self.0, dummy);
     }
 }
-
-// `k256::ecdsa::SigningKey: ZeroizeOnDrop` unconditionally (via the `ecdsa`
-// crate's own impl), so Rust drop glue wipes the inner scalar when the
-// wrapper drops — no explicit `Drop` impl on the wrapper is needed. The
-// marker simply forwards that guarantee at the wrapper layer.
-impl zeroize::ZeroizeOnDrop for WrappedSigningKey {}
 
 impl Serialize for WrappedSigningKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/core/service/src/cryptography/signatures.rs
+++ b/core/service/src/cryptography/signatures.rs
@@ -4,14 +4,12 @@ use crate::{
     impl_generic_versionize,
 };
 use ::signature::{Signer, Verifier};
-use aes_prng::AesRng;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{Eip712Domain, SolStruct};
 use hashing::DomainSep;
 use k256::ecdsa::{SigningKey, VerifyingKey};
 use nom::AsBytes;
-use rand::SeedableRng;
 use serde::{Deserialize, Deserializer, Serialize, de::Visitor};
 use std::sync::Arc;
 use strum_macros::Display;
@@ -266,25 +264,18 @@ struct WrappedSigningKey(k256::ecdsa::SigningKey);
 impl_generic_versionize!(WrappedSigningKey);
 
 impl Zeroize for WrappedSigningKey {
-    // We want to allow unused assignments here as we are intentionally overwriting the key material
-    #[warn(unused_assignments)]
     fn zeroize(&mut self) {
-        let mut rng = AesRng::seed_from_u64(0);
-        // The simplest way is to overwrite the entire key with a random, static key, since we cannot directly zerorize the content of the key
-        let (_pk, sk) = gen_sig_keys(&mut rng);
-        // SAFETY: We're modifying a local copy of the key bytes, but this does not modify the actual key in memory.
-        // To securely zeroize the key, use the Zeroize trait on the underlying scalar or key type if available.
-        unsafe {
-            std::ptr::write(self, sk.sk);
-        }
+        // Swap in a known-valid dummy and let the original drop —
+        // `SigningKey<Secp256k1>: ZeroizeOnDrop` wipes its scalar.
+        // `[1u8; 32]` is `0x0101…01` ≪ secp256k1 order `n`, so
+        // `from_slice` accepts it (rejects only len ≠ 32, scalar = 0,
+        // or scalar ≥ n; length is fixed by `FieldBytesSize = U32`).
+        let dummy = SigningKey::from_slice(&[1u8; 32]).expect("0x0101…01 < secp256k1 n");
+        let _wiped = std::mem::replace(&mut self.0, dummy);
     }
 }
 
-impl Drop for WrappedSigningKey {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
+impl zeroize::ZeroizeOnDrop for WrappedSigningKey {}
 
 impl Serialize for WrappedSigningKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/core/service/src/cryptography/signatures.rs
+++ b/core/service/src/cryptography/signatures.rs
@@ -275,6 +275,10 @@ impl Zeroize for WrappedSigningKey {
     }
 }
 
+// `k256::ecdsa::SigningKey: ZeroizeOnDrop` unconditionally (via the `ecdsa`
+// crate's own impl), so Rust drop glue wipes the inner scalar when the
+// wrapper drops — no explicit `Drop` impl on the wrapper is needed. The
+// marker simply forwards that guarantee at the wrapper layer.
 impl zeroize::ZeroizeOnDrop for WrappedSigningKey {}
 
 impl Serialize for WrappedSigningKey {


### PR DESCRIPTION
## Description of changes
Two `unsafe` blocks in `core/service/src/cryptography/` had unsound invariants. 
This commit replaces both with safe invariants.

## Issue ticket number and link
First commit within https://github.com/zama-ai/kms-internal/issues/2834

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new pub item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
