### PR TITLE
chore(core-client): remove explicit party_id from config toml and derive it

### DIFF
--- a/core-client/config/client_local_centralized.toml
+++ b/core-client/config/client_local_centralized.toml
@@ -20,9 +20,6 @@ fhe_params = "Test" # Small, insecure parameters for testing
 
 # List of connection info to each of the cores (in the centralized case, there will only be a single core)
 [[cores]]
-# The ID of the given KMS server (monotonically increasing positive integer starting at 1)
-# (in the centralized case it must be 1)
-party_id = 1
 # The address of the given KMS server, including the port
 address = "localhost:50051"
 # The S3 endpoint where the public material of the given server can be reached

--- a/core-client/config/client_local_kind_centralized.toml
+++ b/core-client/config/client_local_kind_centralized.toml
@@ -20,9 +20,6 @@ fhe_params = "Default" # Large, secure parameters
 
 # List of connection info to each of the cores (in the centralized case, there will only be a single core)
 [[cores]]
-# The ID of the given KMS server (monotonically increasing positive integer starting at 1)
-# (in the centralized case it must be 1)
-party_id = 1
 # The address of the given KMS server, including the port
 address = "localhost:50100"
 # The S3 endpoint where the public material of the given server can be reached

--- a/core-client/config/client_local_kind_threshold.toml
+++ b/core-client/config/client_local_kind_threshold.toml
@@ -18,13 +18,10 @@ decryption_mode="NoiseFloodSmall"
 # fhe_params = "Test" # Small, insecure parameters for testing
 fhe_params="Default" # Large, secure parameters
 
-# List of connection info to each of the cores
-
-
-
+# List of connection info to each of the cores.
+# Each core's party ID is derived from its position in this list (the first
+# [[cores]] entry is party 1, the second party 2, and so on).
 [[cores]]
-# The ID of the given KMS server (monotonically increasing positive integer starting at 1)
-party_id = 1
 # The address of the given KMS server, including the port
 address = "localhost:50100"
 # The S3 endpoint where the public material of the given server can be reached
@@ -34,8 +31,6 @@ object_folder = "PUB-p1"
 
 
 [[cores]]
-# The ID of the given KMS server (monotonically increasing positive integer starting at 1)
-party_id = 2
 # The address of the given KMS server, including the port
 address = "localhost:50200"
 # The S3 endpoint where the public material of the given server can be reached
@@ -45,8 +40,6 @@ object_folder = "PUB-p2"
 
 
 [[cores]]
-# The ID of the given KMS server (monotonically increasing positive integer starting at 1)
-party_id = 3
 # The address of the given KMS server, including the port
 address = "localhost:50300"
 # The S3 endpoint where the public material of the given server can be reached
@@ -56,8 +49,6 @@ object_folder = "PUB-p3"
 
 
 [[cores]]
-# The ID of the given KMS server (monotonically increasing positive integer starting at 1)
-party_id = 4
 # The address of the given KMS server, including the port
 address = "localhost:50400"
 # The S3 endpoint where the public material of the given server can be reached

--- a/core-client/config/client_local_threshold.toml
+++ b/core-client/config/client_local_threshold.toml
@@ -18,10 +18,10 @@ decryption_mode = "NoiseFloodSmall"
 fhe_params = "Test" # Small, insecure parameters for testing
 # fhe_params = "Default" # Large, secure parameters
 
-# List of connection info to each of the cores
+# List of connection info to each of the cores.
+# Each core's party ID is derived from its position in this list (the first
+# [[cores]] entry is party 1, the second party 2, and so on).
 [[cores]]
-# The ID of the given KMS server (monotonically increasing positive integer starting at 1)
-party_id = 1
 # The address of the given KMS server, including the port
 address = "localhost:50100"
 # The S3 endpoint where the public material of the given server can be reached
@@ -39,7 +39,6 @@ private_object_folder = "PRIV-p1"
 config_path = "../core/service/config/compose_1.toml"
 
 [[cores]]
-party_id = 2
 address = "localhost:50200"
 s3_endpoint = "http://localhost:9000/kms"
 object_folder = "PUB-p2"
