### PR TITLE
chore: insecure preprocessing for threshold mpc

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -130,7 +130,9 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
 - **Key generation** — `KeyGenPreproc` / `KeyGenPreprocResult` (threshold
   preprocessing), `KeyGen`, and `NewMpcEpoch` for key rotation. Multiple keyset
   configurations are supported (standard, decompression-only, compressed
-  variants).
+  variants). Insecure key generation still requires an explicit preprocessing
+  ID: centralized deployments accept either dummy preprocessing endpoint, while
+  threshold deployments require preprocessing from `InsecureKeyGenPreproc`.
   Standard threshold keygen persists a dedicated OPRF LWE secret-key share in
   each party's private key material and includes the corresponding OPRF server
   key in the generated TFHE server key. Legacy private keysets that predate this

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -131,8 +131,7 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   preprocessing), `KeyGen`, and `NewMpcEpoch` for key rotation. Multiple keyset
   configurations are supported (standard, decompression-only, compressed
   variants). Insecure key generation still requires an explicit preprocessing
-  ID: centralized deployments accept either dummy preprocessing endpoint, while
-  threshold deployments require preprocessing from `InsecureKeyGenPreproc`.
+  ID for both the centralized and threshold cases.
   Standard threshold keygen persists a dedicated OPRF LWE secret-key share in
   each party's private key material and includes the corresponding OPRF server
   key in the generated TFHE server key. Legacy private keysets that predate this

--- a/charts/kms-core/Chart.yaml
+++ b/charts/kms-core/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-core
 description: A helm chart to distribute and deploy the Zama KMS core service.
-version: 1.6.0-6
+version: 1.6.0-7
 appVersion: 0.13.20   # Minimum kms version to run this chart
 apiVersion: v2
 keywords:

--- a/charts/kms-core/templates/kms-gen-keys-configmap.yaml
+++ b/charts/kms-core/templates/kms-gen-keys-configmap.yaml
@@ -99,7 +99,18 @@ data:
     else
       echo "Launching new KMS key generation with config:"
       cat config.toml
-      result_key_id=$(bin/kms-core-client -f config.toml {{ .Values.kmsGenKeys.keyGenArgs }})
+      key_gen_args="{{ .Values.kmsGenKeys.keyGenArgs }}"
+      if [ "$key_gen_args" = "insecure-key-gen" ]; then
+        result_preproc_id=$(bin/kms-core-client -f config.toml insecure-preproc-key-gen)
+        KMS_PREPROC_ID=$(echo $result_preproc_id | grep request_id | cut -d'"' -f4)
+        if [ -z "$KMS_PREPROC_ID" ]; then
+          echo "Error: insecure-preproc-key-gen failed. Exiting."
+          exit 1
+        fi
+        result_key_id=$(bin/kms-core-client -f config.toml insecure-key-gen -i "$KMS_PREPROC_ID")
+      else
+        result_key_id=$(bin/kms-core-client -f config.toml {{ .Values.kmsGenKeys.keyGenArgs }})
+      fi
       KMS_KEY_ID=$(echo $result_key_id | grep request_id | cut -d'"' -f4)
       if [ -z "$KMS_KEY_ID" ]; then
         echo "Error: key-gen failed. Exiting."

--- a/charts/kms-core/templates/kms-gen-keys-configmap.yaml
+++ b/charts/kms-core/templates/kms-gen-keys-configmap.yaml
@@ -100,6 +100,8 @@ data:
       echo "Launching new KMS key generation with config:"
       cat config.toml
       key_gen_args="{{ .Values.kmsGenKeys.keyGenArgs }}"
+      # First whitespace-delimited token, i.e. the subcommand.
+      key_gen_cmd=${key_gen_args%% *}
       if [ "$key_gen_args" = "insecure-key-gen" ]; then
         result_preproc_id=$(bin/kms-core-client -f config.toml insecure-preproc-key-gen)
         KMS_PREPROC_ID=$(echo $result_preproc_id | grep request_id | cut -d'"' -f4)
@@ -108,6 +110,13 @@ data:
           exit 1
         fi
         result_key_id=$(bin/kms-core-client -f config.toml insecure-key-gen -i "$KMS_PREPROC_ID")
+      elif [ "$key_gen_cmd" = "insecure-key-gen" ]; then
+        # Extra flags (e.g. "insecure-key-gen --uncompressed") are not supported
+        # here: this script only knows how to run the preprocessing + keygen flow
+        # for a bare "insecure-key-gen". Fail hard rather than silently skipping
+        # the required insecure-preproc-key-gen step.
+        echo "Error: insecure-key-gen with extra arguments is not supported by this script (got: '$key_gen_args'). Use exactly 'insecure-key-gen'. Exiting."
+        exit 1
       else
         result_key_id=$(bin/kms-core-client -f config.toml {{ .Values.kmsGenKeys.keyGenArgs }})
       fi

--- a/ci/perf-testing/argo-workflow/centralized-test-suite-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/centralized-test-suite-workflow-kms-ci.yaml
@@ -82,8 +82,22 @@ spec:
           ##########################################################################
           # insecure Keygen
           ##########################################################################
-          - name: insecure-key-gen
+          - name: insecure-preproc-key-gen
             dependencies: ["key-gen"]
+            template: run-test
+            continueOn:
+              failed: true
+            arguments:
+              parameters:
+                - name: test-name
+                  value: "insecure-preproc-key-gen"
+                - name: test-command
+                  value: "insecure-preproc-key-gen"
+                - name: fhe-params
+                  value: "Default"
+
+          - name: insecure-key-gen
+            dependencies: ["insecure-preproc-key-gen"]
             template: run-test
             continueOn:
               failed: true
@@ -92,7 +106,7 @@ spec:
                 - name: test-name
                   value: "insecure-key-gen"
                 - name: test-command
-                  value: "insecure-key-gen"
+                  value: "insecure-key-gen -i {{tasks.insecure-preproc-key-gen.outputs.parameters.request-id}}"
                 - name: fhe-params
                   value: "Default"
 

--- a/ci/perf-testing/argo-workflow/centralizedWithEnclave-test-suite-workflow-kms-enclave-ci.yaml
+++ b/ci/perf-testing/argo-workflow/centralizedWithEnclave-test-suite-workflow-kms-enclave-ci.yaml
@@ -82,8 +82,22 @@ spec:
           ##########################################################################
           # insecure Keygen
           ##########################################################################
-          - name: insecure-key-gen
+          - name: insecure-preproc-key-gen
             dependencies: ["key-gen"]
+            template: run-test
+            continueOn:
+              failed: true
+            arguments:
+              parameters:
+                - name: test-name
+                  value: "insecure-preproc-key-gen"
+                - name: test-command
+                  value: "insecure-preproc-key-gen"
+                - name: fhe-params
+                  value: "Default"
+
+          - name: insecure-key-gen
+            dependencies: ["insecure-preproc-key-gen"]
             template: run-test
             continueOn:
               failed: true
@@ -92,7 +106,7 @@ spec:
                 - name: test-name
                   value: "insecure-key-gen"
                 - name: test-command
-                  value: "insecure-key-gen"
+                  value: "insecure-key-gen -i {{tasks.insecure-preproc-key-gen.outputs.parameters.request-id}}"
                 - name: fhe-params
                   value: "Default"
 

--- a/ci/perf-testing/argo-workflow/threshold-test-suite-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/threshold-test-suite-workflow-kms-ci.yaml
@@ -82,8 +82,22 @@ spec:
           ##########################################################################
           # insecure Keygen
           ##########################################################################
-          - name: insecure-key-gen
+          - name: insecure-preproc-key-gen
             dependencies: ["key-gen"]
+            template: run-test
+            continueOn:
+              failed: true
+            arguments:
+              parameters:
+                - name: test-name
+                  value: "insecure-preproc-key-gen"
+                - name: test-command
+                  value: "insecure-preproc-key-gen"
+                - name: fhe-params
+                  value: "Default"
+
+          - name: insecure-key-gen
+            dependencies: ["insecure-preproc-key-gen"]
             template: run-test
             continueOn:
               failed: true
@@ -92,7 +106,7 @@ spec:
                 - name: test-name
                   value: "insecure-key-gen"
                 - name: test-command
-                  value: "insecure-key-gen"
+                  value: "insecure-key-gen -i {{tasks.insecure-preproc-key-gen.outputs.parameters.request-id}}"
                 - name: fhe-params
                   value: "Default"
 

--- a/ci/perf-testing/argo-workflow/thresholdWithEnclave-test-suite-workflow-kms-enclave-ci.yaml
+++ b/ci/perf-testing/argo-workflow/thresholdWithEnclave-test-suite-workflow-kms-enclave-ci.yaml
@@ -85,8 +85,22 @@ spec:
           ##########################################################################
           # insecure Keygen
           ##########################################################################
-          - name: insecure-key-gen
+          - name: insecure-preproc-key-gen
             dependencies: ["key-gen"]
+            template: run-test
+            continueOn:
+              failed: true
+            arguments:
+              parameters:
+                - name: test-name
+                  value: "insecure-preproc-key-gen"
+                - name: test-command
+                  value: "insecure-preproc-key-gen"
+                - name: fhe-params
+                  value: "Default"
+
+          - name: insecure-key-gen
+            dependencies: ["insecure-preproc-key-gen"]
             template: run-test
             continueOn:
               failed: true
@@ -95,7 +109,7 @@ spec:
                 - name: test-name
                   value: "insecure-key-gen"
                 - name: test-command
-                  value: "insecure-key-gen"
+                  value: "insecure-key-gen -i {{tasks.insecure-preproc-key-gen.outputs.parameters.request-id}}"
                 - name: fhe-params
                   value: "Default"
 

--- a/core-client/src/keygen.rs
+++ b/core-client/src/keygen.rs
@@ -152,23 +152,27 @@ pub(crate) async fn do_keygen(
     }
 
     let mut req_response_vec = Vec::new();
+    let mut req_errors = Vec::new();
     while let Some(inner) = req_tasks.join_next().await {
         match inner {
             Ok(Ok(resp)) => req_response_vec.push(resp.into_inner()),
             Ok(Err(e)) => {
                 tracing::warn!("Keygen request to a core failed: {e}");
+                req_errors.push(format!("request failed: {e}"));
             }
             Err(e) => {
                 tracing::warn!("Keygen request task panicked: {e}");
+                req_errors.push(format!("task panicked: {e}"));
             }
         }
     }
     if req_response_vec.len() < num_expected_responses {
         anyhow::bail!(
-            "Only {}/{} keygen requests succeeded, need at least {}",
+            "Only {}/{} keygen requests succeeded, need at least {}. Errors: {}",
             req_response_vec.len(),
             num_parties,
-            num_expected_responses
+            num_expected_responses,
+            req_errors.join("; ")
         );
     }
 
@@ -604,6 +608,7 @@ pub(crate) async fn do_preproc(
     context_id: Option<&ContextId>,
     epoch_id: Option<&EpochId>,
     keyset_config: Option<kms_grpc::kms::v1::KeySetConfig>,
+    insecure: bool,
 ) -> anyhow::Result<RequestId> {
     let req_id = RequestId::new_random(rng);
 
@@ -621,16 +626,22 @@ pub(crate) async fn do_preproc(
     )?;
     let extra_data = pp_req.extra_data.clone();
 
-    // make parallel requests by calling insecure keygen in a thread
+    // make parallel requests by calling preprocessing in a thread
     let mut req_tasks = JoinSet::new();
 
     for ce in core_endpoints.values() {
         let req_cloned = pp_req.clone();
         let mut cur_client = ce.clone();
         req_tasks.spawn(async move {
-            cur_client
-                .key_gen_preproc(tonic::Request::new(req_cloned))
-                .await
+            if insecure {
+                cur_client
+                    .insecure_key_gen_preproc(tonic::Request::new(req_cloned))
+                    .await
+            } else {
+                cur_client
+                    .key_gen_preproc(tonic::Request::new(req_cloned))
+                    .await
+            }
         });
     }
 
@@ -654,7 +665,8 @@ pub(crate) async fn do_preproc(
         );
     }
 
