### PR TITLE
chore!: remove multiparty support for kms-gen-keys

### DIFF
--- a/charts/kms-core/Chart.yaml
+++ b/charts/kms-core/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-core
 description: A helm chart to distribute and deploy the Zama KMS core service.
-version: 1.6.0-4
+version: 1.6.0-5
 appVersion: 0.13.20   # Minimum kms version to run this chart
 apiVersion: v2
 keywords:

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -80,11 +80,6 @@ data:
     {{- if .Values.kmsCore.thresholdMode.enabled }}
     [threshold]
     my_id = "${KMS_CORE__THRESHOLD__MY_ID}"
-      {{- if .Values.kmsCore.thresholdMode.peersList }}
-    num_parties = {{ len .Values.kmsCore.thresholdMode.peersList }}
-      {{- else }}
-    num_parties = {{ int .Values.kmsPeers.count }}
-      {{- end }}
       {{- if .Values.kmsCore.addressOverride }}
     tls_subject = "{{ .Values.kmsCore.addressOverride }}-{{ .Values.kmsPeers.id}}"
       {{- else }}

--- a/charts/kms-core/templates/kms-core-statefulset.yaml
+++ b/charts/kms-core/templates/kms-core-statefulset.yaml
@@ -347,11 +347,6 @@ spec:
               {{ include "kmsCoreMode" . }} \
             {{- if .Values.kmsCore.thresholdMode.enabled }}
               --signing-key-party-id ${KMS_CORE__THRESHOLD__MY_ID} \
-            {{- if .Values.kmsCore.thresholdMode.peersList }}
-              --num-parties {{ len .Values.kmsCore.thresholdMode.peersList }} \
-            {{- else }}
-              --num-parties {{ int .Values.kmsPeers.count }} \
-            {{- end }}
             {{- if .Values.kmsCore.addressOverride }}
               --tls-subject {{ .Values.kmsCore.addressOverride | quote }}
             {{- else }}

--- a/core/service/src/bin/kms-gen-keys.rs
+++ b/core/service/src/bin/kms-gen-keys.rs
@@ -389,7 +389,7 @@ async fn handle_threshold_cmd<PubS: Storage, PrivS: Storage>(
         args.overwrite,
     )
     .await;
-    if !ensure_threshold_server_signing_key_exists(
+    ensure_threshold_server_signing_key_exists(
         args.pub_storage,
         args.priv_storage,
         &SIGNING_KEY_ID,
@@ -399,10 +399,7 @@ async fn handle_threshold_cmd<PubS: Storage, PrivS: Storage>(
         args.tls_wildcard,
     )
     .await
-    .expect("Could not access storage")
-    {
-        tracing::warn!("Threshold signing keys already exist, skipping generation");
-    }
+    .expect("Could not access storage");
 }
 
 async fn process_signing_key_cmds<PubS: Storage, PrivS: Storage>(

--- a/core/service/src/bin/kms-gen-keys.rs
+++ b/core/service/src/bin/kms-gen-keys.rs
@@ -4,9 +4,7 @@ use futures_util::future::OptionFuture;
 use kms_grpc::RequestId;
 use kms_grpc::rpc_types::{PrivDataType, PubDataType};
 use kms_lib::{
-    conf::{
-        AwsKmsKeySpec, AwsKmsKeychain, FileStorage, Keychain, S3Storage, Storage as StorageConf,
-    },
+    conf::{AwsKmsKeySpec, AwsKmsKeychain, Keychain},
     consts::SIGNING_KEY_ID,
     cryptography::attestation::make_security_module,
     util::key_setup::{
@@ -16,7 +14,11 @@ use kms_lib::{
         Vault,
         aws::build_aws_sdk_config,
         keychain::{awskms::build_aws_kms_client, make_keychain_proxy},
-        storage::{Storage, StorageType, delete_at_request_id, make_storage, s3::build_s3_client},
+        storage::{
+            Storage, StorageProxy, StorageType, delete_at_request_id,
+            file::FileStorage,
+            s3::{S3Storage, build_s3_client},
+        },
     },
 };
 use observability::conf::TelemetryConfig;
@@ -240,28 +242,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create storages (one pub + one priv per invocation; multi-party
     // deployments invoke this binary once per party)
-    let mut pub_storage = make_storage(
-        match args.public_storage {
-            StorageCommand::File => args.public_file_path.as_ref().map(|path| {
-                StorageConf::File(FileStorage {
-                    path: path.to_path_buf(),
-                    prefix: args.public_file_prefix.clone(),
-                })
-            }),
-            StorageCommand::S3 => Some(StorageConf::S3(S3Storage {
-                // clap's `required_if_eq` on `public_s3_bucket` guarantees this
-                // is `Some` whenever public_storage == s3.
-                bucket: args
-                    .public_s3_bucket
-                    .as_ref()
-                    .expect("clap-required: public_s3_bucket")
-                    .clone(),
-                prefix: args.public_s3_prefix.clone(),
-            })),
-        },
-        StorageType::PUB,
-        s3_client.clone(),
-    )?;
+    let mut pub_storage = match args.public_storage {
+        StorageCommand::File => StorageProxy::from(FileStorage::new(
+            args.public_file_path.as_deref(),
+            StorageType::PUB,
+            args.public_file_prefix.as_deref(),
+        )?),
+        StorageCommand::S3 => StorageProxy::from(S3Storage::new(
+            // `need_s3_client` covers public_storage == s3, so the client is built above
+            s3_client
+                .clone()
+                .expect("S3 client is built when public_storage == s3"),
+            // clap's `required_if_eq` on `public_s3_bucket` guarantees this
+            // is `Some` whenever public_storage == s3.
+            args.public_s3_bucket
+                .clone()
+                .expect("clap-required: public_s3_bucket"),
+            StorageType::PUB,
+            args.public_s3_prefix.as_deref(),
+        )?),
+    };
     let private_keychain = OptionFuture::from(
         args.root_key_id
             .as_ref()
@@ -286,28 +286,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await
     .transpose()?;
     let mut priv_vault = Vault {
-        storage: make_storage(
-            match args.private_storage {
-                StorageCommand::File => args.private_file_path.as_ref().map(|path| {
-                    StorageConf::File(FileStorage {
-                        path: path.to_path_buf(),
-                        prefix: args.private_file_prefix.clone(),
-                    })
-                }),
-                StorageCommand::S3 => Some(StorageConf::S3(S3Storage {
-                    // clap's `required_if_eq` on `private_s3_bucket` guarantees
-                    // this is `Some` whenever private_storage == s3.
-                    bucket: args
-                        .private_s3_bucket
-                        .as_ref()
-                        .expect("clap-required: private_s3_bucket")
-                        .clone(),
-                    prefix: args.private_s3_prefix.clone(),
-                })),
-            },
-            StorageType::PRIV,
-            s3_client.clone(),
-        )?,
+        storage: match args.private_storage {
+            StorageCommand::File => StorageProxy::from(FileStorage::new(
+                args.private_file_path.as_deref(),
+                StorageType::PRIV,
+                args.private_file_prefix.as_deref(),
+            )?),
+            StorageCommand::S3 => StorageProxy::from(S3Storage::new(
+                // `need_s3_client` covers private_storage == s3, so the client is built above
+                s3_client
+                    .clone()
+                    .expect("S3 client is built when private_storage == s3"),
+                // clap's `required_if_eq` on `private_s3_bucket` guarantees
+                // this is `Some` whenever private_storage == s3.
+                args.private_s3_bucket
+                    .clone()
+                    .expect("clap-required: private_s3_bucket"),
+                StorageType::PRIV,
+                args.private_s3_prefix.as_deref(),
+            )?),
+        },
         keychain: private_keychain,
     };
 

--- a/core/service/src/bin/kms-gen-keys.rs
+++ b/core/service/src/bin/kms-gen-keys.rs
@@ -1,7 +1,6 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use core::fmt;
 use futures_util::future::OptionFuture;
-use itertools::Itertools;
 use kms_grpc::RequestId;
 use kms_grpc::rpc_types::{PrivDataType, PubDataType};
 use kms_lib::{
@@ -11,8 +10,7 @@ use kms_lib::{
     consts::SIGNING_KEY_ID,
     cryptography::attestation::make_security_module,
     util::key_setup::{
-        ThresholdSigningKeyConfig, ensure_central_server_signing_keys_exist,
-        ensure_threshold_server_signing_keys_exist,
+        ensure_central_server_signing_keys_exist, ensure_threshold_server_signing_key_exists,
     },
     vault::{
         Vault,
@@ -32,8 +30,8 @@ use url::Url;
 #[clap(
     about = "A CLI tool for generating server signing keys and TLS certificates. \
     In centralized mode it produces a single signing key plus its verification material. \
-    In threshold mode it produces per-party signing keys and the self-signed CA certificates \
-    used for mTLS between parties. \
+    In threshold mode it produces the signing key and self-signed CA certificate for one party; \
+    run it once per party in a multi-party deployment. \
     Multiple options are supported which can be explored with \
     kms-gen-keys --help"
 )]
@@ -70,24 +68,58 @@ struct Args {
     mock_enclave: bool,
     #[clap(long, default_value_t = StorageCommand::File, value_enum)]
     private_storage: StorageCommand,
-    #[clap(long, default_value = None)]
+    #[clap(
+        long,
+        default_value = None,
+        conflicts_with_all = ["private_s3_bucket", "private_s3_prefix"],
+    )]
     private_file_path: Option<PathBuf>,
-    #[clap(long, default_value = None)]
+    #[clap(
+        long,
+        default_value = None,
+        conflicts_with_all = ["private_s3_bucket", "private_s3_prefix"],
+    )]
     private_file_prefix: Option<String>,
-    #[clap(long, default_value = None)]
+    #[clap(
+        long,
+        default_value = None,
+        required_if_eq("private_storage", "s3"),
+        conflicts_with_all = ["private_file_path", "private_file_prefix"],
+    )]
     private_s3_bucket: Option<String>,
-    #[clap(long, default_value = None)]
+    #[clap(
+        long,
+        default_value = None,
+        conflicts_with_all = ["private_file_path", "private_file_prefix"],
+    )]
     private_s3_prefix: Option<String>,
 
     #[clap(long, default_value_t = StorageCommand::File, value_enum)]
     public_storage: StorageCommand,