@@ -47,7 +46,6 @@ private_object_folder = "PRIV-p2"
 config_path = "../core/service/config/compose_2.toml"
 
 [[cores]]
-party_id = 3
 address = "localhost:50300"
 s3_endpoint = "http://localhost:9000/kms"
 object_folder = "PUB-p3"
@@ -55,7 +53,6 @@ private_object_folder = "PRIV-p3"
 config_path = "../core/service/config/compose_3.toml"
 
 [[cores]]
-party_id = 4
 address = "localhost:50400"
 s3_endpoint = "http://localhost:9000/kms"
 object_folder = "PUB-p4"

--- a/core-client/config/client_local_threshold_alternative.toml
+++ b/core-client/config/client_local_threshold_alternative.toml
@@ -20,10 +20,10 @@ decryption_mode = "NoiseFloodSmall"
 # fhe_params = "Test" # Small, insecure parameters for testing
 fhe_params = "Default" # Large, secure parameters
 
-# List of connection info to each of the cores
+# List of connection info to each of the cores.
+# Each core's party ID is derived from its position in this list (the first
+# [[cores]] entry is party 1, the second party 2, and so on).
 [[cores]]
-# The ID of the given KMS server (monotonically increasing positive integer starting at 1)
-party_id = 1
 # The address of the given KMS server, including the port
 address = "localhost:50500"
 # The S3 endpoint where the public material of the given server can be reached
@@ -41,7 +41,6 @@ private_object_folder = "PRIV-p5"
 config_path = "../core/service/config/compose_5.toml"
 
 [[cores]]
-party_id = 2
 address = "localhost:50600"
 s3_endpoint = "http://localhost:9000/kms"
 object_folder = "PUB-p6"
@@ -49,7 +48,6 @@ private_object_folder = "PRIV-p6"
 config_path = "../core/service/config/compose_6.toml"
 
 [[cores]]
-party_id = 3
 address = "localhost:50300"
 s3_endpoint = "http://localhost:9000/kms"
 object_folder = "PUB-p3"
@@ -57,7 +55,6 @@ private_object_folder = "PRIV-p3"
 config_path = "../core/service/config/compose_3.toml"
 
 [[cores]]
-party_id = 4
 address = "localhost:50400"
 s3_endpoint = "http://localhost:9000/kms"
 object_folder = "PUB-p4"