-    let responses = get_preproc_keygen_responses(core_endpoints, req_id, max_iter).await?;
+    let responses =
+        get_preproc_keygen_responses(core_endpoints, req_id, max_iter, insecure).await?;
     for response in responses {
         // this part also verifies the signature
         internal_client.process_preproc_response(
@@ -734,7 +746,7 @@ pub(crate) async fn do_partial_preproc(
         );
     }
 
-    let responses = get_preproc_keygen_responses(core_endpoints, req_id, max_iter).await?;
+    let responses = get_preproc_keygen_responses(core_endpoints, req_id, max_iter, false).await?;
     for response in responses {
         internal_client.process_preproc_response(
             &req_id,
@@ -751,7 +763,21 @@ pub(crate) async fn get_preproc_keygen_responses(
     core_endpoints: &HashMap<CoreConf, CoreServiceEndpointClient<Channel>>,
     request_id: RequestId,
     max_iter: usize,
+    insecure: bool,
 ) -> anyhow::Result<Vec<KeyGenPreprocResult>> {
+    async fn fetch_result(
+        client: &mut CoreServiceEndpointClient<Channel>,
+        request_id: RequestId,
+        insecure: bool,
+    ) -> Result<tonic::Response<KeyGenPreprocResult>, tonic::Status> {
+        let req = tonic::Request::new(request_id.into());
+        if insecure {
+            client.get_insecure_key_gen_preproc_result(req).await
+        } else {
+            client.get_key_gen_preproc_result(req).await
+        }
+    }
+
     let mut resp_tasks = JoinSet::new();
     for (core_conf, client) in core_endpoints.iter() {
         let mut client = client.clone();
@@ -767,9 +793,7 @@ pub(crate) async fn get_preproc_keygen_responses(
                 "Polling preproc result for request {} from party {}",
                 request_id, core_conf.party_id
             );
-            let mut response = client
-                .get_key_gen_preproc_result(tonic::Request::new(request_id.into()))
-                .await;
+            let mut response = fetch_result(&mut client, request_id, insecure).await;
             let mut ctr = 0_usize;
             while response.is_err()
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
@@ -790,9 +814,7 @@ pub(crate) async fn get_preproc_keygen_responses(
                     "Preproc result not ready yet for request {} from party {} (retry {}/{})",
                     request_id, core_conf.party_id, ctr, max_iter
                 );
-                response = client
-                    .get_key_gen_preproc_result(tonic::Request::new(request_id.into()))
-                    .await;
+                response = fetch_result(&mut client, request_id, insecure).await;
             }
 
             let resp = response.map_err(|e| {

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -36,6 +36,7 @@ use kms_grpc::{ContextId, KeyId, RequestId};
 use kms_lib::backup::custodian::{InternalCustodianRecoveryOutput, InternalCustodianSetupMessage};
 use kms_lib::client::client_wasm::Client;
 use kms_lib::consts::{DEFAULT_PARAM, SIGNING_KEY_ID, TEST_PARAM};
+use kms_lib::engine::base::INSECURE_PREPROCESSING_ID;
 use kms_lib::util::file_handling::{
     read_element, safe_read_element_versioned, safe_write_element_versioned, write_element,
 };
@@ -667,6 +668,12 @@ pub struct KeyGenParameters {
 /// Parameters for insecure key generation (testing/development only).
 #[derive(Debug, Parser, Clone)]
 pub struct InsecureKeyGenParameters {
+    /// ID of an existing insecure preprocessing (see `insecure-preproc-key-gen`)
+    /// to consume. When omitted, the well-known `INSECURE_PREPROCESSING_ID` is
+    /// used, for which the server synthesizes an insecure (dummy) preprocessing
+    /// entry on the fly.
+    #[clap(long, short = 'i')]
+    pub preproc_id: Option<RequestId>,
     #[command(flatten)]
     pub shared_args: SharedKeyGenParameters,
 }
@@ -870,6 +877,22 @@ pub struct KeyGenPreprocParameters {
     pub from_existing_shares: bool,
 }
 
+/// Parameters for insecure (dummy) key-generation preprocessing
+/// (testing/development only). No keyset configuration is taken because the
+/// insecure preprocessing generates no material; it only records the request
+/// ID so it can be consumed by a subsequent insecure key generation.
+#[derive(Debug, Parser, Clone, Default)]
+pub struct InsecureKeyGenPreprocParameters {
+    /// Optionally specify the context ID to use for the preprocessing.
+    /// Defaults to the default context if not specified.
+    #[clap(long)]
+    pub context_id: Option<ContextId>,
+    /// Optionally specify the epoch ID to use for the preprocessing.
+    /// Defaults to the default epoch if not specified.
+    #[clap(long)]
+    pub epoch_id: Option<EpochId>,
+}
+
 #[derive(Debug, Parser, Clone)]
 pub struct PartialKeyGenPreprocParameters {
     #[clap(long)]
@@ -892,6 +915,8 @@ pub enum CCCommand {
     KeyGen(KeyGenParameters),
     KeyGenResult(KeyGenResultParameters),
     AbortKeyGen(AbortParameters),
+    InsecurePreprocKeyGen(InsecureKeyGenPreprocParameters),
+    InsecurePreprocKeyGenResult(ResultParameters),
     InsecureKeyGen(InsecureKeyGenParameters),
     InsecureKeyGenResult(KeyGenResultParameters),
     Encrypt(CipherParameters),
@@ -1836,13 +1861,20 @@ pub async fn execute_cmd(
 
             vec![(Some(req_id), "keygen done".to_string())]
         }
-        CCCommand::InsecureKeyGen(InsecureKeyGenParameters { shared_args }) => {
+        CCCommand::InsecureKeyGen(InsecureKeyGenParameters {
+            preproc_id,
+            shared_args,
+        }) => {
             let mut internal_client = internal_client.unwrap();
             tracing::info!(
                 "Insecure key generation with parameter {}.",
                 fhe_params.as_str_name()
             );
-            let dummy_preproc_id = RequestId::new_random(&mut rng);
+            // The insecure keygen requires a preprocessing ID just like the
+            // secure one. If none is given, the well-known
+            // INSECURE_PREPROCESSING_ID is used, for which the server
+            // synthesizes an insecure (dummy) preprocessing entry on the fly.
+            let preproc_id = preproc_id.unwrap_or(*INSECURE_PREPROCESSING_ID);
             let req_id = do_keygen(
                 &mut internal_client,
                 &core_endpoints_req,
@@ -1852,7 +1884,7 @@ pub async fn execute_cmd(
                 num_parties,
                 &kms_addrs,
                 fhe_params,
-                dummy_preproc_id,
+                preproc_id,
                 true,
                 shared_args,
                 destination_prefix,
@@ -1966,9 +1998,34 @@ pub async fn execute_cmd(
                 context_id.as_ref(),
                 epoch_id.as_ref(),
                 keyset_config,
+                false,
             )
             .await?;
             vec![(Some(req_id), "preproc done".to_string())]
+        }
+        CCCommand::InsecurePreprocKeyGen(InsecureKeyGenPreprocParameters {
+            context_id,
+            epoch_id,
+        }) => {
+            let mut internal_client = internal_client.unwrap();
+            tracing::info!(
+                "Insecure (dummy) preprocessing with parameter {}.",
+                fhe_params.as_str_name()
+            );
+            let req_id = do_preproc(
+                &mut internal_client,
+                &core_endpoints_req,
+                &mut rng,
+                cmd_config,
+                num_parties,
+                fhe_params,
+                context_id.as_ref(),
+                epoch_id.as_ref(),
+                None,
+                true,
+            )
+            .await?;
+            vec![(Some(req_id), "insecure preproc done".to_string())]
         }
         CCCommand::PartialPreprocKeyGen(partial_params) => {
             let mut internal_client = internal_client.unwrap();
@@ -2027,8 +2084,15 @@ pub async fn execute_cmd(
         }
         CCCommand::PreprocKeyGenResult(result_parameters) => {
             let req_id: RequestId = result_parameters.request_id;
-            let _ = get_preproc_keygen_responses(&core_endpoints_req, req_id, max_iter).await?;
+            let _ =
+                get_preproc_keygen_responses(&core_endpoints_req, req_id, max_iter, false).await?;
             vec![(Some(req_id), "preproc result queried".to_string())]
+        }
+        CCCommand::InsecurePreprocKeyGenResult(result_parameters) => {
+            let req_id: RequestId = result_parameters.request_id;
+            let _ =
+                get_preproc_keygen_responses(&core_endpoints_req, req_id, max_iter, true).await?;
+            vec![(Some(req_id), "insecure preproc result queried".to_string())]
         }
         CCCommand::KeyGenResult(result_parameters) => {
             let num_expected_responses = if expect_all_responses {

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -36,7 +36,6 @@ use kms_grpc::{ContextId, KeyId, RequestId};
 use kms_lib::backup::custodian::{InternalCustodianRecoveryOutput, InternalCustodianSetupMessage};
 use kms_lib::client::client_wasm::Client;
 use kms_lib::consts::{DEFAULT_PARAM, SIGNING_KEY_ID, TEST_PARAM};
-use kms_lib::engine::base::INSECURE_PREPROCESSING_ID;
 use kms_lib::util::file_handling::{
     read_element, safe_read_element_versioned, safe_write_element_versioned, write_element,
 };
@@ -668,12 +667,12 @@ pub struct KeyGenParameters {
 /// Parameters for insecure key generation (testing/development only).
 #[derive(Debug, Parser, Clone)]
 pub struct InsecureKeyGenParameters {
-    /// ID of an existing insecure preprocessing (see `insecure-preproc-key-gen`)
-    /// to consume. When omitted, the well-known `INSECURE_PREPROCESSING_ID` is
-    /// used, for which the server synthesizes an insecure (dummy) preprocessing
-    /// entry on the fly.
+    /// ID of an existing preprocessing to consume.
+    ///
+    /// In threshold mode this must come from `insecure-preproc-key-gen`.
+    /// In centralized mode any key-generation preprocessing entry can be used.
     #[clap(long, short = 'i')]
-    pub preproc_id: Option<RequestId>,
+    pub preproc_id: RequestId,
     #[command(flatten)]
     pub shared_args: SharedKeyGenParameters,
 }
@@ -1870,11 +1869,6 @@ pub async fn execute_cmd(
                 "Insecure key generation with parameter {}.",
                 fhe_params.as_str_name()
             );
-            // The insecure keygen requires a preprocessing ID just like the
-            // secure one. If none is given, the well-known
-            // INSECURE_PREPROCESSING_ID is used, for which the server
-            // synthesizes an insecure (dummy) preprocessing entry on the fly.
-            let preproc_id = preproc_id.unwrap_or(*INSECURE_PREPROCESSING_ID);
             let req_id = do_keygen(
                 &mut internal_client,
                 &core_endpoints_req,
@@ -1884,7 +1878,7 @@ pub async fn execute_cmd(
                 num_parties,
                 &kms_addrs,
                 fhe_params,
-                preproc_id,
+                *preproc_id,
                 true,
                 shared_args,
                 destination_prefix,

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -880,6 +880,10 @@ pub struct KeyGenPreprocParameters {
 /// (testing/development only). No keyset configuration is taken because the
 /// insecure preprocessing generates no material; it only records the request
 /// ID so it can be consumed by a subsequent insecure key generation.
+///
+/// Unlike `KeyGenPreprocParameters`, there are no arguments for `uncompressed`
+/// or `from_existing_shares` because the insecure preprocessing endpoint does
+/// not use them.
 #[derive(Debug, Parser, Clone, Default)]
 pub struct InsecureKeyGenPreprocParameters {
     /// Optionally specify the context ID to use for the preprocessing.

--- a/core-client/tests/README.md
+++ b/core-client/tests/README.md
@@ -158,7 +158,7 @@ async fn k8s_test_keygen_and_crs() {
 | Method | Description |
 |--------|-------------|
 | `new(name)` | Create context, print test header |
-| `insecure_keygen()` | Run `InsecureKeyGen`, return key ID |
+| `insecure_keygen()` | Run `InsecurePreprocKeyGen` then `InsecureKeyGen`, return key ID |
 | `crs_gen()` | Run `CrsGen`, return CRS ID |
 | `encrypt(key_id, plaintext, FheType)` | Fetch public FHE key from cluster, encrypt locally, write ciphertext to workspace; returns `EncryptionResult` (path + original plaintext + type) |
 | `public_decrypt_from_file(enc)` | Send ciphertext from `EncryptionResult` to threshold parties, verify result matches original — panics on mismatch; returns `DecryptionResult` (party response count) |

--- a/core-client/tests/README.md
+++ b/core-client/tests/README.md
@@ -60,7 +60,7 @@ The client binary accepts these commands (passed as `CCCommand` in tests via `ex
 
 | Command | Description | Requires epoch | Requires PRSS |
 |---------|-------------|----------------|---------------|
-| `InsecureKeyGen` | Threshold DKG, no preprocessing (insecure) | ✅ | ❌ |
+| `InsecureKeyGen` | Threshold DKG with dummy preprocessing (insecure) | ✅ | ❌ |
 | `KeyGen` | Threshold DKG with preprocessing (secure) | ✅ | ✅ |
 | `PreprocKeyGen` | Offline preprocessing phase for DKG | ✅ | ✅ |
 | `CrsGen` | Generate CRS (ZK ceremony, secure) | ✅ | ✅ |

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1001,25 +1001,13 @@ fn cipher_params(
     }
 }
 
-/// Helper to run insecure key generation via CLI (isolated version)
+/// Helper to run insecure preprocessing and key generation via CLI.
 async fn insecure_key_gen(
     config_path: &Path,
     test_path: &Path,
     uncompressed: bool,
 ) -> Result<String> {
-    let config = cmd_config(
-        config_path,
-        CCCommand::InsecureKeyGen(InsecureKeyGenParameters {
-            preproc_id: None,
-            shared_args: SharedKeyGenParameters {
-                uncompressed,
-                ..Default::default()
-            },
-        }),
-        200,
-    );
-    let id = run_cmd(&config, test_path, "insecure key-gen").await?;
-    Ok(id.to_string())
+    insecure_preproc_and_keygen(config_path, test_path, uncompressed).await
 }
 
 /// Helper to run the insecure (dummy) preprocessing and insecure key generation
@@ -1042,7 +1030,7 @@ async fn insecure_preproc_and_keygen(
     let keygen_config = cmd_config(
         config_path,
         CCCommand::InsecureKeyGen(InsecureKeyGenParameters {
-            preproc_id: Some(preproc_id),
+            preproc_id,
             shared_args: SharedKeyGenParameters {
                 uncompressed,
                 ..Default::default()
@@ -2117,9 +2105,6 @@ async fn test_centralized_insecure_default_keygen() -> Result<()> {
     let (material_dir, _server, config_path) =
         setup_isolated_centralized_cli_test("centralized_insecure_default_keygen").await?;
 
-    // Use the explicit insecure-preproc flow here so both the explicit
-    // `--preproc-id` path and the automatic fallback (used by the other
-    // insecure keygen tests) are covered.
     let keys_folder = material_dir.path();
     let key_id = insecure_preproc_and_keygen(&config_path, keys_folder, false).await?;
     assert!(!key_id.is_empty());
@@ -2454,9 +2439,6 @@ async fn test_threshold_insecure_default_keygen() -> Result<()> {
     let (material_dir, _servers, config_path) =
         setup_isolated_threshold_cli_test_with_prss("threshold_insecure_default_keygen", 4).await?;
 
-    // Use the explicit insecure-preproc flow here so both the explicit
-    // `--preproc-id` path and the automatic fallback (used by the other
-    // insecure keygen tests) are covered.
     let keys_folder = material_dir.path();
     let key_id = insecure_preproc_and_keygen(&config_path, keys_folder, false).await?;
     assert!(!key_id.is_empty());

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1010,6 +1010,7 @@ async fn insecure_key_gen(
     let config = cmd_config(
         config_path,
         CCCommand::InsecureKeyGen(InsecureKeyGenParameters {
+            preproc_id: None,
             shared_args: SharedKeyGenParameters {
                 uncompressed,
                 ..Default::default()
@@ -1019,6 +1020,38 @@ async fn insecure_key_gen(
     );
     let id = run_cmd(&config, test_path, "insecure key-gen").await?;
     Ok(id.to_string())
+}
+
+/// Helper to run the insecure (dummy) preprocessing and insecure key generation
+/// via CLI (isolated version), exercising the explicit `--preproc-id` flow.
+async fn insecure_preproc_and_keygen(
+    config_path: &Path,
+    test_path: &Path,
+    uncompressed: bool,
+) -> Result<String> {
+    let preproc_config = cmd_config(
+        config_path,
+        CCCommand::InsecurePreprocKeyGen(InsecureKeyGenPreprocParameters {
+            context_id: None,
+            epoch_id: None,
+        }),
+        200,
+    );
+    let preproc_id = run_cmd(&preproc_config, test_path, "insecure preprocessing").await?;
+
+    let keygen_config = cmd_config(
+        config_path,
+        CCCommand::InsecureKeyGen(InsecureKeyGenParameters {
+            preproc_id: Some(preproc_id),
+            shared_args: SharedKeyGenParameters {
+                uncompressed,
+                ..Default::default()
+            },
+        }),
+        200,
+    );
+    let key_id = run_cmd(&keygen_config, test_path, "insecure key-gen").await?;
+    Ok(key_id.to_string())
 }
 
 // ============================================================================
@@ -2084,8 +2117,11 @@ async fn test_centralized_insecure_default_keygen() -> Result<()> {
     let (material_dir, _server, config_path) =
         setup_isolated_centralized_cli_test("centralized_insecure_default_keygen").await?;
 
+    // Use the explicit insecure-preproc flow here so both the explicit
+    // `--preproc-id` path and the automatic fallback (used by the other
+    // insecure keygen tests) are covered.
     let keys_folder = material_dir.path();
-    let key_id = insecure_key_gen(&config_path, keys_folder, false).await?;
+    let key_id = insecure_preproc_and_keygen(&config_path, keys_folder, false).await?;
     assert!(!key_id.is_empty());
 
     Ok(())
@@ -2418,8 +2454,11 @@ async fn test_threshold_insecure_default_keygen() -> Result<()> {
     let (material_dir, _servers, config_path) =
         setup_isolated_threshold_cli_test_with_prss("threshold_insecure_default_keygen", 4).await?;
 
+    // Use the explicit insecure-preproc flow here so both the explicit
+    // `--preproc-id` path and the automatic fallback (used by the other
+    // insecure keygen tests) are covered.
     let keys_folder = material_dir.path();
-    let key_id = insecure_key_gen(&config_path, keys_folder, false).await?;
+    let key_id = insecure_preproc_and_keygen(&config_path, keys_folder, false).await?;
     assert!(!key_id.is_empty());
 
     Ok(())

--- a/core-client/tests/kind-testing/kubernetes_test_centralized.rs
+++ b/core-client/tests/kind-testing/kubernetes_test_centralized.rs
@@ -115,6 +115,7 @@ impl K8sTestContext {
 
         let results = self
             .execute(CCCommand::InsecureKeyGen(InsecureKeyGenParameters {
+                preproc_id: None,
                 shared_args: SharedKeyGenParameters::default(),
             }))
             .await;

--- a/core-client/tests/kind-testing/kubernetes_test_centralized.rs
+++ b/core-client/tests/kind-testing/kubernetes_test_centralized.rs
@@ -113,9 +113,22 @@ impl K8sTestContext {
         info!("[K8S-CENTRALIZED] Executing InsecureKeyGen...");
         let start = std::time::Instant::now();
 
+        let preproc_results = self
+            .execute(CCCommand::InsecurePreprocKeyGen(
+                InsecureKeyGenPreprocParameters {
+                    context_id: None,
+                    epoch_id: None,
+                },
+            ))
+            .await;
+        let preproc_id = *preproc_results
+            .first()
+            .and_then(|(id, _)| id.as_ref())
+            .expect("InsecurePreprocKeyGen must return a preprocessing ID");
+
         let results = self
             .execute(CCCommand::InsecureKeyGen(InsecureKeyGenParameters {
-                preproc_id: None,
+                preproc_id,
                 shared_args: SharedKeyGenParameters::default(),
             }))
             .await;

--- a/core-client/tests/kind-testing/kubernetes_test_threshold.rs
+++ b/core-client/tests/kind-testing/kubernetes_test_threshold.rs
@@ -144,6 +144,7 @@ impl K8sTestContext {
 
         let results = self
             .execute(CCCommand::InsecureKeyGen(InsecureKeyGenParameters {
+                preproc_id: None,
                 shared_args: SharedKeyGenParameters::default(),
             }))
             .await;

--- a/core-client/tests/kind-testing/kubernetes_test_threshold.rs
+++ b/core-client/tests/kind-testing/kubernetes_test_threshold.rs
@@ -142,9 +142,22 @@ impl K8sTestContext {
         info!("[K8S-THRESHOLD] Executing InsecureKeyGen...");
         let start = std::time::Instant::now();
 
+        let preproc_results = self
+            .execute(CCCommand::InsecurePreprocKeyGen(
+                InsecureKeyGenPreprocParameters {
+                    context_id: None,
+                    epoch_id: None,
+                },
+            ))
+            .await;
+        let preproc_id = *preproc_results
+            .first()
+            .and_then(|(id, _)| id.as_ref())
+            .expect("InsecurePreprocKeyGen must return a preprocessing ID");
+
         let results = self
             .execute(CCCommand::InsecureKeyGen(InsecureKeyGenParameters {
-                preproc_id: None,
+                preproc_id,
                 shared_args: SharedKeyGenParameters::default(),
             }))
             .await;
@@ -298,10 +311,10 @@ impl Drop for K8sTestContext {
 // TESTS
 // ============================================================================
 
-/// Smoke test: Generate a key (insecure DKG, no preprocessing) and a CRS.
+/// Smoke test: Generate a key (insecure DKG with dummy preprocessing) and a CRS.
 ///
-/// Uses `InsecureKeyGen` — a testing shortcut that skips the keygen preprocessing
-/// (offline DKG phase) by using a dummy preproc ID. PRSS is still active.
+/// Uses `InsecurePreprocKeyGen` + `InsecureKeyGen` — a testing shortcut that skips
+/// the secure offline DKG phase by using a dummy preprocessing entry. PRSS is still active.
 /// Production keygen uses `PreprocKeyGen` + `KeyGen`. This test validates that
 /// the fundamental MPC cluster wiring (gRPC, mTLS, party coordination) works.
 #[tokio::test]

--- a/core-client/tests/kind-testing/kubernetes_test_threshold.rs
+++ b/core-client/tests/kind-testing/kubernetes_test_threshold.rs
@@ -332,8 +332,8 @@ async fn k8s_test_keygen_and_crs() {
 
 /// Test that sequential insecure key generations produce unique keys.
 ///
-/// Uses `InsecureKeyGen` (no keygen preprocessing) to verify that the MPC protocol assigns
-/// a fresh, unique key ID on each call. Not representative of production keygen.
+/// Uses `InsecurePreprocKeyGen` + `InsecureKeyGen` to verify that the MPC protocol
+/// assigns a fresh, unique key ID on each call. Not representative of production keygen.
 #[tokio::test]
 async fn k8s_test_keygen_uniqueness() {
     let ctx = K8sTestContext::new("k8s_test_keygen_uniqueness");
@@ -352,8 +352,8 @@ async fn k8s_test_keygen_uniqueness() {
 
 /// Cluster smoke test: insecure keygen → encrypt → threshold public decrypt → verify.
 ///
-/// Uses `InsecureKeyGen` (no keygen preprocessing) — a testing shortcut not used in
-/// production, where `PreprocKeyGen` + `KeyGen` is required. The `Encrypt` step
+/// Uses `InsecurePreprocKeyGen` + `InsecureKeyGen` — a testing shortcut not used
+/// in production, where `PreprocKeyGen` + `KeyGen` is required. The `Encrypt` step
 /// fetches both the `PublicKey` and `ServerKey` from the cluster; in real client
 /// operation only the `PublicKey` is needed for encryption.
 ///
@@ -391,7 +391,7 @@ async fn k8s_test_insecure_keygen_encrypt_and_public_decrypt() {
 
 /// Cluster smoke test: one insecure key handles multiple FHE types correctly.
 ///
-/// Uses `InsecureKeyGen` (no keygen preprocessing) — see `k8s_test_insecure_keygen_encrypt_and_public_decrypt`
+/// Uses `InsecurePreprocKeyGen` + `InsecureKeyGen` — see `k8s_test_insecure_keygen_encrypt_and_public_decrypt`
 /// for caveats. Validates that a single threshold key correctly serves ciphertexts
 /// of different FHE types in sequence:
 /// 1. Generate one threshold FHE key

--- a/core/grpc/proto/kms-service-insecure.v1.proto
+++ b/core/grpc/proto/kms-service-insecure.v1.proto
@@ -17,6 +17,10 @@ service CoreServiceEndpoint {
 
   rpc GetKeyGenPreprocResult(kms.v1.RequestId) returns (kms.v1.KeyGenPreprocResult);
 
+  rpc InsecureKeyGenPreproc(kms.v1.KeyGenPreprocRequest) returns (kms.v1.Empty);
+
+  rpc GetInsecureKeyGenPreprocResult(kms.v1.RequestId) returns (kms.v1.KeyGenPreprocResult);
+
   rpc KeyGen(kms.v1.KeyGenRequest) returns (kms.v1.Empty);
 
   rpc GetKeyGenResult(kms.v1.RequestId) returns (kms.v1.KeyGenResult);

--- a/core/grpc/proto/kms-service-insecure.v1.proto
+++ b/core/grpc/proto/kms-service-insecure.v1.proto
@@ -9,6 +9,19 @@ import "kms.v1.proto";
 // the documentation. Please see the documentation of the secure endpoint.
 // All insecure RPCs (i.e., the ones that have `Insecure` in the prefix)
 // have the same semantics as the secure ones.
+//
+// How key-generation preprocessing relates to key generation differs between
+// the centralized and threshold KMS:
+//   - Threshold: the preprocessing type and the keygen type must match. Normal
+//     preprocessing (`KeyGenPreproc`) produces real correlated randomness and
+//     may ONLY be consumed by the secure `KeyGen`; insecure preprocessing
+//     (`InsecureKeyGenPreproc`) generates no material and may ONLY be consumed
+//     by `InsecureKeyGen`. Each keygen rejects a preprocessing ID of the other
+//     type.
+//   - Centralized: there is no distinction between normal and insecure
+//     preprocessing (both are dummy and stored identically), so a preprocessing
+//     produced by either `KeyGenPreproc` or `InsecureKeyGenPreproc` can be
+//     consumed by either `KeyGen` or `InsecureKeyGen`.
 service CoreServiceEndpoint {
 
   rpc KeyGenPreproc(kms.v1.KeyGenPreprocRequest) returns (kms.v1.Empty);

--- a/core/service/src/client/tests/threshold/common.rs
+++ b/core/service/src/client/tests/threshold/common.rs
@@ -1,15 +1,48 @@
 use core::future::Future;
 
+use crate::client::tests::common::default_isolated_extra_data;
 use crate::consts::{DEFAULT_EPOCH_ID, DEFAULT_MPC_CONTEXT, MAX_TRIES};
+use crate::dummy_domain;
+use crate::engine::base::derive_request_id;
+use crate::testing::helpers::domain_to_msg;
 use kms_grpc::RequestId;
+use kms_grpc::kms::v1::{KeyGenPreprocRequest, KeyGenRequest};
 use kms_grpc::kms_service::v1::core_service_endpoint_client::CoreServiceEndpointClient;
 use std::collections::HashMap;
 use std::pin::Pin;
+use tokio::task::JoinSet;
 use tonic::transport::Channel;
 use tonic::{Request, Response, Status};
 
 /// RequestIds as they are represented in the current version of the ProtoBuf API.
 type ProtoRequestId = kms_grpc::kms::v1::RequestId;
+
+async fn poll_result_with_retries<R: Send>(
+    mut client: CoreServiceEndpointClient<Channel>,
+    party_id: u32,
+    request_id: ProtoRequestId,
+    operation: &'static str,
+    poll_fn: impl for<'a> Fn(
+        &'a mut CoreServiceEndpointClient<Channel>,
+        Request<ProtoRequestId>,
+    )
+        -> Pin<Box<dyn Future<Output = Result<Response<R>, Status>> + Send + 'a>>,
+) -> Result<Response<R>, Status> {
+    let mut result = poll_fn(&mut client, Request::new(request_id.clone())).await;
+    let mut retries = 0_usize;
+    while matches!(result.as_ref(), Err(status) if status.code() == tonic::Code::Unavailable) {
+        if retries >= MAX_TRIES {
+            return Err(Status::deadline_exceeded(format!(
+                "timeout while waiting for {operation} from party {party_id} for request {} after {MAX_TRIES} retries",
+                request_id.request_id
+            )));
+        }
+        retries += 1;
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        result = poll_fn(&mut client, Request::new(request_id.clone())).await;
+    }
+    result
+}
 
 // =============================================================================
 // ISOLATED TEST HELPERS
@@ -18,10 +51,72 @@ type ProtoRequestId = kms_grpc::kms::v1::RequestId;
 // module (kms_lib::testing). They provide simplified interfaces for common
 // threshold operations without requiring the full test setup infrastructure.
 
+/// Helper to run the insecure (dummy) preprocessing on all clients.
+///
+/// This sends insecure_key_gen_preproc requests to all clients and waits for
+/// them to complete, so the resulting preprocessing ID can be consumed by a
+/// subsequent insecure key generation.
+///
+/// # Arguments
+/// * `clients` - Map of party ID to gRPC client
+/// * `preproc_id` - Unique identifier for this preprocessing request
+/// * `params` - FHE parameters to store with the preprocessing
+///
+/// # Returns
+/// * `Ok(())` once the preprocessing is finished on all parties
+/// * `Err` if any party failed
+pub(crate) async fn run_insecure_preproc(
+    clients: &HashMap<u32, CoreServiceEndpointClient<Channel>>,
+    preproc_id: &kms_grpc::RequestId,
+    params: kms_grpc::kms::v1::FheParameter,
+) -> anyhow::Result<()> {
+    let domain_msg = domain_to_msg(&dummy_domain());
+
+    let mut preproc_tasks = JoinSet::new();
+    for client in clients.values() {
+        let mut cur_client = client.clone();
+        let preproc_req = KeyGenPreprocRequest {
+            request_id: Some((*preproc_id).into()),
+            params: params as i32,
+            domain: Some(domain_msg.clone()),
+            keyset_config: None,
+            context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
+            epoch_id: Some((*DEFAULT_EPOCH_ID).into()),
+            extra_data: default_isolated_extra_data(),
+        };
+        preproc_tasks.spawn(async move {
+            cur_client
+                .insecure_key_gen_preproc(tonic::Request::new(preproc_req))
+                .await
+        });
+    }
+
+    while let Some(res) = preproc_tasks.join_next().await {
+        res??;
+    }
+
+    // Wait for the (instant) insecure preprocessing to be ready on all parties
+    for (party_id, client) in clients.iter() {
+        poll_result_with_retries(
+            client.clone(),
+            *party_id,
+            (*preproc_id).into(),
+            "insecure preprocessing result",
+            |client, request| {
+                Box::pin(async move { client.get_insecure_key_gen_preproc_result(request).await })
+            },
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
 /// Helper to generate threshold key using insecure mode.
 ///
-/// This function sends insecure_key_gen requests to all clients and waits for
-/// key generation to complete. It's designed for use with ThresholdTestEnv.
+/// This function first runs the insecure (dummy) preprocessing, then sends
+/// insecure_key_gen requests to all clients and waits for key generation to
+/// complete. It's designed for use with ThresholdTestEnv.
 ///
 /// # Arguments
 /// * `clients` - Map of party ID to gRPC client
@@ -31,7 +126,8 @@ type ProtoRequestId = kms_grpc::kms::v1::RequestId;
 /// * `keyset_added_info` - Optional migration info (e.g. for `UseExisting` keygen)
 ///
 /// # Returns
-/// * `Ok(responses)` - per-party `(party_id, KeyGenResult)` for use with `verify_keygen_responses`
+/// * `Ok((preproc_id, responses))` - the preprocessing ID that was consumed and
+///   per-party `(party_id, KeyGenResult)` for use with `verify_keygen_responses`
 /// * `Err` if any party failed
 pub async fn threshold_insecure_key_gen(
     clients: &HashMap<u32, CoreServiceEndpointClient<Channel>>,
@@ -39,29 +135,27 @@ pub async fn threshold_insecure_key_gen(
     params: kms_grpc::kms::v1::FheParameter,
     keyset_config: Option<kms_grpc::kms::v1::KeySetConfig>,
     keyset_added_info: Option<kms_grpc::kms::v1::KeySetAddedInfo>,
-) -> anyhow::Result<
+) -> anyhow::Result<(
+    kms_grpc::RequestId,
     Vec<(
         u32,
         Result<tonic::Response<kms_grpc::kms::v1::KeyGenResult>, tonic::Status>,
     )>,
-> {
-    use crate::client::tests::common::default_isolated_extra_data;
-    use crate::dummy_domain;
-    use crate::engine::base::INSECURE_PREPROCESSING_ID;
-    use crate::testing::helpers::domain_to_msg;
-    use kms_grpc::kms::v1::KeyGenRequest;
-    use tokio::task::JoinSet;
-
+)> {
     let domain_msg = domain_to_msg(&dummy_domain());
 
-    // Use insecure_key_gen endpoint which bypasses preprocessing validation
+    // The insecure keygen requires an existing preprocessing ID,
+    // so run the insecure (dummy) preprocessing first.
+    let preproc_id = derive_request_id(&format!("insecure-preproc-{request_id}"))?;
+    run_insecure_preproc(clients, &preproc_id, params).await?;
+
     let mut keygen_tasks = JoinSet::new();
     for client in clients.values() {
         let mut cur_client = client.clone();
         let keygen_req = KeyGenRequest {
             request_id: Some((*request_id).into()),
             params: Some(params as i32),
-            preproc_id: Some((*INSECURE_PREPROCESSING_ID).into()),
+            preproc_id: Some(preproc_id.into()),
             domain: Some(domain_msg.clone()),
             keyset_config,
             keyset_added_info: keyset_added_info.clone(),
@@ -83,20 +177,20 @@ pub async fn threshold_insecure_key_gen(
     // Wait for key generation to complete on all parties and collect responses
     let mut responses = Vec::new();
     for (party_id, client) in clients.iter() {
-        let mut cur_client = client.clone();
-        let mut result = cur_client
-            .get_insecure_key_gen_result(tonic::Request::new((*request_id).into()))
-            .await;
-        while result.is_err() && result.as_ref().unwrap_err().code() == tonic::Code::Unavailable {
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-            result = cur_client
-                .get_insecure_key_gen_result(tonic::Request::new((*request_id).into()))
-                .await;
-        }
+        let result = poll_result_with_retries(
+            client.clone(),
+            *party_id,
+            (*request_id).into(),
+            "insecure keygen result",
+            |client, request| {
+                Box::pin(async move { client.get_insecure_key_gen_result(request).await })
+            },
+        )
+        .await;
         responses.push((*party_id, result));
     }
 
-    Ok(responses)
+    Ok((preproc_id, responses))
 }
 
 /// Helper to generate threshold key using secure mode with preprocessing.
@@ -130,12 +224,6 @@ pub async fn threshold_secure_key_gen(
         Result<tonic::Response<kms_grpc::kms::v1::KeyGenResult>, tonic::Status>,
     )>,
 > {
-    use crate::client::tests::common::default_isolated_extra_data;
-    use crate::dummy_domain;
-    use crate::testing::helpers::domain_to_msg;
-    use kms_grpc::kms::v1::{KeyGenPreprocRequest, KeyGenRequest};
-    use tokio::task::JoinSet;
-
     // Note: Isolated callers always use the default context/epoch; if that ever changes
     // we'd need to resolve `context_id` / `epoch_id` to concrete ids and rebuild
     // extra_data via `make_extra_data` so the signed bytes stay consistent.
@@ -171,18 +259,17 @@ pub async fn threshold_secure_key_gen(
     }
 
     // Wait for preprocessing to complete
-    for client in clients.values() {
-        let mut cur_client = client.clone();
-        let mut result = cur_client
-            .get_key_gen_preproc_result(tonic::Request::new((*preproc_id).into()))
-            .await;
-        while result.is_err() && result.as_ref().unwrap_err().code() == tonic::Code::Unavailable {
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-            result = cur_client
-                .get_key_gen_preproc_result(tonic::Request::new((*preproc_id).into()))
-                .await;
-        }
-        result?;
+    for (party_id, client) in clients.iter() {
+        poll_result_with_retries(
+            client.clone(),
+            *party_id,
+            (*preproc_id).into(),
+            "preprocessing result",
+            |client, request| {
+                Box::pin(async move { client.get_key_gen_preproc_result(request).await })
+            },
+        )
+        .await?;
     }
 
     // Step 2: Run key generation using the preprocessed material
@@ -211,16 +298,14 @@ pub async fn threshold_secure_key_gen(
     // Wait for key generation to complete and collect responses
     let mut responses = Vec::new();
     for (party_id, client) in clients.iter() {
-        let mut cur_client = client.clone();
-        let mut result = cur_client
-            .get_key_gen_result(tonic::Request::new((*keygen_id).into()))
-            .await;
-        while result.is_err() && result.as_ref().unwrap_err().code() == tonic::Code::Unavailable {
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-            result = cur_client
-                .get_key_gen_result(tonic::Request::new((*keygen_id).into()))
-                .await;
-        }
+        let result = poll_result_with_retries(
+            client.clone(),
+            *party_id,
+            (*keygen_id).into(),
+            "keygen result",
+            |client, request| Box::pin(async move { client.get_key_gen_result(request).await }),
+        )
+        .await;
         responses.push((*party_id, result));
     }
 

--- a/core/service/src/client/tests/threshold/custodian_backup_tests.rs
+++ b/core/service/src/client/tests/threshold/custodian_backup_tests.rs
@@ -20,8 +20,7 @@ use crate::cryptography::signatures::PrivateSigKey;
 use crate::cryptography::signatures::PublicSigKey;
 use crate::engine::base::derive_request_id;
 use crate::engine::base::{
-    CrsGenMetadata, DSEP_PUBDATA_KEY, INSECURE_PREPROCESSING_ID,
-    safe_serialize_hash_element_versioned,
+    CrsGenMetadata, DSEP_PUBDATA_KEY, safe_serialize_hash_element_versioned,
 };
 use crate::engine::context::ContextInfo;
 use crate::testing::setup::ThresholdTestEnv;
@@ -385,6 +384,10 @@ async fn decrypt_after_recovery(amount_custodians: usize, threshold: u32) {
         "decrypt_after_recovery_threshold_key_{n}_{amount_custodians}_{threshold}"
     ))
     .unwrap();
+    let preproc_id: RequestId = derive_request_id(&format!(
+        "decrypt_after_recovery_threshold_preproc_{n}_{amount_custodians}_{threshold}"
+    ))
+    .unwrap();
 
     // Generate a key
     let (keyset_config, keyset_added_info) = keygen_config();
@@ -392,7 +395,7 @@ async fn decrypt_after_recovery(amount_custodians: usize, threshold: u32) {
         FheParameter::Test,
         env.kms_clients(),
         env.internal_client(),
-        &INSECURE_PREPROCESSING_ID,
+        &preproc_id,
         &req_key_id,
         keyset_config,
         keyset_added_info,
@@ -546,6 +549,10 @@ async fn decrypt_after_recovery_negative(amount_custodians: usize, threshold: u3
         "decrypt_after_recovery_threshold_negative_key_{n}_{amount_custodians}_{threshold}"
     ))
     .unwrap();
+    let preproc_id: RequestId = derive_request_id(&format!(
+        "decrypt_after_recovery_threshold_negative_preproc_{n}_{amount_custodians}_{threshold}"
+    ))
+    .unwrap();
 
     // Generate a key so we have FHE material to delete + recover.
     let (keyset_config, keyset_added_info) = keygen_config();
@@ -553,7 +560,7 @@ async fn decrypt_after_recovery_negative(amount_custodians: usize, threshold: u3
         FheParameter::Test,
         env.kms_clients(),
         env.internal_client(),
-        &INSECURE_PREPROCESSING_ID,
+        &preproc_id,
         &req_key_id,
         keyset_config,
         keyset_added_info,
@@ -677,6 +684,8 @@ async fn test_keygen_backup_presence_threshold() {
     let mut env = ThresholdBackupTestEnv::new("test_keygen_backup_presence_threshold", 3, 1).await;
     let req_key_id: RequestId =
         derive_request_id("test_keygen_backup_presence_threshold_key").unwrap();
+    let preproc_id: RequestId =
+        derive_request_id("test_keygen_backup_presence_threshold_preproc").unwrap();
 
     // Generate a key
     let (keyset_config, keyset_added_info) = uncompressed_keygen_config();
@@ -684,7 +693,7 @@ async fn test_keygen_backup_presence_threshold() {
         FheParameter::Test,
         env.kms_clients(),
         env.internal_client(),
-        &INSECURE_PREPROCESSING_ID,
+        &preproc_id,
         &req_key_id,
         keyset_config,
         keyset_added_info,
@@ -727,6 +736,8 @@ async fn test_custodian_reencryption_with_existing_data_threshold() {
         derive_request_id("test_custodian_reencryption_threshold_cus_b").unwrap();
     let req_key_id: RequestId =
         derive_request_id("test_custodian_reencryption_threshold_key").unwrap();
+    let preproc_id: RequestId =
+        derive_request_id("test_custodian_reencryption_threshold_preproc").unwrap();
 
     // Generate a key
     let (keyset_config, keyset_added_info) = uncompressed_keygen_config();
@@ -734,7 +745,7 @@ async fn test_custodian_reencryption_with_existing_data_threshold() {
         FheParameter::Test,
         env.kms_clients(),
         env.internal_client(),
-        &INSECURE_PREPROCESSING_ID,
+        &preproc_id,
         &req_key_id,
         keyset_config,
         keyset_added_info,
@@ -891,6 +902,8 @@ async fn test_backup_after_reshare_threshold() {
     let n = ThresholdBackupTestEnv::AMOUNT_PARTIES;
     let req_key_id: RequestId =
         derive_request_id("test_backup_after_reshare_threshold_key").unwrap();
+    let preproc_id: RequestId =
+        derive_request_id("test_backup_after_reshare_threshold_preproc").unwrap();
     let crs_req: RequestId = derive_request_id("test_backup_after_reshare_threshold_crs").unwrap();
     let new_epoch_id: EpochId = derive_request_id("test_backup_after_reshare_threshold_epoch")
         .unwrap()
@@ -902,7 +915,7 @@ async fn test_backup_after_reshare_threshold() {
         FheParameter::Test,
         env.kms_clients(),
         env.internal_client(),
-        &INSECURE_PREPROCESSING_ID,
+        &preproc_id,
         &req_key_id,
         keyset_config,
         keyset_added_info,
@@ -956,7 +969,7 @@ async fn test_backup_after_reshare_threshold() {
         epoch_id: Some((*DEFAULT_EPOCH_ID).into()),
         keys_info: vec![KeyInfo {
             key_id: Some(req_key_id.into()),
-            preproc_id: Some((*INSECURE_PREPROCESSING_ID).into()),
+            preproc_id: Some(preproc_id.into()),
             key_parameters: FheParameter::Test.into(),
             key_digests: vec![
                 kms_grpc::kms::v1::KeyDigest {

--- a/core/service/src/client/tests/threshold/custodian_backup_tests.rs
+++ b/core/service/src/client/tests/threshold/custodian_backup_tests.rs
@@ -4,6 +4,7 @@ use crate::backup::seed_phrase::custodian_from_seed_phrase;
 use crate::client::client_wasm::Client;
 use crate::client::test_tools::ServerHandle;
 use crate::client::tests::common::{keygen_config, uncompressed_keygen_config};
+use crate::client::tests::threshold::common::run_insecure_preproc;
 use crate::client::tests::threshold::crs_gen_tests::run_crs;
 use crate::client::tests::threshold::custodian_context_tests::run_new_cus_context;
 use crate::client::tests::threshold::key_gen_tests::run_threshold_keygen;
@@ -391,6 +392,9 @@ async fn decrypt_after_recovery(amount_custodians: usize, threshold: u32) {
 
     // Generate a key
     let (keyset_config, keyset_added_info) = keygen_config();
+    run_insecure_preproc(env.kms_clients(), &preproc_id, FheParameter::Test)
+        .await
+        .unwrap();
     let _keys = run_threshold_keygen(
         FheParameter::Test,
         env.kms_clients(),
@@ -556,6 +560,9 @@ async fn decrypt_after_recovery_negative(amount_custodians: usize, threshold: u3
 
     // Generate a key so we have FHE material to delete + recover.
     let (keyset_config, keyset_added_info) = keygen_config();
+    run_insecure_preproc(env.kms_clients(), &preproc_id, FheParameter::Test)
+        .await
+        .unwrap();
     let _keys = run_threshold_keygen(
         FheParameter::Test,
         env.kms_clients(),
@@ -689,6 +696,9 @@ async fn test_keygen_backup_presence_threshold() {
 
     // Generate a key
     let (keyset_config, keyset_added_info) = uncompressed_keygen_config();
+    run_insecure_preproc(env.kms_clients(), &preproc_id, FheParameter::Test)
+        .await
+        .unwrap();
     let _keys = run_threshold_keygen(
         FheParameter::Test,
         env.kms_clients(),
@@ -741,6 +751,9 @@ async fn test_custodian_reencryption_with_existing_data_threshold() {
 
     // Generate a key
     let (keyset_config, keyset_added_info) = uncompressed_keygen_config();
+    run_insecure_preproc(env.kms_clients(), &preproc_id, FheParameter::Test)
+        .await
+        .unwrap();
     let _keys = run_threshold_keygen(
         FheParameter::Test,
         env.kms_clients(),
@@ -911,6 +924,9 @@ async fn test_backup_after_reshare_threshold() {
 
     // Generate a key (so we have material to reshare)
     let (keyset_config, keyset_added_info) = uncompressed_keygen_config();
+    run_insecure_preproc(env.kms_clients(), &preproc_id, FheParameter::Test)
+        .await
+        .unwrap();
     let (keyset, _) = run_threshold_keygen(
         FheParameter::Test,
         env.kms_clients(),

--- a/core/service/src/client/tests/threshold/key_gen_tests.rs
+++ b/core/service/src/client/tests/threshold/key_gen_tests.rs
@@ -183,6 +183,7 @@ async fn test_insecure_compressed_dkg(#[case] amount_parties: usize) -> anyhow::
     let preproc_id = derive_request_id(&format!(
         "test_insecure_compressed_dkg_preproc_{amount_parties}_{TEST_PARAM:?}"
     ))?;
+    run_insecure_preproc(&kms_clients, &preproc_id, FheParameter::Test).await?;
     let keys = run_threshold_keygen(
         FheParameter::Test,
         &kms_clients,
@@ -230,6 +231,9 @@ async fn secure_threshold_compressed_keygen_test() {
     .await;
 }
 
+/// Runs only the (secure or insecure) key generation step. The matching
+/// preprocessing — `run_preproc` for secure, `run_insecure_preproc` for
+/// insecure — must already have been run for `preproc_req_id` by the caller.
 #[expect(clippy::too_many_arguments)]
 pub(crate) async fn run_threshold_keygen(
     parameter: FheParameter,
@@ -244,12 +248,6 @@ pub(crate) async fn run_threshold_keygen(
     expected_num_parties_crashed: usize,
 ) -> (TestKeyGenResult, Option<HashMap<Role, ThresholdFheKeys>>) {
     let domain = dummy_domain();
-
-    if insecure {
-        run_insecure_preproc(kms_clients, preproc_req_id, parameter)
-            .await
-            .unwrap();
-    }
 
     let req_keygen = internal_client
         .key_gen_request(
@@ -493,7 +491,11 @@ pub(crate) async fn run_threshold_decompression_keygen(
     };
     let test_path = material_dir.path();
 
-    if !insecure {
+    if insecure {
+        run_insecure_preproc(&kms_clients, &preproc_id_1, parameter)
+            .await
+            .unwrap();
+    } else {
         run_preproc(
             amount_parties,
             parameter,
@@ -524,7 +526,11 @@ pub(crate) async fn run_threshold_decompression_keygen(
     .0;
     let (client_key_1, _public_key_1, server_key_1) = keys1.get_uncompressed();
 
-    if !insecure {
+    if insecure {
+        run_insecure_preproc(&kms_clients, &preproc_id_2, parameter)
+            .await
+            .unwrap();
+    } else {
         run_preproc(
             amount_parties,
             parameter,
@@ -555,9 +561,11 @@ pub(crate) async fn run_threshold_decompression_keygen(
     .0;
     let (client_key_2, _public_key_2, _server_key_2) = keys2.get_uncompressed();
 
-    // For the insecure variant the (dummy) preprocessing
-    // is run by `run_threshold_keygen` itself
-    if !insecure {
+    if insecure {
+        run_insecure_preproc(&kms_clients, &preproc_id_3, parameter)
+            .await
+            .unwrap();
+    } else {
         run_preproc(
             amount_parties,
             parameter,
@@ -732,17 +740,23 @@ pub(crate) async fn preproc_and_keygen(
                 let clients_clone = Arc::clone(&arc_clients);
                 let internalclient_clone = Arc::clone(&arc_internalclient);
                 async move {
-                    run_preproc(
-                        amount_parties,
-                        parameter,
-                        &clients_clone,
-                        &internalclient_clone,
-                        &preproc_id,
-                        None,
-                        expected_num_parties_crashed,
-                        partial_preproc,
-                    )
-                    .await
+                    if insecure_key_gen {
+                        run_insecure_preproc(&clients_clone, &preproc_id, parameter)
+                            .await
+                            .unwrap();
+                    } else {
+                        run_preproc(
+                            amount_parties,
+                            parameter,
+                            &clients_clone,
+                            &internalclient_clone,
+                            &preproc_id,
+                            None,
+                            expected_num_parties_crashed,
+                            partial_preproc,
+                        )
+                        .await
+                    }
                 }
             });
         }
@@ -774,7 +788,6 @@ pub(crate) async fn preproc_and_keygen(
                 let internalclient_clone = Arc::clone(&arc_internalclient);
                 let path_clone = test_path.clone();
                 async move {
-                    // todo proper use of insecure to skip preproc
                     (
                         key_id,
                         run_threshold_keygen(
@@ -826,17 +839,23 @@ pub(crate) async fn preproc_and_keygen(
         tracing::info!("Finished concurrent preproc and keygen");
     } else {
         for preproc_id in preproc_ids.iter() {
-            run_preproc(
-                amount_parties,
-                parameter,
-                &kms_clients,
-                &internal_client,
-                preproc_id,
-                None,
-                expected_num_parties_crashed,
-                partial_preproc,
-            )
-            .await;
+            if insecure_key_gen {
+                run_insecure_preproc(&kms_clients, preproc_id, parameter)
+                    .await
+                    .unwrap();
+            } else {
+                run_preproc(
+                    amount_parties,
+                    parameter,
+                    &kms_clients,
+                    &internal_client,
+                    preproc_id,
+                    None,
+                    expected_num_parties_crashed,
+                    partial_preproc,
+                )
+                .await;
+            }
         }
         expected_num_parties_crashed += crash_parties_for_keygen(
             party_ids_to_crash_keygen,

--- a/core/service/src/client/tests/threshold/key_gen_tests.rs
+++ b/core/service/src/client/tests/threshold/key_gen_tests.rs
@@ -19,9 +19,9 @@ use crate::client::tests::common::OptKeySetConfigAccessor;
 use crate::client::tests::common::keygen_config;
 #[cfg(feature = "slow_tests")]
 use crate::client::tests::common::{decompression_keygen_config, uncompressed_keygen_config};
-use crate::client::tests::threshold::common::threshold_insecure_key_gen;
 #[cfg(feature = "slow_tests")]
 use crate::client::tests::threshold::common::threshold_secure_key_gen;
+use crate::client::tests::threshold::common::{run_insecure_preproc, threshold_insecure_key_gen};
 #[cfg(feature = "slow_tests")]
 use crate::client::tests::threshold::public_decryption_tests::run_decryption_threshold;
 use crate::consts::MAX_TRIES;
@@ -242,6 +242,16 @@ pub(crate) async fn run_threshold_keygen(
     expected_num_parties_crashed: usize,
 ) -> (TestKeyGenResult, Option<HashMap<Role, ThresholdFheKeys>>) {
     let domain = dummy_domain();
+
+    // Insecure keygen either consumes an explicit dummy preprocessing entry or
+    // uses the well-known ID as an implicit dummy preprocessing.
+    let explicit_insecure_preproc = insecure && *preproc_req_id != *INSECURE_PREPROCESSING_ID;
+    if explicit_insecure_preproc {
+        run_insecure_preproc(kms_clients, preproc_req_id, parameter)
+            .await
+            .unwrap();
+    }
+
     let req_keygen = internal_client
         .key_gen_request(
             keygen_req_id,
@@ -267,6 +277,7 @@ pub(crate) async fn run_threshold_keygen(
         kms_clients,
         internal_client,
         insecure,
+        explicit_insecure_preproc,
         &keyset_config,
         extra_data,
         data_root_path,
@@ -310,6 +321,7 @@ async fn wait_for_keygen_result(
     kms_clients: &HashMap<u32, CoreServiceEndpointClient<Channel>>,
     internal_client: &Client,
     insecure: bool,
+    explicit_insecure_preproc: bool,
     keyset_config: &Option<KeySetConfig>,
     extra_data: Vec<u8>,
     data_root_path: Option<&Path>,
@@ -410,12 +422,12 @@ async fn wait_for_keygen_result(
         (out, all_private_keys) = (Some(res.0), Some(res.1));
     }
 
-    if !insecure {
+    if !insecure || explicit_insecure_preproc {
         // Try to request another kg with the same preproc but another request id,
-        // we should see that it fails because the preproc material is consumed.
-        //
-        // We only test for the secure variant of the dkg because the insecure
-        // variant does not use preprocessing material.
+        // we should see that it fails because the preproc entry is consumed.
+        // This holds for secure preprocessing and explicit insecure dummy
+        // preprocessing. The well-known insecure preprocessing ID is implicit,
+        // so it intentionally remains reusable after a key generation.
         tracing::debug!("starting another dkg with a used preproc ID");
         let other_key_gen_id = derive_request_id("test_dkg other key id").unwrap();
         let keygen_req_data = internal_client
@@ -445,25 +457,17 @@ pub(crate) async fn run_threshold_decompression_keygen(
     parameter: FheParameter,
     insecure: bool,
 ) {
-    let preproc_id_1 = if insecure {
-        *INSECURE_PREPROCESSING_ID
-    } else {
-        derive_request_id(&format!(
-            "decom_dkg_preproc_{amount_parties}_{parameter:?}_1"
-        ))
-        .unwrap()
-    };
+    let preproc_id_1 = derive_request_id(&format!(
+        "decom_dkg_preproc_{amount_parties}_{parameter:?}_1"
+    ))
+    .unwrap();
     let key_id_1: RequestId =
         derive_request_id(&format!("decom_dkg_key_{amount_parties}_{parameter:?}_1")).unwrap();
 
-    let preproc_id_2 = if insecure {
-        *INSECURE_PREPROCESSING_ID
-    } else {
-        derive_request_id(&format!(
-            "decom_dkg_preproc_{amount_parties}_{parameter:?}_2"
-        ))
-        .unwrap()
-    };
+    let preproc_id_2 = derive_request_id(&format!(
+        "decom_dkg_preproc_{amount_parties}_{parameter:?}_2"
+    ))
+    .unwrap();
     let key_id_2: RequestId =
         derive_request_id(&format!("decom_dkg_key_{amount_parties}_{parameter:?}_2")).unwrap();
 
@@ -559,18 +563,21 @@ pub(crate) async fn run_threshold_decompression_keygen(
     .0;
     let (client_key_2, _public_key_2, _server_key_2) = keys2.get_uncompressed();
 
-    // We always need to run preproc for the last keygen
-    run_preproc(
-        amount_parties,
-        parameter,
-        &kms_clients,
-        &internal_client,
-        &preproc_id_3,
-        None,
-        0,
-        None,
-    )
-    .await;
+    // For the insecure variant the (dummy) preprocessing
+    // is run by `run_threshold_keygen` itself
+    if !insecure {
+        run_preproc(
+            amount_parties,
+            parameter,
+            &kms_clients,
+            &internal_client,
+            &preproc_id_3,
+            None,
+            0,
+            None,
+        )
+        .await;
+    }
 
     // finally do the decompression keygen between the first and second keysets
     let (keyset_config, keyset_added_info) = decompression_keygen_config(&key_id_1, &key_id_2);
@@ -1368,7 +1375,7 @@ async fn test_insecure_dkg() -> anyhow::Result<()> {
     let key_id = derive_request_id("test_insecure_dkg")?;
 
     // Generate key using insecure mode
-    let responses =
+    let (preproc_id, responses) =
         threshold_insecure_key_gen(&env.clients, &key_id, FheParameter::Test, None, None).await?;
 
     // Reconstruct ClientKey from shares and run encrypt/decrypt sanity check
@@ -1377,7 +1384,7 @@ async fn test_insecure_dkg() -> anyhow::Result<()> {
         responses,
         Some(env.material_dir.path()),
         &internal_client,
-        &INSECURE_PREPROCESSING_ID,
+        &preproc_id,
         &key_id,
         &crate::dummy_domain(),
         make_extra_data(2, Some(&DEFAULT_MPC_CONTEXT), Some(&DEFAULT_EPOCH_ID)).unwrap(),
@@ -1426,7 +1433,7 @@ async fn default_insecure_dkg() -> anyhow::Result<()> {
     let key_id = derive_request_id("default_insecure_dkg")?;
 
     // Use FheParameter::Default to match MaterialType::Default
-    let responses =
+    let (preproc_id, responses) =
         threshold_insecure_key_gen(&env.clients, &key_id, FheParameter::Default, None, None)
             .await?;
 
@@ -1438,7 +1445,7 @@ async fn default_insecure_dkg() -> anyhow::Result<()> {
         responses,
         Some(env.material_dir.path()),
         &internal_client,
-        &INSECURE_PREPROCESSING_ID,
+        &preproc_id,
         &key_id,
         &crate::dummy_domain(),
         make_extra_data(2, Some(&DEFAULT_MPC_CONTEXT), Some(&DEFAULT_EPOCH_ID)).unwrap(),
@@ -2277,13 +2284,13 @@ async fn test_insecure_threshold_decompression_keygen() -> anyhow::Result<()> {
 
     // Step 1: Generate first keyset (insecure mode), reconstruct ClientKey + ServerKey
     let key_id_1 = derive_request_id("decom_dkg_key_1")?;
-    let responses_1 =
+    let (preproc_id_1, responses_1) =
         threshold_insecure_key_gen(&env.clients, &key_id_1, FheParameter::Test, None, None).await?;
     let (keys_1, _) = verify_keygen_responses(
         responses_1,
         Some(&material_path),
         &internal_client,
-        &INSECURE_PREPROCESSING_ID,
+        &preproc_id_1,
         &key_id_1,
         &dummy_domain(),
         default_extra_data(),
@@ -2301,13 +2308,13 @@ async fn test_insecure_threshold_decompression_keygen() -> anyhow::Result<()> {
 
     // Step 2: Generate second keyset (insecure mode), reconstruct ClientKey
     let key_id_2 = derive_request_id("decom_dkg_key_2")?;
-    let responses_2 =
+    let (preproc_id_2, responses_2) =
         threshold_insecure_key_gen(&env.clients, &key_id_2, FheParameter::Test, None, None).await?;
     let (keys_2, _) = verify_keygen_responses(
         responses_2,
         Some(&material_path),
         &internal_client,
-        &INSECURE_PREPROCESSING_ID,
+        &preproc_id_2,
         &key_id_2,
         &dummy_domain(),
         default_extra_data(),

--- a/core/service/src/client/tests/threshold/key_gen_tests.rs
+++ b/core/service/src/client/tests/threshold/key_gen_tests.rs
@@ -31,7 +31,6 @@ use crate::consts::default_extra_data;
 use crate::consts::{DEFAULT_EPOCH_ID, DEFAULT_MPC_CONTEXT};
 use crate::consts::{PRIVATE_STORAGE_PREFIX_THRESHOLD_ALL, PUBLIC_STORAGE_PREFIX_THRESHOLD_ALL};
 use crate::dummy_domain;
-use crate::engine::base::INSECURE_PREPROCESSING_ID;
 use crate::engine::base::derive_request_id;
 use crate::engine::threshold::service::ThresholdFheKeys;
 use crate::engine::utils::make_extra_data;
@@ -181,11 +180,14 @@ async fn test_insecure_compressed_dkg(#[case] amount_parties: usize) -> anyhow::
     let (kms_clients, _kms_servers, material_path, _guards) = env.into_parts();
 
     let (keyset_config, keyset_added_info) = keygen_config();
+    let preproc_id = derive_request_id(&format!(
+        "test_insecure_compressed_dkg_preproc_{amount_parties}_{TEST_PARAM:?}"
+    ))?;
     let keys = run_threshold_keygen(
         FheParameter::Test,
         &kms_clients,
         &internal_client,
-        &INSECURE_PREPROCESSING_ID,
+        &preproc_id,
         &key_id,
         keyset_config,
         keyset_added_info,
@@ -243,10 +245,7 @@ pub(crate) async fn run_threshold_keygen(
 ) -> (TestKeyGenResult, Option<HashMap<Role, ThresholdFheKeys>>) {
     let domain = dummy_domain();
 
-    // Insecure keygen either consumes an explicit dummy preprocessing entry or
-    // uses the well-known ID as an implicit dummy preprocessing.
-    let explicit_insecure_preproc = insecure && *preproc_req_id != *INSECURE_PREPROCESSING_ID;
-    if explicit_insecure_preproc {
+    if insecure {
         run_insecure_preproc(kms_clients, preproc_req_id, parameter)
             .await
             .unwrap();
@@ -277,7 +276,6 @@ pub(crate) async fn run_threshold_keygen(
         kms_clients,
         internal_client,
         insecure,
-        explicit_insecure_preproc,
         &keyset_config,
         extra_data,
         data_root_path,
@@ -321,7 +319,6 @@ async fn wait_for_keygen_result(
     kms_clients: &HashMap<u32, CoreServiceEndpointClient<Channel>>,
     internal_client: &Client,
     insecure: bool,
-    explicit_insecure_preproc: bool,
     keyset_config: &Option<KeySetConfig>,
     extra_data: Vec<u8>,
     data_root_path: Option<&Path>,
@@ -422,30 +419,25 @@ async fn wait_for_keygen_result(
         (out, all_private_keys) = (Some(res.0), Some(res.1));
     }
 
-    if !insecure || explicit_insecure_preproc {
-        // Try to request another kg with the same preproc but another request id,
-        // we should see that it fails because the preproc entry is consumed.
-        // This holds for secure preprocessing and explicit insecure dummy
-        // preprocessing. The well-known insecure preprocessing ID is implicit,
-        // so it intentionally remains reusable after a key generation.
-        tracing::debug!("starting another dkg with a used preproc ID");
-        let other_key_gen_id = derive_request_id("test_dkg other key id").unwrap();
-        let keygen_req_data = internal_client
-            .key_gen_request(
-                &other_key_gen_id,
-                &req_preproc,
-                None,
-                None,
-                Some(FheParameter::Test),
-                None,
-                None,
-                domain,
-            )
-            .unwrap();
-        let responses = launch_dkg(keygen_req_data.clone(), kms_clients, insecure).await;
-        for response in responses {
-            assert_eq!(response.unwrap_err().code(), tonic::Code::NotFound);
-        }
+    // Try to request another kg with the same preproc but another request id;
+    // the preprocessing entry must have been consumed.
+    tracing::debug!("starting another dkg with a used preproc ID");
+    let other_key_gen_id = derive_request_id("test_dkg other key id").unwrap();
+    let keygen_req_data = internal_client
+        .key_gen_request(
+            &other_key_gen_id,
+            &req_preproc,
+            None,
+            None,
+            Some(FheParameter::Test),
+            None,
+            None,
+            domain,
+        )
+        .unwrap();
+    let responses = launch_dkg(keygen_req_data.clone(), kms_clients, insecure).await;
+    for response in responses {
+        assert_eq!(response.unwrap_err().code(), tonic::Code::NotFound);
     }
     (out.unwrap(), all_private_keys)
 }

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -4,7 +4,6 @@ use crate::consts::SAFE_SER_SIZE_LIMIT;
 use crate::cryptography::decompression;
 use crate::cryptography::internal_crypto_types::WrappedDKGParams;
 use crate::cryptography::signatures::compute_eip712_signature;
-use crate::engine::utils::MetricedError;
 
 use crate::cryptography::signatures::internal_sign;
 use crate::cryptography::signatures::{PrivateSigKey, PublicSigKey, Signature};
@@ -77,36 +76,6 @@ pub const DSEP_PUBDATA_CRS: DomainSep = *b"PDAT_CRS";
 
 pub static INSECURE_PREPROCESSING_ID: LazyLock<RequestId> =
     LazyLock::new(|| crate::engine::base::derive_request_id("INSECURE_PREPROCESSING_ID").unwrap());
-
-pub(crate) fn resolve_keygen_preproc_id(
-    op_tag: &'static str,
-    key_req_id: RequestId,
-    preproc_id: Option<RequestId>,
-    insecure: bool,
-) -> Result<RequestId, MetricedError> {
-    match preproc_id {
-        Some(preproc_id) => Ok(preproc_id),
-        None if insecure => Ok(*INSECURE_PREPROCESSING_ID),
-        None => Err(MetricedError::new(
-            op_tag,
-            Some(key_req_id),
-            anyhow::anyhow!("Missing preprocessing ID in key generation request"),
-            tonic::Code::InvalidArgument,
-        )),
-    }
-}
-
-pub(crate) fn select_keygen_dkg_params(
-    request_dkg_params: DKGParams,
-    request_params_set: bool,
-    stored_dkg_params: Option<DKGParams>,
-) -> DKGParams {
-    if request_params_set {
-        request_dkg_params
-    } else {
-        stored_dkg_params.unwrap_or(request_dkg_params)
-    }
-}
 
 #[derive(Clone, Serialize, Deserialize, VersionsDispatch)]
 pub enum KmsFheKeyHandlesVersions {

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -4,6 +4,7 @@ use crate::consts::SAFE_SER_SIZE_LIMIT;
 use crate::cryptography::decompression;
 use crate::cryptography::internal_crypto_types::WrappedDKGParams;
 use crate::cryptography::signatures::compute_eip712_signature;
+use crate::engine::utils::MetricedError;
 
 use crate::cryptography::signatures::internal_sign;
 use crate::cryptography::signatures::{PrivateSigKey, PublicSigKey, Signature};
@@ -76,6 +77,36 @@ pub const DSEP_PUBDATA_CRS: DomainSep = *b"PDAT_CRS";
 
 pub static INSECURE_PREPROCESSING_ID: LazyLock<RequestId> =
     LazyLock::new(|| crate::engine::base::derive_request_id("INSECURE_PREPROCESSING_ID").unwrap());
+
+pub(crate) fn resolve_keygen_preproc_id(
+    op_tag: &'static str,
+    key_req_id: RequestId,
+    preproc_id: Option<RequestId>,
+    insecure: bool,
+) -> Result<RequestId, MetricedError> {
+    match preproc_id {
+        Some(preproc_id) => Ok(preproc_id),
+        None if insecure => Ok(*INSECURE_PREPROCESSING_ID),
+        None => Err(MetricedError::new(
+            op_tag,
+            Some(key_req_id),
+            anyhow::anyhow!("Missing preprocessing ID in key generation request"),
+            tonic::Code::InvalidArgument,
+        )),
+    }
+}
+
+pub(crate) fn select_keygen_dkg_params(
+    request_dkg_params: DKGParams,
+    request_params_set: bool,
+    stored_dkg_params: Option<DKGParams>,
+) -> DKGParams {
+    if request_params_set {
+        request_dkg_params
+    } else {
+        stored_dkg_params.unwrap_or(request_dkg_params)
+    }
+}
 
 #[derive(Clone, Serialize, Deserialize, VersionsDispatch)]
 pub enum KmsFheKeyHandlesVersions {

--- a/core/service/src/engine/centralized/endpoint.rs
+++ b/core/service/src/engine/centralized/endpoint.rs
@@ -84,6 +84,32 @@ impl<
             .map_err(|e| e.into())
     }
 
+    // In the centralized case the insecure preprocessing is identical to the
+    // secure one as both are dummy and only store the preprocessing ID.
+    #[cfg(feature = "insecure")]
+    #[tracing::instrument(skip(self, request))]
+    async fn insecure_key_gen_preproc(
+        &self,
+        request: Request<KeyGenPreprocRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        METRICS.increment_request_counter(OP_INSECURE_KEYGEN_PREPROC_REQUEST);
+        preprocessing_impl(self, request)
+            .await
+            .map_err(|e| e.into())
+    }
+
+    #[cfg(feature = "insecure")]
+    #[tracing::instrument(skip(self, request))]
+    async fn get_insecure_key_gen_preproc_result(
+        &self,
+        request: Request<v1::RequestId>,
+    ) -> Result<Response<KeyGenPreprocResult>, Status> {
+        METRICS.increment_request_counter(OP_INSECURE_KEYGEN_PREPROC_RESULT);
+        get_preprocessing_res_impl(self, request)
+            .await
+            .map_err(|e| e.into())
+    }
+
     #[cfg(feature = "insecure")]
     #[tracing::instrument(skip(self, request))]
     async fn insecure_key_gen(

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -454,7 +454,7 @@ pub(crate) mod tests {
 
         // at this point the key is generated (compressed by default)
         // We execute in the secure mode, i.e. pretending that the preprocessing is done
-        test_standard_keygen(&kms, key_id, &preproc_id, false).await;
+        test_standard_keygen(&kms, key_id, Some(&preproc_id), false).await;
 
         // Read compressed keyset and decompress to get pk + server key
         let compressed_keyset: CompressedXofKeySet = {

--- a/core/service/src/engine/centralized/service/key_gen.rs
+++ b/core/service/src/engine/centralized/service/key_gen.rs
@@ -106,6 +106,13 @@ pub async fn key_gen_impl<
     // also check that the request ID is not used yet
     // If all is ok write the request ID to the meta store
     // All validation must be done before inserting the request ID
+    //
+    // Unlike the threshold KMS, the centralized KMS draws no distinction between
+    // secure and insecure preprocessing: both `key_gen_preproc` and
+    // `insecure_key_gen_preproc` store an identical dummy entry in the same
+    // `preprocessing_meta_store`. We therefore retrieve by ID without checking
+    // how the preprocessing was produced, so either a normal or an insecure
+    // keygen can consume either kind of preprocessing.
     let (params, permit) = {
         let preproc = retrieve_from_meta_store(
             service.preprocessing_meta_store.read().await,

--- a/core/service/src/engine/centralized/service/key_gen.rs
+++ b/core/service/src/engine/centralized/service/key_gen.rs
@@ -1,8 +1,5 @@
 use crate::cryptography::signatures::PrivateSigKey;
-use crate::engine::base::{
-    DSEP_PUBDATA_KEY, INSECURE_PREPROCESSING_ID, KeyGenMetadata, compute_info_decompression_keygen,
-    resolve_keygen_preproc_id, select_keygen_dkg_params,
-};
+use crate::engine::base::{DSEP_PUBDATA_KEY, KeyGenMetadata, compute_info_decompression_keygen};
 use crate::engine::centralized::central_kms::{
     CentralizedKeyGenResult, CentralizedKms, async_generate_decompression_keys,
     async_generate_fhe_keys,
@@ -75,9 +72,6 @@ pub async fn key_gen_impl<
         preproc_id,
         context_id,
         epoch_id,
-        // The DKG parameters of the request are used by the implicit insecure
-        // preprocessing fallback; otherwise the parameters stored during
-        // preprocessing take precedence.
         dkg_params_of_request,
         internal_keyset_config,
         eip712_domain,
@@ -99,44 +93,41 @@ pub async fn key_gen_impl<
         ));
     }
 
-    let preproc_id = resolve_keygen_preproc_id(op_tag, req_id, preproc_id, insecure)?;
-    let stored_preproc_exists = service
-        .preprocessing_meta_store
-        .read()
-        .await
-        .exists(&preproc_id);
-    let implicit_insecure_preproc =
-        insecure && preproc_id == *INSECURE_PREPROCESSING_ID && !stored_preproc_exists;
+    let preproc_id = preproc_id.ok_or_else(|| {
+        MetricedError::new(
+            op_tag,
+            Some(req_id),
+            anyhow::anyhow!("Missing preprocessing ID in key generation request"),
+            tonic::Code::InvalidArgument,
+        )
+    })?;
 
     // Check for existence of request preprocessing ID
     // also check that the request ID is not used yet
     // If all is ok write the request ID to the meta store
     // All validation must be done before inserting the request ID
     let (params, permit) = {
-        // Explicit preprocessing entries must exist. The implicit insecure fallback
-        // has no stored preprocessing entry and uses the request/default params.
-        let stored_dkg_params = if implicit_insecure_preproc {
-            None
-        } else {
-            let preproc = retrieve_from_meta_store(
-                service.preprocessing_meta_store.read().await,
-                &preproc_id,
+        let preproc = retrieve_from_meta_store(
+            service.preprocessing_meta_store.read().await,
+            &preproc_id,
+            op_tag,
+        )
+        .await
+        .map_err(|e| {
+            // Remap the error to include the correct request ID
+            MetricedError::new(
                 op_tag,
+                Some(req_id),
+                anyhow::anyhow!(e.internal_err().to_string()),
+                e.code(),
             )
-            .await
-            .map_err(|e| {
-                // Remap the error to include the correct request ID
-                MetricedError::new(
-                    op_tag,
-                    Some(req_id),
-                    anyhow::anyhow!(e.internal_err().to_string()),
-                    e.code(),
-                )
-            })?;
-            Some(preproc.dkg_param)
+        })?;
+        // Request params take precedence; otherwise use the params stored during preprocessing.
+        let params = if request_params_set {
+            dkg_params_of_request
+        } else {
+            preproc.dkg_param
         };
-        let params =
-            select_keygen_dkg_params(dkg_params_of_request, request_params_set, stored_dkg_params);
 
         // Ensure that no key already exists for a given request.
         let already_exists = service
@@ -206,21 +197,19 @@ pub async fn key_gen_impl<
     let preproc_meta_store = Arc::clone(&service.preprocessing_meta_store);
     let keygen_background = async move {
         // "Remove" the preprocessing material by deleting its entry from the meta store
-        if !implicit_insecure_preproc {
-            tracing::info!("Deleting preprocessed material with ID {preproc_id} from meta store");
-            let handle = {
-                let mut meta_store_guard = preproc_meta_store.write().await;
-                meta_store_guard.delete(&preproc_id)
-            };
-            match handle_res(handle, &preproc_id).await {
-                Ok(_) => {
-                    tracing::info!(
-                        "Successfully deleted preprocessing ID {preproc_id} after keygen completion for request ID {req_id}"
-                    );
-                }
-                Err(e) => {
-                    MetricedError::handle_unreturnable_error(op_tag, Some(req_id), e);
-                }
+        tracing::info!("Deleting preprocessed material with ID {preproc_id} from meta store");
+        let handle = {
+            let mut meta_store_guard = preproc_meta_store.write().await;
+            meta_store_guard.delete(&preproc_id)
+        };
+        match handle_res(handle, &preproc_id).await {
+            Ok(_) => {
+                tracing::info!(
+                    "Successfully deleted preprocessing ID {preproc_id} after keygen completion for request ID {req_id}"
+                );
+            }
+            Err(e) => {
+                MetricedError::handle_unreturnable_error(op_tag, Some(req_id), e);
             }
         }
         key_gen_background(
@@ -690,62 +679,13 @@ pub(crate) mod tests {
         assert_eq!(err.code(), tonic::Code::NotFound);
     }
 
-    /// The insecure keygen works without a preprocessing ID (and without any
-    /// prior preprocessing call): the server uses the well-known
-    /// INSECURE_PREPROCESSING_ID as an implicit one-shot dummy preprocessing.
+    /// The insecure keygen must reject a request without a preprocessing ID.
     #[cfg(feature = "insecure")]
     #[tokio::test]
-    async fn insecure_keygen_default_preproc_id() {
+    async fn insecure_keygen_missing_preproc_id() {
         let mut rng = AesRng::seed_from_u64(42);
         let (kms, _) = setup_central_test_kms(&mut rng).await;
-        let request_id = derive_request_id("test_insecure_keygen_default_preproc").unwrap();
-        test_standard_keygen(&kms, &request_id, None, true).await;
-        let result = get_key_gen_result_impl(&kms, tonic::Request::new(request_id.into()), true)
-            .await
-            .unwrap()
-            .into_inner();
-        assert_eq!(
-            RequestId::try_from(result.preprocessing_id.unwrap()).unwrap(),
-            *INSECURE_PREPROCESSING_ID
-        );
-
-        // The implicit preprocessing path must not create a metastore entry.
-        assert!(
-            !kms.preprocessing_meta_store
-                .read()
-                .await
-                .exists(&INSECURE_PREPROCESSING_ID)
-        );
-
-        // A second keygen without a preprocessing ID must work too,
-        // using a fresh implicit entry. Also pass the well-known ID explicitly to
-        // check that it behaves the same as an absent one.
-        let other_request_id =
-            derive_request_id("test_insecure_keygen_default_preproc_other").unwrap();
-        test_standard_keygen(
-            &kms,
-            &other_request_id,
-            Some(&INSECURE_PREPROCESSING_ID),
-            true,
-        )
-        .await;
-    }
-
-    /// The implicit insecure preprocessing path uses the well-known ID, so an
-    /// ongoing keygen with that ID must be rejected instead of overwriting the
-    /// existing cancellation token.
-    #[cfg(feature = "insecure")]
-    #[tokio::test]
-    async fn insecure_keygen_default_preproc_id_already_ongoing() {
-        let mut rng = AesRng::seed_from_u64(42);
-        let (kms, _) = setup_central_test_kms(&mut rng).await;
-        let token = CancellationToken::new();
-        kms.ongoing_key_gen
-            .lock()
-            .await
-            .insert(*INSECURE_PREPROCESSING_ID, token.clone());
-
-        let request_id = derive_request_id("test_insecure_keygen_default_preproc_ongoing").unwrap();
+        let request_id = derive_request_id("test_insecure_keygen_missing_preproc_id").unwrap();
         let request = KeyGenRequest {
             params: Some(FheParameter::Test.into()),
             keyset_config: None,
@@ -761,14 +701,7 @@ pub(crate) mod tests {
         let err = key_gen_impl(&kms, tonic::Request::new(request), true)
             .await
             .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::AlreadyExists);
-        assert!(!token.is_cancelled());
-        assert!(
-            kms.ongoing_key_gen
-                .lock()
-                .await
-                .contains_key(&INSECURE_PREPROCESSING_ID)
-        );
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 
     /// The secure keygen must reject a request without a preprocessing ID.

--- a/core/service/src/engine/centralized/service/key_gen.rs
+++ b/core/service/src/engine/centralized/service/key_gen.rs
@@ -1,5 +1,8 @@
 use crate::cryptography::signatures::PrivateSigKey;
-use crate::engine::base::{DSEP_PUBDATA_KEY, KeyGenMetadata, compute_info_decompression_keygen};
+use crate::engine::base::{
+    DSEP_PUBDATA_KEY, INSECURE_PREPROCESSING_ID, KeyGenMetadata, compute_info_decompression_keygen,
+    resolve_keygen_preproc_id, select_keygen_dkg_params,
+};
 use crate::engine::centralized::central_kms::{
     CentralizedKeyGenResult, CentralizedKms, async_generate_decompression_keys,
     async_generate_fhe_keys,
@@ -65,13 +68,17 @@ pub async fn key_gen_impl<
         .start();
 
     let inner = request.into_inner();
+    let request_params_set = inner.params.is_some();
 
     let (
         req_id,
         preproc_id,
         context_id,
         epoch_id,
-        dkg_params,
+        // The DKG parameters of the request are used by the implicit insecure
+        // preprocessing fallback; otherwise the parameters stored during
+        // preprocessing take precedence.
+        dkg_params_of_request,
         internal_keyset_config,
         eip712_domain,
         extra_data,
@@ -92,13 +99,25 @@ pub async fn key_gen_impl<
         ));
     }
 
+    let preproc_id = resolve_keygen_preproc_id(op_tag, req_id, preproc_id, insecure)?;
+    let stored_preproc_exists = service
+        .preprocessing_meta_store
+        .read()
+        .await
+        .exists(&preproc_id);
+    let implicit_insecure_preproc =
+        insecure && preproc_id == *INSECURE_PREPROCESSING_ID && !stored_preproc_exists;
+
     // Check for existence of request preprocessing ID
     // also check that the request ID is not used yet
     // If all is ok write the request ID to the meta store
     // All validation must be done before inserting the request ID
     let (params, permit) = {
-        // If we're in insecure mode, we skip removing preprocessed material since it may not exist
-        let params = if !insecure {
+        // Explicit preprocessing entries must exist. The implicit insecure fallback
+        // has no stored preprocessing entry and uses the request/default params.
+        let stored_dkg_params = if implicit_insecure_preproc {
+            None
+        } else {
             let preproc = retrieve_from_meta_store(
                 service.preprocessing_meta_store.read().await,
                 &preproc_id,
@@ -114,10 +133,10 @@ pub async fn key_gen_impl<
                     e.code(),
                 )
             })?;
-            preproc.dkg_param
-        } else {
-            dkg_params
+            Some(preproc.dkg_param)
         };
+        let params =
+            select_keygen_dkg_params(dkg_params_of_request, request_params_set, stored_dkg_params);
 
         // Ensure that no key already exists for a given request.
         let already_exists = service
@@ -138,11 +157,6 @@ pub async fn key_gen_impl<
             ));
         }
 
-        // check that the request ID is not used yet
-        // and then insert the request ID only if it's unused
-        // all validation must be done before inserting the request ID
-        add_req_to_meta_store(&mut service.key_meta_map.write().await, &req_id, op_tag)?;
-
         (params, permit)
     };
 
@@ -162,12 +176,29 @@ pub async fn key_gen_impl<
 
     let token = CancellationToken::new();
     {
-        service
-            .ongoing_key_gen
-            .lock()
-            .await
-            .insert(preproc_id, token.clone());
+        let mut ongoing_key_gen = service.ongoing_key_gen.lock().await;
+        if ongoing_key_gen.contains_key(&preproc_id) {
+            return Err(MetricedError::new(
+                op_tag,
+                Some(req_id),
+                anyhow::anyhow!(
+                    "Key generation with preprocessing ID {preproc_id} is already ongoing"
+                ),
+                tonic::Code::AlreadyExists,
+            ));
+        }
+        ongoing_key_gen.insert(preproc_id, token.clone());
     }
+
+    // check that the request ID is not used yet
+    // and then insert the request ID only if it's unused
+    // all validation must be done before inserting the request ID
+    if let Err(e) = add_req_to_meta_store(&mut service.key_meta_map.write().await, &req_id, op_tag)
+    {
+        service.ongoing_key_gen.lock().await.remove(&preproc_id);
+        return Err(e);
+    }
+
     let ongoing = Arc::clone(&service.ongoing_key_gen);
     let crypto_storage = service.crypto_storage.clone();
     let crypto_storage_cancel = service.crypto_storage.clone();
@@ -175,19 +206,21 @@ pub async fn key_gen_impl<
     let preproc_meta_store = Arc::clone(&service.preprocessing_meta_store);
     let keygen_background = async move {
         // "Remove" the preprocessing material by deleting its entry from the meta store
-        tracing::info!("Deleting preprocessed material with ID {preproc_id} from meta store");
-        let handle = {
-            let mut meta_store_guard = preproc_meta_store.write().await;
-            meta_store_guard.delete(&preproc_id)
-        };
-        match handle_res(handle, &preproc_id).await {
-            Ok(_) => {
-                tracing::info!(
-                    "Successfully deleted preprocessing ID {preproc_id} after keygen completion for request ID {req_id}"
-                );
-            }
-            Err(e) => {
-                MetricedError::handle_unreturnable_error(op_tag, Some(req_id), e);
+        if !implicit_insecure_preproc {
+            tracing::info!("Deleting preprocessed material with ID {preproc_id} from meta store");
+            let handle = {
+                let mut meta_store_guard = preproc_meta_store.write().await;
+                meta_store_guard.delete(&preproc_id)
+            };
+            match handle_res(handle, &preproc_id).await {
+                Ok(_) => {
+                    tracing::info!(
+                        "Successfully deleted preprocessing ID {preproc_id} after keygen completion for request ID {req_id}"
+                    );
+                }
+                Err(e) => {
+                    MetricedError::handle_unreturnable_error(op_tag, Some(req_id), e);
+                }
             }
         }
         key_gen_background(
@@ -587,7 +620,7 @@ pub(crate) mod tests {
     pub(crate) async fn test_standard_keygen(
         kms: &RealCentralizedKms<RamStorage, RamStorage>,
         req_id: &RequestId,
-        preproc_id: &RequestId,
+        preproc_id: Option<&RequestId>,
         insecure: bool,
     ) {
         let request = KeyGenRequest {
@@ -596,7 +629,7 @@ pub(crate) mod tests {
             keyset_added_info: None,
             request_id: Some((*req_id).into()),
             context_id: None,
-            preproc_id: Some((*preproc_id).into()),
+            preproc_id: preproc_id.map(|id| (*id).into()),
             domain: Some(alloy_to_protobuf_domain(&dummy_domain()).unwrap()),
             epoch_id: None,
             extra_data: vec![],
@@ -617,7 +650,149 @@ pub(crate) mod tests {
         let preproc_id = derive_request_id("test_keygen_sunshine_preproc").unwrap();
         let (kms, _) = setup_test_kms_with_preproc(&mut rng, &preproc_id).await;
         let request_id = derive_request_id("test_keygen_sunshine").unwrap();
-        test_standard_keygen(&kms, &request_id, &preproc_id, false).await
+        test_standard_keygen(&kms, &request_id, Some(&preproc_id), false).await
+    }
+
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_sunshine() {
+        let mut rng = AesRng::seed_from_u64(42);
+        let preproc_id = derive_request_id("test_insecure_keygen_sunshine_preproc").unwrap();
+        let (kms, _) = setup_test_kms_with_preproc(&mut rng, &preproc_id).await;
+        let request_id = derive_request_id("test_insecure_keygen_sunshine").unwrap();
+        test_standard_keygen(&kms, &request_id, Some(&preproc_id), true).await
+    }
+
+    /// The insecure keygen must fail when the preprocessing ID was never registered,
+    /// just like the secure keygen.
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_keygen_preproc_not_found() {
+        let mut rng = AesRng::seed_from_u64(42);
+        let (kms, _) = setup_central_test_kms(&mut rng).await;
+        let preproc_id = derive_request_id("test_insecure_keygen_missing_preproc").unwrap();
+        let request_id = derive_request_id("test_insecure_keygen_missing_preproc_key").unwrap();
+
+        let request = KeyGenRequest {
+            params: Some(FheParameter::Test.into()),
+            keyset_config: None,
+            keyset_added_info: None,
+            request_id: Some(request_id.into()),
+            context_id: None,
+            preproc_id: Some(preproc_id.into()),
+            domain: Some(alloy_to_protobuf_domain(&dummy_domain()).unwrap()),
+            epoch_id: None,
+            extra_data: vec![],
+        };
+        let err = key_gen_impl(&kms, tonic::Request::new(request), true)
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    /// The insecure keygen works without a preprocessing ID (and without any
+    /// prior preprocessing call): the server uses the well-known
+    /// INSECURE_PREPROCESSING_ID as an implicit one-shot dummy preprocessing.
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_keygen_default_preproc_id() {
+        let mut rng = AesRng::seed_from_u64(42);
+        let (kms, _) = setup_central_test_kms(&mut rng).await;
+        let request_id = derive_request_id("test_insecure_keygen_default_preproc").unwrap();
+        test_standard_keygen(&kms, &request_id, None, true).await;
+        let result = get_key_gen_result_impl(&kms, tonic::Request::new(request_id.into()), true)
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            RequestId::try_from(result.preprocessing_id.unwrap()).unwrap(),
+            *INSECURE_PREPROCESSING_ID
+        );
+
+        // The implicit preprocessing path must not create a metastore entry.
+        assert!(
+            !kms.preprocessing_meta_store
+                .read()
+                .await
+                .exists(&INSECURE_PREPROCESSING_ID)
+        );
+
+        // A second keygen without a preprocessing ID must work too,
+        // using a fresh implicit entry. Also pass the well-known ID explicitly to
+        // check that it behaves the same as an absent one.
+        let other_request_id =
+            derive_request_id("test_insecure_keygen_default_preproc_other").unwrap();
+        test_standard_keygen(
+            &kms,
+            &other_request_id,
+            Some(&INSECURE_PREPROCESSING_ID),
+            true,
+        )
+        .await;
+    }
+
+    /// The implicit insecure preprocessing path uses the well-known ID, so an
+    /// ongoing keygen with that ID must be rejected instead of overwriting the
+    /// existing cancellation token.
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_keygen_default_preproc_id_already_ongoing() {
+        let mut rng = AesRng::seed_from_u64(42);
+        let (kms, _) = setup_central_test_kms(&mut rng).await;
+        let token = CancellationToken::new();
+        kms.ongoing_key_gen
+            .lock()
+            .await
+            .insert(*INSECURE_PREPROCESSING_ID, token.clone());
+
+        let request_id = derive_request_id("test_insecure_keygen_default_preproc_ongoing").unwrap();
+        let request = KeyGenRequest {
+            params: Some(FheParameter::Test.into()),
+            keyset_config: None,
+            keyset_added_info: None,
+            request_id: Some(request_id.into()),
+            context_id: None,
+            preproc_id: None,
+            domain: Some(alloy_to_protobuf_domain(&dummy_domain()).unwrap()),
+            epoch_id: None,
+            extra_data: vec![],
+        };
+
+        let err = key_gen_impl(&kms, tonic::Request::new(request), true)
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::AlreadyExists);
+        assert!(!token.is_cancelled());
+        assert!(
+            kms.ongoing_key_gen
+                .lock()
+                .await
+                .contains_key(&INSECURE_PREPROCESSING_ID)
+        );
+    }
+
+    /// The secure keygen must reject a request without a preprocessing ID.
+    #[tokio::test]
+    async fn secure_keygen_missing_preproc_id() {
+        let mut rng = AesRng::seed_from_u64(42);
+        let (kms, _) = setup_central_test_kms(&mut rng).await;
+        let request_id = derive_request_id("test_keygen_missing_preproc_id").unwrap();
+
+        let request = KeyGenRequest {
+            params: Some(FheParameter::Test.into()),
+            keyset_config: None,
+            keyset_added_info: None,
+            request_id: Some(request_id.into()),
+            context_id: None,
+            preproc_id: None,
+            domain: Some(alloy_to_protobuf_domain(&dummy_domain()).unwrap()),
+            epoch_id: None,
+            extra_data: vec![],
+        };
+        let err = key_gen_impl(&kms, tonic::Request::new(request), false)
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 
     #[tokio::test]
@@ -870,6 +1045,22 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
+        // The first key generation consumed the preprocessing entry, so register
+        // it again to make sure the second request fails on the duplicate request
+        // ID and not on the missing preprocessing.
+        let preproc_req = KeyGenPreprocRequest {
+            params: FheParameter::Test.into(),
+            keyset_config: None,
+            request_id: Some(preproc_id.into()),
+            context_id: None,
+            domain: Some(domain.clone()),
+            epoch_id: None,
+            extra_data: vec![],
+        };
+        preprocessing_impl(&kms, tonic::Request::new(preproc_req))
+            .await
+            .unwrap();
+
         let err = key_gen_impl(
             &kms,
             tonic::Request::new(request.clone()),
@@ -893,7 +1084,7 @@ pub(crate) mod tests {
         // the second one should fail with not found because the preprocessing ID is removed after use
         {
             // Execute, emulating a secure key generation, i.e. with "emulated" preprocessing
-            test_standard_keygen(&kms, &request_id, &preproc_id, false).await;
+            test_standard_keygen(&kms, &request_id, Some(&preproc_id), false).await;
 
             let new_request_id = derive_request_id("test_keygen_already_exists_key_id_2").unwrap();
             let request = KeyGenRequest {

--- a/core/service/src/engine/threshold/endpoint.rs
+++ b/core/service/src/engine/threshold/endpoint.rs
@@ -68,6 +68,26 @@ impl_endpoint! {
             self.keygen_preprocessor.partial_key_gen_preproc(request).await.map_err(|e| e.into())
         }
 
+        #[cfg(feature = "insecure")]
+        #[tracing::instrument(skip(self, request))]
+        async fn insecure_key_gen_preproc(
+            &self,
+            request: Request<KeyGenPreprocRequest>,
+        ) -> Result<Response<Empty>, Status> {
+            METRICS.increment_request_counter(OP_INSECURE_KEYGEN_PREPROC_REQUEST);
+            self.keygen_preprocessor.insecure_key_gen_preproc(request).await.map_err(|e| e.into())
+        }
+
+        #[cfg(feature = "insecure")]
+        #[tracing::instrument(skip(self, request))]
+        async fn get_insecure_key_gen_preproc_result(
+            &self,
+            request: Request<RequestId>,
+        ) -> Result<Response<KeyGenPreprocResult>, Status> {
+            METRICS.increment_request_counter(OP_INSECURE_KEYGEN_PREPROC_RESULT);
+            self.keygen_preprocessor.get_insecure_result(request).await.map_err(|e| e.into())
+        }
+
         #[tracing::instrument(skip(self, request))]
         async fn get_key_gen_preproc_result(
             &self,

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -54,7 +54,7 @@ use crate::{
         base::{
             BaseKmsStruct, DSEP_PUBDATA_KEY, KeyGenMetadata, compute_info_compressed_keygen,
             compute_info_decompression_keygen, compute_info_uncompressed_keygen,
-            retrieve_parameters,
+            resolve_keygen_preproc_id, select_keygen_dkg_params,
         },
         keyset_configuration::InternalKeySetConfig,
         threshold::{
@@ -84,7 +84,7 @@ use crate::{
 };
 
 // === Current Module Imports ===
-use super::BucketMetaStore;
+use super::{BucketMetaStore, PreprocMaterial};
 
 const DKG_Z64_SESSION_COUNTER: u64 = 1;
 const DKG_Z128_SESSION_COUNTER: u64 = 2;
@@ -183,7 +183,7 @@ impl<
                 ongoing: Arc::clone(&value.ongoing),
                 rate_limiter: value.rate_limiter.clone(),
                 _kg: std::marker::PhantomData,
-                serial_lock: Arc::new(Mutex::new(())),
+                serial_lock: Arc::clone(&value.serial_lock),
             },
         }
     }
@@ -235,7 +235,30 @@ pub enum PreprocHandleWithMode {
             Arc<Mutex<Box<dyn DKGPreprocessing<ResiduePolyF4Z128>>>>,
         ),
     ),
-    Insecure,
+    Insecure(RequestId),
+}
+
+impl PreprocHandleWithMode {
+    fn preprocessing_id(&self) -> RequestId {
+        match self {
+            Self::Secure((preproc_id, _)) | Self::Insecure(preproc_id) => *preproc_id,
+        }
+    }
+}
+
+/// Outcome of [`RealKeyGenerator::resolve_preprocessing`]: everything the DKG
+/// launch needs to know about the preprocessing backing a key generation request.
+struct ResolvedPreprocessing {
+    /// The preprocessing handle (real material or insecure marker) together with
+    /// its preprocessing ID.
+    handle: PreprocHandleWithMode,
+    /// DKG parameters to run with. These are the parameters from the request if
+    /// it set them, otherwise the parameters stored during preprocessing.
+    dkg_params: DKGParams,
+    /// Whether the preprocessing entry should be deleted from the meta store once
+    /// the keygen starts. This is `true` for stored entries (real or insecure) and
+    /// `false` for the implicit insecure fallback, which has no stored entry.
+    consume_preproc_entry: bool,
 }
 
 #[cfg(feature = "insecure")]
@@ -260,16 +283,19 @@ impl<
     #[expect(clippy::too_many_arguments)]
     async fn launch_dkg(
         &self,
-        dkg_params: DKGParams,
         internal_keyset_config: InternalKeySetConfig,
-        preproc_handle_w_mode: PreprocHandleWithMode,
+        resolved_preprocessing: ResolvedPreprocessing,
         req_id: RequestId,
         eip712_domain: &alloy_sol_types::Eip712Domain,
         extra_data: Vec<u8>,
         context_id: ContextId,
         epoch_id: EpochId,
         permit: OwnedSemaphorePermit,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), MetricedError> {
+        let preproc_handle_w_mode = resolved_preprocessing.handle;
+        let dkg_params = resolved_preprocessing.dkg_params;
+        let consume_preproc_entry = resolved_preprocessing.consume_preproc_entry;
+
         //Retrieve the right metric tag
         let op_tag = match (
             &preproc_handle_w_mode,
@@ -287,7 +313,7 @@ impl<
                 ddec_keyset_config::KeySetConfig::DecompressionOnly,
             ) => OP_DECOMPRESSION_KEYGEN,
             (
-                PreprocHandleWithMode::Insecure,
+                PreprocHandleWithMode::Insecure(_),
                 ddec_keyset_config::KeySetConfig::Standard(inner),
             ) => match inner.compressed_key_config {
                 ddec_keyset_config::CompressedKeyConfig::None => OP_INSECURE_STANDARD_KEYGEN,
@@ -296,7 +322,7 @@ impl<
                 }
             },
             (
-                PreprocHandleWithMode::Insecure,
+                PreprocHandleWithMode::Insecure(_),
                 ddec_keyset_config::KeySetConfig::DecompressionOnly,
             ) => OP_INSECURE_DECOMPRESSION_KEYGEN,
         };
@@ -308,7 +334,11 @@ impl<
 
         // Prepare the timer before giving it to the tokio task
         // that runs the computation
-        let my_role = self.session_maker.my_role(&context_id).await?;
+        let my_role = self
+            .session_maker
+            .my_role(&context_id)
+            .await
+            .map_err(|e| MetricedError::new(op_tag, Some(req_id), e, tonic::Code::Internal))?;
         let timer = metrics::METRICS
             .time_operation(op_tag)
             .tag(TAG_PARTY_ID, my_role.to_string());
@@ -317,17 +347,22 @@ impl<
         // Note that not all the sessions is going to be needed,
         // but to keep the code clean, we just make all the possible sessions.
         let dkg_sessions = {
-            let session_id_z64 = req_id.derive_session_id_with_counter(DKG_Z64_SESSION_COUNTER)?;
-            let session_id_z128 =
-                req_id.derive_session_id_with_counter(DKG_Z128_SESSION_COUNTER)?;
+            let session_id_z64 = req_id
+                .derive_session_id_with_counter(DKG_Z64_SESSION_COUNTER)
+                .map_err(|e| MetricedError::new(op_tag, Some(req_id), e, tonic::Code::Internal))?;
+            let session_id_z128 = req_id
+                .derive_session_id_with_counter(DKG_Z128_SESSION_COUNTER)
+                .map_err(|e| MetricedError::new(op_tag, Some(req_id), e, tonic::Code::Internal))?;
             let session_z64 = self
                 .session_maker
                 .make_small_async_session_z64(session_id_z64, context_id, epoch_id)
-                .await?;
+                .await
+                .map_err(|e| MetricedError::new(op_tag, Some(req_id), e, tonic::Code::Internal))?;
             let session_z128 = self
                 .session_maker
                 .make_small_async_session_z128(session_id_z128, context_id, epoch_id)
-                .await?;
+                .await
+                .map_err(|e| MetricedError::new(op_tag, Some(req_id), e, tonic::Code::Internal))?;
             DkgSessions {
                 session_z64,
                 session_z128,
@@ -337,33 +372,15 @@ impl<
         // Clone all the Arcs to give them to the tokio thread
         let meta_store = Arc::clone(&self.dkg_pubinfo_meta_store);
         let meta_store_cancelled = Arc::clone(&self.dkg_pubinfo_meta_store);
-        let sk = self.base_kms.sig_key()?;
+        let sk = self.base_kms.sig_key().map_err(|e| {
+            MetricedError::new(op_tag, Some(req_id), e, tonic::Code::FailedPrecondition)
+        })?;
         let crypto_storage = self.crypto_storage.clone();
         let crypto_storage_cancelled = self.crypto_storage.clone();
         let eip712_domain_copy = eip712_domain.clone();
         let ongoing = Arc::clone(&self.ongoing);
 
-        let preproc_id = match &preproc_handle_w_mode {
-            PreprocHandleWithMode::Secure((preproc_id, _)) => *preproc_id,
-            PreprocHandleWithMode::Insecure => {
-                #[cfg(not(feature = "insecure"))]
-                {
-                    panic!(
-                        "attempting to call insecure keygen when the insecure feature is not set"
-                    );
-                }
-                #[cfg(feature = "insecure")]
-                {
-                    // NOTE that using a static preprocessing ID for the insecure keygen
-                    // This means that concurrent calls to the insecure keygen are not allowed!
-                    *INSECURE_PREPROCESSING_ID
-                }
-            }
-        };
-        let token = CancellationToken::new();
-        {
-            self.ongoing.lock().await.insert(preproc_id, token.clone());
-        }
+        let preproc_id = preproc_handle_w_mode.preprocessing_id();
 
         // we need to clone the req ID because async closures are not stable
         let req_id_clone = req_id;
@@ -371,12 +388,25 @@ impl<
         let preproc_bucket = self.preproc_buckets.clone();
 
         // we must validate the parameter before passing it into the background process
-        internal_keyset_config.validate()?;
+        internal_keyset_config.validate().map_err(|e| {
+            MetricedError::new(op_tag, Some(req_id), e, tonic::Code::InvalidArgument)
+        })?;
 
         // Read existing key tag from public storage if needed
         let existing_key_tag: Option<tfhe::Tag> = if internal_keyset_config.use_existing_key_tag() {
-            let existing_keyset_id = internal_keyset_config.get_existing_keyset_id()?;
-            Some(Self::read_existing_key_tag(&crypto_storage, &existing_keyset_id).await?)
+            let existing_keyset_id =
+                internal_keyset_config
+                    .get_existing_keyset_id()
+                    .map_err(|e| {
+                        MetricedError::new(op_tag, Some(req_id), e, tonic::Code::InvalidArgument)
+                    })?;
+            Some(
+                Self::read_existing_key_tag(&crypto_storage, &existing_keyset_id)
+                    .await
+                    .map_err(|e| {
+                        MetricedError::new(op_tag, Some(req_id), e, tonic::Code::Internal)
+                    })?,
+            )
         } else {
             None
         };
@@ -398,43 +428,67 @@ impl<
                         ddec_keyset_config::CompressedKeyConfig::All
                     ) =>
                 {
-                    let existing_keyset_id = internal_keyset_config.get_existing_keyset_id()?;
+                    let existing_keyset_id = internal_keyset_config
+                        .get_existing_keyset_id()
+                        .map_err(|e| {
+                            MetricedError::new(
+                                op_tag,
+                                Some(req_id),
+                                e,
+                                tonic::Code::InvalidArgument,
+                            )
+                        })?;
                     Some(
                         Self::read_existing_compact_public_key(
                             &crypto_storage,
                             &existing_keyset_id,
                             &epoch_id,
                         )
-                        .await?,
+                        .await
+                        .map_err(|e| {
+                            MetricedError::new(op_tag, Some(req_id), e, tonic::Code::Internal)
+                        })?,
                     )
                 }
                 _ => None,
             };
 
+        let token = CancellationToken::new();
+        {
+            let mut ongoing_lock = self.ongoing.lock().await;
+            if ongoing_lock.contains_key(&preproc_id) {
+                return Err(MetricedError::new(
+                    op_tag,
+                    Some(req_id),
+                    anyhow::anyhow!(
+                        "Key generation with preprocessing ID {preproc_id} is already ongoing"
+                    ),
+                    tonic::Code::AlreadyExists,
+                ));
+            }
+            ongoing_lock.insert(preproc_id, token.clone());
+        }
+
         let keygen_background = async move {
-            // Remove the preprocessing material
-            match &preproc_handle_w_mode {
-                PreprocHandleWithMode::Secure((preproc_id, _)) => {
-                    tracing::info!(
-                        "Deleting preprocessed material with ID {preproc_id} from meta store"
-                    );
-                    let handle = {
-                        let mut meta_store_guard = preproc_bucket.write().await;
-                        meta_store_guard.delete(preproc_id)
-                    };
-                    match handle_res(handle, preproc_id).await {
-                        Ok(_) => {
-                            tracing::info!(
-                                "Successfully deleted preprocessing ID {preproc_id} after keygen completion for request ID {req_id}"
-                            );
-                        }
-                        Err(e) => {
-                            MetricedError::handle_unreturnable_error(op_tag, Some(req_id), e);
-                        }
+            // Remove the preprocessing entry from the meta store.
+            // Implicit insecure preprocessing has no stored entry to consume.
+            if consume_preproc_entry {
+                tracing::info!(
+                    "Deleting preprocessed material with ID {preproc_id} from meta store"
+                );
+                let handle = {
+                    let mut meta_store_guard = preproc_bucket.write().await;
+                    meta_store_guard.delete(&preproc_id)
+                };
+                match handle_res(handle, &preproc_id).await {
+                    Ok(_) => {
+                        tracing::info!(
+                            "Successfully deleted preprocessing ID {preproc_id} after keygen completion for request ID {req_id}"
+                        );
                     }
-                }
-                PreprocHandleWithMode::Insecure => {
-                    // Nothing to remove
+                    Err(e) => {
+                        MetricedError::handle_unreturnable_error(op_tag, Some(req_id), e);
+                    }
                 }
             }
 
@@ -526,13 +580,13 @@ impl<
         // Note: We increase the request counter only in launch_dkg
         // so we don't increase the error counter here either
         let inner = request.into_inner();
-        let params = inner.params;
+        let request_params_set = inner.params.is_some();
         let (
             req_id,
             preproc_id,
             context_id,
             epoch_id,
-            _dkg_params,
+            dkg_params_of_request,
             internal_keyset_config,
             eip712_domain,
             extra_data,
@@ -548,13 +602,14 @@ impl<
         let metric_tags = vec![(TAG_PARTY_ID, my_role.to_string())];
         timer.tags(metric_tags);
 
-        let (preproc_handle, dkg_params) =
-            // Processes the bucket meta information. This is a slightly funky as in certain situations it may override the DKGParams sepcified in the request
-            Self::retrieve_preproc_handle(
+        let resolved_preprocessing =
+            // Processes the bucket meta information. This is slightly funky as in certain situations it may override the DKGParams specified in the request.
+            Self::resolve_preprocessing(
                 self.preproc_buckets.read().await,
                 req_id,
                 preproc_id,
-                params,
+                dkg_params_of_request,
+                request_params_set,
                 insecure,
             )
             .await?;
@@ -590,19 +645,32 @@ impl<
             insecure
         );
 
-        self.launch_dkg(
-            dkg_params,
-            internal_keyset_config,
-            preproc_handle,
-            req_id,
-            &eip712_domain,
-            extra_data,
-            context_id,
-            epoch_id,
-            permit,
-        )
-        .await
-        .map_err(|e| MetricedError::new(op_tag, Some(req_id), e, tonic::Code::Internal))?;
+        if let Err(e) = self
+            .launch_dkg(
+                internal_keyset_config,
+                resolved_preprocessing,
+                req_id,
+                &eip712_domain,
+                extra_data,
+                context_id,
+                epoch_id,
+                permit,
+            )
+            .await
+        {
+            let launch_error = e.internal_err().to_string();
+            if let Err(update_error) = self
+                .dkg_pubinfo_meta_store
+                .write()
+                .await
+                .update(&req_id, Err(launch_error))
+            {
+                tracing::warn!(
+                    "Failed to mark key generation request {req_id} as failed after launch error: {update_error}"
+                );
+            }
+            return Err(e);
+        }
 
         //Always answer with Empty
         Ok(Response::new(Empty {}))
@@ -625,61 +693,106 @@ impl<
         }
     }
 
-    /// Retrieve the preprocessing handle, parameters and preprocessing ID from the request.
-    /// This method also does NOT delete the preprocessing entry from the meta store
-    async fn retrieve_preproc_handle(
+    /// Resolve the preprocessing handle, parameters and whether a stored entry should be consumed.
+    async fn resolve_preprocessing(
         bucket_metastore: RwLockReadGuard<'_, MetaStore<BucketMetaStore>>,
         key_req_id: RequestId,
-        preproc_id: RequestId,
-        params: Option<i32>,
+        preproc_id: Option<RequestId>,
+        request_dkg_params: DKGParams,
+        request_params_set: bool,
         insecure: bool,
-    ) -> Result<(PreprocHandleWithMode, DKGParams), MetricedError> {
+    ) -> Result<ResolvedPreprocessing, MetricedError> {
         // Retrieve the correct tag
         let op_tag = if insecure {
             OP_INSECURE_KEYGEN_REQUEST
         } else {
             OP_KEYGEN_REQUEST
         };
-        let standard_dkg_params = retrieve_parameters(params)
-            .map_err(|e| MetricedError::new(op_tag, Some(key_req_id), e, tonic::Code::Internal))?;
-        // If params are not set, then we need to retrieve the preprocessing
-        // unless we are in insecure mode.
-        // In the insecure mode the default parameters will be used if not set.
-        if insecure {
-            Ok((PreprocHandleWithMode::Insecure, standard_dkg_params))
-        } else {
-            let preproc_bucket =
-                retrieve_from_meta_store(bucket_metastore, &preproc_id, OP_KEYGEN_REQUEST)
-                    .await
-                    .map_err(|e| {
-                        // Remap the error to include the correct request ID
-                        MetricedError::new(
-                            OP_KEYGEN_REQUEST,
-                            Some(key_req_id),
-                            anyhow::anyhow!(e.internal_err().to_string()),
-                            e.code(),
-                        )
-                    })?;
-            if preproc_bucket.preprocessing_id != preproc_id {
-                return Err(MetricedError::new(
-                    op_tag,
-                    Some(key_req_id),
-                    format!(
-                        "Preprocessing ID mismatch: expected {}, found {}",
-                        preproc_id, preproc_bucket.preprocessing_id
-                    ),
-                    tonic::Code::Internal,
-                ));
-            }
-            let dkg_param = match params {
-                Some(_) => standard_dkg_params,
-                None => preproc_bucket.dkg_param,
+
+        let preproc_id = resolve_keygen_preproc_id(op_tag, key_req_id, preproc_id, insecure)?;
+
+        // Explicit preprocessing entries must exist. The implicit insecure
+        // fallback has no stored preprocessing entry.
+        let preproc_bucket =
+            match retrieve_from_meta_store(bucket_metastore, &preproc_id, op_tag).await {
+                Ok(bucket) => bucket,
+                #[cfg(feature = "insecure")]
+                Err(e)
+                    if insecure
+                        && preproc_id == *INSECURE_PREPROCESSING_ID
+                        && e.code() == tonic::Code::NotFound =>
+                {
+                    return Ok(ResolvedPreprocessing {
+                        handle: PreprocHandleWithMode::Insecure(preproc_id),
+                        dkg_params: request_dkg_params,
+                        consume_preproc_entry: false,
+                    });
+                }
+                Err(e) => {
+                    // Remap the error to include the correct request ID
+                    return Err(MetricedError::new(
+                        op_tag,
+                        Some(key_req_id),
+                        anyhow::anyhow!(e.internal_err().to_string()),
+                        e.code(),
+                    ));
+                }
             };
-            Ok((
-                PreprocHandleWithMode::Secure((preproc_id, preproc_bucket.preprocessing_store)),
-                dkg_param,
-            ))
+        if preproc_bucket.preprocessing_id != preproc_id {
+            return Err(MetricedError::new(
+                op_tag,
+                Some(key_req_id),
+                format!(
+                    "Preprocessing ID mismatch: expected {}, found {}",
+                    preproc_id, preproc_bucket.preprocessing_id
+                ),
+                tonic::Code::Internal,
+            ));
         }
+        // If params are set in the request they take precedence,
+        // otherwise the parameters stored during preprocessing are used.
+        let dkg_param = select_keygen_dkg_params(
+            request_dkg_params,
+            request_params_set,
+            Some(preproc_bucket.dkg_param),
+        );
+        // The mode of the keygen request must match the mode of the stored
+        // preprocessing: real material is required for the secure keygen and
+        // insecure (dummy) preprocessing may only be used by the insecure keygen.
+        let preproc_handle = match preproc_bucket.preprocessing_store {
+            PreprocMaterial::Real(preprocessing_store) => {
+                if insecure {
+                    return Err(MetricedError::new(
+                        op_tag,
+                        Some(key_req_id),
+                        format!(
+                            "Insecure keygen requires an insecure preprocessing, but preprocessing ID {preproc_id} holds real preprocessing material"
+                        ),
+                        tonic::Code::FailedPrecondition,
+                    ));
+                }
+                PreprocHandleWithMode::Secure((preproc_id, preprocessing_store))
+            }
+            #[cfg(feature = "insecure")]
+            PreprocMaterial::Insecure => {
+                if !insecure {
+                    return Err(MetricedError::new(
+                        op_tag,
+                        Some(key_req_id),
+                        format!(
+                            "Secure keygen requires real preprocessing material, but preprocessing ID {preproc_id} was generated by the insecure preprocessing"
+                        ),
+                        tonic::Code::FailedPrecondition,
+                    ));
+                }
+                PreprocHandleWithMode::Insecure(preproc_id)
+            }
+        };
+        Ok(ResolvedPreprocessing {
+            handle: preproc_handle,
+            dkg_params: dkg_param,
+            consume_preproc_entry: true,
+        })
     }
 
     async fn inner_get_result(
@@ -1018,10 +1131,11 @@ impl<
         let _permit = permit;
         let start = Instant::now();
         let (prep_id, dkg_res) = match preproc_handle_w_mode {
-            PreprocHandleWithMode::Insecure => {
+            PreprocHandleWithMode::Insecure(insecure_prep_id) => {
                 // sanity check to make sure we're using the insecure feature
                 #[cfg(not(feature = "insecure"))]
                 {
+                    let _ = insecure_prep_id;
                     panic!(
                         "attempting to call insecure compression keygen when the insecure feature is not set"
                     );
@@ -1029,7 +1143,7 @@ impl<
                 #[cfg(feature = "insecure")]
                 {
                     (
-                        *INSECURE_PREPROCESSING_ID,
+                        insecure_prep_id,
                         match Self::get_glwe_and_compression_key_shares(
                             keyset_added_info,
                             epoch_id,
@@ -1245,10 +1359,11 @@ impl<
         let _permit = permit;
         let start = Instant::now();
         let (prep_id, dkg_res) = match preproc_handle_w_mode {
-            PreprocHandleWithMode::Insecure => {
+            PreprocHandleWithMode::Insecure(insecure_prep_id) => {
                 // sanity check to make sure we're using the insecure feature
                 #[cfg(not(feature = "insecure"))]
                 {
+                    let _ = insecure_prep_id;
                     panic!(
                         "attempting to call insecure keygen when the insecure feature is not set"
                     );
@@ -1256,7 +1371,7 @@ impl<
                 #[cfg(feature = "insecure")]
                 {
                     (
-                        *INSECURE_PREPROCESSING_ID,
+                        insecure_prep_id,
                         match (
                             keyset_config.secret_key_config,
                             keyset_config.computation_key_type,
@@ -1807,6 +1922,8 @@ mod tests {
     };
     use threshold_types::network::NetworkMode;
 
+    #[cfg(feature = "insecure")]
+    use crate::consts::MAX_TRIES;
     use crate::{
         consts::{DEFAULT_EPOCH_ID, DEFAULT_MPC_CONTEXT, TEST_PARAM},
         dummy_domain,
@@ -1916,8 +2033,8 @@ mod tests {
             let dummy_prep = BucketMetaStore {
                 preprocessing_id: *prep_id,
                 external_signature: vec![],
-                preprocessing_store: Arc::new(Mutex::new(Box::new(DummyPreprocessing::new(
-                    42, &session,
+                preprocessing_store: PreprocMaterial::Real(Arc::new(Mutex::new(Box::new(
+                    DummyPreprocessing::new(42, &session),
                 )))),
                 dkg_param: TEST_PARAM,
             };
@@ -2285,6 +2402,255 @@ mod tests {
         let random_id = RequestId::new_random(&mut rng);
         let status = kg.abort_key_gen(random_id).await;
         assert_eq!(status.code(), tonic::Code::NotFound);
+    }
+
+    /// Insert an insecure (dummy) preprocessing bucket, as stored by the
+    /// insecure preprocessing endpoint, into the key generator's bucket store.
+    #[cfg(feature = "insecure")]
+    async fn insert_insecure_bucket<
+        KG: OnlineDistributedKeyGen<Z128, { ResiduePolyF4Z128::EXTENSION_DEGREE }> + 'static,
+    >(
+        kg: &RealKeyGenerator<ram::RamStorage, ram::RamStorage, KG>,
+        prep_id: &RequestId,
+    ) {
+        let bucket = BucketMetaStore {
+            preprocessing_id: *prep_id,
+            external_signature: vec![],
+            preprocessing_store: PreprocMaterial::Insecure,
+            dkg_param: TEST_PARAM,
+        };
+        let mut guarded_prep_bucket = kg.preproc_buckets.write().await;
+        guarded_prep_bucket.insert(prep_id).unwrap();
+        guarded_prep_bucket.update(prep_id, Ok(bucket)).unwrap();
+    }
+
+    #[cfg(feature = "insecure")]
+    fn keygen_request(
+        key_id: RequestId,
+        prep_id: Option<RequestId>,
+    ) -> tonic::Request<KeyGenRequest> {
+        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
+        tonic::Request::new(KeyGenRequest {
+            request_id: Some(key_id.into()),
+            params: Some(FheParameter::Test as i32),
+            preproc_id: prep_id.map(|id| id.into()),
+            domain: Some(domain),
+            keyset_config: None,
+            keyset_added_info: None,
+            context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
+            epoch_id: None,
+            extra_data: vec![],
+        })
+    }
+
+    /// The insecure keygen must reject a preprocessing bucket that holds real material.
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_keygen_rejects_real_bucket() {
+        let (prep_ids, kg) = setup_key_generator::<
+            DroppingOnlineDistributedKeyGen128<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
+        >()
+        .await;
+        let ikg = RealInsecureKeyGenerator::from_real_keygen(&kg).await;
+        let mut rng = AesRng::seed_from_u64(9);
+        let key_id = RequestId::new_random(&mut rng);
+
+        // prep_ids hold real (dummy) preprocessing material
+        assert_eq!(
+            ikg.insecure_key_gen(keygen_request(key_id, Some(prep_ids[0])))
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::FailedPrecondition
+        );
+    }
+
+    /// The secure keygen must reject a preprocessing bucket that was created
+    /// by the insecure preprocessing (i.e. holds no material).
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn secure_keygen_rejects_insecure_bucket() {
+        let (_prep_ids, kg) = setup_key_generator::<
+            DroppingOnlineDistributedKeyGen128<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
+        >()
+        .await;
+        let mut rng = AesRng::seed_from_u64(10);
+        let insecure_prep_id = RequestId::new_random(&mut rng);
+        insert_insecure_bucket(&kg, &insecure_prep_id).await;
+        let key_id = RequestId::new_random(&mut rng);
+
+        assert_eq!(
+            kg.key_gen(keygen_request(key_id, Some(insecure_prep_id)))
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::FailedPrecondition
+        );
+    }
+
+    /// The insecure keygen must fail if the preprocessing ID does not exist.
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_keygen_not_found() {
+        let (prep_ids, kg) = setup_key_generator::<
+            DroppingOnlineDistributedKeyGen128<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
+        >()
+        .await;
+        let ikg = RealInsecureKeyGenerator::from_real_keygen(&kg).await;
+        let mut rng = AesRng::seed_from_u64(11);
+        let key_id = RequestId::new_random(&mut rng);
+        let bad_prep_id = RequestId::new_random(&mut rng);
+        assert!(!prep_ids.contains(&bad_prep_id));
+
+        assert_eq!(
+            ikg.insecure_key_gen(keygen_request(key_id, Some(bad_prep_id)))
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::NotFound
+        );
+    }
+
+    /// The insecure keygen consumes the insecure preprocessing entry, so a
+    /// second keygen with the same preprocessing ID must fail with `NotFound`.
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_keygen_consumes_preproc() {
+        let (_prep_ids, kg) = setup_key_generator::<
+            DroppingOnlineDistributedKeyGen128<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
+        >()
+        .await;
+        let ikg = RealInsecureKeyGenerator::from_real_keygen(&kg).await;
+        let mut rng = AesRng::seed_from_u64(12);
+        let insecure_prep_id = RequestId::new_random(&mut rng);
+        insert_insecure_bucket(&kg, &insecure_prep_id).await;
+        let key_id = RequestId::new_random(&mut rng);
+
+        ikg.insecure_key_gen(keygen_request(key_id, Some(insecure_prep_id)))
+            .await
+            .unwrap();
+
+        // The preprocessing entry is deleted at the start of the background task,
+        // independently of whether the key generation itself succeeds.
+        let mut deleted = false;
+        for _ in 0..MAX_TRIES {
+            if !kg.preproc_buckets.read().await.exists(&insecure_prep_id) {
+                deleted = true;
+                break;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+        assert!(deleted, "insecure preprocessing entry was not consumed");
+
+        // A second keygen with the same preprocessing ID must fail
+        let other_key_id = RequestId::new_random(&mut rng);
+        assert_eq!(
+            ikg.insecure_key_gen(keygen_request(other_key_id, Some(insecure_prep_id)))
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::NotFound
+        );
+    }
+
+    /// The insecure keygen works without a preprocessing ID (and without any
+    /// prior preprocessing call): the server uses the well-known
+    /// INSECURE_PREPROCESSING_ID as an implicit one-shot dummy preprocessing.
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_keygen_default_preproc_id() {
+        let (_prep_ids, kg) = setup_key_generator::<
+            DroppingOnlineDistributedKeyGen128<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
+        >()
+        .await;
+        let ikg = RealInsecureKeyGenerator::from_real_keygen(&kg).await;
+        let mut rng = AesRng::seed_from_u64(13);
+        let key_id = RequestId::new_random(&mut rng);
+
+        ikg.insecure_key_gen(keygen_request(key_id, None))
+            .await
+            .unwrap();
+
+        let result = ikg
+            .get_result(tonic::Request::new(key_id.into()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            RequestId::try_from(result.preprocessing_id.unwrap()).unwrap(),
+            *INSECURE_PREPROCESSING_ID
+        );
+        assert!(
+            !kg.preproc_buckets
+                .read()
+                .await
+                .exists(&INSECURE_PREPROCESSING_ID),
+            "implicit preprocessing must not create a metastore entry"
+        );
+
+        // A second keygen must work too, using a fresh implicit entry. Also pass
+        // the well-known ID explicitly to check that it behaves the same as an
+        // absent one.
+        let other_key_id = RequestId::new_random(&mut rng);
+        ikg.insecure_key_gen(keygen_request(
+            other_key_id,
+            Some(*INSECURE_PREPROCESSING_ID),
+        ))
+        .await
+        .unwrap();
+    }
+
+    /// The implicit insecure preprocessing path uses the well-known ID, so an
+    /// ongoing keygen with that ID must be rejected instead of overwriting the
+    /// existing cancellation token.
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_keygen_default_preproc_id_already_ongoing() {
+        let (_prep_ids, kg) = setup_key_generator::<
+            DroppingOnlineDistributedKeyGen128<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
+        >()
+        .await;
+        let ikg = RealInsecureKeyGenerator::from_real_keygen(&kg).await;
+        let token = CancellationToken::new();
+        kg.ongoing
+            .lock()
+            .await
+            .insert(*INSECURE_PREPROCESSING_ID, token.clone());
+        let mut rng = AesRng::seed_from_u64(15);
+        let key_id = RequestId::new_random(&mut rng);
+
+        let err = ikg
+            .insecure_key_gen(keygen_request(key_id, None))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::AlreadyExists);
+        assert!(!token.is_cancelled());
+        assert!(
+            kg.ongoing
+                .lock()
+                .await
+                .contains_key(&INSECURE_PREPROCESSING_ID)
+        );
+    }
+
+    /// The secure keygen must reject a request without a preprocessing ID.
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn secure_keygen_missing_preproc_id() {
+        let (_prep_ids, kg) = setup_key_generator::<
+            DroppingOnlineDistributedKeyGen128<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
+        >()
+        .await;
+        let mut rng = AesRng::seed_from_u64(14);
+        let key_id = RequestId::new_random(&mut rng);
+
+        assert_eq!(
+            kg.key_gen(keygen_request(key_id, None))
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::InvalidArgument
+        );
     }
 
     /// Dummy preprocessing (pre-populated into the bucket by [`setup_key_generator`]) is

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -471,7 +471,7 @@ impl<
             match handle_res(handle, &preproc_id).await {
                 Ok(_) => {
                     tracing::info!(
-                        "Successfully deleted preprocessing ID {preproc_id} after keygen completion for request ID {req_id}"
+                        "Successfully deleted preprocessing ID {preproc_id} before running keygen for request ID {req_id}"
                     );
                 }
                 Err(e) => {

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -54,7 +54,6 @@ use crate::{
         base::{
             BaseKmsStruct, DSEP_PUBDATA_KEY, KeyGenMetadata, compute_info_compressed_keygen,
             compute_info_decompression_keygen, compute_info_uncompressed_keygen,
-            resolve_keygen_preproc_id, select_keygen_dkg_params,
         },
         keyset_configuration::InternalKeySetConfig,
         threshold::{
@@ -113,8 +112,6 @@ enum ThresholdKeyGenResult {
 }
 
 // === Insecure Feature-Specific Imports ===
-#[cfg(feature = "insecure")]
-use crate::engine::base::INSECURE_PREPROCESSING_ID;
 #[cfg(feature = "insecure")]
 use crate::engine::threshold::traits::InsecureKeyGenerator;
 #[cfg(feature = "insecure")]
@@ -255,10 +252,6 @@ struct ResolvedPreprocessing {
     /// DKG parameters to run with. These are the parameters from the request if
     /// it set them, otherwise the parameters stored during preprocessing.
     dkg_params: DKGParams,
-    /// Whether the preprocessing entry should be deleted from the meta store once
-    /// the keygen starts. This is `true` for stored entries (real or insecure) and
-    /// `false` for the implicit insecure fallback, which has no stored entry.
-    consume_preproc_entry: bool,
 }
 
 #[cfg(feature = "insecure")]
@@ -294,7 +287,6 @@ impl<
     ) -> Result<(), MetricedError> {
         let preproc_handle_w_mode = resolved_preprocessing.handle;
         let dkg_params = resolved_preprocessing.dkg_params;
-        let consume_preproc_entry = resolved_preprocessing.consume_preproc_entry;
 
         //Retrieve the right metric tag
         let op_tag = match (
@@ -471,24 +463,19 @@ impl<
 
         let keygen_background = async move {
             // Remove the preprocessing entry from the meta store.
-            // Implicit insecure preprocessing has no stored entry to consume.
-            if consume_preproc_entry {
-                tracing::info!(
-                    "Deleting preprocessed material with ID {preproc_id} from meta store"
-                );
-                let handle = {
-                    let mut meta_store_guard = preproc_bucket.write().await;
-                    meta_store_guard.delete(&preproc_id)
-                };
-                match handle_res(handle, &preproc_id).await {
-                    Ok(_) => {
-                        tracing::info!(
-                            "Successfully deleted preprocessing ID {preproc_id} after keygen completion for request ID {req_id}"
-                        );
-                    }
-                    Err(e) => {
-                        MetricedError::handle_unreturnable_error(op_tag, Some(req_id), e);
-                    }
+            tracing::info!("Deleting preprocessed material with ID {preproc_id} from meta store");
+            let handle = {
+                let mut meta_store_guard = preproc_bucket.write().await;
+                meta_store_guard.delete(&preproc_id)
+            };
+            match handle_res(handle, &preproc_id).await {
+                Ok(_) => {
+                    tracing::info!(
+                        "Successfully deleted preprocessing ID {preproc_id} after keygen completion for request ID {req_id}"
+                    );
+                }
+                Err(e) => {
+                    MetricedError::handle_unreturnable_error(op_tag, Some(req_id), e);
                 }
             }
 
@@ -709,25 +696,18 @@ impl<
             OP_KEYGEN_REQUEST
         };
 
-        let preproc_id = resolve_keygen_preproc_id(op_tag, key_req_id, preproc_id, insecure)?;
+        let preproc_id = preproc_id.ok_or_else(|| {
+            MetricedError::new(
+                op_tag,
+                Some(key_req_id),
+                anyhow::anyhow!("Missing preprocessing ID in key generation request"),
+                tonic::Code::InvalidArgument,
+            )
+        })?;
 
-        // Explicit preprocessing entries must exist. The implicit insecure
-        // fallback has no stored preprocessing entry.
         let preproc_bucket =
             match retrieve_from_meta_store(bucket_metastore, &preproc_id, op_tag).await {
                 Ok(bucket) => bucket,
-                #[cfg(feature = "insecure")]
-                Err(e)
-                    if insecure
-                        && preproc_id == *INSECURE_PREPROCESSING_ID
-                        && e.code() == tonic::Code::NotFound =>
-                {
-                    return Ok(ResolvedPreprocessing {
-                        handle: PreprocHandleWithMode::Insecure(preproc_id),
-                        dkg_params: request_dkg_params,
-                        consume_preproc_entry: false,
-                    });
-                }
                 Err(e) => {
                     // Remap the error to include the correct request ID
                     return Err(MetricedError::new(
@@ -751,11 +731,11 @@ impl<
         }
         // If params are set in the request they take precedence,
         // otherwise the parameters stored during preprocessing are used.
-        let dkg_param = select_keygen_dkg_params(
-            request_dkg_params,
-            request_params_set,
-            Some(preproc_bucket.dkg_param),
-        );
+        let dkg_param = if request_params_set {
+            request_dkg_params
+        } else {
+            preproc_bucket.dkg_param
+        };
         // The mode of the keygen request must match the mode of the stored
         // preprocessing: real material is required for the secure keygen and
         // insecure (dummy) preprocessing may only be used by the insecure keygen.
@@ -791,7 +771,6 @@ impl<
         Ok(ResolvedPreprocessing {
             handle: preproc_handle,
             dkg_params: dkg_param,
-            consume_preproc_entry: true,
         })
     }
 
@@ -2553,12 +2532,10 @@ mod tests {
         );
     }
 
-    /// The insecure keygen works without a preprocessing ID (and without any
-    /// prior preprocessing call): the server uses the well-known
-    /// INSECURE_PREPROCESSING_ID as an implicit one-shot dummy preprocessing.
+    /// The insecure keygen must reject a request without a preprocessing ID.
     #[cfg(feature = "insecure")]
     #[tokio::test]
-    async fn insecure_keygen_default_preproc_id() {
+    async fn insecure_keygen_missing_preproc_id() {
         let (_prep_ids, kg) = setup_key_generator::<
             DroppingOnlineDistributedKeyGen128<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
         >()
@@ -2567,69 +2544,12 @@ mod tests {
         let mut rng = AesRng::seed_from_u64(13);
         let key_id = RequestId::new_random(&mut rng);
 
-        ikg.insecure_key_gen(keygen_request(key_id, None))
-            .await
-            .unwrap();
-
-        let result = ikg
-            .get_result(tonic::Request::new(key_id.into()))
-            .await
-            .unwrap()
-            .into_inner();
         assert_eq!(
-            RequestId::try_from(result.preprocessing_id.unwrap()).unwrap(),
-            *INSECURE_PREPROCESSING_ID
-        );
-        assert!(
-            !kg.preproc_buckets
-                .read()
+            ikg.insecure_key_gen(keygen_request(key_id, None))
                 .await
-                .exists(&INSECURE_PREPROCESSING_ID),
-            "implicit preprocessing must not create a metastore entry"
-        );
-
-        // A second keygen must work too, using a fresh implicit entry. Also pass
-        // the well-known ID explicitly to check that it behaves the same as an
-        // absent one.
-        let other_key_id = RequestId::new_random(&mut rng);
-        ikg.insecure_key_gen(keygen_request(
-            other_key_id,
-            Some(*INSECURE_PREPROCESSING_ID),
-        ))
-        .await
-        .unwrap();
-    }
-
-    /// The implicit insecure preprocessing path uses the well-known ID, so an
-    /// ongoing keygen with that ID must be rejected instead of overwriting the
-    /// existing cancellation token.
-    #[cfg(feature = "insecure")]
-    #[tokio::test]
-    async fn insecure_keygen_default_preproc_id_already_ongoing() {
-        let (_prep_ids, kg) = setup_key_generator::<
-            DroppingOnlineDistributedKeyGen128<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
-        >()
-        .await;
-        let ikg = RealInsecureKeyGenerator::from_real_keygen(&kg).await;
-        let token = CancellationToken::new();
-        kg.ongoing
-            .lock()
-            .await
-            .insert(*INSECURE_PREPROCESSING_ID, token.clone());
-        let mut rng = AesRng::seed_from_u64(15);
-        let key_id = RequestId::new_random(&mut rng);
-
-        let err = ikg
-            .insecure_key_gen(keygen_request(key_id, None))
-            .await
-            .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::AlreadyExists);
-        assert!(!token.is_cancelled());
-        assert!(
-            kg.ongoing
-                .lock()
-                .await
-                .contains_key(&INSECURE_PREPROCESSING_ID)
+                .unwrap_err()
+                .code(),
+            tonic::Code::InvalidArgument
         );
     }
 

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -408,12 +408,56 @@ impl std::fmt::Debug for ThresholdFheKeys {
     }
 }
 
+/// Entry of the preprocessing meta store, produced by the key generation
+/// preprocessing endpoints and consumed (deleted) by key generation.
 #[derive(Clone)]
 pub struct BucketMetaStore {
     pub(crate) preprocessing_id: RequestId,
     pub(crate) external_signature: Vec<u8>,
-    pub(crate) preprocessing_store: Arc<Mutex<Box<dyn DKGPreprocessing<ResiduePolyF4Z128>>>>,
+    pub(crate) preprocessing_store: PreprocMaterial,
     pub(crate) dkg_param: DKGParams,
+}
+
+/// The preprocessing material backing a [`BucketMetaStore`] entry.
+///
+/// `Real` holds the actual correlated randomness produced by the secure
+/// preprocessing endpoint. `Insecure` is a marker stored by the insecure
+/// preprocessing endpoint: no material exists and the entry may only be
+/// consumed by the insecure key generation, mirroring the dummy
+/// preprocessing of the centralized KMS.
+#[derive(Clone)]
+pub enum PreprocMaterial {
+    Real(Arc<Mutex<Box<dyn DKGPreprocessing<ResiduePolyF4Z128>>>>),
+    #[cfg(feature = "insecure")]
+    Insecure,
+}
+
+/// Build the meta-store entry stored by the insecure (dummy) preprocessing:
+/// no material is generated, only the external signature is computed.
+///
+/// Used both by the insecure preprocessing endpoint and by the insecure key
+/// generation when it synthesizes the well-known
+/// [`crate::engine::base::INSECURE_PREPROCESSING_ID`] entry on the fly.
+#[cfg(feature = "insecure")]
+pub(crate) fn new_insecure_preproc_bucket(
+    sk: &crate::cryptography::signatures::PrivateSigKey,
+    preprocessing_id: RequestId,
+    dkg_param: DKGParams,
+    domain: &alloy_sol_types::Eip712Domain,
+    extra_data: Vec<u8>,
+) -> anyhow::Result<BucketMetaStore> {
+    let external_signature = crate::engine::base::compute_external_signature_preprocessing(
+        sk,
+        &preprocessing_id,
+        domain,
+        extra_data,
+    )?;
+    Ok(BucketMetaStore {
+        preprocessing_id,
+        external_signature,
+        preprocessing_store: PreprocMaterial::Insecure,
+        dkg_param,
+    })
 }
 
 #[cfg(not(feature = "insecure"))]

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -434,10 +434,6 @@ pub enum PreprocMaterial {
 
 /// Build the meta-store entry stored by the insecure (dummy) preprocessing:
 /// no material is generated, only the external signature is computed.
-///
-/// Used both by the insecure preprocessing endpoint and by the insecure key
-/// generation when it synthesizes the well-known
-/// [`crate::engine::base::INSECURE_PREPROCESSING_ID`] entry on the fly.
 #[cfg(feature = "insecure")]
 pub(crate) fn new_insecure_preproc_bucket(
     sk: &crate::cryptography::signatures::PrivateSigKey,

--- a/core/service/src/engine/threshold/service/preprocessor.rs
+++ b/core/service/src/engine/threshold/service/preprocessor.rs
@@ -569,18 +569,24 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
             ));
         }
 
+        // The kind of result requested must match the kind of preprocessing
+        // stored: the insecure endpoint must not return real material, and the
+        // secure endpoint must not return insecure (dummy) material.
         #[cfg(feature = "insecure")]
-        if op_tag == OP_INSECURE_KEYGEN_PREPROC_RESULT
-            && !matches!(preproc_data.preprocessing_store, PreprocMaterial::Insecure)
         {
-            return Err(MetricedError::new(
-                op_tag,
-                Some(request_id),
-                anyhow::anyhow!(
-                    "Insecure preprocessing result requested for real preprocessing ID {request_id}"
-                ),
-                tonic::Code::FailedPrecondition,
-            ));
+            let is_insecure_tag = op_tag == OP_INSECURE_KEYGEN_PREPROC_RESULT;
+            let is_insecure_store =
+                matches!(preproc_data.preprocessing_store, PreprocMaterial::Insecure);
+            if is_insecure_tag != is_insecure_store {
+                return Err(MetricedError::new(
+                    op_tag,
+                    Some(request_id),
+                    anyhow::anyhow!(
+                        "Preprocessing kind mismatch for ID {request_id}: is_insecure_tag={is_insecure_tag} != is_insecure_store={is_insecure_store}",
+                    ),
+                    tonic::Code::FailedPrecondition,
+                ));
+            }
         }
 
         Ok(Response::new(KeyGenPreprocResult {

--- a/core/service/src/engine/threshold/service/preprocessor.rs
+++ b/core/service/src/engine/threshold/service/preprocessor.rs
@@ -8,6 +8,10 @@ use kms_grpc::{
     identifiers::{ContextId, EpochId},
     kms::v1::{self, Empty, KeyGenPreprocRequest, KeyGenPreprocResult},
 };
+#[cfg(feature = "insecure")]
+use observability::metrics_names::{
+    OP_INSECURE_KEYGEN_PREPROC_REQUEST, OP_INSECURE_KEYGEN_PREPROC_RESULT,
+};
 use observability::{
     metrics::{DurationGuard, METRICS},
     metrics_names::{
@@ -51,8 +55,11 @@ use crate::{
     },
 };
 
+#[cfg(feature = "insecure")]
+use crate::util::meta_store::update_req_in_meta_store;
+
 // === Current Module Imports ===
-use super::BucketMetaStore;
+use super::{BucketMetaStore, PreprocMaterial};
 
 pub struct RealPreprocessor<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>>
 {
@@ -338,7 +345,7 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
             handle_update.clone().map(|inner| BucketMetaStore {
                 external_signature,
                 preprocessing_id: *req_id,
-                preprocessing_store: inner,
+                preprocessing_store: PreprocMaterial::Real(inner),
                 dkg_param: params,
             }),
         );
@@ -433,6 +440,154 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>>> Rea
             )?;
         Ok(Response::new(Empty {}))
     }
+
+    /// Insecure (dummy) preprocessing: no preprocessing material is generated,
+    /// only the preprocessing ID, the external signature and the DKG parameters
+    /// are stored in the meta store, mirroring the centralized KMS preprocessing.
+    /// The stored entry can only be consumed by the insecure key generation.
+    #[cfg(feature = "insecure")]
+    async fn inner_insecure_key_gen_preproc(
+        &self,
+        request: KeyGenPreprocRequest,
+    ) -> Result<Response<Empty>, MetricedError> {
+        let _permit = self.rate_limiter.start_preproc().await?;
+        let mut timer = METRICS
+            .time_operation(OP_INSECURE_KEYGEN_PREPROC_REQUEST)
+            .start();
+
+        let (
+            request_id,
+            context_id,
+            epoch_id,
+            dkg_params,
+            _keyset_config,
+            eip712_domain,
+            extra_data,
+        ) = validate_preproc_request(request)?;
+        let my_role = validate_context_and_epoch(
+            OP_INSECURE_KEYGEN_PREPROC_REQUEST,
+            &self.session_maker,
+            Some(request_id),
+            &context_id,
+            &epoch_id,
+        )
+        .await?;
+        timer.tags(vec![(TAG_PARTY_ID, my_role.to_string())]);
+
+        // Add preprocessing to metastore and fail in case it is already present
+        add_req_to_meta_store(
+            &mut self.preproc_buckets.write().await,
+            &request_id,
+            OP_INSECURE_KEYGEN_PREPROC_REQUEST,
+        )?;
+
+        let sk = self.base_kms.sig_key().map_err(|e| {
+            MetricedError::new(
+                OP_INSECURE_KEYGEN_PREPROC_REQUEST,
+                Some(request_id),
+                e,
+                tonic::Code::FailedPrecondition,
+            )
+        })?;
+        let preproc_bucket = super::new_insecure_preproc_bucket(
+            &sk,
+            request_id,
+            dkg_params,
+            &eip712_domain,
+            extra_data,
+        )
+        .map_err(|e| e.to_string());
+        let preproc_error = preproc_bucket.as_ref().err().cloned();
+
+        if !update_req_in_meta_store(
+            &mut self.preproc_buckets.write().await,
+            &request_id,
+            preproc_bucket,
+            OP_INSECURE_KEYGEN_PREPROC_REQUEST,
+        ) {
+            return Err(MetricedError::new(
+                OP_INSECURE_KEYGEN_PREPROC_REQUEST,
+                Some(request_id),
+                anyhow::anyhow!(
+                    "Failed to store insecure preprocessing result for Request ID {request_id}"
+                ),
+                tonic::Code::Internal,
+            ));
+        }
+        if let Some(error) = preproc_error {
+            return Err(MetricedError::new(
+                OP_INSECURE_KEYGEN_PREPROC_REQUEST,
+                Some(request_id),
+                anyhow::anyhow!(
+                    "Failed to build insecure preprocessing bucket for Request ID {request_id}: {error}"
+                ),
+                tonic::Code::Internal,
+            ));
+        }
+        tracing::warn!(
+            "Stored insecure (dummy) preprocessing for Request ID {} - no preprocessing material was generated",
+            request_id
+        );
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn inner_get_result(
+        &self,
+        request: Request<v1::RequestId>,
+        op_tag: &'static str,
+    ) -> Result<Response<KeyGenPreprocResult>, MetricedError> {
+        let request_id =
+            parse_grpc_request_id(&request.into_inner(), RequestIdParsingErr::PreprocResponse)
+                .map_err(|e| MetricedError::new(op_tag, None, e, tonic::Code::InvalidArgument))?;
+
+        tracing::info!(
+            "Polling preproc result for request {} (waiting up to {}s)",
+            request_id,
+            DURATION_WAITING_ON_PREPROC_RESULT_SECONDS,
+        );
+
+        let preproc_data = retrieve_from_meta_store_with_timeout(
+            self.preproc_buckets.read().await,
+            &request_id,
+            op_tag,
+            DURATION_WAITING_ON_PREPROC_RESULT_SECONDS,
+        )
+        .await?;
+
+        tracing::info!("Preproc result ready for request {}", request_id);
+
+        if preproc_data.preprocessing_id != request_id {
+            return Err(MetricedError::new(
+                op_tag,
+                Some(request_id),
+                anyhow::anyhow!(
+                    "Internal error: preprocessing ID mismatch for request ID, expecting {}, got {}",
+                    request_id,
+                    preproc_data.preprocessing_id
+                ),
+                tonic::Code::Internal,
+            ));
+        }
+
+        #[cfg(feature = "insecure")]
+        if op_tag == OP_INSECURE_KEYGEN_PREPROC_RESULT
+            && !matches!(preproc_data.preprocessing_store, PreprocMaterial::Insecure)
+        {
+            return Err(MetricedError::new(
+                op_tag,
+                Some(request_id),
+                anyhow::anyhow!(
+                    "Insecure preprocessing result requested for real preprocessing ID {request_id}"
+                ),
+                tonic::Code::FailedPrecondition,
+            ));
+        }
+
+        Ok(Response::new(KeyGenPreprocResult {
+            preprocessing_id: Some(request_id.into()),
+            external_signature: preproc_data.external_signature,
+        }))
+    }
 }
 
 #[tonic::async_trait]
@@ -469,54 +624,30 @@ impl<P: ProducerFactory<ResiduePolyF4Z128, SmallSession<ResiduePolyF4Z128>> + Se
             .await
     }
 
+    #[cfg(feature = "insecure")]
+    async fn insecure_key_gen_preproc(
+        &self,
+        request: Request<KeyGenPreprocRequest>,
+    ) -> Result<Response<Empty>, MetricedError> {
+        self.inner_insecure_key_gen_preproc(request.into_inner())
+            .await
+    }
+
     async fn get_result(
         &self,
         request: Request<v1::RequestId>,
     ) -> Result<Response<KeyGenPreprocResult>, MetricedError> {
-        let request_id =
-            parse_grpc_request_id(&request.into_inner(), RequestIdParsingErr::PreprocResponse)
-                .map_err(|e| {
-                    MetricedError::new(
-                        OP_KEYGEN_PREPROC_RESULT,
-                        None,
-                        e,
-                        tonic::Code::InvalidArgument,
-                    )
-                })?;
+        self.inner_get_result(request, OP_KEYGEN_PREPROC_RESULT)
+            .await
+    }
 
-        tracing::info!(
-            "Polling preproc result for request {} (waiting up to {}s)",
-            request_id,
-            DURATION_WAITING_ON_PREPROC_RESULT_SECONDS,
-        );
-
-        let preproc_data = retrieve_from_meta_store_with_timeout(
-            self.preproc_buckets.read().await,
-            &request_id,
-            OP_KEYGEN_PREPROC_RESULT,
-            DURATION_WAITING_ON_PREPROC_RESULT_SECONDS,
-        )
-        .await?;
-
-        tracing::info!("Preproc result ready for request {}", request_id);
-
-        if preproc_data.preprocessing_id != request_id {
-            return Err(MetricedError::new(
-                OP_KEYGEN_PREPROC_RESULT,
-                Some(request_id),
-                anyhow::anyhow!(
-                    "Internal error: preprocessing ID mismatch for request ID, expecting {}, got {}",
-                    request_id,
-                    preproc_data.preprocessing_id
-                ),
-                tonic::Code::Internal,
-            ));
-        }
-
-        Ok(Response::new(KeyGenPreprocResult {
-            preprocessing_id: Some(request_id.into()),
-            external_signature: preproc_data.external_signature,
-        }))
+    #[cfg(feature = "insecure")]
+    async fn get_insecure_result(
+        &self,
+        request: Request<v1::RequestId>,
+    ) -> Result<Response<KeyGenPreprocResult>, MetricedError> {
+        self.inner_get_result(request, OP_INSECURE_KEYGEN_PREPROC_RESULT)
+            .await
     }
 
     async fn abort_key_gen_preproc(
@@ -926,6 +1057,123 @@ mod tests {
         prep.get_result(tonic::Request::new(req_id.into()))
             .await
             .unwrap();
+    }
+
+    #[cfg(feature = "insecure")]
+    fn insecure_preproc_request(req_id: RequestId) -> tonic::Request<KeyGenPreprocRequest> {
+        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
+        tonic::Request::new(KeyGenPreprocRequest {
+            request_id: Some(req_id.into()),
+            params: FheParameter::Test as i32,
+            keyset_config: None,
+            context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
+            domain: Some(domain),
+            epoch_id: None,
+            extra_data: vec![],
+        })
+    }
+
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_sunshine() {
+        use kms_grpc::solidity_types::PrepKeygenVerification;
+
+        use crate::cryptography::signatures::recover_address_from_ext_signature;
+
+        let mut rng = AesRng::seed_from_u64(22);
+        let prep = setup_prep::<DummyProducerFactory>(&mut rng, true).await;
+        let verf_key = prep.base_kms.verf_key();
+
+        let req_id = RequestId::new_random(&mut rng);
+        prep.insecure_key_gen_preproc(insecure_preproc_request(req_id))
+            .await
+            .unwrap();
+
+        // The insecure preprocessing is instant, so the result is available right away
+        let inner_res = prep
+            .get_insecure_result(tonic::Request::new(req_id.into()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        // Check that the external signature is valid
+        let sol_struct = PrepKeygenVerification::new(
+            &inner_res.preprocessing_id.unwrap().try_into().unwrap(),
+            vec![],
+        );
+        assert_eq!(
+            recover_address_from_ext_signature(
+                &sol_struct,
+                &dummy_domain(),
+                &inner_res.external_signature
+            )
+            .unwrap(),
+            verf_key.address()
+        );
+
+        // The stored bucket must hold no preprocessing material
+        let bucket = retrieve_from_meta_store_with_timeout(
+            prep.preproc_buckets.read().await,
+            &req_id,
+            "test",
+            1,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            bucket.preprocessing_store,
+            super::PreprocMaterial::Insecure
+        ));
+    }
+
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_result_rejects_real_preproc() {
+        let mut rng = AesRng::seed_from_u64(22);
+        let prep = setup_prep::<DummyProducerFactory>(&mut rng, true).await;
+        let req_id = RequestId::new_random(&mut rng);
+
+        prep.key_gen_preproc(insecure_preproc_request(req_id))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            prep.get_insecure_result(tonic::Request::new(req_id.into()))
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::FailedPrecondition
+        );
+    }
+
+    #[cfg(feature = "insecure")]
+    #[tokio::test]
+    async fn insecure_already_exists() {
+        let mut rng = AesRng::seed_from_u64(22);
+        let prep = setup_prep::<DummyProducerFactory>(&mut rng, true).await;
+        let req_id = RequestId::new_random(&mut rng);
+
+        prep.insecure_key_gen_preproc(insecure_preproc_request(req_id))
+            .await
+            .unwrap();
+
+        // a second request with the same ID must be rejected
+        assert_eq!(
+            prep.insecure_key_gen_preproc(insecure_preproc_request(req_id))
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::AlreadyExists
+        );
+
+        // it must also be rejected by the secure preprocessing endpoint
+        assert_eq!(
+            prep.key_gen_preproc(insecure_preproc_request(req_id))
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::AlreadyExists
+        );
     }
 
     #[tokio::test]

--- a/core/service/src/engine/threshold/traits.rs
+++ b/core/service/src/engine/threshold/traits.rs
@@ -70,7 +70,23 @@ pub trait KeyGenPreprocessor {
         request: Request<PartialKeyGenPreprocRequest>,
     ) -> Result<Response<Empty>, MetricedError>;
 
+    /// Insecure (dummy) preprocessing that only records the preprocessing ID
+    /// in the meta store, to be consumed by the insecure key generation.
+    #[cfg(feature = "insecure")]
+    async fn insecure_key_gen_preproc(
+        &self,
+        request: Request<KeyGenPreprocRequest>,
+    ) -> Result<Response<Empty>, MetricedError>;
+
     async fn get_result(
+        &self,
+        request: Request<RequestId>,
+    ) -> Result<Response<KeyGenPreprocResult>, MetricedError>;
+
+    /// Same as [`Self::get_result`] but for preprocessing started via
+    /// [`Self::insecure_key_gen_preproc`] (only the metric tag differs).
+    #[cfg(feature = "insecure")]
+    async fn get_insecure_result(
         &self,
         request: Request<RequestId>,
     ) -> Result<Response<KeyGenPreprocResult>, MetricedError>;

--- a/core/service/src/engine/threshold/traits.rs
+++ b/core/service/src/engine/threshold/traits.rs
@@ -70,8 +70,8 @@ pub trait KeyGenPreprocessor {
         request: Request<PartialKeyGenPreprocRequest>,
     ) -> Result<Response<Empty>, MetricedError>;
 
-    /// Insecure (dummy) preprocessing that only records the preprocessing ID
-    /// in the meta store, to be consumed by the insecure key generation.
+    /// Insecure (dummy) preprocessing that records metadata but no preprocessing
+    /// material in the meta store, to be consumed by the insecure key generation.
     #[cfg(feature = "insecure")]
     async fn insecure_key_gen_preproc(
         &self,
@@ -84,7 +84,7 @@ pub trait KeyGenPreprocessor {
     ) -> Result<Response<KeyGenPreprocResult>, MetricedError>;
 
     /// Same as [`Self::get_result`] but for preprocessing started via
-    /// [`Self::insecure_key_gen_preproc`] (only the metric tag differs).
+    /// [`Self::insecure_key_gen_preproc`].
     #[cfg(feature = "insecure")]
     async fn get_insecure_result(
         &self,

--- a/core/service/src/engine/validation_non_wasm.rs
+++ b/core/service/src/engine/validation_non_wasm.rs
@@ -770,7 +770,7 @@ pub(crate) fn validate_key_gen_request(
 ) -> Result<
     (
         RequestId,
-        RequestId,
+        Option<RequestId>,
         ContextId,
         EpochId,
         DKGParams,
@@ -795,7 +795,7 @@ fn unpack_key_gen_request(
     req: KeyGenRequest,
 ) -> anyhow::Result<(
     RequestId,
-    RequestId,
+    Option<RequestId>,
     ContextId,
     EpochId,
     DKGParams,
@@ -805,8 +805,15 @@ fn unpack_key_gen_request(
 )> {
     let req_id =
         parse_optional_grpc_request_id(&req.request_id, RequestIdParsingErr::KeyGenRequest)?;
-    let preproc_id =
-        parse_optional_grpc_request_id(&req.preproc_id, RequestIdParsingErr::PreprocRequest)?;
+    // The preprocessing ID may be absent: it is required for the secure key
+    // generation but optional for the insecure one (which defaults to the
+    // well-known insecure preprocessing ID), so presence is enforced by the
+    // caller and only the format is validated here.
+    let preproc_id = req
+        .preproc_id
+        .as_ref()
+        .map(|id| parse_grpc_request_id(id, RequestIdParsingErr::PreprocRequest))
+        .transpose()?;
 
     tracing::info!(
         request_id = ?req_id,

--- a/core/service/src/engine/validation_non_wasm.rs
+++ b/core/service/src/engine/validation_non_wasm.rs
@@ -805,10 +805,8 @@ fn unpack_key_gen_request(
 )> {
     let req_id =
         parse_optional_grpc_request_id(&req.request_id, RequestIdParsingErr::KeyGenRequest)?;
-    // The preprocessing ID may be absent: it is required for the secure key
-    // generation but optional for the insecure one (which defaults to the
-    // well-known insecure preprocessing ID), so presence is enforced by the
-    // caller and only the format is validated here.
+    // Presence of the preprocessing ID is enforced by the caller; only the
+    // format is validated here.
     let preproc_id = req
         .preproc_id
         .as_ref()

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -373,7 +373,7 @@ Upon success, both the command to request to generate a key _and_ the command to
 
 #### Insecure (Dummy) Preprocessing
 
-Like the secure flow, an insecure key-generation consumes a preprocessing entry, but the insecure preprocessing is a dummy: no correlated randomness is generated and only the request ID is recorded, so the call completes almost instantly. It can be triggered explicitly via:
+Like the secure flow, an insecure key-generation consumes a preprocessing entry, but the insecure preprocessing is a dummy: no correlated randomness is generated and only metadata such as the request ID, parameters, and external signature is recorded, so the call completes almost instantly. It can be triggered explicitly via:
 
 ```{bash}
 $ cargo run -- -f <path-to-toml-config-file> insecure-preproc-key-gen [--context-id <CONTEXT_ID>] [--epoch-id <EPOCH_ID>]

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -346,12 +346,12 @@ These commands generate a set of private and public FHE keys. It will return a `
 _Insecure_ key-generation can be done using the following command:
 
 ```{bash}
-$ cargo run -- -f <path-to-toml-config-file> insecure-key-gen [--compressed] [--keyset-type <TYPE>]
+$ cargo run -- -f <path-to-toml-config-file> insecure-key-gen [--preproc-id <REQUEST_ID>] [--uncompressed]
 ```
 
 Optional arguments:
- - `-c`/`--compressed`: Generate compressed keys using XOF-seeded compression (default: disabled).
- - `-t`/`--keyset-type <TYPE>`: Keyset type for key generation. Currently only `standard` is supported (default: `standard`).
+ - `-i`/`--preproc-id <REQUEST_ID>`: ID of an existing insecure (dummy) preprocessing to consume (see [below](#insecure-dummy-preprocessing)). When omitted, the server uses the well-known `INSECURE_PREPROCESSING_ID` as an implicit one-shot dummy preprocessing.
+ - `-u`/`--uncompressed`: Generate legacy uncompressed public key material (`PublicKey` + `ServerKey`). By default key generation stores compressed key material.
 
 This means that a single KMS core will generate a set of FHE keys in plain. In a threshold KMS, the contained private key material will then be secret shared between all KMS cores.
 
@@ -359,10 +359,31 @@ Note that this operation does *NOT* run a secure distributed keygen protocol, an
 
 It is also possible to fetch the result of an insecure key generation through its `REQUEST_ID` using the following command:
 ```{bash}
-$ cargo run -- -f <path-to-toml-config-file> insecure-key-gen-result --request-id <REQUEST_ID> [--compressed]
+$ cargo run -- -f <path-to-toml-config-file> insecure-key-gen-result --request-id <REQUEST_ID> [--uncompressed]
 ```
 
 Upon success, both the command to request to generate a key _and_ the command to fetch the result, will save the key material produced by the core in the `object_folder` given in the configuration file.
+
+#### Insecure (Dummy) Preprocessing
+
+Like the secure flow, an insecure key-generation consumes a preprocessing entry, but the insecure preprocessing is a dummy: no correlated randomness is generated and only the request ID is recorded, so the call completes almost instantly. It can be triggered explicitly via:
+
+```{bash}
+$ cargo run -- -f <path-to-toml-config-file> insecure-preproc-key-gen [--context-id <CONTEXT_ID>] [--epoch-id <EPOCH_ID>]
+```
+
+Optional arguments:
+ - `--context-id <CONTEXT_ID>`: the context ID to use for the preprocessing. Defaults to the default context if not specified.
+ - `--epoch-id <EPOCH_ID>`: the epoch ID to use for the preprocessing. Defaults to the default epoch if not specified.
+
+The resulting `REQUEST_ID` can then be passed to `insecure-key-gen` via `--preproc-id`. Each explicit entry is consumed by the key generation, so a fresh insecure preprocessing is needed for each insecure key-generation call that passes an explicit preprocessing ID. If `insecure-key-gen` is invoked without `--preproc-id`, this step is not needed: the server uses the well-known `INSECURE_PREPROCESSING_ID` as an implicit one-shot dummy preprocessing (which also means concurrent no-argument insecure key generations against the same cluster are not supported).
+
+Note that in the threshold setting an insecure preprocessing entry can only be consumed by `insecure-key-gen`, and a secure preprocessing entry only by `key-gen`; in the centralized setting both preprocessing variants are identical dummies and are interchangeable.
+
+It is also possible to fetch the status of an insecure preprocessing through its `REQUEST_ID` using the following command:
+```{bash}
+$ cargo run -- -f <path-to-toml-config-file> insecure-preproc-key-gen-result --request-id <REQUEST_ID>
+```
 
 #### Preprocessing for Secure Key-Generation
 

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -78,10 +78,15 @@ docker run -v ./core-client/config:/config \
   kms-core-client -f /config/client_local_threshold.toml <command>
 
 # Example: Generate insecure keys
+PREPROC_ID=$(docker run -v ./core-client/config:/config \
+  --network host \
+  ghcr.io/zama-ai/kms/core-client:latest \
+  kms-core-client -f /config/client_local_threshold.toml insecure-preproc-key-gen \
+  | grep request_id | cut -d'"' -f4)
 docker run -v ./core-client/config:/config \
   --network host \
   ghcr.io/zama-ai/kms/core-client:latest \
-  kms-core-client -f /config/client_local_threshold.toml insecure-key-gen
+  kms-core-client -f /config/client_local_threshold.toml insecure-key-gen --preproc-id "$PREPROC_ID"
 ```
 
 The Docker image also includes the **kms-health-check** tool for monitoring KMS deployments:
@@ -346,11 +351,13 @@ These commands generate a set of private and public FHE keys. It will return a `
 _Insecure_ key-generation can be done using the following command:
 
 ```{bash}
-$ cargo run -- -f <path-to-toml-config-file> insecure-key-gen [--preproc-id <REQUEST_ID>] [--uncompressed]
+$ cargo run -- -f <path-to-toml-config-file> insecure-key-gen --preproc-id <REQUEST_ID> [--uncompressed]
 ```
 
+Required arguments:
+ - `-i`/`--preproc-id <REQUEST_ID>`: ID of an existing preprocessing entry to consume (see [below](#insecure-dummy-preprocessing)). In threshold mode this must come from `insecure-preproc-key-gen`; in centralized mode either preprocessing endpoint can be used.
+
 Optional arguments:
- - `-i`/`--preproc-id <REQUEST_ID>`: ID of an existing insecure (dummy) preprocessing to consume (see [below](#insecure-dummy-preprocessing)). When omitted, the server uses the well-known `INSECURE_PREPROCESSING_ID` as an implicit one-shot dummy preprocessing.
  - `-u`/`--uncompressed`: Generate legacy uncompressed public key material (`PublicKey` + `ServerKey`). By default key generation stores compressed key material.
 
 This means that a single KMS core will generate a set of FHE keys in plain. In a threshold KMS, the contained private key material will then be secret shared between all KMS cores.
@@ -376,9 +383,9 @@ Optional arguments:
  - `--context-id <CONTEXT_ID>`: the context ID to use for the preprocessing. Defaults to the default context if not specified.
  - `--epoch-id <EPOCH_ID>`: the epoch ID to use for the preprocessing. Defaults to the default epoch if not specified.
 
-The resulting `REQUEST_ID` can then be passed to `insecure-key-gen` via `--preproc-id`. Each explicit entry is consumed by the key generation, so a fresh insecure preprocessing is needed for each insecure key-generation call that passes an explicit preprocessing ID. If `insecure-key-gen` is invoked without `--preproc-id`, this step is not needed: the server uses the well-known `INSECURE_PREPROCESSING_ID` as an implicit one-shot dummy preprocessing (which also means concurrent no-argument insecure key generations against the same cluster are not supported).
+The resulting `REQUEST_ID` must then be passed to `insecure-key-gen` via `--preproc-id`. Each entry is consumed by the key generation, so a fresh preprocessing is needed for each insecure key-generation call.
 
-Note that in the threshold setting an insecure preprocessing entry can only be consumed by `insecure-key-gen`, and a secure preprocessing entry only by `key-gen`; in the centralized setting both preprocessing variants are identical dummies and are interchangeable.
+Note that in the threshold setting an insecure preprocessing entry can only be consumed by `insecure-key-gen`, and a secure preprocessing entry only by `key-gen`; in the centralized setting both preprocessing variants are dummy entries and are interchangeable.
 
 It is also possible to fetch the status of an insecure preprocessing through its `REQUEST_ID` using the following command:
 ```{bash}
@@ -692,7 +699,8 @@ This prints the public key for each configured core.
 
 - Generate a set of private and public FHE keys for testing in a threshold KMS using the default threshold config. This command will expect all responses (`-a`) and will output logs (`-l`).
     ```{bash}
-    $ cargo run --bin kms-core-client -- -f core-client/config/client_local_threshold.toml -a -l insecure-key-gen
+    $ PREPROC_ID=$(cargo run --bin kms-core-client -- -f core-client/config/client_local_threshold.toml -a -l insecure-preproc-key-gen | grep request_id | cut -d'"' -f4)
+    $ cargo run --bin kms-core-client -- -f core-client/config/client_local_threshold.toml -a -l insecure-key-gen --preproc-id "$PREPROC_ID"
     ```
 - Generate an encryption of `0x2342` of type `euint16` and ask for a user decryption from the threshold KMS using the default threshold config. This command assumes that previously an FHE key with key id `948ddb338f9279d5b06a45911be7c93dd7f45c8d6bc66c36140470432bce7e06` was created. This command will continue once it has enough responses (the `-a` flag is not provided) and will write logs (`-l`).
     ```{bash}

--- a/docs/guides/entry_points.md
+++ b/docs/guides/entry_points.md
@@ -67,7 +67,7 @@ The KMS Cores will post the result of the key generation to a public storage sys
 The key generation process is slow and may take a couple of hours, even when running on strong machines.
 
 #### Insecure mode
-To support a fast setup in test situations, the Zama KMS supports an "insecure" mode for key generation, where preprocessing is not required and where the key generation itself only takes a few seconds. However, as the name suggests, this mode is _not_ threshold secure. I.e. it should only be used for testing purposes.
+To support a fast setup in test situations, the Zama KMS supports an "insecure" mode for key generation, where only a dummy insecure preprocessing request is required and where the key generation itself only takes a few seconds. However, as the name suggests, this mode is _not_ threshold secure. I.e. it should only be used for testing purposes.
 
 ### CRS generation
 CRS generation allows the generation of a Common Reference String (CRS) in a distributed secure manner. The CRS is what is known as "powers-of-tau". Amongst other things, it can be used to do zero-knowledge proofs of plaintext knowledge for FHE encrypted messages. See [this paper](https://eprint.iacr.org/2023/800.pdf) for more information.

--- a/docs/references/api/core_grpc.md
+++ b/docs/references/api/core_grpc.md
@@ -392,7 +392,7 @@ Insecure version of `KeyGenPreproc`, where _no_ correlated randomness is generat
 Only the preprocessing ID (along with the parameters and the external signature) is recorded, so a subsequent `InsecureKeyGen` call with `preproc_id` set to the current `request_id` can validate and consume it.
 Because nothing is generated, this call completes (almost) instantly.
 
-As for the secure variant, an explicit preprocessing entry is consumed by _each_ insecure key generation call that references it. Calling this endpoint explicitly is optional however: when `InsecureKeyGen` is invoked without a `preproc_id` (or with the well-known `INSECURE_PREPROCESSING_ID` and no stored entry), the server uses the well-known ID as an implicit one-shot dummy preprocessing.
+As for the secure variant, a preprocessing entry is consumed by _each_ insecure key generation call that references it. Calling this endpoint explicitly is required before threshold `InsecureKeyGen`.
 In the __threshold__ setting the stored entry can only be consumed by `InsecureKeyGen` (calling the secure `KeyGen` with such a `preproc_id` will fail with `FailedPrecondition`, and vice versa).
 In the __centralized__ setting this endpoint is identical to `KeyGenPreproc` — both are dummies that only record the `request_id` — so the stored entry carries no mode and can be consumed by either `KeyGen` or `InsecureKeyGen`.
 Completion status can be validated using the `GetInsecureKeyGenPreprocResult` endpoint.
@@ -527,9 +527,7 @@ message Empty {}
 Insecure version of `KeyGen`, where MPC is _not_ used for key generation.
 This RPC initiates the __asynchronous__ generation of a new TFHE keyset with parameters defined by the provided `params`. The status or result can be retrieved using the `GetKeyGenResult` or `GetInsecureKeyGenResult` endpoint.
 
-The `preproc_id` must be the `request_id` of a finished `InsecureKeyGenPreproc` request, mirroring the secure flow. The entry is consumed by this call, so each insecure key generation requires its own insecure preprocessing. In the __threshold__ setting a `preproc_id` produced by the secure `KeyGenPreproc` cannot be consumed by this endpoint (it fails with `FailedPrecondition`); in the __centralized__ setting both preprocessing endpoints are identical dummies, so their entries are interchangeable.
-
-Unlike the secure flow, the `preproc_id` may also be omitted: it then defaults to the well-known `INSECURE_PREPROCESSING_ID` (derived from that string), which the server treats as an implicit one-shot dummy preprocessing if no stored entry exists. The same happens when this well-known ID is passed explicitly. This means the insecure key generation can be called without any prior preprocessing call, but note that concurrent insecure key generations sharing the well-known ID are not supported.
+The `preproc_id` must be the `request_id` of a finished preprocessing request and is consumed by this call, so each insecure key generation requires its own preprocessing. In the __threshold__ setting the preprocessing must have been produced by `InsecureKeyGenPreproc`; a `preproc_id` produced by the secure `KeyGenPreproc` fails with `FailedPrecondition`. In the __centralized__ setting both preprocessing endpoints are identical dummies, so their entries are interchangeable.
 
 The `keyset_config` is the information about the keys to generate.
 The `keyset_added_info` contains the relevant `RequestId`s for key(s) needed to generate the key switching key.

--- a/docs/references/api/core_grpc.md
+++ b/docs/references/api/core_grpc.md
@@ -317,14 +317,13 @@ message KeyGenPreprocRequest {
 ### Output
 
 ```proto
-message KeyGenPreprocResult {}
+message Empty {}
 ```
 
 ### Description
 
-This RPC is only relevant in the __threshold__ case.
-
-It triggers the __asynchronous__ correlated randomness generation that is necessary to perform the Distributed Key Generation on the specified `param` using the specific settings of `keyset_config`.
+In the __threshold__ case it triggers the __asynchronous__ correlated randomness generation that is necessary to perform the Distributed Key Generation on the specified `param` using the specific settings of `keyset_config`.
+In the __centralized__ case no correlated randomness is needed, so this is a dummy that only records the `request_id`; the entry must nonetheless exist before calling `KeyGen`.
 
 This correlated randomness will then be consumed when calling `KeyGen` with the `preproc_id` set to the current `request_id`.
 
@@ -343,7 +342,14 @@ message RequestId { string request_id = 1; }
 
 ### Output
 
-There is no output. If the call is successful then it means preprocessing is completed.
+```proto
+message KeyGenPreprocResult {
+  RequestId preprocessing_id = 1;
+  bytes external_signature = 2;
+}
+```
+
+If the call is successful then it means preprocessing is completed.
 Otherwise, it may fail with the following `tonic::Code` error codes:
 
 - `NotFound`: There has not been a `KeyGenPreproc` call for the provided `request_id`.
@@ -355,15 +361,71 @@ Otherwise, it may fail with the following `tonic::Code` error codes:
 This RPC allows to check the status of the correlated randomness generation.
 
 Correlated randomness generation is a slow process (several hours), and we thus provide a way to query its status via its unique identifier `request_id`.
-This is because, to initiate a Distributed Key Generation, we must provide a `preproc_id` that is the `RequestId` of a `Finished` preprocessing.
+This is because, to initiate a Distributed Key Generation, we must provide a `preproc_id` that is the `RequestId` of a finished preprocessing.
 
-The meaning of the enum is as follows:
+</details>
 
-- `Missing`: There has not been a `KeyGenPreprocRequest` for the provided `request_id`.
-- `InProgess`: The core is still generating the correlated randomness for the specified `request_id`.
-- `Finished`: The core is done generating the correlated randomness, and we can thus now call `KeyGen` with `preproc_id` set to the current `request_id`.
-- `Error`: An irrecoverable internal server error has occurred during the correlated randomness generation.
+<details>
+    <summary> InsecureKeyGenPreproc </summary>
 
+___NOTE_: This is a temporary workaround and will only be available in testing/debugging setups. **NOT in production**__
+
+### Input
+
+```proto
+message KeyGenPreprocRequest {
+  FheParameter params = 1;
+  KeySetConfig keyset_config = 2;
+  RequestId request_id = 3;
+}
+```
+
+### Output
+
+```proto
+message Empty {}
+```
+
+### Description
+
+Insecure version of `KeyGenPreproc`, where _no_ correlated randomness is generated.
+Only the preprocessing ID (along with the parameters and the external signature) is recorded, so a subsequent `InsecureKeyGen` call with `preproc_id` set to the current `request_id` can validate and consume it.
+Because nothing is generated, this call completes (almost) instantly.
+
+As for the secure variant, an explicit preprocessing entry is consumed by _each_ insecure key generation call that references it. Calling this endpoint explicitly is optional however: when `InsecureKeyGen` is invoked without a `preproc_id` (or with the well-known `INSECURE_PREPROCESSING_ID` and no stored entry), the server uses the well-known ID as an implicit one-shot dummy preprocessing.
+In the __threshold__ setting the stored entry can only be consumed by `InsecureKeyGen` (calling the secure `KeyGen` with such a `preproc_id` will fail with `FailedPrecondition`, and vice versa).
+In the __centralized__ setting this endpoint is identical to `KeyGenPreproc` — both are dummies that only record the `request_id` — so the stored entry carries no mode and can be consumed by either `KeyGen` or `InsecureKeyGen`.
+Completion status can be validated using the `GetInsecureKeyGenPreprocResult` endpoint.
+</details>
+
+<details>
+    <summary> GetInsecureKeyGenPreprocResult </summary>
+
+### Input
+
+```proto
+message RequestId { string request_id = 1; }
+```
+
+### Output
+
+```proto
+message KeyGenPreprocResult {
+  RequestId preprocessing_id = 1;
+  bytes external_signature = 2;
+}
+```
+
+If the call is successful then it means preprocessing is completed.
+Otherwise, it may fail with the following `tonic::Code` error codes:
+
+- `NotFound`: There has not been an `InsecureKeyGenPreproc` call for the provided `request_id`.
+- `Internal`: The `InsecureKeyGenPreproc` for the queried `request_id` has failed due to an internal and unrecoverable server error.
+
+### Description
+
+This RPC allows to check the status of an insecure preprocessing request.
+Functionally this call is similar to `GetKeyGenPreprocResult`.
 </details>
 
 <details>
@@ -392,7 +454,7 @@ message Empty {}
 
 This RPC initiates the __asynchronous__ generation of a new TFHE keyset with parameters defined by the provided `params`. The status or result can be retrieved using the `GetKeyGenResult` endpoint.
 
-The `preproc_id` must be the `request_id` of a `Finished` `KeyGenPreprocRequest` in the __threshold__ setting. In the __centralized__ setting, this can be ignored.
+The `preproc_id` must be the `request_id` of a `Finished` `KeyGenPreprocRequest`. This holds in both the __threshold__ and the __centralized__ setting; in the latter the preprocessing is a dummy that only records the `request_id`, but the entry must still exist.
 The `keyset_config` is the information about the keys to generate and _must_ match the similar argument used during preprocessing in `KeyGenPreprocRequest`.
 The `keyset_added_info` contains the relevant `RequestId`s for key(s) needed to generate the key switching key.
 
@@ -465,7 +527,9 @@ message Empty {}
 Insecure version of `KeyGen`, where MPC is _not_ used for key generation.
 This RPC initiates the __asynchronous__ generation of a new TFHE keyset with parameters defined by the provided `params`. The status or result can be retrieved using the `GetKeyGenResult` or `GetInsecureKeyGenResult` endpoint.
 
-The `preproc_id` can be ignored.
+The `preproc_id` must be the `request_id` of a finished `InsecureKeyGenPreproc` request, mirroring the secure flow. The entry is consumed by this call, so each insecure key generation requires its own insecure preprocessing. In the __threshold__ setting a `preproc_id` produced by the secure `KeyGenPreproc` cannot be consumed by this endpoint (it fails with `FailedPrecondition`); in the __centralized__ setting both preprocessing endpoints are identical dummies, so their entries are interchangeable.
+
+Unlike the secure flow, the `preproc_id` may also be omitted: it then defaults to the well-known `INSECURE_PREPROCESSING_ID` (derived from that string), which the server treats as an implicit one-shot dummy preprocessing if no stored entry exists. The same happens when this well-known ID is passed explicitly. This means the insecure key generation can be called without any prior preprocessing call, but note that concurrent insecure key generations sharing the well-known ID are not supported.
 
 The `keyset_config` is the information about the keys to generate.
 The `keyset_added_info` contains the relevant `RequestId`s for key(s) needed to generate the key switching key.

--- a/docs/references/api/core_grpc.md
+++ b/docs/references/api/core_grpc.md
@@ -372,7 +372,7 @@ This is because, to initiate a Distributed Key Generation, we must provide a `pr
 <details>
     <summary> InsecureKeyGenPreproc </summary>
 
-___NOTE_: This is a temporary workaround and will only be available in testing/debugging setups. **NOT in production**__
+___NOTE_: This is a temporary workaround and will only be available in testing/debugging setups. **NOT in production**___
 
 ### Input
 

--- a/docs/references/api/core_grpc.md
+++ b/docs/references/api/core_grpc.md
@@ -308,9 +308,13 @@ Type representing information on the format of a ciphertext.
 
 ```proto
 message KeyGenPreprocRequest {
-  FheParameter params = 1;
-  KeySetConfig keyset_config = 2;
-  RequestId request_id = 3;
+  RequestId request_id = 1;
+  FheParameter params = 2;
+  KeySetConfig keyset_config = 3;
+  Eip712DomainMsg domain = 4;
+  RequestId context_id = 5;
+  RequestId epoch_id = 6;
+  bytes extra_data = 7;
 }
 ```
 
@@ -323,7 +327,7 @@ message Empty {}
 ### Description
 
 In the __threshold__ case it triggers the __asynchronous__ correlated randomness generation that is necessary to perform the Distributed Key Generation on the specified `param` using the specific settings of `keyset_config`.
-In the __centralized__ case no correlated randomness is needed, so this is a dummy that only records the `request_id`; the entry must nonetheless exist before calling `KeyGen`.
+In the __centralized__ case no correlated randomness is needed, so this is a dummy that records preprocessing metadata but no material; the entry must nonetheless exist before calling `KeyGen`.
 
 This correlated randomness will then be consumed when calling `KeyGen` with the `preproc_id` set to the current `request_id`.
 
@@ -374,9 +378,13 @@ ___NOTE_: This is a temporary workaround and will only be available in testing/d
 
 ```proto
 message KeyGenPreprocRequest {
-  FheParameter params = 1;
-  KeySetConfig keyset_config = 2;
-  RequestId request_id = 3;
+  RequestId request_id = 1;
+  FheParameter params = 2;
+  KeySetConfig keyset_config = 3;
+  Eip712DomainMsg domain = 4;
+  RequestId context_id = 5;
+  RequestId epoch_id = 6;
+  bytes extra_data = 7;
 }
 ```
 
@@ -394,7 +402,7 @@ Because nothing is generated, this call completes (almost) instantly.
 
 As for the secure variant, a preprocessing entry is consumed by _each_ insecure key generation call that references it. Calling this endpoint explicitly is required before threshold `InsecureKeyGen`.
 In the __threshold__ setting the stored entry can only be consumed by `InsecureKeyGen` (calling the secure `KeyGen` with such a `preproc_id` will fail with `FailedPrecondition`, and vice versa).
-In the __centralized__ setting this endpoint is identical to `KeyGenPreproc` — both are dummies that only record the `request_id` — so the stored entry carries no mode and can be consumed by either `KeyGen` or `InsecureKeyGen`.
+In the __centralized__ setting this endpoint is identical to `KeyGenPreproc` — both are dummies that record preprocessing metadata but no material — so the stored entry carries no mode and can be consumed by either `KeyGen` or `InsecureKeyGen`.
 Completion status can be validated using the `GetInsecureKeyGenPreprocResult` endpoint.
 </details>
 
@@ -420,6 +428,8 @@ If the call is successful then it means preprocessing is completed.
 Otherwise, it may fail with the following `tonic::Code` error codes:
 
 - `NotFound`: There has not been an `InsecureKeyGenPreproc` call for the provided `request_id`.
+- `Unavailable`: The `InsecureKeyGenPreproc` for the queried `request_id` has started but is not finished yet.
+- `FailedPrecondition`: In threshold mode, the provided `request_id` belongs to a real `KeyGenPreproc` entry rather than an insecure preprocessing entry.
 - `Internal`: The `InsecureKeyGenPreproc` for the queried `request_id` has failed due to an internal and unrecoverable server error.
 
 ### Description
@@ -435,12 +445,15 @@ Functionally this call is similar to `GetKeyGenPreprocResult`.
 
 ```proto
 message KeyGenRequest {
-  FheParameter params = 1;
-  RequestId preproc_id = 2;
-  RequestId request_id = 3;
+  RequestId request_id = 1;
+  optional FheParameter params = 2;
+  RequestId preproc_id = 3;
   Eip712DomainMsg domain = 4;
   KeySetConfig keyset_config = 5;
   KeySetAddedInfo keyset_added_info = 6;
+  RequestId context_id = 7;
+  RequestId epoch_id = 8;
+  bytes extra_data = 9;
 }
 ```
 
@@ -454,7 +467,7 @@ message Empty {}
 
 This RPC initiates the __asynchronous__ generation of a new TFHE keyset with parameters defined by the provided `params`. The status or result can be retrieved using the `GetKeyGenResult` endpoint.
 
-The `preproc_id` must be the `request_id` of a `Finished` `KeyGenPreprocRequest`. This holds in both the __threshold__ and the __centralized__ setting; in the latter the preprocessing is a dummy that only records the `request_id`, but the entry must still exist.
+The `preproc_id` must be the `request_id` of a finished `KeyGenPreprocRequest`. This holds in both the __threshold__ and the __centralized__ setting; in the latter the preprocessing is a dummy that records metadata but no material, and the entry must still exist.
 The `keyset_config` is the information about the keys to generate and _must_ match the similar argument used during preprocessing in `KeyGenPreprocRequest`.
 The `keyset_added_info` contains the relevant `RequestId`s for key(s) needed to generate the key switching key.
 
@@ -474,9 +487,16 @@ message RequestId { string request_id = 1; }
 ### Output
 
 ```proto
+message KeyDigest {
+  string key_type = 1;
+  bytes digest = 2;
+}
+
 message KeyGenResult {
   RequestId request_id = 1;
-  map<string, SignedPubDataHandle> key_results = 2;
+  RequestId preprocessing_id = 2;
+  repeated KeyDigest key_digests = 3;
+  bytes external_signature = 4;
 }
 ```
 
@@ -490,11 +510,7 @@ Because this call is dependent on previous call, it may fail with the following 
 - `Unavailable`: The `KeyGen` for the queried `request_id` has started but is not finished yet.
 - `Internal`: The `KeyGen` for the queried `request_id` has failed due to an internal and unrecoverable server error.
 
-If the call is successful, the `KeyGenResult` will contain the `request_id` used in the query, as well as the following map:
-
-- Key: `"PublicKey"`, Value: The `SignedPubDataHandle` corresponding to the generated `tfhe::CompactPublicKey`.
-- Key: `"ServerKey"`, Value: The `SignedPubDataHandle` corresponding to the generated `tfhe::ServerKey`.
-- __If the setting is threshold__ Key: `"SnsKey"`, Value: The `SignedPubDataHandle` corresponding to the generated `SwitchAndSquashKey`.
+If the call is successful, the `KeyGenResult` will contain the `request_id` used in the query, the `preprocessing_id` consumed by the key generation, the digests of the generated public key material, and the EIP-712 `external_signature` over the result.
 
 </details>
 
@@ -507,12 +523,15 @@ ___NOTE_: This is a temporary workaround and will only be available in testing/d
 
 ```proto
 message KeyGenRequest {
-  FheParameter params = 1;
-  RequestId preproc_id = 2;
-  RequestId request_id = 3;
+  RequestId request_id = 1;
+  optional FheParameter params = 2;
+  RequestId preproc_id = 3;
   Eip712DomainMsg domain = 4;
   KeySetConfig keyset_config = 5;
   KeySetAddedInfo keyset_added_info = 6;
+  RequestId context_id = 7;
+  RequestId epoch_id = 8;
+  bytes extra_data = 9;
 }
 ```
 
@@ -545,27 +564,30 @@ message RequestId { string request_id = 1; }
 ### Output
 
 ```proto
+message KeyDigest {
+  string key_type = 1;
+  bytes digest = 2;
+}
+
 message KeyGenResult {
   RequestId request_id = 1;
-  map<string, SignedPubDataHandle> key_results = 2;
+  RequestId preprocessing_id = 2;
+  repeated KeyDigest key_digests = 3;
+  bytes external_signature = 4;
 }
 ```
 
 ### Description
 
-This RPC allows to retrieve the public key material if the `request_id` is that of a finished `KeyGen`.
+This RPC allows to retrieve the insecure key generation result if the `request_id` is that of a finished `InsecureKeyGen`.
 
 Because this call is dependent on previous call, it may fail with the following `tonic::Code` error codes:
 
-- `NotFound`: There has not been a `KeyGen` call for the provided `request_id`.
-- `Unavailable`: The `KeyGen` for the queried `request_id` has started but is not finished yet.
-- `Internal`: The `KeyGen` for the queried `request_id` has failed.
+- `NotFound`: There has not been an `InsecureKeyGen` call for the provided `request_id`.
+- `Unavailable`: The `InsecureKeyGen` for the queried `request_id` has started but is not finished yet.
+- `Internal`: The `InsecureKeyGen` for the queried `request_id` has failed.
 
-If the call is successful, the `KeyGenResult` will contain the `request_id` used in the query, as well as the following map:
-
-- Key: `"PublicKey"`, Value: The `SignedPubDataHandle` corresponding to the generated `tfhe::CompactPublicKey`.
-- Key: `"ServerKey"`, Value: The `SignedPubDataHandle` corresponding to the generated `tfhe::ServerKey`.
-- __If the setting is threshold__ Key: `"SnsKey"`, Value: The `SignedPubDataHandle` corresponding to the generated `SwitchAndSquashKey`.
+If the call is successful, the `KeyGenResult` will contain the `request_id` used in the query, the `preprocessing_id` consumed by the key generation, the digests of the generated public key material, and the EIP-712 `external_signature` over the result.
 
 Functionally this call is similar to `GetKeyGenResult`.
 </details>

--- a/docs/tutorials/showcase.md
+++ b/docs/tutorials/showcase.md
@@ -32,7 +32,8 @@ In a different terminal, we can now interact with the running cores from the pre
 in the config file used in the next step.
 3. Then, generate a set of private and public FHE keys by running the following command, pointing to your desired config file after the `-f` flag:
     ```{bash}
-    $ cargo run --bin kms-core-client -- -f core-client/config/client_local_threshold.toml -a -l insecure-key-gen
+    $ PREPROC_ID=$(cargo run --bin kms-core-client -- -f core-client/config/client_local_threshold.toml -a -l insecure-preproc-key-gen | grep request_id | cut -d'"' -f4)
+    $ cargo run --bin kms-core-client -- -f core-client/config/client_local_threshold.toml -a -l insecure-key-gen --preproc-id "$PREPROC_ID"
     ```
     The command will print plenty of logs and return the `key-id` that we require in the following step. The output looks like this, where `948ddb338f9279d5b06a45911be7c93dd7f45c8d6bc66c36140470432bce7e06` is the `key-id`:
     ```

--- a/observability/src/metrics_names.rs
+++ b/observability/src/metrics_names.rs
@@ -11,6 +11,8 @@ pub const OP_INSECURE_KEYGEN_REQUEST: &str = "insecure_keygen_request";
 pub const OP_INSECURE_KEYGEN_RESULT: &str = "insecure_keygen_result";
 pub const OP_KEYGEN_PREPROC_REQUEST: &str = "keygen_preproc_request";
 pub const OP_KEYGEN_PREPROC_RESULT: &str = "keygen_preproc_result";
+pub const OP_INSECURE_KEYGEN_PREPROC_REQUEST: &str = "insecure_keygen_preproc_request";
+pub const OP_INSECURE_KEYGEN_PREPROC_RESULT: &str = "insecure_keygen_preproc_result";
 // More specific metrics for key generation, only used with counters
 pub const OP_INSECURE_STANDARD_KEYGEN: &str = "insecure_standard_keygen";
 pub const OP_INSECURE_COMPRESSED_KEYGEN: &str = "insecure_compressed_keygen";


### PR DESCRIPTION
## Description of changes

Insecure preprocessing for threshold MPC.

Insecure preprocessing normally does not exist in the threshold setting, since no triples are used. But we need this functionality so that it matches the behaviour of secure keygen, so that it can be used in E2E tests.

This PR adds the insecure preprocessing functionality by extending the `PreprocHandleWithMode` type in the meta store to an enum, where a new variant `Insecure` is included when the code is compiled with the `insecure` feature. An insecure keygen can be called if there's is a preprocessing element (identified by the preprocessing ID) under the `Insecure` variant in the meta store.

The existing functionality of insecure keygen is not preserved. Concretely, insecure preprocessing must be done prior to insecure keygen (in the case of centralized KMS, insecure preprocessing is the same as secure preprocessing, so it does not matter). Consequently, the performance workflows are updated.


## Issue ticket number and link
Closes zama-ai/kms-internal#3035

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
