### PR TITLE
perf(storage): avoid full-size copies of FHE keys on the keygen store…

### DIFF
--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -171,6 +171,7 @@ non-wasm = [
     "dep:observability",
     "dep:rustls-webpki",
     "dep:rcgen",
+    "dep:tempfile",
     "dep:test-utils",
     "dep:thread-handles",
     "dep:tokio",

--- a/core/service/src/engine/centralized/central_kms.rs
+++ b/core/service/src/engine/centralized/central_kms.rs
@@ -986,6 +986,7 @@ impl<
             rate_limiter.clone(),
             Arc::clone(&user_dec_meta_store),
             Arc::clone(&pub_dec_meta_store),
+            crypto_storage.clone(),
             telemetry_conf.refresh_interval(),
         );
         let (health_reporter, health_service) = tonic_health::server::health_reporter();
@@ -1084,15 +1085,21 @@ impl<
     }
 }
 
-fn update_central_kms_system_metrics(
+fn update_central_kms_system_metrics<PubS, PrivS>(
     rate_limiter: RateLimiter,
     user_meta_store: Arc<RwLock<MetaStore<UserDecryptCallValues>>>,
     public_meta_store: Arc<RwLock<MetaStore<PubDecCallValues>>>,
+    crypto_storage: CentralizedCryptoMaterialStorage<PubS, PrivS>,
     refresh_interval: std::time::Duration,
-) -> tokio::task::JoinHandle<()> {
+) -> tokio::task::JoinHandle<()>
+where
+    PubS: Storage + Send + Sync + 'static,
+    PrivS: StorageExt + Send + Sync + 'static,
+{
     tokio::spawn(async move {
         loop {
             METRICS.record_rate_limiter_usage(rate_limiter.tokens_used());
+            METRICS.record_fhe_key_cache_size(crypto_storage.cached_fhe_key_count().await as u64);
             {
                 let user_meta_store_guard = user_meta_store.read().await;
                 METRICS.record_meta_storage_user_decryptions(

--- a/core/service/src/engine/centralized/central_kms.rs
+++ b/core/service/src/engine/centralized/central_kms.rs
@@ -1099,7 +1099,11 @@ where
     tokio::spawn(async move {
         loop {
             METRICS.record_rate_limiter_usage(rate_limiter.tokens_used());
-            METRICS.record_fhe_key_cache_size(crypto_storage.cached_fhe_key_count().await as u64);
+            // Skipped when the cache lock is contended: the gauge keeps its
+            // previous value rather than stalling the whole metrics loop.
+            if let Some(count) = crypto_storage.cached_fhe_key_count() {
+                METRICS.record_fhe_key_cache_size(count as u64);
+            }
             {
                 let user_meta_store_guard = user_meta_store.read().await;
                 METRICS.record_meta_storage_user_decryptions(

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -673,8 +673,6 @@ impl<
                     // from the newly generated compressed keyset. Revisit whether it should
                     // instead preserve the old keyset's CompactPublicKey to keep the
                     // externally visible public key stable across epochs of the same key_id.
-                    // `CompressedXofKeySet::decompress` takes `&self`, so decompress in
-                    // place instead of first cloning the whole (multi-GiB) keyset.
                     let compact_public_key = compressed_keyset
                         .decompress()
                         .map_err(|e| {
@@ -702,8 +700,6 @@ impl<
                         }
                     };
 
-                    // Last use of `compressed_keyset` — move it instead of deep-cloning
-                    // the (multi-GiB) keyset.
                     let public_material = PublicKeyMaterial::new(compressed_keyset);
 
                     let threshold_fhe_keys = ThresholdFheKeys::new(
@@ -1406,15 +1402,10 @@ impl<
         )
         .await;
 
-        // Reclaim the in-memory FHE key cache for this epoch. `destroy_epoch`
-        // only deletes the on-disk material; without this the (potentially
-        // tens-of-GiB) decompressed key material would stay resident until
-        // process restart. This is pure memory reclaim with no decryption-
-        // behaviour change: decryptions under a destroyed epoch are already
-        // rejected by epoch validation (the epoch is removed from the session
-        // maker above). Done unconditionally (the epoch is torn down regardless)
-        // and best-effort; it only touches the `fhe_keys` cache, the last lock
-        // in the documented order.
+        // `destroy_epoch` only deletes on-disk material; also drop the cached
+        // decompressed keys or they stay resident until restart. Safe even if
+        // destruction partially failed: the epoch is already gone from the
+        // session maker, so nothing can reach these entries anymore.
         let removed = self.crypto_storage.purge_epoch_from_cache(&epoch_id).await;
         if removed > 0 {
             tracing::info!(

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1395,13 +1395,31 @@ impl<
 
         let priv_storage = Arc::clone(&self.crypto_storage.inner.private_storage);
 
-        Self::destroy_epoch(
+        let res = Self::destroy_epoch(
             &epoch_id,
             &[PrivDataType::FheKeyInfo, PrivDataType::CrsInfo],
             &priv_storage,
             &self.session_maker,
         )
-        .await
+        .await;
+
+        // Reclaim the in-memory FHE key cache for this epoch. `destroy_epoch`
+        // only deletes the on-disk material; without this the (potentially
+        // tens-of-GiB) decompressed key material would stay resident until
+        // process restart. This is pure memory reclaim with no decryption-
+        // behaviour change: decryptions under a destroyed epoch are already
+        // rejected by epoch validation (the epoch is removed from the session
+        // maker above). Done unconditionally (the epoch is torn down regardless)
+        // and best-effort; it only touches the `fhe_keys` cache, the last lock
+        // in the documented order.
+        let removed = self.crypto_storage.purge_epoch_from_cache(&epoch_id).await;
+        if removed > 0 {
+            tracing::info!(
+                "Freed {removed} in-memory FHE key cache entries for destroyed epoch {epoch_id}"
+            );
+        }
+
+        res
     }
 
     async fn get_epoch_result(

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1407,11 +1407,9 @@ impl<
         // until restart. Safe even if destruction partially failed: the epoch is
         // already gone from the session maker, so nothing can reach these entries.
         let removed = self.crypto_storage.purge_epoch_from_cache(&epoch_id).await;
-        if removed > 0 {
-            tracing::info!(
-                "Freed {removed} in-memory FHE key cache entries for destroyed epoch {epoch_id}"
-            );
-        }
+        tracing::info!(
+            "Freed {removed} in-memory FHE key cache entries for destroyed epoch {epoch_id}"
+        );
 
         res
     }

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -673,8 +673,9 @@ impl<
                     // from the newly generated compressed keyset. Revisit whether it should
                     // instead preserve the old keyset's CompactPublicKey to keep the
                     // externally visible public key stable across epochs of the same key_id.
+                    // `CompressedXofKeySet::decompress` takes `&self`, so decompress in
+                    // place instead of first cloning the whole (multi-GiB) keyset.
                     let compact_public_key = compressed_keyset
-                        .clone()
                         .decompress()
                         .map_err(|e| {
                             anyhow::anyhow!("Failed to decompress reshared compressed keyset: {e}")
@@ -701,7 +702,9 @@ impl<
                         }
                     };
 
-                    let public_material = PublicKeyMaterial::new(compressed_keyset.clone());
+                    // Last use of `compressed_keyset` — move it instead of deep-cloning
+                    // the (multi-GiB) keyset.
+                    let public_material = PublicKeyMaterial::new(compressed_keyset);
 
                     let threshold_fhe_keys = ThresholdFheKeys::new(
                         Arc::new(new_private_keyset),

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1402,10 +1402,10 @@ impl<
         )
         .await;
 
-        // `destroy_epoch` only deletes on-disk material; also drop the cached
-        // decompressed keys or they stay resident until restart. Safe even if
-        // destruction partially failed: the epoch is already gone from the
-        // session maker, so nothing can reach these entries anymore.
+        // `destroy_epoch` above removes only the on-disk material, so the cached
+        // decompressed keys must be dropped here separately or they stay resident
+        // until restart. Safe even if destruction partially failed: the epoch is
+        // already gone from the session maker, so nothing can reach these entries.
         let removed = self.crypto_storage.purge_epoch_from_cache(&epoch_id).await;
         if removed > 0 {
             tracing::info!(

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -1512,9 +1512,14 @@ impl<
                     }
                 };
 
+                // Wrap the compressed keyset in an `Arc` once and share the same
+                // allocation between the private-side `PublicKeyMaterial` and the
+                // public-storage `PublicKeySet` below. This previously deep-cloned
+                // the entire (multi-GiB) compressed keyset.
+                let compressed_keyset = Arc::new(compressed_keyset);
                 let threshold_fhe_keys = ThresholdFheKeys::new(
                     Arc::new(private_keys),
-                    PublicKeyMaterial::new(compressed_keyset.clone()),
+                    PublicKeyMaterial::from_arc(Arc::clone(&compressed_keyset)),
                     info,
                 );
 
@@ -1527,7 +1532,8 @@ impl<
                         threshold_fhe_keys,
                         PublicKeySet::Compressed {
                             compact_public_key: Arc::new(compact_public_key),
-                            compressed_keyset: Arc::new(compressed_keyset),
+                            // Shared `Arc` built above — no second copy of the keyset.
+                            compressed_keyset,
                         },
                         Arc::clone(&meta_store),
                         op_tag,

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -1512,14 +1512,17 @@ impl<
                     }
                 };
 
-                // One shared allocation for both the private-side material and the
-                // public-storage keyset below — the keyset is multi-GiB.
-                let compressed_keyset = Arc::new(compressed_keyset);
                 let threshold_fhe_keys = ThresholdFheKeys::new(
                     Arc::new(private_keys),
-                    PublicKeyMaterial::from_arc(Arc::clone(&compressed_keyset)),
+                    PublicKeyMaterial::new(compressed_keyset),
                     info,
                 );
+                // Share the material's keyset allocation with the public-storage
+                // set below — the keyset is multi-GiB.
+                let compressed_keyset = threshold_fhe_keys
+                    .public_material
+                    .compressed_keyset()
+                    .expect("material was just built compressed");
 
                 // NOTE: when there is an existing compact pk from an older keygen (an older key ID),
                 // then this pk is effectively copied to the new key ID.

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -1512,10 +1512,8 @@ impl<
                     }
                 };
 
-                // Wrap the compressed keyset in an `Arc` once and share the same
-                // allocation between the private-side `PublicKeyMaterial` and the
-                // public-storage `PublicKeySet` below. This previously deep-cloned
-                // the entire (multi-GiB) compressed keyset.
+                // One shared allocation for both the private-side material and the
+                // public-storage keyset below — the keyset is multi-GiB.
                 let compressed_keyset = Arc::new(compressed_keyset);
                 let threshold_fhe_keys = ThresholdFheKeys::new(
                     Arc::new(private_keys),
@@ -1532,7 +1530,6 @@ impl<
                         threshold_fhe_keys,
                         PublicKeySet::Compressed {
                             compact_public_key: Arc::new(compact_public_key),
-                            // Shared `Arc` built above — no second copy of the keyset.
                             compressed_keyset,
                         },
                         Arc::clone(&meta_store),

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -175,6 +175,13 @@ impl PublicKeyMaterial {
         }
     }
 
+    /// Build compressed key material from an already-`Arc`'d keyset. Lets the
+    /// caller share one allocation with the public-storage `PublicKeySet` instead
+    /// of deep-cloning the (multi-GiB) compressed keyset.
+    pub fn from_arc(keyset: Arc<CompressedXofKeySet>) -> Self {
+        Self::Compressed { keyset }
+    }
+
     pub fn new_uncompressed(
         integer_server_key: Arc<ServerKey>,
         sns_key: Option<Arc<NoiseSquashingKey>>,

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -337,8 +337,10 @@ impl ThresholdFheKeys {
                     decompression_key: decompression_key.clone(),
                 },
                 PublicKeyMaterial::Compressed { keyset } => {
-                    let cloned = (**keyset).clone(); // TODO(dp): can possibly get rid of this later once tfhe-rs #3469 lands
-                    let (_pk, sk) = cloned
+                    // `CompressedXofKeySet::decompress` takes `&self` (tfhe 1.6.1), so we
+                    // decompress through the `Arc` directly instead of first cloning the
+                    // whole (multi-GiB) compressed keyset.
+                    let (_pk, sk) = keyset
                         .decompress()
                         .expect("Call is infallible")
                         .into_raw_parts();

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -178,7 +178,7 @@ impl PublicKeyMaterial {
     /// Hand out a shared reference to the owned compressed keyset, if any.
     /// Cheap (`Arc` clone) — lets callers reuse the allocation instead of
     /// deep-cloning the multi-GiB keyset.
-    pub fn compressed_keyset(&self) -> Option<Arc<CompressedXofKeySet>> {
+    pub(crate) fn compressed_keyset(&self) -> Option<Arc<CompressedXofKeySet>> {
         match self {
             Self::Compressed { keyset } => Some(Arc::clone(keyset)),
             Self::Uncompressed { .. } => None,

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -175,9 +175,14 @@ impl PublicKeyMaterial {
         }
     }
 
-    /// Like [`Self::new`], but shares the caller's `Arc` instead of allocating.
-    pub fn from_arc(keyset: Arc<CompressedXofKeySet>) -> Self {
-        Self::Compressed { keyset }
+    /// Hand out a shared reference to the owned compressed keyset, if any.
+    /// Cheap (`Arc` clone) — lets callers reuse the allocation instead of
+    /// deep-cloning the multi-GiB keyset.
+    pub fn compressed_keyset(&self) -> Option<Arc<CompressedXofKeySet>> {
+        match self {
+            Self::Compressed { keyset } => Some(Arc::clone(keyset)),
+            Self::Uncompressed { .. } => None,
+        }
     }
 
     pub fn new_uncompressed(
@@ -1069,22 +1074,6 @@ mod tests {
         assert!(matches!(v3, PublicKeyMaterial::Compressed { .. }));
     }
 
-    #[test]
-    fn from_arc_shares_the_keyset_allocation() {
-        let mut rng = AesRng::seed_from_u64(7);
-        let (_keyset, compressed_keyset) =
-            gen_key_set(TEST_PARAM, tfhe::Tag::default(), &mut rng).unwrap();
-        let shared = Arc::new(compressed_keyset);
-
-        let material = PublicKeyMaterial::from_arc(Arc::clone(&shared));
-        match &material {
-            PublicKeyMaterial::Compressed { keyset } => {
-                assert!(Arc::ptr_eq(keyset, &shared), "keyset must not be copied");
-            }
-            PublicKeyMaterial::Uncompressed { .. } => panic!("expected compressed material"),
-        }
-    }
-
     /// Verify that a V3 ThresholdFheKeys with Compressed keys can roundtrip through
     /// safe_serialize / safe_deserialize, and that lazy decompression works after.
     #[test]
@@ -1105,6 +1094,16 @@ mod tests {
             ),
         );
         assert!(original.is_compressed());
+        // The material owns the keyset and hands out shared (not copied) refs.
+        let shared = original
+            .public_material
+            .compressed_keyset()
+            .expect("compressed material");
+        match &original.public_material {
+            PublicKeyMaterial::Compressed { keyset } => assert!(Arc::ptr_eq(&shared, keyset)),
+            PublicKeyMaterial::Uncompressed { .. } => unreachable!(),
+        }
+        drop(shared);
 
         // Decompress the original before serialization so we have reference values
         let orig_srv_key = bc2wrap::serialize(&*original.integer_server_key()).unwrap();

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -337,7 +337,7 @@ impl ThresholdFheKeys {
                     decompression_key: decompression_key.clone(),
                 },
                 PublicKeyMaterial::Compressed { keyset } => {
-                    // `CompressedXofKeySet::decompress` takes `&self` (tfhe 1.6.1), so we
+                    // `CompressedXofKeySet::decompress` takes `&self` (since tfhe 1.6), so we
                     // decompress through the `Arc` directly instead of first cloning the
                     // whole (multi-GiB) compressed keyset.
                     let (_pk, sk) = keyset
@@ -1074,6 +1074,24 @@ mod tests {
 
         let v3: PublicKeyMaterial = v0.upgrade().unwrap();
         assert!(matches!(v3, PublicKeyMaterial::Compressed { .. }));
+    }
+
+    /// Sunshine: `from_arc` wraps the given `Arc` without copying — the resulting
+    /// material shares the caller's allocation instead of deep-cloning the keyset.
+    #[test]
+    fn from_arc_shares_the_keyset_allocation() {
+        let mut rng = AesRng::seed_from_u64(7);
+        let (_keyset, compressed_keyset) =
+            gen_key_set(TEST_PARAM, tfhe::Tag::default(), &mut rng).unwrap();
+        let shared = Arc::new(compressed_keyset);
+
+        let material = PublicKeyMaterial::from_arc(Arc::clone(&shared));
+        match &material {
+            PublicKeyMaterial::Compressed { keyset } => {
+                assert!(Arc::ptr_eq(keyset, &shared), "keyset must not be copied");
+            }
+            PublicKeyMaterial::Uncompressed { .. } => panic!("expected compressed material"),
+        }
     }
 
     /// Verify that a V3 ThresholdFheKeys with Compressed keys can roundtrip through

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -883,8 +883,11 @@ where
             metrics::METRICS.record_rate_limiter_usage(rate_limiter.tokens_used());
             metrics::METRICS.record_active_sessions(session_maker.active_sessions().await);
             metrics::METRICS.record_inactive_sessions(session_maker.inactive_sessions().await);
-            metrics::METRICS
-                .record_fhe_key_cache_size(crypto_storage.cached_fhe_key_count().await as u64);
+            // Skipped when the cache lock is contended: the gauge keeps its
+            // previous value rather than stalling the whole metrics loop.
+            if let Some(count) = crypto_storage.cached_fhe_key_count() {
+                metrics::METRICS.record_fhe_key_cache_size(count as u64);
+            }
             {
                 let user_meta_store_guard = user_meta_store.read().await;
                 metrics::METRICS.record_meta_storage_user_decryptions(

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -838,6 +838,7 @@ where
         immutable_session_maker.clone(),
         Arc::clone(&user_decrypt_meta_store),
         Arc::clone(&pub_dec_meta_store),
+        crypto_storage.clone(),
         telemetry_conf.refresh_interval(),
     );
 
@@ -867,18 +868,25 @@ where
     ))
 }
 
-fn update_threshold_kms_system_metrics(
+fn update_threshold_kms_system_metrics<PubS, PrivS>(
     rate_limiter: RateLimiter,
     session_maker: ImmutableSessionMaker,
     user_meta_store: Arc<RwLock<MetaStore<UserDecryptCallValues>>>,
     public_meta_store: Arc<RwLock<MetaStore<PubDecCallValues>>>,
+    crypto_storage: ThresholdCryptoMaterialStorage<PubS, PrivS>,
     refresh_interval: std::time::Duration,
-) -> tokio::task::JoinHandle<()> {
+) -> tokio::task::JoinHandle<()>
+where
+    PubS: Storage + Send + Sync + 'static,
+    PrivS: StorageExt + Send + Sync + 'static,
+{
     tokio::spawn(async move {
         loop {
             metrics::METRICS.record_rate_limiter_usage(rate_limiter.tokens_used());
             metrics::METRICS.record_active_sessions(session_maker.active_sessions().await);
             metrics::METRICS.record_inactive_sessions(session_maker.inactive_sessions().await);
+            metrics::METRICS
+                .record_fhe_key_cache_size(crypto_storage.cached_fhe_key_count().await as u64);
             {
                 let user_meta_store_guard = user_meta_store.read().await;
                 metrics::METRICS.record_meta_storage_user_decryptions(

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -175,9 +175,7 @@ impl PublicKeyMaterial {
         }
     }
 
-    /// Build compressed key material from an already-`Arc`'d keyset. Lets the
-    /// caller share one allocation with the public-storage `PublicKeySet` instead
-    /// of deep-cloning the (multi-GiB) compressed keyset.
+    /// Like [`Self::new`], but shares the caller's `Arc` instead of allocating.
     pub fn from_arc(keyset: Arc<CompressedXofKeySet>) -> Self {
         Self::Compressed { keyset }
     }
@@ -325,31 +323,26 @@ impl ThresholdFheKeys {
     }
 
     fn expand_keys(&self) -> &UncompressedKeys {
-        self.key_cache.get_or_init(|| {
-            match &self.public_material {
-                PublicKeyMaterial::Uncompressed {
-                    integer_server_key,
-                    sns_key,
-                    decompression_key,
-                } => UncompressedKeys {
-                    integer_server_key: integer_server_key.clone(),
-                    sns_key: sns_key.clone(),
-                    decompression_key: decompression_key.clone(),
-                },
-                PublicKeyMaterial::Compressed { keyset } => {
-                    // `CompressedXofKeySet::decompress` takes `&self` (since tfhe 1.6), so we
-                    // decompress through the `Arc` directly instead of first cloning the
-                    // whole (multi-GiB) compressed keyset.
-                    let (_pk, sk) = keyset
-                        .decompress()
-                        .expect("Call is infallible")
-                        .into_raw_parts();
-                    let (isk, _, _, decompk, snsk, _, _, _, _) = sk.into_raw_parts();
-                    UncompressedKeys {
-                        integer_server_key: Arc::new(isk),
-                        sns_key: snsk.map(Arc::new),
-                        decompression_key: decompk.map(Arc::new),
-                    }
+        self.key_cache.get_or_init(|| match &self.public_material {
+            PublicKeyMaterial::Uncompressed {
+                integer_server_key,
+                sns_key,
+                decompression_key,
+            } => UncompressedKeys {
+                integer_server_key: integer_server_key.clone(),
+                sns_key: sns_key.clone(),
+                decompression_key: decompression_key.clone(),
+            },
+            PublicKeyMaterial::Compressed { keyset } => {
+                let (_pk, sk) = keyset
+                    .decompress()
+                    .expect("Call is infallible")
+                    .into_raw_parts();
+                let (isk, _, _, decompk, snsk, _, _, _, _) = sk.into_raw_parts();
+                UncompressedKeys {
+                    integer_server_key: Arc::new(isk),
+                    sns_key: snsk.map(Arc::new),
+                    decompression_key: decompk.map(Arc::new),
                 }
             }
         })
@@ -1076,8 +1069,6 @@ mod tests {
         assert!(matches!(v3, PublicKeyMaterial::Compressed { .. }));
     }
 
-    /// Sunshine: `from_arc` wraps the given `Arc` without copying — the resulting
-    /// material shares the caller's allocation instead of deep-cloning the keyset.
     #[test]
     fn from_arc_shares_the_keyset_allocation() {
         let mut rng = AesRng::seed_from_u64(7);

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -68,10 +68,6 @@ pub async fn safe_write_element_versioned<
         .map_err(|e| anyhow::anyhow!("failed to sync {}: {e}", tmp.path().display()))?;
     tmp.persist(file_path)
         .map_err(|e| anyhow::anyhow!("failed to persist {}: {e}", file_path.display()))?;
-    // Best-effort fsync of the parent dir so the rename itself is durable.
-    if let Ok(dir) = std::fs::File::open(parent) {
-        let _ = dir.sync_all();
-    }
     Ok(())
 }
 

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -1,6 +1,5 @@
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use tfhe::named::Named;
 use tfhe::safe_serialization::{safe_deserialize, safe_serialize};
@@ -22,7 +21,7 @@ pub async fn write_bytes<P: AsRef<Path>>(file_path: P, bytes: &[u8]) -> anyhow::
 /// [`safe_write_element_versioned`]. On drop it removes the temp file unless it
 /// has been [`disarm`](TempFileGuard::disarm)ed (which only happens after a
 /// successful rename), so a failed write — at any of the create / serialize /
-/// flush / rename steps — never strands an orphaned `.<name>.partial.*` file.
+/// sync / rename steps — never strands an orphaned `.<name>.partial.*` file.
 struct TempFileGuard {
     path: Option<PathBuf>,
 }
@@ -52,16 +51,17 @@ impl Drop for TempFileGuard {
 /// This is a wrapper around safe_serialize versioned for the async use case.
 ///
 /// The serialization is streamed straight to disk (into a sibling temp file that
-/// is then atomically renamed into place) instead of going through an in-memory
-/// `Vec<u8>`. For production FHE keys the serialized blob is ~tens of GiB, and
-/// buffering it in memory would roughly double peak RSS at write time by holding
-/// the full serialized copy alongside `element`. The serialize+write is run
+/// is synced and then atomically renamed into place) instead of going through an
+/// in-memory `Vec<u8>`. For production FHE keys the serialized blob is multiple
+/// GiB (bounded by [`SAFE_SER_SIZE_LIMIT`]), and buffering it in memory would
+/// roughly double peak RSS at write time by holding the full serialized copy
+/// alongside `element`. The serialize+write is run
 /// inline (synchronously): `safe_serialize` borrows `element`, so it cannot be
 /// moved into `spawn_blocking`, and `block_in_place` would panic on the
 /// current-thread runtimes used by the storage tests. Key writes happen once per
 /// keygen, so briefly blocking the worker thread here is acceptable.
 ///
-/// On any write error (create / serialize / flush / rename) the temp file is
+/// On any write error (create / serialize / sync / rename) the temp file is
 /// removed before returning (see [`TempFileGuard`]); without this, repeated
 /// failures (e.g. disk full / permission issues) would accumulate hidden,
 /// uniquely-named partials and waste disk space.
@@ -77,8 +77,11 @@ pub async fn safe_write_element_versioned<
     if let Some(p) = file_path.parent() {
         tokio::fs::create_dir_all(p).await?
     };
-    // Write to a sibling temp file first, then atomically rename into place, so a
-    // crash mid-write cannot leave a partially-serialized key file at `file_path`.
+    // Write to a sibling temp file first, fsync it, then atomically rename into
+    // place, so a crash mid-write cannot leave a partially-serialized key file at
+    // `file_path`. The fsync matters: rename alone is only a namespace operation,
+    // so without it a power loss shortly after the rename could leave a
+    // complete-looking but empty/truncated file at `file_path`.
     // The temp name is dot-prefixed (hidden): if a crash leaves one behind, directory
     // listings skip it (e.g. `FileStorage::all_data_ids` ignores dot-files but parses
     // every other name as a `RequestId`, so a non-hidden leftover would break listing).
@@ -105,18 +108,35 @@ pub async fn safe_write_element_versioned<
         }
     };
     // Remove the temp file on any early return below (a failed create / serialize /
-    // flush / rename); only a successful rename disarms it.
+    // sync / rename); only a successful rename disarms it.
     let cleanup = TempFileGuard::new(tmp_path.clone());
     {
         let file = std::fs::File::create(&tmp_path)
             .map_err(|e| anyhow::anyhow!("failed to create {}: {e}", tmp_path.display()))?;
         let mut writer = std::io::BufWriter::new(file);
-        safe_serialize(element, &mut writer, SAFE_SER_SIZE_LIMIT)?;
-        writer
-            .flush()
+        safe_serialize(element, &mut writer, SAFE_SER_SIZE_LIMIT)
+            .map_err(|e| anyhow::anyhow!("failed to serialize into {}: {e}", tmp_path.display()))?;
+        let file = writer
+            .into_inner()
             .map_err(|e| anyhow::anyhow!("failed to flush {}: {e}", tmp_path.display()))?;
+        file.sync_all()
+            .map_err(|e| anyhow::anyhow!("failed to sync {}: {e}", tmp_path.display()))?;
     }
-    tokio::fs::rename(&tmp_path, file_path).await?;
+    tokio::fs::rename(&tmp_path, file_path).await.map_err(|e| {
+        anyhow::anyhow!(
+            "failed to rename {} to {}: {e}",
+            tmp_path.display(),
+            file_path.display()
+        )
+    })?;
+    // Best-effort fsync of the parent directory so the rename (the directory
+    // entry) is durable as well; a failure here must not fail an otherwise
+    // complete write.
+    if let Some(parent) = file_path.parent()
+        && let Ok(dir) = std::fs::File::open(parent)
+    {
+        let _ = dir.sync_all();
+    }
     // The temp file has become `file_path`; keep it instead of removing it.
     cleanup.disarm();
     Ok(())

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -46,15 +46,23 @@ pub async fn safe_write_element_versioned<
     // The temp name is dot-prefixed (hidden): if a crash leaves one behind, directory
     // listings skip it (e.g. `FileStorage::all_data_ids` ignores dot-files but parses
     // every other name as a `RequestId`, so a non-hidden leftover would break listing).
-    // Per-path writes are serialized by the storage-layer mutex, so the fixed name
-    // cannot collide with a concurrent write to the same path.
+    // The name also carries a per-writer suffix (process id + a process-local counter)
+    // so two concurrent writers to the same `file_path` cannot create, interleave, and
+    // rename the same temp file. A fixed name is not safe here: this function is also
+    // called outside the storage layer (e.g. `kms-custodian`), and the storage-layer
+    // mutex is per-instance, so it guards neither separate processes nor separate
+    // storage instances pointed at the same directory.
     let tmp_path = {
         let file_name = file_path
             .file_name()
             .ok_or_else(|| anyhow::anyhow!("invalid file path: {}", file_path.display()))?;
+        // Unique among all live writers: the pid distinguishes processes and the
+        // counter distinguishes concurrent writes within this process.
+        static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let mut name = std::ffi::OsString::from(".");
         name.push(file_name);
-        name.push(".partial");
+        name.push(format!(".partial.{}.{seq}", std::process::id()));
         match file_path.parent() {
             Some(parent) => parent.join(name),
             None => PathBuf::from(name),
@@ -118,7 +126,11 @@ pub async fn read_element<T: DeserializeOwned + Serialize, P: AsRef<Path>>(
 
 #[cfg(test)]
 mod tests {
-    use crate::util::file_handling::{read_element, write_bytes, write_element};
+    use crate::util::file_handling::{
+        read_element, safe_read_element_versioned, safe_write_element_versioned, write_bytes,
+        write_element,
+    };
+    use crate::vault::storage::tests::TestType;
     use tokio::fs::remove_file;
 
     #[tokio::test]
@@ -144,5 +156,123 @@ mod tests {
         let read_element: String = read_element(file_name.clone()).await.unwrap();
         assert_eq!(read_element, msg);
         remove_file(file_name).await.unwrap();
+    }
+
+    // Sunshine: a versioned element written with `safe_write_element_versioned`
+    // round-trips through `safe_read_element_versioned`.
+    #[tokio::test]
+    async fn safe_write_then_read_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sub").join("element");
+        let element = TestType { i: 7 };
+        safe_write_element_versioned(&path, &element).await.unwrap();
+        let read_back: TestType = safe_read_element_versioned(&path).await.unwrap();
+        assert_eq!(read_back, element);
+    }
+
+    // A successful write must leave only the final file behind: the dot-prefixed
+    // `.<name>.partial.*` temp file is renamed into place, not left as litter.
+    #[tokio::test]
+    async fn safe_write_leaves_no_partial_tempfile() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("element");
+        safe_write_element_versioned(&path, &TestType { i: 1 })
+            .await
+            .unwrap();
+        assert!(path.exists());
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".partial"))
+            .collect();
+        assert!(leftovers.is_empty(), "leftover temp files: {leftovers:?}");
+    }
+
+    // A path with no file name component is rejected before any file is touched.
+    #[tokio::test]
+    async fn safe_write_rejects_path_without_filename() {
+        let res = safe_write_element_versioned(std::path::Path::new("/"), &TestType { i: 0 }).await;
+        assert!(res.is_err());
+    }
+
+    // Concurrent writers targeting the same path must not collide on the temp file:
+    // every write succeeds and the destination is left as a complete, valid element
+    // (one writer's value), never a corrupted interleaving. Run on a multi-thread
+    // runtime so the inline blocking I/O of the writers actually overlaps.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_writes_to_same_path_are_not_corrupted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = std::sync::Arc::new(dir.path().join("element"));
+        let mut handles = Vec::new();
+        for i in 0..8u32 {
+            let path = std::sync::Arc::clone(&path);
+            handles.push(tokio::spawn(async move {
+                safe_write_element_versioned(path.as_path(), &TestType { i }).await
+            }));
+        }
+        for h in handles {
+            // No write may fail with a spurious collision error.
+            h.await.unwrap().unwrap();
+        }
+        // The destination deserializes to one of the written values, i.e. it is a
+        // complete element rather than a mix of several writers' bytes.
+        let read_back: TestType = safe_read_element_versioned(path.as_path()).await.unwrap();
+        assert!(read_back.i < 8, "unexpected value {}", read_back.i);
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".partial"))
+            .collect();
+        assert!(leftovers.is_empty(), "leftover temp files: {leftovers:?}");
+    }
+
+    // If the write fails before the rename (here: the sibling temp file cannot be
+    // created because the parent directory is read-only), a pre-existing destination
+    // must be left untouched rather than truncated or partially overwritten.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn safe_write_failure_keeps_existing_destination() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("element");
+
+        // Seed the destination with a known-good element.
+        let original = TestType { i: 111 };
+        safe_write_element_versioned(&path, &original)
+            .await
+            .unwrap();
+
+        // Make the parent read-only so the temp file cannot be created.
+        let saved = std::fs::metadata(dir.path()).unwrap().permissions();
+        let mut read_only = saved.clone();
+        read_only.set_mode(0o555);
+        std::fs::set_permissions(dir.path(), read_only).unwrap();
+
+        // Self-guard: if files can still be created here (e.g. running as root, which
+        // ignores directory permissions) the failure can't be induced, so skip the
+        // negative assertion rather than fail spuriously.
+        let probe = dir.path().join(".probe");
+        let perms_enforced = std::fs::File::create(&probe).is_err();
+        let _ = std::fs::remove_file(&probe);
+        let write_result = if perms_enforced {
+            Some(safe_write_element_versioned(&path, &TestType { i: 222 }).await)
+        } else {
+            None
+        };
+
+        // Always restore permissions so the tempdir can be cleaned up.
+        std::fs::set_permissions(dir.path(), saved).unwrap();
+
+        if let Some(res) = write_result {
+            assert!(
+                res.is_err(),
+                "write should fail when the temp can't be created"
+            );
+        }
+        // The destination still holds the original element, never a partial file.
+        let read_back: TestType = safe_read_element_versioned(&path).await.unwrap();
+        assert_eq!(read_back, original);
     }
 }

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -17,11 +17,8 @@ pub async fn write_bytes<P: AsRef<Path>>(file_path: P, bytes: &[u8]) -> anyhow::
     Ok(())
 }
 
-/// Best-effort cleanup for the sibling temp file used by
-/// [`safe_write_element_versioned`]. On drop it removes the temp file unless it
-/// has been [`disarm`](TempFileGuard::disarm)ed (which only happens after a
-/// successful rename), so a failed write — at any of the create / serialize /
-/// sync / rename steps — never strands an orphaned `.<name>.partial.*` file.
+/// Removes the temp file on drop unless [`disarm`](TempFileGuard::disarm)ed,
+/// so a failed write never strands a partial file.
 struct TempFileGuard {
     path: Option<PathBuf>,
 }
@@ -31,8 +28,7 @@ impl TempFileGuard {
         Self { path: Some(path) }
     }
 
-    /// Disarm the guard once the temp file has been renamed into place, so the
-    /// now-persisted file is not removed.
+    /// Call once the temp file has been renamed into place.
     fn disarm(mut self) {
         self.path = None;
     }
@@ -41,8 +37,7 @@ impl TempFileGuard {
 impl Drop for TempFileGuard {
     fn drop(&mut self) {
         if let Some(path) = self.path.take() {
-            // Best-effort: the primary error (if any) has already propagated to
-            // the caller, so a failure to clean up here must not mask it.
+            // Best-effort; must not mask the error that got us here.
             let _ = std::fs::remove_file(&path);
         }
     }
@@ -50,21 +45,12 @@ impl Drop for TempFileGuard {
 
 /// This is a wrapper around safe_serialize versioned for the async use case.
 ///
-/// The serialization is streamed straight to disk (into a sibling temp file that
-/// is synced and then atomically renamed into place) instead of going through an
-/// in-memory `Vec<u8>`. For production FHE keys the serialized blob is multiple
-/// GiB (bounded by [`SAFE_SER_SIZE_LIMIT`]), and buffering it in memory would
-/// roughly double peak RSS at write time by holding the full serialized copy
-/// alongside `element`. The serialize+write is run
-/// inline (synchronously): `safe_serialize` borrows `element`, so it cannot be
-/// moved into `spawn_blocking`, and `block_in_place` would panic on the
-/// current-thread runtimes used by the storage tests. Key writes happen once per
-/// keygen, so briefly blocking the worker thread here is acceptable.
-///
-/// On any write error (create / serialize / sync / rename) the temp file is
-/// removed before returning (see [`TempFileGuard`]); without this, repeated
-/// failures (e.g. disk full / permission issues) would accumulate hidden,
-/// uniquely-named partials and waste disk space.
+/// Streams the serialization into a sibling temp file (synced, then atomically
+/// renamed into place) rather than buffering the multi-GiB blob in memory.
+/// Serialization runs inline: `safe_serialize` borrows `element`, so it cannot
+/// move into `spawn_blocking`, and `block_in_place` panics on current-thread
+/// runtimes. Key writes are rare enough that blocking here is acceptable.
+/// On any error the temp file is removed (see [`TempFileGuard`]).
 pub async fn safe_write_element_versioned<
     T: Serialize + Versionize + Named + Send,
     P: AsRef<Path>,
@@ -77,26 +63,17 @@ pub async fn safe_write_element_versioned<
     if let Some(p) = file_path.parent() {
         tokio::fs::create_dir_all(p).await?
     };
-    // Write to a sibling temp file first, fsync it, then atomically rename into
-    // place, so a crash mid-write cannot leave a partially-serialized key file at
-    // `file_path`. The fsync matters: rename alone is only a namespace operation,
-    // so without it a power loss shortly after the rename could leave a
-    // complete-looking but empty/truncated file at `file_path`.
-    // The temp name is dot-prefixed (hidden): if a crash leaves one behind, directory
-    // listings skip it (e.g. `FileStorage::all_data_ids` ignores dot-files but parses
-    // every other name as a `RequestId`, so a non-hidden leftover would break listing).
-    // The name also carries a per-writer suffix (process id + a process-local counter)
-    // so two concurrent writers to the same `file_path` cannot create, interleave, and
-    // rename the same temp file. A fixed name is not safe here: this function is also
-    // called outside the storage layer (e.g. `kms-custodian`), and the storage-layer
-    // mutex is per-instance, so it guards neither separate processes nor separate
-    // storage instances pointed at the same directory.
+    // Temp file + fsync + atomic rename, so a crash mid-write cannot leave a
+    // partial file at `file_path` (rename alone is not a durability barrier).
+    // The temp name is dot-prefixed so directory listings skip a leftover
+    // (`FileStorage::all_data_ids` parses every non-hidden name as a
+    // `RequestId`), and carries a pid+counter suffix because concurrent writers
+    // to the same path are possible: the storage mutex is per-instance and
+    // callers like `kms-custodian` bypass the storage layer entirely.
     let tmp_path = {
         let file_name = file_path
             .file_name()
             .ok_or_else(|| anyhow::anyhow!("invalid file path: {}", file_path.display()))?;
-        // Unique among all live writers: the pid distinguishes processes and the
-        // counter distinguishes concurrent writes within this process.
         static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let mut name = std::ffi::OsString::from(".");
@@ -107,8 +84,6 @@ pub async fn safe_write_element_versioned<
             None => PathBuf::from(name),
         }
     };
-    // Remove the temp file on any early return below (a failed create / serialize /
-    // sync / rename); only a successful rename disarms it.
     let cleanup = TempFileGuard::new(tmp_path.clone());
     {
         let file = std::fs::File::create(&tmp_path)
@@ -129,15 +104,12 @@ pub async fn safe_write_element_versioned<
             file_path.display()
         )
     })?;
-    // Best-effort fsync of the parent directory so the rename (the directory
-    // entry) is durable as well; a failure here must not fail an otherwise
-    // complete write.
+    // Best-effort fsync of the parent dir so the rename itself is durable.
     if let Some(parent) = file_path.parent()
         && let Ok(dir) = std::fs::File::open(parent)
     {
         let _ = dir.sync_all();
     }
-    // The temp file has become `file_path`; keep it instead of removing it.
     cleanup.disarm();
     Ok(())
 }
@@ -219,8 +191,6 @@ mod tests {
         remove_file(file_name).await.unwrap();
     }
 
-    // Sunshine: a versioned element written with `safe_write_element_versioned`
-    // round-trips through `safe_read_element_versioned`.
     #[tokio::test]
     async fn safe_write_then_read_roundtrips() {
         let dir = tempfile::tempdir().unwrap();
@@ -231,8 +201,6 @@ mod tests {
         assert_eq!(read_back, element);
     }
 
-    // A successful write must leave only the final file behind: the dot-prefixed
-    // `.<name>.partial.*` temp file is renamed into place, not left as litter.
     #[tokio::test]
     async fn safe_write_leaves_no_partial_tempfile() {
         let dir = tempfile::tempdir().unwrap();
@@ -250,14 +218,10 @@ mod tests {
         assert!(leftovers.is_empty(), "leftover temp files: {leftovers:?}");
     }
 
-    // A failed write must not strand a `.<name>.partial.*` temp file. Here the
-    // final rename fails because the destination is an existing directory; the
-    // cleanup guard must still remove the partial that was already written.
     #[tokio::test]
     async fn safe_write_cleans_up_partial_on_failure() {
         let dir = tempfile::tempdir().unwrap();
-        // Make the destination an existing directory so the final rename fails
-        // (a file cannot be renamed on top of a directory).
+        // An existing directory at the destination makes the final rename fail.
         let path = dir.path().join("element");
         std::fs::create_dir(&path).unwrap();
 
@@ -283,10 +247,7 @@ mod tests {
         assert!(res.is_err());
     }
 
-    // Concurrent writers targeting the same path must not collide on the temp file:
-    // every write succeeds and the destination is left as a complete, valid element
-    // (one writer's value), never a corrupted interleaving. Run on a multi-thread
-    // runtime so the inline blocking I/O of the writers actually overlaps.
+    // Multi-thread runtime so the inline blocking writes actually overlap.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_writes_to_same_path_are_not_corrupted() {
         let dir = tempfile::tempdir().unwrap();
@@ -299,11 +260,9 @@ mod tests {
             }));
         }
         for h in handles {
-            // No write may fail with a spurious collision error.
             h.await.unwrap().unwrap();
         }
-        // The destination deserializes to one of the written values, i.e. it is a
-        // complete element rather than a mix of several writers' bytes.
+        // One writer's complete value, never interleaved bytes.
         let read_back: TestType = safe_read_element_versioned(path.as_path()).await.unwrap();
         assert!(read_back.i < 8, "unexpected value {}", read_back.i);
         let leftovers: Vec<String> = std::fs::read_dir(dir.path())
@@ -315,9 +274,8 @@ mod tests {
         assert!(leftovers.is_empty(), "leftover temp files: {leftovers:?}");
     }
 
-    // If the write fails before the rename (here: the sibling temp file cannot be
-    // created because the parent directory is read-only), a pre-existing destination
-    // must be left untouched rather than truncated or partially overwritten.
+    // A write that fails before the rename must leave a pre-existing
+    // destination untouched.
     #[cfg(unix)]
     #[tokio::test]
     async fn safe_write_failure_keeps_existing_destination() {
@@ -337,9 +295,8 @@ mod tests {
         read_only.set_mode(0o555);
         std::fs::set_permissions(dir.path(), read_only).unwrap();
 
-        // Self-guard: if files can still be created here (e.g. running as root, which
-        // ignores directory permissions) the failure can't be induced, so skip the
-        // negative assertion rather than fail spuriously.
+        // Root ignores directory permissions; skip the negative assertion if
+        // the failure can't be induced.
         let probe = dir.path().join(".probe");
         let perms_enforced = std::fs::File::create(&probe).is_err();
         let _ = std::fs::remove_file(&probe);

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tfhe::named::Named;
 use tfhe::safe_serialization::{safe_deserialize, safe_serialize};
 use tfhe::{Unversionize, Versionize};
@@ -17,32 +17,6 @@ pub async fn write_bytes<P: AsRef<Path>>(file_path: P, bytes: &[u8]) -> anyhow::
     Ok(())
 }
 
-/// Removes the temp file on drop unless [`disarm`](TempFileGuard::disarm)ed,
-/// so a failed write never strands a partial file.
-struct TempFileGuard {
-    path: Option<PathBuf>,
-}
-
-impl TempFileGuard {
-    fn new(path: PathBuf) -> Self {
-        Self { path: Some(path) }
-    }
-
-    /// Call once the temp file has been renamed into place.
-    fn disarm(mut self) {
-        self.path = None;
-    }
-}
-
-impl Drop for TempFileGuard {
-    fn drop(&mut self) {
-        if let Some(path) = self.path.take() {
-            // Best-effort; must not mask the error that got us here.
-            let _ = std::fs::remove_file(&path);
-        }
-    }
-}
-
 /// This is a wrapper around safe_serialize versioned for the async use case.
 ///
 /// Streams the serialization into a sibling temp file (synced, then atomically
@@ -50,7 +24,7 @@ impl Drop for TempFileGuard {
 /// Serialization runs inline: `safe_serialize` borrows `element`, so it cannot
 /// move into `spawn_blocking`, and `block_in_place` panics on current-thread
 /// runtimes. Key writes are rare enough that blocking here is acceptable.
-/// On any error the temp file is removed (see [`TempFileGuard`]).
+/// On any error the temp file is removed (`NamedTempFile` deletes on drop).
 pub async fn safe_write_element_versioned<
     T: Serialize + Versionize + Named + Send,
     P: AsRef<Path>,
@@ -59,63 +33,45 @@ pub async fn safe_write_element_versioned<
     element: &T,
 ) -> anyhow::Result<()> {
     let file_path = file_path.as_ref();
+    if file_path.file_name().is_none() {
+        anyhow::bail!("invalid file path: {}", file_path.display());
+    }
     // Create the parent directories of the file path if they don't exist
     if let Some(p) = file_path.parent() {
         tokio::fs::create_dir_all(p).await?
     };
     // Serialize into a sibling temp file, fsync it, then atomically rename it
     // over `file_path`, so a crash mid-write cannot leave a partial file there
-    // (rename alone is not a durability barrier).
-    // The temp name is dot-prefixed so directory listings skip a leftover
-    // (`FileStorage::all_data_ids` parses every non-hidden name as a
-    // `RequestId`), and carries a pid+counter suffix because concurrent writers
-    // to the same path are possible: the storage mutex is per-instance and
-    // callers like `kms-custodian` bypass the storage layer entirely.
-    let tmp_path = {
-        let file_name = file_path
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("invalid file path: {}", file_path.display()))?;
-        // A function-local `static` is initialized once per process, not per
-        // call: every call shares this one counter, and `fetch_add` returns the
-        // previous value, so concurrent writers in this process get 0, 1, 2, ...
-        // The pid distinguishes writers across processes.
-        static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-        let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let mut name = std::ffi::OsString::from(".");
-        name.push(file_name);
-        name.push(format!(".partial.{}.{seq}", std::process::id()));
-        match file_path.parent() {
-            Some(parent) => parent.join(name),
-            None => PathBuf::from(name),
-        }
+    // (rename alone is not a durability barrier). The temp file must live in
+    // the same directory (rename cannot cross filesystems); its dot-prefixed
+    // name is skipped by directory listings (`FileStorage::all_data_ids`
+    // parses every non-hidden name as a `RequestId`) and is unique per writer,
+    // so concurrent writers to the same path cannot collide.
+    let parent = match file_path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        _ => Path::new("."),
     };
-    let cleanup = TempFileGuard::new(tmp_path.clone());
-    {
-        let file = std::fs::File::create(&tmp_path)
-            .map_err(|e| anyhow::anyhow!("failed to create {}: {e}", tmp_path.display()))?;
-        let mut writer = std::io::BufWriter::new(file);
-        safe_serialize(element, &mut writer, SAFE_SER_SIZE_LIMIT)
-            .map_err(|e| anyhow::anyhow!("failed to serialize into {}: {e}", tmp_path.display()))?;
-        let file = writer
-            .into_inner()
-            .map_err(|e| anyhow::anyhow!("failed to flush {}: {e}", tmp_path.display()))?;
-        file.sync_all()
-            .map_err(|e| anyhow::anyhow!("failed to sync {}: {e}", tmp_path.display()))?;
-    }
-    tokio::fs::rename(&tmp_path, file_path).await.map_err(|e| {
+    let tmp = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|e| anyhow::anyhow!("failed to create temp file in {}: {e}", parent.display()))?;
+    let mut writer = std::io::BufWriter::new(tmp);
+    safe_serialize(element, &mut writer, SAFE_SER_SIZE_LIMIT).map_err(|e| {
         anyhow::anyhow!(
-            "failed to rename {} to {}: {e}",
-            tmp_path.display(),
-            file_path.display()
+            "failed to serialize into {}: {e}",
+            writer.get_ref().path().display()
         )
     })?;
+    let tmp = writer
+        .into_inner()
+        .map_err(|e| anyhow::anyhow!("failed to flush temp file: {e}"))?;
+    tmp.as_file()
+        .sync_all()
+        .map_err(|e| anyhow::anyhow!("failed to sync {}: {e}", tmp.path().display()))?;
+    tmp.persist(file_path)
+        .map_err(|e| anyhow::anyhow!("failed to persist {}: {e}", file_path.display()))?;
     // Best-effort fsync of the parent dir so the rename itself is durable.
-    if let Some(parent) = file_path.parent()
-        && let Ok(dir) = std::fs::File::open(parent)
-    {
+    if let Ok(dir) = std::fs::File::open(parent) {
         let _ = dir.sync_all();
     }
-    cleanup.disarm();
     Ok(())
 }
 
@@ -196,6 +152,16 @@ mod tests {
         remove_file(file_name).await.unwrap();
     }
 
+    /// Anything in `dir` other than `expected` is a stranded temp file.
+    fn leftovers(dir: &std::path::Path, expected: &str) -> Vec<String> {
+        std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n != expected)
+            .collect()
+    }
+
     #[tokio::test]
     async fn safe_write_then_read_roundtrips() {
         let dir = tempfile::tempdir().unwrap();
@@ -204,23 +170,9 @@ mod tests {
         safe_write_element_versioned(&path, &element).await.unwrap();
         let read_back: TestType = safe_read_element_versioned(&path).await.unwrap();
         assert_eq!(read_back, element);
-    }
-
-    #[tokio::test]
-    async fn safe_write_leaves_no_partial_tempfile() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("element");
-        safe_write_element_versioned(&path, &TestType { i: 1 })
-            .await
-            .unwrap();
-        assert!(path.exists());
-        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
-            .unwrap()
-            .filter_map(Result::ok)
-            .map(|e| e.file_name().to_string_lossy().into_owned())
-            .filter(|n| n.contains(".partial"))
-            .collect();
-        assert!(leftovers.is_empty(), "leftover temp files: {leftovers:?}");
+        // Only the final file remains; the temp was renamed, not left behind.
+        let stranded = leftovers(path.parent().unwrap(), "element");
+        assert!(stranded.is_empty(), "leftover temp files: {stranded:?}");
     }
 
     #[tokio::test]
@@ -233,15 +185,10 @@ mod tests {
         let res = safe_write_element_versioned(&path, &TestType { i: 3 }).await;
         assert!(res.is_err(), "write onto an existing directory should fail");
 
-        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
-            .unwrap()
-            .filter_map(Result::ok)
-            .map(|e| e.file_name().to_string_lossy().into_owned())
-            .filter(|n| n.contains(".partial"))
-            .collect();
+        let stranded = leftovers(dir.path(), "element");
         assert!(
-            leftovers.is_empty(),
-            "failed write left partial temp files: {leftovers:?}"
+            stranded.is_empty(),
+            "failed write left partial temp files: {stranded:?}"
         );
     }
 
@@ -270,13 +217,8 @@ mod tests {
         // One writer's complete value, never interleaved bytes.
         let read_back: TestType = safe_read_element_versioned(path.as_path()).await.unwrap();
         assert!(read_back.i < 8, "unexpected value {}", read_back.i);
-        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
-            .unwrap()
-            .filter_map(Result::ok)
-            .map(|e| e.file_name().to_string_lossy().into_owned())
-            .filter(|n| n.contains(".partial"))
-            .collect();
-        assert!(leftovers.is_empty(), "leftover temp files: {leftovers:?}");
+        let stranded = leftovers(dir.path(), "element");
+        assert!(stranded.is_empty(), "leftover temp files: {stranded:?}");
     }
 
     // A write that fails before the rename must leave a pre-existing

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use std::path::Path;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use tfhe::named::Named;
 use tfhe::safe_serialization::{safe_deserialize, safe_serialize};
 use tfhe::{Unversionize, Versionize};
@@ -18,6 +19,16 @@ pub async fn write_bytes<P: AsRef<Path>>(file_path: P, bytes: &[u8]) -> anyhow::
 }
 
 /// This is a wrapper around safe_serialize versioned for the async use case.
+///
+/// The serialization is streamed straight to disk (into a sibling temp file that
+/// is then atomically renamed into place) instead of going through an in-memory
+/// `Vec<u8>`. For production FHE keys the serialized blob is ~tens of GiB, and
+/// buffering it in memory would roughly double peak RSS at write time by holding
+/// the full serialized copy alongside `element`. The serialize+write is run
+/// inline (synchronously): `safe_serialize` borrows `element`, so it cannot be
+/// moved into `spawn_blocking`, and `block_in_place` would panic on the
+/// current-thread runtimes used by the storage tests. Key writes happen once per
+/// keygen, so briefly blocking the worker thread here is acceptable.
 pub async fn safe_write_element_versioned<
     T: Serialize + Versionize + Named + Send,
     P: AsRef<Path>,
@@ -25,13 +36,30 @@ pub async fn safe_write_element_versioned<
     file_path: P,
     element: &T,
 ) -> anyhow::Result<()> {
+    let file_path = file_path.as_ref();
     // Create the parent directories of the file path if they don't exist
-    if let Some(p) = file_path.as_ref().parent() {
+    if let Some(p) = file_path.parent() {
         tokio::fs::create_dir_all(p).await?
     };
-    let mut serialized_data = Vec::new();
-    safe_serialize(element, &mut serialized_data, SAFE_SER_SIZE_LIMIT)?;
-    tokio::fs::write(file_path, serialized_data.as_slice()).await?;
+    // Write to a sibling temp file first, then atomically rename into place, so a
+    // crash mid-write cannot leave a partially-serialized key file at `file_path`.
+    // Per-path writes are serialized by the storage-layer mutex, so a fixed
+    // ".partial" suffix cannot collide with a concurrent write to the same path.
+    let tmp_path = {
+        let mut p = file_path.as_os_str().to_owned();
+        p.push(".partial");
+        PathBuf::from(p)
+    };
+    {
+        let file = std::fs::File::create(&tmp_path)
+            .map_err(|e| anyhow::anyhow!("failed to create {}: {e}", tmp_path.display()))?;
+        let mut writer = std::io::BufWriter::new(file);
+        safe_serialize(element, &mut writer, SAFE_SER_SIZE_LIMIT)?;
+        writer
+            .flush()
+            .map_err(|e| anyhow::anyhow!("failed to flush {}: {e}", tmp_path.display()))?;
+    }
+    tokio::fs::rename(&tmp_path, file_path).await?;
     Ok(())
 }
 

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -199,28 +199,6 @@ mod tests {
         assert!(res.is_err());
     }
 
-    // Multi-thread runtime so the inline blocking writes actually overlap.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn concurrent_writes_to_same_path_are_not_corrupted() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = std::sync::Arc::new(dir.path().join("element"));
-        let mut handles = Vec::new();
-        for i in 0..8u32 {
-            let path = std::sync::Arc::clone(&path);
-            handles.push(tokio::spawn(async move {
-                safe_write_element_versioned(path.as_path(), &TestType { i }).await
-            }));
-        }
-        for h in handles {
-            h.await.unwrap().unwrap();
-        }
-        // One writer's complete value, never interleaved bytes.
-        let read_back: TestType = safe_read_element_versioned(path.as_path()).await.unwrap();
-        assert!(read_back.i < 8, "unexpected value {}", read_back.i);
-        let stranded = leftovers(dir.path(), "element");
-        assert!(stranded.is_empty(), "leftover temp files: {stranded:?}");
-    }
-
     // A write that fails before the rename must leave a pre-existing
     // destination untouched.
     #[cfg(unix)]

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -18,6 +18,37 @@ pub async fn write_bytes<P: AsRef<Path>>(file_path: P, bytes: &[u8]) -> anyhow::
     Ok(())
 }
 
+/// Best-effort cleanup for the sibling temp file used by
+/// [`safe_write_element_versioned`]. On drop it removes the temp file unless it
+/// has been [`disarm`](TempFileGuard::disarm)ed (which only happens after a
+/// successful rename), so a failed write — at any of the create / serialize /
+/// flush / rename steps — never strands an orphaned `.<name>.partial.*` file.
+struct TempFileGuard {
+    path: Option<PathBuf>,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path: Some(path) }
+    }
+
+    /// Disarm the guard once the temp file has been renamed into place, so the
+    /// now-persisted file is not removed.
+    fn disarm(mut self) {
+        self.path = None;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if let Some(path) = self.path.take() {
+            // Best-effort: the primary error (if any) has already propagated to
+            // the caller, so a failure to clean up here must not mask it.
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
 /// This is a wrapper around safe_serialize versioned for the async use case.
 ///
 /// The serialization is streamed straight to disk (into a sibling temp file that
@@ -29,6 +60,11 @@ pub async fn write_bytes<P: AsRef<Path>>(file_path: P, bytes: &[u8]) -> anyhow::
 /// moved into `spawn_blocking`, and `block_in_place` would panic on the
 /// current-thread runtimes used by the storage tests. Key writes happen once per
 /// keygen, so briefly blocking the worker thread here is acceptable.
+///
+/// On any write error (create / serialize / flush / rename) the temp file is
+/// removed before returning (see [`TempFileGuard`]); without this, repeated
+/// failures (e.g. disk full / permission issues) would accumulate hidden,
+/// uniquely-named partials and waste disk space.
 pub async fn safe_write_element_versioned<
     T: Serialize + Versionize + Named + Send,
     P: AsRef<Path>,
@@ -68,6 +104,9 @@ pub async fn safe_write_element_versioned<
             None => PathBuf::from(name),
         }
     };
+    // Remove the temp file on any early return below (a failed create / serialize /
+    // flush / rename); only a successful rename disarms it.
+    let cleanup = TempFileGuard::new(tmp_path.clone());
     {
         let file = std::fs::File::create(&tmp_path)
             .map_err(|e| anyhow::anyhow!("failed to create {}: {e}", tmp_path.display()))?;
@@ -78,6 +117,8 @@ pub async fn safe_write_element_versioned<
             .map_err(|e| anyhow::anyhow!("failed to flush {}: {e}", tmp_path.display()))?;
     }
     tokio::fs::rename(&tmp_path, file_path).await?;
+    // The temp file has become `file_path`; keep it instead of removing it.
+    cleanup.disarm();
     Ok(())
 }
 
@@ -187,6 +228,32 @@ mod tests {
             .filter(|n| n.contains(".partial"))
             .collect();
         assert!(leftovers.is_empty(), "leftover temp files: {leftovers:?}");
+    }
+
+    // A failed write must not strand a `.<name>.partial.*` temp file. Here the
+    // final rename fails because the destination is an existing directory; the
+    // cleanup guard must still remove the partial that was already written.
+    #[tokio::test]
+    async fn safe_write_cleans_up_partial_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        // Make the destination an existing directory so the final rename fails
+        // (a file cannot be renamed on top of a directory).
+        let path = dir.path().join("element");
+        std::fs::create_dir(&path).unwrap();
+
+        let res = safe_write_element_versioned(&path, &TestType { i: 3 }).await;
+        assert!(res.is_err(), "write onto an existing directory should fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".partial"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "failed write left partial temp files: {leftovers:?}"
+        );
     }
 
     // A path with no file name component is rejected before any file is touched.

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -43,12 +43,22 @@ pub async fn safe_write_element_versioned<
     };
     // Write to a sibling temp file first, then atomically rename into place, so a
     // crash mid-write cannot leave a partially-serialized key file at `file_path`.
-    // Per-path writes are serialized by the storage-layer mutex, so a fixed
-    // ".partial" suffix cannot collide with a concurrent write to the same path.
+    // The temp name is dot-prefixed (hidden): if a crash leaves one behind, directory
+    // listings skip it (e.g. `FileStorage::all_data_ids` ignores dot-files but parses
+    // every other name as a `RequestId`, so a non-hidden leftover would break listing).
+    // Per-path writes are serialized by the storage-layer mutex, so the fixed name
+    // cannot collide with a concurrent write to the same path.
     let tmp_path = {
-        let mut p = file_path.as_os_str().to_owned();
-        p.push(".partial");
-        PathBuf::from(p)
+        let file_name = file_path
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("invalid file path: {}", file_path.display()))?;
+        let mut name = std::ffi::OsString::from(".");
+        name.push(file_name);
+        name.push(".partial");
+        match file_path.parent() {
+            Some(parent) => parent.join(name),
+            None => PathBuf::from(name),
+        }
     };
     {
         let file = std::fs::File::create(&tmp_path)

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -63,8 +63,9 @@ pub async fn safe_write_element_versioned<
     if let Some(p) = file_path.parent() {
         tokio::fs::create_dir_all(p).await?
     };
-    // Temp file + fsync + atomic rename, so a crash mid-write cannot leave a
-    // partial file at `file_path` (rename alone is not a durability barrier).
+    // Serialize into a sibling temp file, fsync it, then atomically rename it
+    // over `file_path`, so a crash mid-write cannot leave a partial file there
+    // (rename alone is not a durability barrier).
     // The temp name is dot-prefixed so directory listings skip a leftover
     // (`FileStorage::all_data_ids` parses every non-hidden name as a
     // `RequestId`), and carries a pid+counter suffix because concurrent writers
@@ -74,6 +75,10 @@ pub async fn safe_write_element_versioned<
         let file_name = file_path
             .file_name()
             .ok_or_else(|| anyhow::anyhow!("invalid file path: {}", file_path.display()))?;
+        // A function-local `static` is initialized once per process, not per
+        // call: every call shares this one counter, and `fetch_add` returns the
+        // previous value, so concurrent writers in this process get 0, 1, 2, ...
+        // The pid distinguishes writers across processes.
         static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let mut name = std::ffi::OsString::from(".");

--- a/core/service/src/vault/storage/crypto_material/centralized.rs
+++ b/core/service/src/vault/storage/crypto_material/centralized.rs
@@ -129,8 +129,10 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
     }
 
     /// Number of cached FHE key entries (feeds the `fhe_key_cache_size` gauge).
-    pub(crate) async fn cached_fhe_key_count(&self) -> usize {
-        self.fhe_keys.read().await.len()
+    /// Non-blocking: returns `None` when the lock is contended, so the metrics
+    /// loop observes the cache without ever waiting on it.
+    pub(crate) fn cached_fhe_key_count(&self) -> Option<usize> {
+        self.fhe_keys.try_read().ok().map(|cache| cache.len())
     }
 
     /// Read the key materials for decryption in the centralized case.

--- a/core/service/src/vault/storage/crypto_material/centralized.rs
+++ b/core/service/src/vault/storage/crypto_material/centralized.rs
@@ -128,8 +128,7 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
         storage_ok
     }
 
-    /// Number of FHE key entries currently held in the in-memory cache.
-    /// Exposed for observability (see the `fhe_key_cache_size` metric).
+    /// Number of cached FHE key entries (feeds the `fhe_key_cache_size` gauge).
     pub(crate) async fn cached_fhe_key_count(&self) -> usize {
         self.fhe_keys.read().await.len()
     }

--- a/core/service/src/vault/storage/crypto_material/centralized.rs
+++ b/core/service/src/vault/storage/crypto_material/centralized.rs
@@ -128,6 +128,12 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
         storage_ok
     }
 
+    /// Number of FHE key entries currently held in the in-memory cache.
+    /// Exposed for observability (see the `fhe_key_cache_size` metric).
+    pub(crate) async fn cached_fhe_key_count(&self) -> usize {
+        self.fhe_keys.read().await.len()
+    }
+
     /// Read the key materials for decryption in the centralized case.
     ///
     /// If the key material is not in the cache,

--- a/core/service/src/vault/storage/crypto_material/tests.rs
+++ b/core/service/src/vault/storage/crypto_material/tests.rs
@@ -369,6 +369,8 @@ async fn write_central_keys() {
         err.contains("Error while updating meta store for") && err.contains("request is missing"),
         "expected meta-store update failure when empty, got: {err}"
     );
+    // The failed write must not populate the in-memory cache.
+    assert_eq!(crypto_storage.cached_fhe_key_count().await, 0);
 
     // update the meta store and the write should be ok
     {
@@ -387,6 +389,8 @@ async fn write_central_keys() {
         )
         .await;
     assert!(result.is_ok(), "expected success: {result:?}");
+    // The successful write caches exactly one FHE key entry.
+    assert_eq!(crypto_storage.cached_fhe_key_count().await, 1);
 
     // writing the same thing should fail because the
     // meta store disallow updating a cell that is set

--- a/core/service/src/vault/storage/crypto_material/tests.rs
+++ b/core/service/src/vault/storage/crypto_material/tests.rs
@@ -689,6 +689,72 @@ async fn write_threshold_keys_meta_update() {
 }
 
 #[tokio::test]
+async fn purge_epoch_from_cache_removes_only_matching_epoch() {
+    // Two cached keys under two different epochs in the SAME storage.
+    let req_a = derive_request_id("purge_epoch_cache_a").unwrap();
+    let epoch_a: EpochId = derive_request_id("purge_epoch_cache_epoch_a")
+        .unwrap()
+        .into();
+    let req_b = derive_request_id("purge_epoch_cache_b").unwrap();
+    let epoch_b: EpochId = derive_request_id("purge_epoch_cache_epoch_b")
+        .unwrap()
+        .into();
+
+    let (crypto_storage, keys_a, pubset_a) = setup_threshold_store(&req_a);
+    // A second keyset; the throwaway storage is unused, only the key material is.
+    let (_throwaway, keys_b, pubset_b) = setup_threshold_store(&req_b);
+
+    let meta_store = Arc::new(RwLock::new(MetaStore::new_unlimited()));
+    {
+        let mut guard = meta_store.write().await;
+        guard.insert(&req_a).unwrap();
+        guard.insert(&req_b).unwrap();
+    }
+
+    crypto_storage
+        .write_fhe_keys(
+            &req_a,
+            &epoch_a,
+            keys_a,
+            PublicKeySet::Uncompressed(Arc::new(pubset_a)),
+            meta_store.clone(),
+            "",
+        )
+        .await
+        .unwrap();
+    crypto_storage
+        .write_fhe_keys(
+            &req_b,
+            &epoch_b,
+            keys_b,
+            PublicKeySet::Uncompressed(Arc::new(pubset_b)),
+            meta_store.clone(),
+            "",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(crypto_storage.cached_fhe_key_count().await, 2);
+
+    // Purging epoch_a removes exactly its one entry; epoch_b is untouched.
+    let removed = crypto_storage.purge_epoch_from_cache(&epoch_a).await;
+    assert_eq!(removed, 1);
+    assert_eq!(crypto_storage.cached_fhe_key_count().await, 1);
+    assert!(
+        crypto_storage
+            .read_guarded_fhe_keys(&req_b, &epoch_b)
+            .await
+            .is_ok(),
+        "the non-purged epoch's key must remain available"
+    );
+
+    // Purging an epoch with no cached entries is a harmless no-op.
+    let removed_none = crypto_storage.purge_epoch_from_cache(&epoch_a).await;
+    assert_eq!(removed_none, 0);
+    assert_eq!(crypto_storage.cached_fhe_key_count().await, 1);
+}
+
+#[tokio::test]
 async fn write_threshold_keys_failed_storage() {
     let req_id = derive_request_id("write_threshold_keys_failed_storage").unwrap();
     let epoch_id: EpochId = derive_request_id("write_threshold_keys_failed_storage_epoch")

--- a/core/service/src/vault/storage/crypto_material/tests.rs
+++ b/core/service/src/vault/storage/crypto_material/tests.rs
@@ -370,7 +370,7 @@ async fn write_central_keys() {
         "expected meta-store update failure when empty, got: {err}"
     );
     // The failed write must not populate the in-memory cache.
-    assert_eq!(crypto_storage.cached_fhe_key_count().await, 0);
+    assert_eq!(crypto_storage.cached_fhe_key_count().unwrap(), 0);
 
     // update the meta store and the write should be ok
     {
@@ -390,7 +390,7 @@ async fn write_central_keys() {
         .await;
     assert!(result.is_ok(), "expected success: {result:?}");
     // The successful write caches exactly one FHE key entry.
-    assert_eq!(crypto_storage.cached_fhe_key_count().await, 1);
+    assert_eq!(crypto_storage.cached_fhe_key_count().unwrap(), 1);
 
     // writing the same thing should fail because the
     // meta store disallow updating a cell that is set
@@ -738,12 +738,12 @@ async fn purge_epoch_from_cache_removes_only_matching_epoch() {
         .await
         .unwrap();
 
-    assert_eq!(crypto_storage.cached_fhe_key_count().await, 2);
+    assert_eq!(crypto_storage.cached_fhe_key_count().unwrap(), 2);
 
     // Purging epoch_a removes exactly its one entry; epoch_b is untouched.
     let removed = crypto_storage.purge_epoch_from_cache(&epoch_a).await;
     assert_eq!(removed, 1);
-    assert_eq!(crypto_storage.cached_fhe_key_count().await, 1);
+    assert_eq!(crypto_storage.cached_fhe_key_count().unwrap(), 1);
     assert!(
         crypto_storage
             .read_guarded_fhe_keys(&req_b, &epoch_b)
@@ -755,7 +755,7 @@ async fn purge_epoch_from_cache_removes_only_matching_epoch() {
     // Purging an epoch with no cached entries is a harmless no-op.
     let removed_none = crypto_storage.purge_epoch_from_cache(&epoch_a).await;
     assert_eq!(removed_none, 0);
-    assert_eq!(crypto_storage.cached_fhe_key_count().await, 1);
+    assert_eq!(crypto_storage.cached_fhe_key_count().unwrap(), 1);
 }
 
 #[tokio::test]

--- a/core/service/src/vault/storage/crypto_material/threshold.rs
+++ b/core/service/src/vault/storage/crypto_material/threshold.rs
@@ -219,16 +219,9 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
         storage_ok
     }
 
-    /// Purge **all** in-memory cached threshold FHE keys belonging to the given
-    /// epoch, returning the number of entries removed.
-    ///
-    /// This reclaims the (potentially tens-of-GiB) decompressed key material that
-    /// would otherwise stay resident until process restart once an epoch is
-    /// destroyed. It only touches the in-memory cache (`fhe_keys`, the last lock
-    /// in the documented lock order); the on-disk material is removed separately
-    /// by the caller (see `destroy_epoch`). Decryptions under a destroyed epoch
-    /// are already rejected by epoch validation, so the freed entries are
-    /// unreachable dead memory and removing them changes no decryption behaviour.
+    /// Drop all cached FHE keys for the given epoch, returning the number of
+    /// entries removed. Cache-only — deleting the on-disk material is the
+    /// caller's job (see `destroy_epoch`).
     pub(crate) async fn purge_epoch_from_cache(&self, epoch_id: &EpochId) -> usize {
         let mut guarded_fhe_keys = self.fhe_keys.write().await;
         let before = guarded_fhe_keys.len();
@@ -236,8 +229,7 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
         before.saturating_sub(guarded_fhe_keys.len())
     }
 
-    /// Number of FHE key entries currently held in the in-memory cache.
-    /// Exposed for observability (see the `fhe_key_cache_size` metric).
+    /// Number of cached FHE key entries (feeds the `fhe_key_cache_size` gauge).
     pub(crate) async fn cached_fhe_key_count(&self) -> usize {
         self.fhe_keys.read().await.len()
     }

--- a/core/service/src/vault/storage/crypto_material/threshold.rs
+++ b/core/service/src/vault/storage/crypto_material/threshold.rs
@@ -219,6 +219,29 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
         storage_ok
     }
 
+    /// Purge **all** in-memory cached threshold FHE keys belonging to the given
+    /// epoch, returning the number of entries removed.
+    ///
+    /// This reclaims the (potentially tens-of-GiB) decompressed key material that
+    /// would otherwise stay resident until process restart once an epoch is
+    /// destroyed. It only touches the in-memory cache (`fhe_keys`, the last lock
+    /// in the documented lock order); the on-disk material is removed separately
+    /// by the caller (see `destroy_epoch`). Decryptions under a destroyed epoch
+    /// are already rejected by epoch validation, so the freed entries are
+    /// unreachable dead memory and removing them changes no decryption behaviour.
+    pub(crate) async fn purge_epoch_from_cache(&self, epoch_id: &EpochId) -> usize {
+        let mut guarded_fhe_keys = self.fhe_keys.write().await;
+        let before = guarded_fhe_keys.len();
+        guarded_fhe_keys.retain(|(_, cached_epoch_id), _| cached_epoch_id != epoch_id);
+        before.saturating_sub(guarded_fhe_keys.len())
+    }
+
+    /// Number of FHE key entries currently held in the in-memory cache.
+    /// Exposed for observability (see the `fhe_key_cache_size` metric).
+    pub(crate) async fn cached_fhe_key_count(&self) -> usize {
+        self.fhe_keys.read().await.len()
+    }
+
     /// After a migration keygen (`UseExisting` + `CompressedKeyConfig::All`) stores the
     /// compressed keyset under `new_key_id`, this function copies it to `old_key_id`
     /// and replaces the `ThresholdFheKeys` at `(old_key_id, old_epoch_id)` with the

--- a/core/service/src/vault/storage/crypto_material/threshold.rs
+++ b/core/service/src/vault/storage/crypto_material/threshold.rs
@@ -230,8 +230,10 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
     }
 
     /// Number of cached FHE key entries (feeds the `fhe_key_cache_size` gauge).
-    pub(crate) async fn cached_fhe_key_count(&self) -> usize {
-        self.fhe_keys.read().await.len()
+    /// Non-blocking: returns `None` when the lock is contended, so the metrics
+    /// loop observes the cache without ever waiting on it.
+    pub(crate) fn cached_fhe_key_count(&self) -> Option<usize> {
+        self.fhe_keys.try_read().ok().map(|cache| cache.len())
     }
 
     /// After a migration keygen (`UseExisting` + `CompressedKeyConfig::All`) stores the

--- a/core/service/src/vault/storage/s3.rs
+++ b/core/service/src/vault/storage/s3.rs
@@ -149,7 +149,10 @@ impl S3Storage {
         let mut buf = Vec::new();
         safe_serialize(data, &mut buf, SAFE_SER_SIZE_LIMIT)?;
 
-        s3_put_blob(&self.s3_client, &self.bucket, key, buf.clone()).await?;
+        // Move `buf` into `s3_put_blob` (it takes ownership and wraps it in a
+        // `ByteStream`); cloning here would duplicate the full serialized blob,
+        // which is ~tens of GiB for production FHE keys.
+        s3_put_blob(&self.s3_client, &self.bucket, key, buf).await?;
 
         Ok(())
     }

--- a/core/service/src/vault/storage/s3.rs
+++ b/core/service/src/vault/storage/s3.rs
@@ -151,7 +151,7 @@ impl S3Storage {
 
         // Move `buf` into `s3_put_blob` (it takes ownership and wraps it in a
         // `ByteStream`); cloning here would duplicate the full serialized blob,
-        // which is ~tens of GiB for production FHE keys.
+        // which is multiple GiB for production FHE keys.
         s3_put_blob(&self.s3_client, &self.bucket, key, buf).await?;
 
         Ok(())

--- a/core/service/src/vault/storage/s3.rs
+++ b/core/service/src/vault/storage/s3.rs
@@ -149,9 +149,6 @@ impl S3Storage {
         let mut buf = Vec::new();
         safe_serialize(data, &mut buf, SAFE_SER_SIZE_LIMIT)?;
 
-        // Move `buf` into `s3_put_blob` (it takes ownership and wraps it in a
-        // `ByteStream`); cloning here would duplicate the full serialized blob,
-        // which is multiple GiB for production FHE keys.
         s3_put_blob(&self.s3_client, &self.bucket, key, buf).await?;
 
         Ok(())

--- a/docs/operations/advanced/metrics.md
+++ b/docs/operations/advanced/metrics.md
@@ -143,6 +143,11 @@ KMS exposes metrics via Prometheus format on the configured metrics endpoint (de
 - **Description**: Memory used by KMS in bytes.
 - **Alarm**: If memory usage exceeds 85% of available memory.
 
+#### Metric Name: `kms_fhe_key_cache_size`
+- **Type**: Gauge
+- **Description**: Number of FHE key entries held in the in-memory crypto-material cache. Each entry can hold multi-GiB decompressed key material, so this gauge tracks the dominant driver of KMS memory usage.
+- **Alarm**: If the count does not drop after an epoch is destroyed (cache entries are expected to be reclaimed).
+
 #### Metric Name: `kms_gauge`
 - **Type**: Gauge
 - **Description**: General-purpose gauge for tracking active operations and other values.

--- a/observability/src/metrics.rs
+++ b/observability/src/metrics.rs
@@ -707,6 +707,20 @@ mod tests {
         );
     }
 
+    /// Sunshine: the FHE key cache gauge reflects the recorded count, including
+    /// zero (empty cache), and clamps values above `i64::MAX` instead of wrapping.
+    #[test]
+    fn record_fhe_key_cache_size_sets_and_clamps() {
+        METRICS.record_fhe_key_cache_size(3);
+        assert_eq!(METRICS.fhe_key_cache_size_gauge.get(), 3);
+
+        METRICS.record_fhe_key_cache_size(u64::MAX);
+        assert_eq!(METRICS.fhe_key_cache_size_gauge.get(), i64::MAX);
+
+        METRICS.record_fhe_key_cache_size(0);
+        assert_eq!(METRICS.fhe_key_cache_size_gauge.get(), 0);
+    }
+
     #[test]
     fn duration_histogram_uses_only_low_cardinality_labels() {
         let _ = &*METRICS;

--- a/observability/src/metrics.rs
+++ b/observability/src/metrics.rs
@@ -45,6 +45,7 @@ pub struct CoreMetrics {
     meta_storage_user_dec_gauge: IntGauge, // Number of ongoing user decryptions in meta storage
     meta_storage_pub_dec_total_gauge: IntGauge, // Total number of public decryptions in meta storage
     meta_storage_user_dec_total_gauge: IntGauge, // Total number of user decryptions in meta storage
+    fhe_key_cache_size_gauge: IntGauge, // Number of FHE key entries in the in-memory crypto-material cache
 
     // System metrics
     total_cpus_gauge: IntGauge,     // Total number of CPUs
@@ -195,6 +196,14 @@ impl CoreMetrics {
         prometheus::register(Box::new(rate_limiter_gauge.clone()))
             .expect("failed to register rate limiter gauge");
 
+        let fhe_key_cache_size_gauge = IntGauge::with_opts(Opts::new(
+            format!("{prefix}_fhe_key_cache_size"),
+            "Number of FHE key entries currently held in the in-memory crypto-material cache",
+        ))
+        .expect("failed to create FHE key cache size gauge");
+        prometheus::register(Box::new(fhe_key_cache_size_gauge.clone()))
+            .expect("failed to register FHE key cache size gauge");
+
         let active_session_gauge = IntGauge::with_opts(Opts::new(
             format!("{prefix}_active_sessions"),
             "Number of active sessions in the KMS",
@@ -307,6 +316,7 @@ impl CoreMetrics {
             socat_task_gauge,
             task_gauge,
             rate_limiter_gauge,
+            fhe_key_cache_size_gauge,
             active_session_gauge,
             inactive_session_gauge,
             meta_storage_pub_dec_gauge,
@@ -442,6 +452,13 @@ impl CoreMetrics {
     /// Record the current rate limiter usage into the gauge
     pub fn record_rate_limiter_usage(&self, count: u64) {
         self.rate_limiter_gauge.set(count as i64);
+    }
+
+    /// Record the current number of FHE key entries held in the in-memory
+    /// crypto-material cache. 0 is a valid value (empty cache), so the gauge is
+    /// set unconditionally.
+    pub fn record_fhe_key_cache_size(&self, count: u64) {
+        self.fhe_key_cache_size_gauge.set(count as i64);
     }
 
     /// Record the sum of active sessions done with other parties into the gauge
@@ -650,6 +667,7 @@ mod tests {
             "kms_active_sessions",
             "kms_backup_errors_total",
             "kms_cpu_load",
+            "kms_fhe_key_cache_size",
             "kms_file_descriptors",
             "kms_inactive_sessions",
             "kms_memory_usage",

--- a/observability/src/metrics.rs
+++ b/observability/src/metrics.rs
@@ -454,11 +454,9 @@ impl CoreMetrics {
         self.rate_limiter_gauge.set(count as i64);
     }
 
-    /// Record the current number of FHE key entries held in the in-memory
-    /// crypto-material cache. 0 is a valid value (empty cache), so the gauge is
-    /// set unconditionally.
     pub fn record_fhe_key_cache_size(&self, count: u64) {
-        self.fhe_key_cache_size_gauge.set(count as i64);
+        let value = i64::try_from(count).unwrap_or(i64::MAX);
+        self.fhe_key_cache_size_gauge.set(value);
     }
 
     /// Record the sum of active sessions done with other parties into the gauge

--- a/observability/src/metrics.rs
+++ b/observability/src/metrics.rs
@@ -454,6 +454,7 @@ impl CoreMetrics {
         self.rate_limiter_gauge.set(count as i64);
     }
 
+    /// Record the number of FHE key entries in the in-memory cache into the gauge
     pub fn record_fhe_key_cache_size(&self, count: u64) {
         let value = i64::try_from(count).unwrap_or(i64::MAX);
         self.fhe_key_cache_size_gauge.set(value);
@@ -707,8 +708,6 @@ mod tests {
         );
     }
 
-    /// Sunshine: the FHE key cache gauge reflects the recorded count, including
-    /// zero (empty cache), and clamps values above `i64::MAX` instead of wrapping.
     #[test]
     fn record_fhe_key_cache_size_sets_and_clamps() {
         METRICS.record_fhe_key_cache_size(3);


### PR DESCRIPTION
## Description of changes
<!-- Please explain the changes you made -->

Reduces peak memory usage when handling multi-GiB FHE key material:

- **Key writes**: stream versioned serialization to disk via a synced temp file + atomic rename — no full serialized copy in RAM, no partial key files on crash, no orphaned temp files on failed writes
- **Keygen**: share one `Arc<CompressedXofKeySet>` between private and public key material instead of deep-cloning the keyset
- **Decrypt / resharing**: decompress compressed keysets in place (`&self`) instead of cloning them first
- **S3**: drop a redundant full-blob clone on the store path
- **Epoch destroy**: purge the in-memory FHE key cache so decompressed key material is reclaimed without a restart
- **Observability**: add an `fhe_key_cache_size` gauge
- No wire-format, serialized-data, or gRPC changes.

## Issue ticket number and link

https://github.com/zama-ai/kms-internal/issues/2834

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