-    #[clap(long, default_value = None)]
+    #[clap(
+        long,
+        default_value = None,
+        conflicts_with_all = ["public_s3_bucket", "public_s3_prefix"],
+    )]
     public_file_path: Option<PathBuf>,
-    #[clap(long, default_value = None)]
+    #[clap(
+        long,
+        default_value = None,
+        conflicts_with_all = ["public_s3_bucket", "public_s3_prefix"],
+    )]
     public_file_prefix: Option<String>,
-    #[clap(long, default_value = None)]
+    #[clap(
+        long,
+        default_value = None,
+        required_if_eq("public_storage", "s3"),
+        conflicts_with_all = ["public_file_path", "public_file_prefix"],
+    )]
     public_s3_bucket: Option<String>,
-    #[clap(long, default_value = None)]
+    #[clap(
+        long,
+        default_value = None,
+        conflicts_with_all = ["public_file_path", "public_file_prefix"],
+    )]
     public_s3_prefix: Option<String>,
     /// Whether to generate keys deterministically,
     /// only use this option for testing.
@@ -114,25 +146,19 @@ enum Mode {
     /// Generate the centralized server signing key.
     Centralized,
 
-    /// Generate per-party signing keys and self-signed CA certificates for a threshold deployment.
+    /// Generate the signing key and self-signed CA certificate for one
+    /// threshold party.
+    ///
+    /// One invocation generates the material for exactly one party; callers
+    /// that operate multiple parties (docker-compose loops, Helm per-pod jobs,
+    /// the enclave bootstrap script) invoke `kms-gen-keys threshold` once per
+    /// party.
     Threshold {
-        /// Generate the signing key for a specific party only.
-        /// If unset, signing keys are generated for all parties.
-        ///
-        /// If set, the party ID cannot be higher than `num_parties`.
-        #[clap(long, default_value = None)]
-        signing_key_party_id: Option<usize>,
+        /// Index of the party to generate keys for (1-based).
+        #[clap(long, value_parser = parse_party_id)]
+        signing_key_party_id: usize,
 
-        /// Set the total number of parties.
-        ///
-        /// This configuration is required even when `signing_key_party_id``
-        /// is given.
-        #[clap(long, default_value_t = 4)]
-        num_parties: usize,
-
-        /// Set the subject in the issued TLS certificate, if
-        /// --signing-key-party-id is set, or the prefix for the subject in
-        /// certificates for all parties if not.
+        /// Subject used in the issued TLS certificate.
         #[clap(long, default_value = "kms-party")]
         tls_subject: String,
 
@@ -151,66 +177,31 @@ struct CentralCmdArgs<'a, PubS: Storage, PrivS: Storage> {
 }
 
 struct ThresholdCmdArgs<'a, PubS: Storage, PrivS: Storage> {
-    pub_storages: &'a mut [PubS],
-    priv_storages: &'a mut [PrivS],
+    pub_storage: &'a mut PubS,
+    priv_storage: &'a mut PrivS,
     deterministic: bool,
     overwrite: bool,
     show_existing: bool,
-    signing_key_party_id: Option<usize>,
-    num_parties: usize,
+    signing_key_party_id: usize,
     tls_subject: String,
     tls_wildcard: bool,
 }
 
-impl<'a, PubS: Storage, PrivS: Storage> ThresholdCmdArgs<'a, PubS, PrivS> {
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        pub_storages: &'a mut [PubS],
-        priv_storages: &'a mut [PrivS],
-        deterministic: bool,
-        overwrite: bool,
-        show_existing: bool,
-        signing_key_party_id: Option<usize>,
-        num_parties: usize,
-        tls_subject: String,
-        tls_wildcard: bool,
-    ) -> anyhow::Result<Self> {
-        if num_parties < 2 {
-            anyhow::bail!("the number of parties should be larger or equal to 2");
-        }
-        if let Some(id) = signing_key_party_id
-            && id > num_parties
-        {
-            anyhow::bail!(
-                "party ID ({}) cannot be greater than num_parties ({})",
-                id,
-                num_parties
-            );
-        }
-        if let Some(id) = signing_key_party_id
-            && id == 0
-        {
-            anyhow::bail!("party ID cannot be 0",);
-        }
-        Ok(Self {
-            pub_storages,
-            priv_storages,
-            deterministic,
-            overwrite,
-            show_existing,
-            signing_key_party_id,
-            num_parties,
-            tls_subject,
-            tls_wildcard,
-        })
+fn parse_party_id(s: &str) -> Result<usize, String> {
+    let id: usize = s
+        .parse()
+        .map_err(|e: std::num::ParseIntError| e.to_string())?;
+    if id == 0 {
+        return Err("party ID must be at least 1".to_string());
     }
+    Ok(id)
 }
 
 /// Generate the server signing keys and TLS material for a KMS deployment.
 ///
 /// Two modes are supported:
 /// - `centralized` produces a single signing key.
-/// - `threshold` produces per-party signing keys and self-signed CA certificates for mTLS.
+/// - `threshold` produces one party's signing key and self-signed CA certificate for mTLS.
 ///
 /// Examples:
 /// ```
@@ -257,95 +248,85 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None
     };
 