--- a/core-client/src/keygen.rs
+++ b/core-client/src/keygen.rs
@@ -238,7 +238,8 @@ pub(crate) async fn fetch_and_check_keygen(
     let first_party_id = party_confs
         .first()
         .ok_or_else(|| anyhow::anyhow!("no party configs returned from fetch_public_elements"))?
-        .party_id as usize;
+        .party_id
+        .get();
     let pub_storage_prefix = Some(cc_conf.cores[first_party_id - 1].object_folder.as_str());
 
     // Even if we did not download all keys, we still check that they are identical

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -135,8 +135,31 @@ pub struct CoreConf {
 fn validate_core_client_conf(conf: &CoreClientConfig) -> Result<(), ValidationError> {
     // The number of parties in the configuration, this may not be the actual number of KMS parties IRL. But is just the ones we currently communicate with.
     let num_parties = conf.cores.len();
+    let mut seen_party_ids = vec![false; num_parties];
 
     for cur_core in &conf.cores {
+        if cur_core.party_id == 0 || cur_core.party_id > num_parties {
+            return Err(ValidationError::new("Party ID Range Error").with_message(
+                format!(
+                    "Party ID {} must be between 1 and {}.",
+                    cur_core.party_id, num_parties
+                )
+                .into(),
+            ));
+        }
+
+        let party_idx = cur_core.party_id - 1;
+        if seen_party_ids[party_idx] {
+            return Err(ValidationError::new("Duplicate Party ID").with_message(
+                format!(
+                    "Party ID {} is duplicated in the configuration.",
+                    cur_core.party_id
+                )
+                .into(),
+            ));
+        }
+        seen_party_ids[party_idx] = true;
+
         if conf
             .cores
             .iter()

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -104,8 +104,10 @@ pub struct CoreClientConfig {
 
 #[derive(Deserialize, Serialize, Clone, Validate, Default, Debug, Hash, PartialEq, Eq)]
 pub struct CoreConf {
-    /// The ID of the given KMS server (monotonically increasing positive integer starting at 1)
-    #[validate(range(min = 1))]
+    /// The 1-based ID of the KMS server. This is not read from the config file;
+    /// it is derived from this core's position in the `cores` list during
+    /// deserialization (the first core is party 1, the second party 2, etc.).
+    #[serde(default)]
     pub party_id: usize,
 
     /// The address of the given KMS server, including the port
@@ -135,30 +137,6 @@ fn validate_core_client_conf(conf: &CoreClientConfig) -> Result<(), ValidationEr
     let num_parties = conf.cores.len();
 
     for cur_core in &conf.cores {
-        if cur_core.party_id == 0 || cur_core.party_id > num_parties {
-            return Err(ValidationError::new("Incorrect Party ID").with_message(
-                format!(
-                    "Party ID must be between 1 and the number of parties ({}), but was {}.",
-                    num_parties, cur_core.party_id
-                )
-                .into(),
-            ));
-        }
-        if conf
-            .cores
-            .iter()
-            .filter(|x| x.party_id == cur_core.party_id)
-            .count()
-            > 1
-        {
-            return Err(ValidationError::new("Duplicate Party ID").with_message(
-                format!(
-                    "Party ID {} is duplicated in the configuration.",
-                    cur_core.party_id
-                )
-                .into(),
-            ));
-        }
         if conf
             .cores
             .iter()
@@ -215,17 +193,6 @@ fn validate_core_client_conf(conf: &CoreClientConfig) -> Result<(), ValidationEr
                     ),
                 );
             }
-            if conf.cores.first().expect("no party IDs found").party_id != 1 {
-                return Err(
-                    ValidationError::new("Centralized Party ID Error").with_message(
-                        format!(
-                    "Party ID of the single core in a centralized config must be 1, but was {}.",
-                    conf.cores.first().unwrap().party_id
-                )
-                        .into(),
-                    ),
-                );
-            }
         }
     }
 
@@ -271,9 +238,16 @@ impl<'de> Deserialize<'de> for CoreClientConfig {
 
         let temp = CoreClientConfigBuffer::deserialize(deserializer)?;
 
+        // Derive each core's 1-based party ID from its position in the list,
+        // ignoring any value present in the config file.
+        let mut cores = temp.cores;
+        for (idx, core) in cores.iter_mut().enumerate() {
+            core.party_id = idx + 1;
+        }
+
         let conf = CoreClientConfig {
             kms_type: temp.kms_type,
-            cores: temp.cores,
+            cores,
             decryption_mode: temp.decryption_mode,
             num_majority: temp.num_majority,
             num_reconstruct: temp.num_reconstruct,

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -51,6 +51,7 @@ use observability::conf::Settings;
 use rand::SeedableRng;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -102,13 +103,20 @@ pub struct CoreClientConfig {
     pub fhe_params: Option<FheParameter>,
 }
 
-#[derive(Deserialize, Serialize, Clone, Validate, Default, Debug, Hash, PartialEq, Eq)]
+/// Placeholder party ID used before [`CoreClientConfig`] deserialization
+/// overwrites it with the core's position-derived ID. `party_id` is `skip`ped
+/// during deserialization, so serde needs a default for it.
+fn placeholder_party_id() -> NonZeroUsize {
+    NonZeroUsize::MIN
+}
+
+#[derive(Deserialize, Serialize, Clone, Validate, Debug, Hash, PartialEq, Eq)]
 pub struct CoreConf {
     /// The 1-based ID of the KMS server. This is not read from the config file;
     /// it is derived from this core's position in the `cores` list during
     /// deserialization (the first core is party 1, the second party 2, etc.).
-    #[serde(default)]
-    pub party_id: usize,
+    #[serde(skip, default = "placeholder_party_id")]
+    pub party_id: NonZeroUsize,
 
     /// The address of the given KMS server, including the port
     #[validate(length(min = 1))]
@@ -138,7 +146,7 @@ fn validate_core_client_conf(conf: &CoreClientConfig) -> Result<(), ValidationEr
     let mut seen_party_ids = vec![false; num_parties];
 
     for cur_core in &conf.cores {
-        if cur_core.party_id == 0 || cur_core.party_id > num_parties {
+        if cur_core.party_id.get() > num_parties {
             return Err(ValidationError::new("Party ID Range Error").with_message(
                 format!(
                     "Party ID {} must be between 1 and {}.",
@@ -148,7 +156,7 @@ fn validate_core_client_conf(conf: &CoreClientConfig) -> Result<(), ValidationEr
             ));
         }
 
-        let party_idx = cur_core.party_id - 1;
+        let party_idx = cur_core.party_id.get() - 1;
         if seen_party_ids[party_idx] {
             return Err(ValidationError::new("Duplicate Party ID").with_message(
                 format!(
@@ -265,7 +273,8 @@ impl<'de> Deserialize<'de> for CoreClientConfig {
         // ignoring any value present in the config file.
         let mut cores = temp.cores;
         for (idx, core) in cores.iter_mut().enumerate() {
-            core.party_id = idx + 1;
+            // idx + 1 >= 1, so this is always a valid NonZeroUsize.
+            core.party_id = NonZeroUsize::new(idx + 1).expect("idx + 1 is always >= 1");
         }
 
         let conf = CoreClientConfig {
@@ -1584,7 +1593,7 @@ pub async fn execute_cmd(
                     core_endpoints_resp.insert(cur_core.clone(), core_endpoint_resp);
 
                     pub_storage.insert(
-                        cur_core.party_id as u32,
+                        cur_core.party_id.get() as u32,
                         FileStorage::new(
                             Some(destination_prefix),
                             StorageType::PUB,
@@ -2625,7 +2634,7 @@ mod tests {
         let cc_conf = CoreClientConfig {
             kms_type: KmsType::Threshold,
             cores: vec![CoreConf {
-                party_id: 1,
+                party_id: NonZeroUsize::MIN,
                 address: "127.0.0.1:0".to_string(),
                 s3_endpoint: format!("file://{}", remote_root.path().display()),
                 object_folder: object_folder.to_string(),

--- a/core-client/src/mpc_context.rs
+++ b/core-client/src/mpc_context.rs
@@ -81,10 +81,10 @@ pub async fn create_test_context_info_from_core_config(
         let peers = threshold_config
             .peers
             .ok_or_else(|| anyhow::anyhow!("Peers not set for core {}", c.party_id))?;
-        let peer = peers.get(c.party_id - 1).ok_or_else(|| {
+        let peer = peers.get(c.party_id.get() - 1).ok_or_else(|| {
             anyhow::anyhow!(
                 "Peer index {} out of bounds (peers len: {}) for core {}",
-                c.party_id - 1,
+                c.party_id.get() - 1,
                 peers.len(),
                 c.party_id
             )

--- a/core-client/src/mpc_epoch.rs
+++ b/core-client/src/mpc_epoch.rs
@@ -291,7 +291,7 @@ pub(crate) async fn do_new_epoch(
 
             // We just checked that we have num_parties of fetched configurations
             let first_party_id = party_confs_successful.first()
-                .expect("unexpected error because we have previously checked that the array has length of num_parties").party_id;
+                .expect("unexpected error because we have previously checked that the array has length of num_parties").party_id.get();
             let pub_storage_prefix = Some(cc_conf.cores[first_party_id - 1].object_folder.as_str());
 
             let preproc_id: RequestId = preproc_id.try_into().map_err(|e| {

--- a/core-client/src/s3_operations.rs
+++ b/core-client/src/s3_operations.rs
@@ -118,7 +118,7 @@ pub(crate) async fn fetch_kms_verification_keys(
                 .read_data(&SIGNING_KEY_ID, &PubDataType::VerfKey.to_string())
                 .await?
         };
-        keys_map.insert(cur_core.party_id, vk);
+        keys_map.insert(cur_core.party_id.get(), vk);
     }
 
     Ok(keys_map)
@@ -155,7 +155,7 @@ pub(crate) async fn fetch_kms_signing_keys(
                 .read_data(&SIGNING_KEY_ID, &PrivDataType::SigningKey.to_string())
                 .await?
         };
-        keys_map.insert(cur_core.party_id, sk);
+        keys_map.insert(cur_core.party_id.get(), sk);
     }
     Ok(keys_map)
 }

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -18,6 +18,7 @@ use observability::conf::Settings;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs::write;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::string::String;
@@ -229,7 +230,7 @@ fn generate_centralized_cli_config(
     let cfg = CoreClientConfig {
         kms_type: KmsType::Centralized,
         cores: vec![CoreConf {
-            party_id: 1,
+            party_id: NonZeroUsize::MIN,
             address: format!("localhost:{}", server.service_port),
             s3_endpoint: format!("file://{}", canonical_path.display()),
             object_folder: "PUB".to_string(),
@@ -496,7 +497,7 @@ fn generate_threshold_cli_config(
         write_core_config_toml(&server_config_path, &core_config)?;
 
         cores.push(CoreConf {
-            party_id: i,
+            party_id: NonZeroUsize::new(i).unwrap(),
             address: format!("localhost:{}", server.service_port),
             s3_endpoint: format!("file://{}", material_dir.path().display()),
             object_folder: format!("PUB-p{i}"),
@@ -881,7 +882,7 @@ async fn setup_party_resharing_servers(
             let server = servers.get(&(i as u32)).unwrap();
             let server_config_path = material_dir.path().join(format!("compose_{i}.toml"));
             CoreConf {
-                party_id: i,
+                party_id: NonZeroUsize::new(i).unwrap(),
                 address: format!("localhost:{}", server.service_port),
                 s3_endpoint: format!("file://{}", material_dir.path().display()),
                 object_folder: format!("PUB-p{i}"),
@@ -918,7 +919,7 @@ async fn setup_party_resharing_servers(
         .map(|(party_id, server_id, compose_path)| {
             let server = servers.get(server_id).unwrap();
             CoreConf {
-                party_id: *party_id,
+                party_id: NonZeroUsize::new(*party_id).unwrap(),
                 address: format!("localhost:{}", server.service_port),
                 s3_endpoint: format!("file://{}", material_dir.path().display()),
                 object_folder: format!("PUB-p{server_id}"),
@@ -2012,7 +2013,7 @@ fn config_conformance_client_local_centralized() {
     assert_eq!(loaded.cores.len(), 1);
     assert_eq!(loaded.fhe_params, Some(FheParameter::Test));
     // party_id is not present in the TOML; the single core must be derived as party 1.
-    assert_eq!(loaded.cores[0].party_id, 1);
+    assert_eq!(loaded.cores[0].party_id.get(), 1);
 }
 
 #[test]
@@ -2041,7 +2042,7 @@ fn config_conformance_client_local_threshold() {
     // party_id is not present in the TOML; it must be derived from each core's
     // 1-based position in the cores list.
     for (i, core) in loaded.cores.iter().enumerate() {
-        assert_eq!(core.party_id, i + 1);
+        assert_eq!(core.party_id.get(), i + 1);
     }
 }
 
@@ -2083,7 +2084,7 @@ object_folder = "PUB-p4"
 "#;
     let conf: CoreClientConfig =
         toml::from_str(raw).expect("threshold config with stale party_id should still parse");
-    let ids: Vec<usize> = conf.cores.iter().map(|c| c.party_id).collect();
+    let ids: Vec<usize> = conf.cores.iter().map(|c| c.party_id.get()).collect();
     assert_eq!(
         ids,
         vec![1, 2, 3, 4],
@@ -2106,7 +2107,7 @@ object_folder = "PUB"
     let conf: CoreClientConfig = toml::from_str(raw_central)
         .expect("centralized config with stale party_id should still parse");
     assert_eq!(conf.cores.len(), 1);
-    assert_eq!(conf.cores[0].party_id, 1);
+    assert_eq!(conf.cores[0].party_id.get(), 1);
 }
 
 // ============================================================================

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -2045,6 +2045,70 @@ fn config_conformance_client_local_threshold() {
     }
 }
 
+/// Backward compatibility: TOMLs may still carry `party_id` keys (stale or out
+/// of order). The deserializer must ignore the supplied values and derive each
+/// core's party_id from its 1-based position in the `cores` list.
+#[test]
+fn deserialize_overwrites_supplied_party_id() {
+    // Threshold config whose party_id values are stale and out of order.
+    let raw = r#"
+kms_type = "threshold"
+num_majority = 2
+num_reconstruct = 3
+fhe_params = "Test"
+
+[[cores]]
+party_id = 3
+address = "localhost:50100"
+s3_endpoint = "http://localhost:9000/kms"
+object_folder = "PUB-p1"
+
+[[cores]]
+party_id = 99
+address = "localhost:50200"
+s3_endpoint = "http://localhost:9000/kms"
+object_folder = "PUB-p2"
+
+[[cores]]
+party_id = 1
+address = "localhost:50300"
+s3_endpoint = "http://localhost:9000/kms"
+object_folder = "PUB-p3"
+
+[[cores]]
+party_id = 2
+address = "localhost:50400"
+s3_endpoint = "http://localhost:9000/kms"
+object_folder = "PUB-p4"
+"#;
+    let conf: CoreClientConfig =
+        toml::from_str(raw).expect("threshold config with stale party_id should still parse");
+    let ids: Vec<usize> = conf.cores.iter().map(|c| c.party_id).collect();
+    assert_eq!(
+        ids,
+        vec![1, 2, 3, 4],
+        "party_id must be derived from list position, not the values in the file"
+    );
+
+    // Centralized config with a wrong party_id must be normalized to party 1.
+    let raw_central = r#"
+kms_type = "centralized"
+num_majority = 1
+num_reconstruct = 1
+fhe_params = "Test"
+
+[[cores]]
+party_id = 7
+address = "localhost:50051"
+s3_endpoint = "http://localhost:9000/kms"
+object_folder = "PUB"
+"#;
+    let conf: CoreClientConfig = toml::from_str(raw_central)
+        .expect("centralized config with stale party_id should still parse");
+    assert_eq!(conf.cores.len(), 1);
+    assert_eq!(conf.cores[0].party_id, 1);
+}
+
 // ============================================================================
 // TESTS
 // ============================================================================

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1975,9 +1975,8 @@ struct StrictCheckedInCoreClientToml {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-#[allow(dead_code)] // Presence validated by deny_unknown_fields; only party_id asserted in tests
+#[allow(dead_code)] // Presence/absence of keys validated by deny_unknown_fields
 struct StrictCheckedInCoreToml {
-    party_id: usize,
     address: String,
     s3_endpoint: String,
     object_folder: String,
@@ -2000,7 +1999,6 @@ fn config_conformance_client_local_centralized() {
     assert_eq!(strict.decryption_mode.as_deref(), Some("NoiseFloodSmall"));
     assert_eq!(strict.fhe_params.as_deref(), Some("Test"));
     assert_eq!(strict.cores.len(), 1);
-    assert_eq!(strict.cores[0].party_id, 1);
     // Use an inert env_prefix so no stray CORE_CLIENT__* env vars can pollute
     // the load.  This avoids the need for unsafe env::remove_var and lets the
     // test run concurrently with other tests that read the environment.
@@ -2013,6 +2011,8 @@ fn config_conformance_client_local_centralized() {
     assert_eq!(loaded.kms_type, KmsType::Centralized);
     assert_eq!(loaded.cores.len(), 1);
     assert_eq!(loaded.fhe_params, Some(FheParameter::Test));
+    // party_id is not present in the TOML; the single core must be derived as party 1.
+    assert_eq!(loaded.cores[0].party_id, 1);
 }
 
 #[test]
@@ -2028,9 +2028,6 @@ fn config_conformance_client_local_threshold() {
     assert_eq!(strict.decryption_mode.as_deref(), Some("NoiseFloodSmall"));
     assert_eq!(strict.fhe_params.as_deref(), Some("Test"));
     assert_eq!(strict.cores.len(), 4);
-    for (i, core) in strict.cores.iter().enumerate() {
-        assert_eq!(core.party_id, i + 1);
-    }
     // Use an inert env_prefix — see config_conformance_client_local_centralized.
     let loaded: CoreClientConfig = Settings::builder()
         .path(path.to_str().expect("utf8 path"))
@@ -2041,6 +2038,11 @@ fn config_conformance_client_local_threshold() {
     assert_eq!(loaded.kms_type, KmsType::Threshold);
     assert_eq!(loaded.cores.len(), 4);
     assert_eq!(loaded.fhe_params, Some(FheParameter::Test));
+    // party_id is not present in the TOML; it must be derived from each core's
+    // 1-based position in the cores list.
+    for (i, core) in loaded.cores.iter().enumerate() {
+        assert_eq!(core.party_id, i + 1);
+    }
 }
 
 // ============================================================================

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -45,8 +45,7 @@ Values inside the TOML configs are:
 - `num_reconstruct` - The minimum number of responses required to reconstruct a value (e.g. in user decryption).
 - `decryption_mode` - For a threshold deployment this must match to what is deployed on the threshold servers. Valid values are `NoiseFloodSmall` (default), `NoiseFloodLarge`, `BitDecSmall`, and `BitDecLarge`.
 - `fhe_params` - The set of FHE parameters to use. Can be either `Default` (for large, secure parameters) or `Test` (for smaller, insecure testing parameters).
-- Each KMS core is configured under a separate `[[cores]]` section containing the following values:
-  - `party_id` - The MPC party id, starting from 1 going up to n.
+- Each KMS core is configured under a separate `[[cores]]` section containing the following values. The MPC party id (from 1 up to n) is derived from the order of the `[[cores]]` sections: the first section is party 1, the second party 2, and so on.
   - `address`- The host name or IP address and port of the cores service interface. Example: `address = "localhost:50100"`.
   - `s3_endpoint` - The host name or IP address and port of the S3 endpoint that is used for public data (public keys, CRS, etc.). Example: `s3_endpoint = "http://localhost:9000/kms"`.
   - `object_folder` - The folder on the S3 endpoint where public key material for this party is stored. Example: `object_folder = "PUB-p1"`.


### PR DESCRIPTION
  ## Summary

  Removes `party_id` from the core-client config TOML. Each core's 1-based party ID is now derived from its position in the `cores` list during deserialization (first `[[cores]]` entry is party 1, second is party 2, etc.) instead of being specified explicitly.

  ## Motivation

  `party_id` was redundant: it is never cryptographically meaningful in the core-client (each server self-identifies in its signed responses, and signature verification keys are resolved via `object_folder`), and in practice it was always equal to the core's position in the list. Worse, several code paths already *assumed* this ordering — e.g. `cores[party_id - 1]` and `peers.get(party_id - 1)` — while validation only checked that `party_id` was unique and in `1..=n`, not that it matched the list order. A config with out-of-order IDs would pass validation and then silently mis-index. Deriving the ID from position removes the redundant field and eliminates that footgun.

  ## Changes

  - `core-client/src/lib.rs`:
    - `CoreConf.party_id` is now `#[serde(default)]`; rustdoc updated to note it is derived, not read from the file.
    - `CoreClientConfig::deserialize` assigns `party_id = index + 1` for every core after parsing, ignoring any value present in the file.
    - Dropped the now-redundant validation (party-id range, duplicate party-id, centralized-must-be-1). Kept duplicate-address, `num_majority` / `num_reconstruct`, and kms-type checks.
  - Removed `party_id` from all 5 config TOMLs in `core-client/config/`; added a comment that position determines the party ID.
  - `core-client/tests/integration/integration_test.rs`: removed `party_id` from the strict `deny_unknown_fields` conformance struct, and added assertions that the loaded config derives `party_id` from position (centralized → party 1,  threshold → 1..=4).
  - `docs/guides/core_client.md`: updated the config reference.

  ## Backward compatibility

  Non-breaking for existing configs. The config structs do not use `deny_unknown_fields`, so already-deployed TOMLs that still contain `party_id = N` continue to parse — the value is simply **overwritten** by position.
  All internal plumbing (logging, sort keys, map keys, `cores[party_id - 1]` indexing) is unchanged because the in-memory `party_id` field still exists and holds the same values as before.

  ## Note for reviewers

  This relaxes config validation: a previously-invalid config (e.g. an out-of-order or out-of-range `party_id`) is now normalized to position order rather than rejected. This is intended.

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.