-    // create storages
-    let amount_storages = match args.mode {
-        Mode::Centralized => 1,
-        Mode::Threshold {
-            signing_key_party_id: _,
-            num_parties: n,
-            tls_subject: _,
-            tls_wildcard: _,
-        } => n,
-    };
-    let mut pub_storages = Vec::with_capacity(amount_storages);
-    let mut priv_vaults = Vec::with_capacity(amount_storages);
-    for _i in 1..=amount_storages {
-        let pub_proxy_storage = make_storage(
-            match args.public_storage {
-                StorageCommand::File => args.public_file_path.as_ref().map(|path| {
+    // create storages (one pub + one priv per invocation; multi-party
+    // deployments invoke this binary once per party)
+    let mut pub_storage = make_storage(
+        match args.public_storage {
+            StorageCommand::File => args.public_file_path.as_ref().map(|path| {
+                StorageConf::File(FileStorage {
+                    path: path.to_path_buf(),
+                    prefix: args.public_file_prefix.clone(),
+                })
+            }),
+            StorageCommand::S3 => Some(StorageConf::S3(S3Storage {
+                // clap's `required_if_eq` on `public_s3_bucket` guarantees this
+                // is `Some` whenever public_storage == s3.
+                bucket: args
+                    .public_s3_bucket
+                    .as_ref()
+                    .expect("clap-required: public_s3_bucket")
+                    .clone(),
+                prefix: args.public_s3_prefix.clone(),
+            })),
+        },
+        StorageType::PUB,
+        s3_client.clone(),
+    )?;
+    let private_keychain = OptionFuture::from(
+        args.root_key_id
+            .as_ref()
+            .zip(args.root_key_spec.as_ref())
+            .map(|(root_key_id, root_key_spec)| {
+                Keychain::AwsKms(AwsKmsKeychain {
+                    root_key_id: root_key_id.clone(),
+                    root_key_spec: root_key_spec.clone(),
+                })
+            })
+            .as_ref()
+            .map(|k| {
+                make_keychain_proxy(
+                    k,
+                    awskms_client.clone(),
+                    security_module.as_ref().map(Arc::clone),
+                    Some(&pub_storage),
+                    false,
+                )
+            }),
+    )
+    .await
+    .transpose()?;
+    let mut priv_vault = Vault {
+        storage: make_storage(
+            match args.private_storage {
+                StorageCommand::File => args.private_file_path.as_ref().map(|path| {
                     StorageConf::File(FileStorage {
                         path: path.to_path_buf(),
-                        prefix: args.public_file_prefix.clone(),
+                        prefix: args.private_file_prefix.clone(),
                     })
                 }),
                 StorageCommand::S3 => Some(StorageConf::S3(S3Storage {
+                    // clap's `required_if_eq` on `private_s3_bucket` guarantees
+                    // this is `Some` whenever private_storage == s3.
                     bucket: args
-                        .public_s3_bucket
+                        .private_s3_bucket
                         .as_ref()
-                        .expect("S3 bucket must be set for public storage")
+                        .expect("clap-required: private_s3_bucket")
                         .clone(),
-                    prefix: args.public_s3_prefix.clone(),
+                    prefix: args.private_s3_prefix.clone(),
                 })),
             },
-            StorageType::PUB,
+            StorageType::PRIV,
             s3_client.clone(),
-        )
-        .unwrap();
-        let private_keychain = OptionFuture::from(
-            args.root_key_id
-                .as_ref()
-                .zip(args.root_key_spec.as_ref())
-                .map(|(root_key_id, root_key_spec)| {
-                    Keychain::AwsKms(AwsKmsKeychain {
-                        root_key_id: root_key_id.clone(),
-                        root_key_spec: root_key_spec.clone(),
-                    })
-                })
-                .as_ref()
-                .map(|k| {
-                    make_keychain_proxy(
-                        k,
-                        awskms_client.clone(),
-                        security_module.as_ref().map(Arc::clone),
-                        Some(&pub_proxy_storage),
-                        false,
-                    )
-                }),
-        )
-        .await
-        .transpose()?;
-        pub_storages.push(pub_proxy_storage);
-        priv_vaults.push(Vault {
-            storage: make_storage(
-                match args.private_storage {
-                    StorageCommand::File => args.private_file_path.as_ref().map(|path| {
-                        StorageConf::File(FileStorage {
-                            path: path.to_path_buf(),
-                            prefix: args.private_file_prefix.clone(),
-                        })
-                    }),
-                    StorageCommand::S3 => Some(StorageConf::S3(S3Storage {
-                        bucket: args
-                            .private_s3_bucket
-                            .as_ref()
-                            .expect("S3 bucket must be set for private storage")
-                            .clone(),
-                        prefix: args.private_s3_prefix.clone(),
-                    })),
-                },
-                StorageType::PRIV,
-                s3_client.clone(),
-            )
-            .unwrap(),
-            keychain: private_keychain,
-        });
-    }
+        )?,
+        keychain: private_keychain,
+    };
+
     // generate keys
     match args.mode {
         Mode::Centralized => {
             let mut cmdargs = CentralCmdArgs {
-                pub_storage: &mut pub_storages[0],
-                priv_storage: &mut priv_vaults[0],
+                pub_storage: &mut pub_storage,
+                priv_storage: &mut priv_vault,
                 deterministic: args.deterministic,
                 overwrite: args.overwrite,
                 show_existing: args.show_existing,
@@ -354,21 +335,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Mode::Threshold {
             signing_key_party_id,
-            num_parties,
             tls_subject,
             tls_wildcard,
         } => {
-            let mut cmdargs = ThresholdCmdArgs::new(
-                &mut pub_storages,
-                &mut priv_vaults,
-                args.deterministic,
-                args.overwrite,
-                args.show_existing,
+            let mut cmdargs = ThresholdCmdArgs {
+                pub_storage: &mut pub_storage,
+                priv_storage: &mut priv_vault,
+                deterministic: args.deterministic,
+                overwrite: args.overwrite,
+                show_existing: args.show_existing,
                 signing_key_party_id,
-                num_parties,
                 tls_subject,
                 tls_wildcard,
-            )?;
+            };
             handle_threshold_cmd(&mut cmdargs).await;
         }
     }
@@ -402,34 +381,21 @@ async fn handle_central_cmd<PubS: Storage, PrivS: Storage>(
 async fn handle_threshold_cmd<PubS: Storage, PrivS: Storage>(
     args: &mut ThresholdCmdArgs<'_, PubS, PrivS>,
 ) {
-    // Will panic if the number of public and private storages is not equal
-    for (pub_storage, priv_storage) in args
-        .pub_storages
-        .iter_mut()
-        .zip_eq(args.priv_storages.iter_mut())
-    {
-        process_signing_key_cmds(
-            pub_storage,
-            priv_storage,
-            &SIGNING_KEY_ID,
-            args.show_existing,
-            args.overwrite,
-        )
-        .await;
-    }
-    if !ensure_threshold_server_signing_keys_exist(
-        args.pub_storages,
-        args.priv_storages,
+    process_signing_key_cmds(
+        args.pub_storage,
+        args.priv_storage,
+        &SIGNING_KEY_ID,
+        args.show_existing,
+        args.overwrite,
+    )
+    .await;
+    if !ensure_threshold_server_signing_key_exists(
+        args.pub_storage,
+        args.priv_storage,
         &SIGNING_KEY_ID,
         args.deterministic,
-        match args.signing_key_party_id {
-            Some(i) => ThresholdSigningKeyConfig::OneParty(i, args.tls_subject.clone()),
-            None => ThresholdSigningKeyConfig::AllParties(
-                (1..=args.num_parties)
-                    .map(|i| format!("{}-{}", args.tls_subject, i))
-                    .collect(),
-            ),
-        },
+        args.signing_key_party_id,
+        args.tls_subject.clone(),
         args.tls_wildcard,
     )
     .await

--- a/core/service/src/bin/kms-gen-keys.rs
+++ b/core/service/src/bin/kms-gen-keys.rs
@@ -21,7 +21,7 @@ use kms_lib::{
 };
 use observability::conf::TelemetryConfig;
 use observability::telemetry::init_tracing;
-use std::{path::PathBuf, sync::Arc};
+use std::{num::NonZeroUsize, path::PathBuf, sync::Arc};
 use strum::EnumIs;
 use url::Url;
 
@@ -155,8 +155,8 @@ enum Mode {
     /// party.
     Threshold {
         /// Index of the party to generate keys for (1-based).
-        #[clap(long, value_parser = parse_party_id)]
-        signing_key_party_id: usize,
+        #[clap(long)]
+        signing_key_party_id: NonZeroUsize,
 
         /// Subject used in the issued TLS certificate.
         #[clap(long, default_value = "kms-party")]
@@ -182,19 +182,9 @@ struct ThresholdCmdArgs<'a, PubS: Storage, PrivS: Storage> {
     deterministic: bool,
     overwrite: bool,
     show_existing: bool,
-    signing_key_party_id: usize,
+    signing_key_party_id: NonZeroUsize,
     tls_subject: String,
     tls_wildcard: bool,
-}
-
-fn parse_party_id(s: &str) -> Result<usize, String> {
-    let id: usize = s
-        .parse()
-        .map_err(|e: std::num::ParseIntError| e.to_string())?;
-    if id == 0 {
-        return Err("party ID must be at least 1".to_string());
-    }
-    Ok(id)
 }
 
 /// Generate the server signing keys and TLS material for a KMS deployment.
@@ -394,7 +384,7 @@ async fn handle_threshold_cmd<PubS: Storage, PrivS: Storage>(
         args.priv_storage,
         &SIGNING_KEY_ID,
         args.deterministic,
-        args.signing_key_party_id,
+        args.signing_key_party_id.get(),
         args.tls_subject.clone(),
         args.tls_wildcard,
     )

--- a/core/service/src/util/key_setup/mod.rs
+++ b/core/service/src/util/key_setup/mod.rs
@@ -17,6 +17,7 @@ cfg_if::cfg_if! {
         use crate::vault::storage::crypto_material::check_data_exists_at_epoch;
         use crate::vault::storage::{delete_at_request_and_epoch_id, delete_at_request_id, store_versioned_at_request_and_epoch_id, StorageExt};
         use futures_util::future;
+        use itertools::Itertools;
         use kms_grpc::identifiers::EpochId;
         use std::sync::Arc;
         use tfhe::Seed;
@@ -37,7 +38,6 @@ use crate::vault::storage::{
     Storage, StorageReader, StorageType, file::FileStorage, read_all_data_versioned,
     store_text_at_request_id, store_versioned_at_request_id,
 };
-use itertools::Itertools;
 use k256::pkcs8::EncodePrivateKey;
 use kms_grpc::RequestId;
 use kms_grpc::rpc_types::{PrivDataType, PubDataType};
@@ -645,8 +645,6 @@ where
 pub enum ThresholdSigningKeyConfig {
     /// All parties participate in signing (requires list of party identifiers)
     AllParties(Vec<String>),
-    /// Only one designated party participates in signing (party index, party identifier)
-    OneParty(usize, String),
 }
 
 /// Generates and stores threshold server signing and verification keys.
@@ -687,18 +685,12 @@ where
         tracing::error!(msg);
         panic!("{}", msg);
     }
-    let parties = match config {
-        ThresholdSigningKeyConfig::AllParties(parties) => {
-            (1..=parties.len()).zip_eq(parties).collect_vec()
-        }
-        ThresholdSigningKeyConfig::OneParty(i, subject) => {
-            std::iter::once((i, subject)).collect_vec()
-        }
-    };
+
+    let ThresholdSigningKeyConfig::AllParties(parties) = config;
 
     // Validate party indices
-    for &(i, _) in &parties {
-        if i == 0 || i > pub_storages.len() {
+    for i in 1..=parties.len() {
+        if i > pub_storages.len() {
             let msg = format!(
                 "Invalid party index: {} (must be between 1 and {})",
                 i,
@@ -709,201 +701,247 @@ where
         }
     }
 
-    for (i, subject_str) in parties {
-        let mut rng = get_rng(deterministic, Some(i as u64));
-
-        // Check if keys already exist with error handling
-        let temp: HashMap<RequestId, PrivateSigKey> = match read_all_data_versioned(
-            &priv_storages[i - 1],
-            &PrivDataType::SigningKey.to_string(),
-        )
-        .await
-        {
-            Ok(keys) => keys,
-            Err(e) => {
-                tracing::error!(
-                    "Failed to read existing server signing keys for party {}: {}",
-                    { i },
-                    e
-                );
-                continue; // Skip this party but try others
-            }
-        };
-
-        if !temp.is_empty() {
-            // If signing keys already exist, then do nothing
-            log_data_exists(
-                priv_storages[i - 1].info(),
-                None::<String>,
-                "",
-                "Threshold server signing keys",
-            );
-            // Even if signing keys exist, CA certificates and VerfAddress might not
-            if let Some(sk) = temp.get(request_id) {
-                // Regenerate VerfAddress if missing
-                if !pub_storages[i - 1]
-                    .data_exists(request_id, &PubDataType::VerfAddress.to_string())
-                    .await?
-                {
-                    let pk = sk.verf_key();
-                    let ethereum_address = pk.address();
-                    if let Err(store_err) = store_text_at_request_id(
-                        &mut pub_storages[i - 1],
-                        request_id,
-                        &ethereum_address.to_string(),
-                        &PubDataType::VerfAddress.to_string(),
-                    )
-                    .await
-                    {
-                        tracing::error!(
-                            "Failed to regenerate VerfAddress for party {}: {}",
-                            i,
-                            store_err
-                        );
-                    } else {
-                        tracing::info!(
-                            "Regenerated VerfAddress {} for party {} from existing signing key",
-                            ethereum_address,
-                            i
-                        );
-                    }
-                }
-
-                // Regenerate VerfKey if missing
-                if !pub_storages[i - 1]
-                    .data_exists(request_id, &PubDataType::VerfKey.to_string())
-                    .await?
-                {
-                    let pk = sk.verf_key();
-                    if let Err(store_err) = store_versioned_at_request_id(
-                        &mut pub_storages[i - 1],
-                        request_id,
-                        &pk,
-                        &PubDataType::VerfKey.to_string(),
-                    )
-                    .await
-                    {
-                        tracing::error!(
-                            "Failed to regenerate VerfKey for party {}: {}",
-                            i,
-                            store_err
-                        );
-                    } else {
-                        tracing::info!(
-                            "Regenerated VerfKey for party {} from existing signing key",
-                            i
-                        );
-                    }
-                }
-
-                // Regenerate CA certificate if missing
-                if !pub_storages[i - 1]
-                    .data_exists(request_id, &PubDataType::CACert.to_string())
-                    .await?
-                {
-                    ensure_ca_cert_exists(
-                        &mut pub_storages[i - 1],
-                        sk,
-                        request_id,
-                        subject_str,
-                        tls_wildcard,
-                    )
-                    .await?;
-                }
-            } else {
-                tracing::error!(
-                    "Failed to regenerate CA certificate from existing server signing key for party {i}"
-                )
-            };
-
-            continue;
-        }
-
-        let (pk, sk) = gen_sig_keys(&mut rng);
-
-        // Store public verification key
-        if let Err(store_err) = store_versioned_at_request_id(
-            &mut pub_storages[i - 1],
+    for (storage_index, subject) in parties.into_iter().enumerate() {
+        ensure_threshold_server_signing_key_for_party(
+            &mut pub_storages[storage_index],
+            &mut priv_storages[storage_index],
             request_id,
-            &pk,
-            &PubDataType::VerfKey.to_string(),
-        )
-        .await
-        {
-            tracing::error!(
-                "Failed to store public verification key for party {}: {}",
-                { i },
-                store_err
-            );
-            continue; // Skip this party but try others
-        }
-        log_storage_success(
-            request_id,
-            pub_storages[i - 1].info(),
-            "server signing key",
-            true,
-            true,
-        );
-
-        let ethereum_address = pk.address();
-
-        // Store ethereum address (derived from public key), needed for KMS signature verification
-        if let Err(store_err) = store_text_at_request_id(
-            &mut pub_storages[i - 1],
-            request_id,
-            &ethereum_address.to_string(),
-            &PubDataType::VerfAddress.to_string(),
-        )
-        .await
-        {
-            tracing::error!(
-                "Failed to store ethereum address for party {}: {}",
-                i,
-                store_err
-            );
-            continue; // Skip this party but try others
-        }
-        tracing::info!(
-            "Successfully stored ethereum address {} under the handle {} in storage \"{}\"",
-            ethereum_address,
-            request_id,
-            pub_storages[i - 1].info()
-        );
-
-        // Store private signing key
-        if let Err(store_err) = store_versioned_at_request_id(
-            &mut priv_storages[i - 1],
-            request_id,
-            &sk,
-            &PrivDataType::SigningKey.to_string(),
-        )
-        .await
-        {
-            tracing::error!(
-                "Failed to store private signing key for party {}: {}",
-                i,
-                store_err
-            );
-            continue; // Skip this party but try others
-        }
-        log_storage_success(
-            request_id,
-            priv_storages[i - 1].info(),
-            "server signing key",
-            false,
-            true,
-        );
-
-        // Generate CA certificate
-        ensure_ca_cert_exists(
-            &mut pub_storages[i - 1],
-            &sk,
-            request_id,
-            subject_str,
+            deterministic,
+            storage_index + 1,
+            subject,
             tls_wildcard,
         )
         .await?;
     }
+    Ok(true)
+}
+
+/// Generates and stores the threshold server signing and verification key for
+/// one configured storage.
+///
+/// This is used by deployment paths where the storage backend already selects
+/// the physical party destination (for example with a per-party storage
+/// prefix). The `party_id` remains the logical 1-based party identifier used
+/// for deterministic test seeding and certificate/log context.
+pub async fn ensure_threshold_server_signing_key_exists<PubS, PrivS>(
+    pub_storage: &mut PubS,
+    priv_storage: &mut PrivS,
+    request_id: &RequestId,
+    deterministic: bool,
+    party_id: usize,
+    subject: String,
+    tls_wildcard: bool,
+) -> anyhow::Result<bool>
+where
+    PubS: Storage,
+    PrivS: Storage,
+{
+    ensure_threshold_server_signing_key_for_party(
+        pub_storage,
+        priv_storage,
+        request_id,
+        deterministic,
+        party_id,
+        subject,
+        tls_wildcard,
+    )
+    .await
+}
+
+async fn ensure_threshold_server_signing_key_for_party<PubS, PrivS>(
+    pub_storage: &mut PubS,
+    priv_storage: &mut PrivS,
+    request_id: &RequestId,
+    deterministic: bool,
+    party_id: usize,
+    subject: String,
+    tls_wildcard: bool,
+) -> anyhow::Result<bool>
+where
+    PubS: Storage,
+    PrivS: Storage,
+{
+    if party_id == 0 {
+        let msg = "Invalid party index: 0 (must be at least 1)";
+        tracing::error!(msg);
+        panic!("{}", msg);
+    }
+
+    let mut rng = get_rng(deterministic, Some(party_id as u64));
+
+    // Check if keys already exist with error handling
+    let temp: HashMap<RequestId, PrivateSigKey> =
+        match read_all_data_versioned(priv_storage, &PrivDataType::SigningKey.to_string()).await {
+            Ok(keys) => keys,
+            Err(e) => {
+                tracing::error!(
+                    "Failed to read existing server signing keys for party {}: {}",
+                    party_id,
+                    e
+                );
+                return Ok(true);
+            }
+        };
+
+    if !temp.is_empty() {
+        // If signing keys already exist, then do nothing
+        log_data_exists(
+            priv_storage.info(),
+            None::<String>,
+            "",
+            "Threshold server signing keys",
+        );
+        // Even if signing keys exist, CA certificates and VerfAddress might not
+        if let Some(sk) = temp.get(request_id) {
+            // Regenerate VerfAddress if missing
+            if !pub_storage
+                .data_exists(request_id, &PubDataType::VerfAddress.to_string())
+                .await?
+            {
+                let pk = sk.verf_key();
+                let ethereum_address = pk.address();
+                if let Err(store_err) = store_text_at_request_id(
+                    pub_storage,
+                    request_id,
+                    &ethereum_address.to_string(),
+                    &PubDataType::VerfAddress.to_string(),
+                )
+                .await
+                {
+                    tracing::error!(
+                        "Failed to regenerate VerfAddress for party {}: {}",
+                        party_id,
+                        store_err
+                    );
+                } else {
+                    tracing::info!(
+                        "Regenerated VerfAddress {} for party {} from existing signing key",
+                        ethereum_address,
+                        party_id
+                    );
+                }
+            }
+
+            // Regenerate VerfKey if missing
+            if !pub_storage
+                .data_exists(request_id, &PubDataType::VerfKey.to_string())
+                .await?
+            {
+                let pk = sk.verf_key();
+                if let Err(store_err) = store_versioned_at_request_id(
+                    pub_storage,
+                    request_id,
+                    &pk,
+                    &PubDataType::VerfKey.to_string(),
+                )
+                .await
+                {
+                    tracing::error!(
+                        "Failed to regenerate VerfKey for party {}: {}",
+                        party_id,
+                        store_err
+                    );
+                } else {
+                    tracing::info!(
+                        "Regenerated VerfKey for party {} from existing signing key",
+                        party_id
+                    );
+                }
+            }
+
+            // Regenerate CA certificate if missing
+            if !pub_storage
+                .data_exists(request_id, &PubDataType::CACert.to_string())
+                .await?
+            {
+                ensure_ca_cert_exists(pub_storage, sk, request_id, subject, tls_wildcard).await?;
+            }
+        } else {
+            tracing::error!(
+                "Failed to regenerate CA certificate from existing server signing key for party {party_id}"
+            )
+        };
+
+        return Ok(true);
+    }
+
+    let (pk, sk) = gen_sig_keys(&mut rng);
+
+    // Store public verification key
+    if let Err(store_err) = store_versioned_at_request_id(
+        pub_storage,
+        request_id,
+        &pk,
+        &PubDataType::VerfKey.to_string(),
+    )
+    .await
+    {
+        tracing::error!(
+            "Failed to store public verification key for party {}: {}",
+            party_id,
+            store_err
+        );
+        return Ok(true);
+    }
+    log_storage_success(
+        request_id,
+        pub_storage.info(),
+        "server signing key",
+        true,
+        true,
+    );
+
+    let ethereum_address = pk.address();
+
+    // Store ethereum address (derived from public key), needed for KMS signature verification
+    if let Err(store_err) = store_text_at_request_id(
+        pub_storage,
+        request_id,
+        &ethereum_address.to_string(),
+        &PubDataType::VerfAddress.to_string(),
+    )
+    .await
+    {
+        tracing::error!(
+            "Failed to store ethereum address for party {}: {}",
+            party_id,
+            store_err
+        );
+        return Ok(true);
+    }
+    tracing::info!(
+        "Successfully stored ethereum address {} under the handle {} in storage \"{}\"",
+        ethereum_address,
+        request_id,
+        pub_storage.info()
+    );
+
+    // Store private signing key
+    if let Err(store_err) = store_versioned_at_request_id(
+        priv_storage,
+        request_id,
+        &sk,
+        &PrivDataType::SigningKey.to_string(),
+    )
+    .await
+    {
+        tracing::error!(
+            "Failed to store private signing key for party {}: {}",
+            party_id,
+            store_err
+        );
+        return Ok(true);
+    }
+    log_storage_success(
+        request_id,
+        priv_storage.info(),
+        "server signing key",
+        false,
+        true,
+    );
+
+    // Generate CA certificate
+    ensure_ca_cert_exists(pub_storage, &sk, request_id, subject, tls_wildcard).await?;
     Ok(true)
 }
 

--- a/core/service/src/util/key_setup/mod.rs
+++ b/core/service/src/util/key_setup/mod.rs
@@ -670,7 +670,7 @@ pub async fn ensure_threshold_server_signing_keys_exist<PubS, PrivS>(
     deterministic: bool,
     config: ThresholdSigningKeyConfig,
     tls_wildcard: bool,
-) -> anyhow::Result<bool>
+) -> anyhow::Result<()>
 where
     PubS: Storage,
     PrivS: Storage,
@@ -713,7 +713,7 @@ where
         )
         .await?;
     }
-    Ok(true)
+    Ok(())
 }
 
 /// Generates and stores the threshold server signing and verification key for
@@ -731,7 +731,7 @@ pub async fn ensure_threshold_server_signing_key_exists<PubS, PrivS>(
     party_id: usize,
     subject: String,
     tls_wildcard: bool,
-) -> anyhow::Result<bool>
+) -> anyhow::Result<()>
 where
     PubS: Storage,
     PrivS: Storage,
@@ -756,32 +756,28 @@ async fn ensure_threshold_server_signing_key_for_party<PubS, PrivS>(
     party_id: usize,
     subject: String,
     tls_wildcard: bool,
-) -> anyhow::Result<bool>
+) -> anyhow::Result<()>
 where
     PubS: Storage,
     PrivS: Storage,
 {
     if party_id == 0 {
-        let msg = "Invalid party index: 0 (must be at least 1)";
-        tracing::error!(msg);
-        panic!("{}", msg);
+        anyhow::bail!("party ID cannot be 0 in the threshold setting")
     }
 
     let mut rng = get_rng(deterministic, Some(party_id as u64));
 
     // Check if keys already exist with error handling
     let temp: HashMap<RequestId, PrivateSigKey> =
-        match read_all_data_versioned(priv_storage, &PrivDataType::SigningKey.to_string()).await {
-            Ok(keys) => keys,
-            Err(e) => {
-                tracing::error!(
+        read_all_data_versioned(priv_storage, &PrivDataType::SigningKey.to_string())
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
                     "Failed to read existing server signing keys for party {}: {}",
                     party_id,
                     e
-                );
-                return Ok(true);
-            }
-        };
+                )
+            })?;
 
     if !temp.is_empty() {
         // If signing keys already exist, then do nothing
@@ -800,26 +796,25 @@ where
             {
                 let pk = sk.verf_key();
                 let ethereum_address = pk.address();
-                if let Err(store_err) = store_text_at_request_id(
+                store_text_at_request_id(
                     pub_storage,
                     request_id,
                     &ethereum_address.to_string(),
                     &PubDataType::VerfAddress.to_string(),
                 )
                 .await
-                {
-                    tracing::error!(
+                .map_err(|store_err| {
+                    anyhow::anyhow!(
                         "Failed to regenerate VerfAddress for party {}: {}",
                         party_id,
                         store_err
-                    );
-                } else {
-                    tracing::info!(
-                        "Regenerated VerfAddress {} for party {} from existing signing key",
-                        ethereum_address,
-                        party_id
-                    );
-                }
+                    )
+                })?;
+                tracing::info!(
+                    "Regenerated VerfAddress {} for party {} from existing signing key",
+                    ethereum_address,
+                    party_id
+                );
             }
 
             // Regenerate VerfKey if missing
@@ -828,25 +823,24 @@ where
                 .await?
             {
                 let pk = sk.verf_key();
-                if let Err(store_err) = store_versioned_at_request_id(
+                store_versioned_at_request_id(
                     pub_storage,
                     request_id,
                     &pk,
                     &PubDataType::VerfKey.to_string(),
                 )
                 .await
-                {
-                    tracing::error!(
+                .map_err(|store_err| {
+                    anyhow::anyhow!(
                         "Failed to regenerate VerfKey for party {}: {}",
                         party_id,
                         store_err
-                    );
-                } else {
-                    tracing::info!(
-                        "Regenerated VerfKey for party {} from existing signing key",
-                        party_id
-                    );
-                }
+                    )
+                })?;
+                tracing::info!(
+                    "Regenerated VerfKey for party {} from existing signing key",
+                    party_id
+                );
             }
 
             // Regenerate CA certificate if missing
@@ -857,32 +851,31 @@ where
                 ensure_ca_cert_exists(pub_storage, sk, request_id, subject, tls_wildcard).await?;
             }
         } else {
-            tracing::error!(
-                "Failed to regenerate CA certificate from existing server signing key for party {party_id}"
+            anyhow::bail!(
+                "Failed to regenerate CA certificate from existing server signing key for party {party_id}: no signing key found under request ID {request_id}"
             )
         };
 
-        return Ok(true);
+        return Ok(());
     }
 
     let (pk, sk) = gen_sig_keys(&mut rng);
 
     // Store public verification key
-    if let Err(store_err) = store_versioned_at_request_id(
+    store_versioned_at_request_id(
         pub_storage,
         request_id,
         &pk,
         &PubDataType::VerfKey.to_string(),
     )
     .await
-    {
-        tracing::error!(
+    .map_err(|store_err| {
+        anyhow::anyhow!(
             "Failed to store public verification key for party {}: {}",
             party_id,
             store_err
-        );
-        return Ok(true);
-    }
+        )
+    })?;
     log_storage_success(
         request_id,
         pub_storage.info(),
@@ -894,21 +887,20 @@ where
     let ethereum_address = pk.address();
 
     // Store ethereum address (derived from public key), needed for KMS signature verification
-    if let Err(store_err) = store_text_at_request_id(
+    store_text_at_request_id(
         pub_storage,
         request_id,
         &ethereum_address.to_string(),
         &PubDataType::VerfAddress.to_string(),
     )
     .await
-    {
-        tracing::error!(
+    .map_err(|store_err| {
+        anyhow::anyhow!(
             "Failed to store ethereum address for party {}: {}",
             party_id,
             store_err
-        );
-        return Ok(true);
-    }
+        )
+    })?;
     tracing::info!(
         "Successfully stored ethereum address {} under the handle {} in storage \"{}\"",
         ethereum_address,
@@ -917,21 +909,20 @@ where
     );
 
     // Store private signing key
-    if let Err(store_err) = store_versioned_at_request_id(
+    store_versioned_at_request_id(
         priv_storage,
         request_id,
         &sk,
         &PrivDataType::SigningKey.to_string(),
     )
     .await
-    {
-        tracing::error!(
+    .map_err(|store_err| {
+        anyhow::anyhow!(
             "Failed to store private signing key for party {}: {}",
             party_id,
             store_err
-        );
-        return Ok(true);
-    }
+        )
+    })?;
     log_storage_success(
         request_id,
         priv_storage.info(),
@@ -942,7 +933,7 @@ where
 
     // Generate CA certificate
     ensure_ca_cert_exists(pub_storage, &sk, request_id, subject, tls_wildcard).await?;
-    Ok(true)
+    Ok(())
 }
 
 /// Generates stores CA certificates that are used to issue ephemeral mTLS

--- a/core/service/src/util/key_setup/mod.rs
+++ b/core/service/src/util/key_setup/mod.rs
@@ -656,8 +656,7 @@ pub enum ThresholdSigningKeyConfig {
 /// 4. Stores keys for each server under [request_id]
 ///
 /// # Returns
-/// - `true` if new keys were generated
-/// - `false` if keys already existed
+/// - `Ok(())` if new keys were generated or keys already existed
 /// - `Err` if an operation failed
 ///
 /// # Panics
@@ -768,7 +767,7 @@ where
     let mut rng = get_rng(deterministic, Some(party_id as u64));
 
     // Check if keys already exist with error handling
-    let temp: HashMap<RequestId, PrivateSigKey> =
+    let signing_keys_map: HashMap<RequestId, PrivateSigKey> =
         read_all_data_versioned(priv_storage, &PrivDataType::SigningKey.to_string())
             .await
             .map_err(|e| {
@@ -779,84 +778,87 @@ where
                 )
             })?;
 
-    if !temp.is_empty() {
-        // If signing keys already exist, then do nothing
+    if let Some(sk) = signing_keys_map.get(request_id) {
+        // If a signing key already exists under this request ID, then do nothing
         log_data_exists(
             priv_storage.info(),
             None::<String>,
             "",
             "Threshold server signing keys",
         );
-        // Even if signing keys exist, CA certificates and VerfAddress might not
-        if let Some(sk) = temp.get(request_id) {
-            // Regenerate VerfAddress if missing
-            if !pub_storage
-                .data_exists(request_id, &PubDataType::VerfAddress.to_string())
-                .await?
-            {
-                let pk = sk.verf_key();
-                let ethereum_address = pk.address();
-                store_text_at_request_id(
-                    pub_storage,
-                    request_id,
-                    &ethereum_address.to_string(),
-                    &PubDataType::VerfAddress.to_string(),
-                )
-                .await
-                .map_err(|store_err| {
-                    anyhow::anyhow!(
-                        "Failed to regenerate VerfAddress for party {}: {}",
-                        party_id,
-                        store_err
-                    )
-                })?;
-                tracing::info!(
-                    "Regenerated VerfAddress {} for party {} from existing signing key",
-                    ethereum_address,
-                    party_id
-                );
-            }
 
-            // Regenerate VerfKey if missing
-            if !pub_storage
-                .data_exists(request_id, &PubDataType::VerfKey.to_string())
-                .await?
-            {
-                let pk = sk.verf_key();
-                store_versioned_at_request_id(
-                    pub_storage,
-                    request_id,
-                    &pk,
-                    &PubDataType::VerfKey.to_string(),
-                )
-                .await
-                .map_err(|store_err| {
-                    anyhow::anyhow!(
-                        "Failed to regenerate VerfKey for party {}: {}",
-                        party_id,
-                        store_err
-                    )
-                })?;
-                tracing::info!(
-                    "Regenerated VerfKey for party {} from existing signing key",
-                    party_id
-                );
-            }
-
-            // Regenerate CA certificate if missing
-            if !pub_storage
-                .data_exists(request_id, &PubDataType::CACert.to_string())
-                .await?
-            {
-                ensure_ca_cert_exists(pub_storage, sk, request_id, subject, tls_wildcard).await?;
-            }
-        } else {
-            anyhow::bail!(
-                "Failed to regenerate CA certificate from existing server signing key for party {party_id}: no signing key found under request ID {request_id}"
+        // Even if the signing key exists, CA certificates and VerfAddress might not
+        // Regenerate VerfAddress if missing
+        if !pub_storage
+            .data_exists(request_id, &PubDataType::VerfAddress.to_string())
+            .await?
+        {
+            let pk = sk.verf_key();
+            let ethereum_address = pk.address();
+            store_text_at_request_id(
+                pub_storage,
+                request_id,
+                &ethereum_address.to_string(),
+                &PubDataType::VerfAddress.to_string(),
             )
-        };
+            .await
+            .map_err(|store_err| {
+                anyhow::anyhow!(
+                    "Failed to regenerate VerfAddress for party {}: {}",
+                    party_id,
+                    store_err
+                )
+            })?;
+            tracing::info!(
+                "Regenerated VerfAddress {} for party {} from existing signing key",
+                ethereum_address,
+                party_id
+            );
+        }
+
+        // Regenerate VerfKey if missing
+        if !pub_storage
+            .data_exists(request_id, &PubDataType::VerfKey.to_string())
+            .await?
+        {
+            let pk = sk.verf_key();
+            store_versioned_at_request_id(
+                pub_storage,
+                request_id,
+                &pk,
+                &PubDataType::VerfKey.to_string(),
+            )
+            .await
+            .map_err(|store_err| {
+                anyhow::anyhow!(
+                    "Failed to regenerate VerfKey for party {}: {}",
+                    party_id,
+                    store_err
+                )
+            })?;
+            tracing::info!(
+                "Regenerated VerfKey for party {} from existing signing key",
+                party_id
+            );
+        }
+
+        // Regenerate CA certificate if missing
+        if !pub_storage
+            .data_exists(request_id, &PubDataType::CACert.to_string())
+            .await?
+        {
+            ensure_ca_cert_exists(pub_storage, sk, request_id, subject, tls_wildcard).await?;
+        }
 
         return Ok(());
+    }
+
+    if !signing_keys_map.is_empty() {
+        tracing::warn!(
+            "Existing signing keys for party {} found under other request IDs but none under request ID {}, generating new keys",
+            party_id,
+            request_id
+        );
     }
 
     let (pk, sk) = gen_sig_keys(&mut rng);

--- a/core/service/tests/integration_test.rs
+++ b/core/service/tests/integration_test.rs
@@ -174,7 +174,7 @@ mod kms_gen_keys_binary_test {
         let temp_dir_pub = tempdir().unwrap();
 
         // party id 0 is invalid (parties are 1-indexed); the value parser
-        // should reject it at parse time.
+        // rejects id 0 at parse time.
         let output = Command::cargo_bin(KMS_GEN_KEYS)
             .unwrap()
             .arg("--private-storage=file")

--- a/core/service/tests/integration_test.rs
+++ b/core/service/tests/integration_test.rs
@@ -189,7 +189,8 @@ mod kms_gen_keys_binary_test {
             .unwrap();
 
         assert!(!output.status.success());
-        assert!(String::from_utf8_lossy(&output.stderr).contains("party ID must be at least 1"));
+        assert!(String::from_utf8_lossy(&output.stderr)
+            .contains("invalid value '0' for '--signing-key-party-id"));
     }
 
     #[test]

--- a/core/service/tests/integration_test.rs
+++ b/core/service/tests/integration_test.rs
@@ -169,12 +169,12 @@ mod kms_gen_keys_binary_test {
 
     #[test]
     #[integration_test]
-    fn threshold_wrong_num_parties() {
+    fn threshold_party_id_zero_rejected() {
         let temp_dir_priv = tempdir().unwrap();
         let temp_dir_pub = tempdir().unwrap();
 
-        // the command below should fail because --num-parties should be
-        // greater or equal to 2
+        // party id 0 is invalid (parties are 1-indexed); the value parser
+        // should reject it at parse time.
         let output = Command::cargo_bin(KMS_GEN_KEYS)
             .unwrap()
             .arg("--private-storage=file")
@@ -184,25 +184,21 @@ mod kms_gen_keys_binary_test {
             .arg("--public-file-path")
             .arg(temp_dir_pub.path())
             .arg("threshold")
-            .arg("--num-parties=1")
+            .arg("--signing-key-party-id=0")
             .output()
             .unwrap();
 
         assert!(!output.status.success());
-        assert!(
-            String::from_utf8_lossy(&output.stderr)
-                .contains("the number of parties should be larger or equal to 2")
-        );
+        assert!(String::from_utf8_lossy(&output.stderr).contains("party ID must be at least 1"));
     }
 
     #[test]
     #[integration_test]
-    fn threshold_signing_key_wrong_party_id() {
+    fn threshold_party_id_required() {
         let temp_dir_priv = tempdir().unwrap();
         let temp_dir_pub = tempdir().unwrap();
 
-        // the command below should fail because `--num-parties` default to 4
-        // but we're asking the CLI to generate a key for party 5
+        // --signing-key-party-id is a required flag now.
         let output = Command::cargo_bin(KMS_GEN_KEYS)
             .unwrap()
             .arg("--private-storage=file")
@@ -212,15 +208,11 @@ mod kms_gen_keys_binary_test {
             .arg("--public-file-path")
             .arg(temp_dir_pub.path())
             .arg("threshold")
-            .arg("--signing-key-party-id=5")
             .output()
             .unwrap();
 
         assert!(!output.status.success());
-        assert!(
-            String::from_utf8_lossy(&output.stderr)
-                .contains("party ID (5) cannot be greater than num_parties (4)")
-        );
+        assert!(String::from_utf8_lossy(&output.stderr).contains("--signing-key-party-id"));
     }
 
     #[test]
@@ -230,7 +222,6 @@ mod kms_gen_keys_binary_test {
         let temp_dir_priv = tempdir().unwrap();
         let temp_dir_pub = tempdir().unwrap();
 
-        // finally we run the command with the right args
         let output = kms_gen_keys_command()
             .arg("--private-storage=file")
             .arg("--private-file-path")
@@ -240,7 +231,6 @@ mod kms_gen_keys_binary_test {
             .arg(temp_dir_pub.path())
             .arg("threshold")
             .arg("--signing-key-party-id=5")
-            .arg("--num-parties=5")
             .output()
             .unwrap();
 

--- a/core/service/tests/integration_test.rs
+++ b/core/service/tests/integration_test.rs
@@ -189,8 +189,10 @@ mod kms_gen_keys_binary_test {
             .unwrap();
 
         assert!(!output.status.success());
-        assert!(String::from_utf8_lossy(&output.stderr)
-            .contains("invalid value '0' for '--signing-key-party-id"));
+        assert!(
+            String::from_utf8_lossy(&output.stderr)
+                .contains("invalid value '0' for '--signing-key-party-id")
+        );
     }
 
     #[test]

--- a/docker-compose-core-threshold-6.yml
+++ b/docker-compose-core-threshold-6.yml
@@ -35,7 +35,7 @@ services:
             --aws-s3-endpoint http://dev-s3-mock:9000 \
             --private-storage s3 --private-s3-bucket kms --private-s3-prefix PRIV-p$$i \
             threshold \
-            --signing-key-party-id $$i --tls-subject dev-kms-core-$$i.com --num-parties 6 \
+            --signing-key-party-id $$i --tls-subject dev-kms-core-$$i.com \
             --tls-wildcard && \
             wget -O ./certs/cert_dev-kms-core-$$i.com.pem ftp://$$AWS_ACCESS_KEY_ID:$$AWS_SECRET_ACCESS_KEY@dev-s3-mock:8021/kms/PUB-p$$i/CACert/60b7070add74be3827160aa635fb255eeeeb88586c4debf7ab1134ddceb4beee && \
             cat ./certs/cert_dev-kms-core-$$i.com.pem; \

--- a/docker/core/service/init_enclave.sh
+++ b/docker/core/service/init_enclave.sh
@@ -150,9 +150,9 @@ has_value "keygen" && \
 	# runtime by kms-server (in centralized mode) or by the threshold
 	# protocol (in threshold mode), so this script only handles signing
 	# keys. Note that in threshold mode, the [threshold] section used for
-	# kms-gen-keys is not the same as one used for kms-server. It has three
-	# fields only: my_id, num_parties, and tls_subject. The latter two are
-	# not accepted by kms-server.
+	# kms-gen-keys is not the same as one used for kms-server. It has two
+	# fields only: my_id and tls_subject. The latter is not accepted by
+	# kms-server.
 	if has_value "threshold"; then
 	    log "generating signing keys for threshold KMS"
 	    PARTY_ID_ARG=""
@@ -160,7 +160,6 @@ has_value "keygen" && \
 		PARTY_ID_ARG="--signing-key-party-id $(get_value "threshold.my_id")"
 	    eval "$KMS_GEN_KEYS_CMD \
                    threshold $PARTY_ID_ARG \
-                   --num-parties $(get_value "threshold.num_parties") \
                    --tls-subject $(get_value "threshold.tls_subject")" \
 		|& logger || fail "cannot generate keys"
 	else

--- a/docs/guides/kms-server-bin.md
+++ b/docs/guides/kms-server-bin.md
@@ -10,8 +10,8 @@ To generate the signing material before the KMS server is started, run one of:
 # for centralized:
 cargo run --bin kms-gen-keys -- centralized
 
-# for threshold:
-cargo run --bin kms-gen-keys -- threshold --signing-key-party-id <SIGNING_KEY_PARTY_ID> --num-parties <NUM_PARTIES>
+# for threshold (run this once per party, with party IDs 1..N):
+cargo run --bin kms-gen-keys -- threshold --signing-key-party-id <SIGNING_KEY_PARTY_ID>
 ```
 
 For local test/dev runs that need pre-baked FHE keys + CRS, use `generate-test-material` instead (see the `generate-test-material-*` targets in the top-level `Makefile`).


### PR DESCRIPTION
## Description of changes
Using kms-gen-keys to generate keys for more than one party is never used in practice, so we're removing this feature from the CLI. Additionally, functions such as `ensure_threshold_server_signing_key_exists` were returning a boolean that is never used by the caller (and it even returned Ok(true) when there's an error), this has been fixed too.

### BREAKING CHANGE

The `kms-gen-keys` CLI does not need `--num-parties` anymore.

## Issue ticket number and link
Closes https://github.com/zama-ai/kms-internal/issues/3030

Note that the issue also mentions another potential improvement - combining kms-gen-keys with kms-gen-tls-certs. But those two CLI have very different code paths, so there's no clean way to combine them. As such, we're only doing the first improvement.

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
