### PR TITLE
Solana-native user-decryption for kms-core (pinned on c57f52f, reference branch)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,15 +2061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,33 +2681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version 0.4.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3010,30 +2974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "educe"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3286,12 +3226,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -4382,14 +4316,12 @@ dependencies = [
  "bc2wrap",
  "bincode 2.0.1",
  "bip39",
- "bs58",
  "cargo_metadata",
  "cbc",
  "cfg-if",
  "ciborium",
  "clap",
  "console_error_panic_hook",
- "ed25519-dalek",
  "enum_dispatch",
  "futures-util",
  "getrandom 0.2.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,6 +2061,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +2690,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,6 +3010,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "educe"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,6 +3286,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -4316,12 +4382,14 @@ dependencies = [
  "bc2wrap",
  "bincode 2.0.1",
  "bip39",
+ "bs58",
  "cargo_metadata",
  "cbc",
  "cfg-if",
  "ciborium",
  "clap",
  "console_error_panic_hook",
+ "ed25519-dalek",
  "enum_dispatch",
  "futures-util",
  "getrandom 0.2.17",
@@ -4344,6 +4412,7 @@ dependencies = [
  "rasn-cms",
  "rayon",
  "rcgen",
+ "reqwest",
  "rsa",
  "rstest",
  "rustls-webpki 0.103.9",
@@ -5692,7 +5761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -5713,7 +5782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,6 @@ backoff = "=0.4.0"  # Retry with exponential backoff - HIGH RISK: Individual mai
 # See https://www.reddit.com/r/rust/comments/1pnz1iz/bincode_development_has_ceased_permanently/
 bincode = { version = "=2.0.1", features = ["serde"] }  # Binary serialization - CRITICAL RISK: bincode-org, 147M+ downloads
 bip39 = { version = "=2.2.2", features = ["alloc"] }  # BIP39 mnemonic seed phrases - LOW RISK: rust-bitcoin org (reputable), CI enabled
-bs58 = "=0.5.1"  # Base58 (Solana addresses) - LOW RISK: RustCrypto-adjacent; RFC-021 user-decrypt client (test-only)
 bytes = "=1.11.1"  # Byte buffer utilities - LOW RISK: tokio team, 100M+ downloads
 cargo_metadata = "=0.23.1"  # Workspace metadata extraction - LOW RISK: oli-obk (rust-lang member) + community, 60M+ downloads, test-only dependency
 cbc = { version = "=0.1.2", features = ["alloc"] }  # CBC block cipher mode - LOW RISK: RustCrypto org, standard cipher mode
@@ -138,7 +137,6 @@ criterion = { version = "=0.5.1", features = ["async_tokio"] }  # Benchmarking f
 crypto-bigint = { version = "=0.6.1", features = ["serde", "rand_core", "extra-sizes"] }  # Big integer operations for crypto - LOW RISK: RustCrypto org
 dashmap = "=6.1.0"  # Concurrent hashmap - HIGH RISK: Individual maintainer (xacrimon), despite 156M+ downloads
 derive_more = { version = "=2.0.1", features = ["display"] }  # Derive macros for common traits - HIGH RISK: Individual maintainer (JelteF), despite 180M+ downloads
-ed25519-dalek = "=2.2.0"  # Ed25519 signatures (Solana signMessage auth) - LOW RISK: dalek-cryptography org; RFC-021 user-decrypt client (test-only)
 enum_dispatch = "=0.3.13"  # Enum dispatch optimization - HIGH RISK: Individual maintainer (Anton Lazarev), despite 29M+ downloads
 futures = "=0.3.31"  # Async futures - LOW RISK: rust-lang team
 futures-util = "=0.3.31"  # Futures utilities - LOW RISK: rust-lang team

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ backoff = "=0.4.0"  # Retry with exponential backoff - HIGH RISK: Individual mai
 # See https://www.reddit.com/r/rust/comments/1pnz1iz/bincode_development_has_ceased_permanently/
 bincode = { version = "=2.0.1", features = ["serde"] }  # Binary serialization - CRITICAL RISK: bincode-org, 147M+ downloads
 bip39 = { version = "=2.2.2", features = ["alloc"] }  # BIP39 mnemonic seed phrases - LOW RISK: rust-bitcoin org (reputable), CI enabled
+bs58 = "=0.5.1"  # Base58 (Solana addresses) - LOW RISK: RustCrypto-adjacent; RFC-021 user-decrypt client (test-only)
 bytes = "=1.11.1"  # Byte buffer utilities - LOW RISK: tokio team, 100M+ downloads
 cargo_metadata = "=0.23.1"  # Workspace metadata extraction - LOW RISK: oli-obk (rust-lang member) + community, 60M+ downloads, test-only dependency
 cbc = { version = "=0.1.2", features = ["alloc"] }  # CBC block cipher mode - LOW RISK: RustCrypto org, standard cipher mode
@@ -137,6 +138,7 @@ criterion = { version = "=0.5.1", features = ["async_tokio"] }  # Benchmarking f
 crypto-bigint = { version = "=0.6.1", features = ["serde", "rand_core", "extra-sizes"] }  # Big integer operations for crypto - LOW RISK: RustCrypto org
 dashmap = "=6.1.0"  # Concurrent hashmap - HIGH RISK: Individual maintainer (xacrimon), despite 156M+ downloads
 derive_more = { version = "=2.0.1", features = ["display"] }  # Derive macros for common traits - HIGH RISK: Individual maintainer (JelteF), despite 180M+ downloads
+ed25519-dalek = "=2.2.0"  # Ed25519 signatures (Solana signMessage auth) - LOW RISK: dalek-cryptography org; RFC-021 user-decrypt client (test-only)
 enum_dispatch = "=0.3.13"  # Enum dispatch optimization - HIGH RISK: Individual maintainer (Anton Lazarev), despite 29M+ downloads
 futures = "=0.3.31"  # Async futures - LOW RISK: rust-lang team
 futures-util = "=0.3.31"  # Futures utilities - LOW RISK: rust-lang team

--- a/core/grpc/src/rpc_types.rs
+++ b/core/grpc/src/rpc_types.rs
@@ -550,6 +550,91 @@ impl crate::kms::v1::UserDecryptionRequest {
     }
 }
 
+/// Computes the Solana-native user-decryption request↔response link.
+///
+/// On EVM, [`crate::kms::v1::UserDecryptionRequest::compute_link_checked`] binds the
+/// triple `(publicKey, handles, userAddress)` via an EIP-712 hash over the gateway domain
+/// (an EVM `verifying_contract` + `chainId`). A Solana host has no EVM verifying contract
+/// and the user identity is a 32-byte ed25519 pubkey rather than a 20-byte `address`, so
+/// the EIP-712 linker cannot represent it.
+///
+/// This binds the same logical triple — the user's ML-KEM `enc_key`, the ciphertext
+/// `handles`, and the 32-byte Solana user pubkey — under the Solana host chain id, with
+/// keccak256 (matching the keccak domain used across the Solana on-chain surface). It is
+/// purely the request↔response binding, so a relayed response cannot be swapped onto a
+/// different request; it is NOT the authorization. Authorization for a Solana user
+/// decryption is enforced by the kms-connector before the core call: the RPC-verified
+/// on-chain ACL (the user holds the use/decrypt role on the handle's `zama-host` ACL
+/// record) plus the user's ed25519 `signMessage` over the canonical native request.
+///
+/// Length-prefixed fields keep the preimage unambiguous; a version tag domain-separates
+/// it from every other keccak preimage on the Solana surface.
+pub fn compute_link_solana(
+    enc_key: &[u8],
+    handles: &[[u8; 32]],
+    solana_user_pubkey: &[u8; 32],
+    host_chain_id: u64,
+) -> Vec<u8> {
+    let mut preimage = Vec::with_capacity(64 + handles.len() * 32 + enc_key.len());
+    preimage.extend_from_slice(b"SolanaUserDecryptionLinker:v0");
+    preimage.extend_from_slice(&host_chain_id.to_be_bytes());
+    preimage.extend_from_slice(solana_user_pubkey);
+    preimage.extend_from_slice(&(handles.len() as u32).to_be_bytes());
+    for handle in handles {
+        preimage.extend_from_slice(handle);
+    }
+    preimage.extend_from_slice(&(enc_key.len() as u32).to_be_bytes());
+    preimage.extend_from_slice(enc_key);
+    alloy_primitives::keccak256(&preimage).to_vec()
+}
+
+#[cfg(test)]
+mod solana_link_tests {
+    use super::compute_link_solana;
+
+    #[test]
+    fn solana_link_is_deterministic_and_field_sensitive() {
+        let enc_key = vec![7u8; 800];
+        let handles = vec![[1u8; 32], [2u8; 32]];
+        let pubkey = [9u8; 32];
+        let chain_id = 9_223_372_036_854_788_153u64; // RFC-021 Solana host chain id
+
+        let base = compute_link_solana(&enc_key, &handles, &pubkey, chain_id);
+        assert_eq!(base.len(), 32, "keccak256 output is 32 bytes");
+        // Deterministic.
+        assert_eq!(base, compute_link_solana(&enc_key, &handles, &pubkey, chain_id));
+
+        // Sensitive to every bound field.
+        let mut other_pubkey = pubkey;
+        other_pubkey[0] ^= 0xff;
+        assert_ne!(base, compute_link_solana(&enc_key, &handles, &other_pubkey, chain_id));
+        assert_ne!(
+            base,
+            compute_link_solana(&enc_key, &[[1u8; 32]], &pubkey, chain_id),
+            "dropping a handle must change the link"
+        );
+        assert_ne!(
+            base,
+            compute_link_solana(&[7u8; 799], &handles, &pubkey, chain_id),
+            "a different enc_key must change the link"
+        );
+        assert_ne!(base, compute_link_solana(&enc_key, &handles, &pubkey, chain_id + 1));
+    }
+
+    #[test]
+    fn solana_link_length_prefixing_prevents_field_boundary_collision() {
+        // Two handles [a,b] vs one handle that is the concatenation a‖b would collide
+        // without length-prefixing; the count prefix must keep them distinct.
+        let enc_key = vec![0u8; 4];
+        let pubkey = [3u8; 32];
+        let two = compute_link_solana(&enc_key, &[[0xaa; 32], [0xbb; 32]], &pubkey, 1);
+        // One 32-byte handle plus enc_key shifted can't reproduce the two-handle preimage
+        // because the handle count (2 vs 1) is hashed in.
+        let one = compute_link_solana(&enc_key, &[[0xaa; 32]], &pubkey, 1);
+        assert_ne!(two, one);
+    }
+}
+
 /// returns a slice of the first N bytes of the vector, padding with zeros if the vector is too short
 fn sub_slice<const N: usize>(vec: &[u8]) -> [u8; N] {
     // Get a slice of the first len bytes, if available

--- a/core/grpc/src/rpc_types.rs
+++ b/core/grpc/src/rpc_types.rs
@@ -602,12 +602,18 @@ mod solana_link_tests {
         let base = compute_link_solana(&enc_key, &handles, &pubkey, chain_id);
         assert_eq!(base.len(), 32, "keccak256 output is 32 bytes");
         // Deterministic.
-        assert_eq!(base, compute_link_solana(&enc_key, &handles, &pubkey, chain_id));
+        assert_eq!(
+            base,
+            compute_link_solana(&enc_key, &handles, &pubkey, chain_id)
+        );
 
         // Sensitive to every bound field.
         let mut other_pubkey = pubkey;
         other_pubkey[0] ^= 0xff;
-        assert_ne!(base, compute_link_solana(&enc_key, &handles, &other_pubkey, chain_id));
+        assert_ne!(
+            base,
+            compute_link_solana(&enc_key, &handles, &other_pubkey, chain_id)
+        );
         assert_ne!(
             base,
             compute_link_solana(&enc_key, &[[1u8; 32]], &pubkey, chain_id),
@@ -618,7 +624,10 @@ mod solana_link_tests {
             compute_link_solana(&[7u8; 799], &handles, &pubkey, chain_id),
             "a different enc_key must change the link"
         );
-        assert_ne!(base, compute_link_solana(&enc_key, &handles, &pubkey, chain_id + 1));
+        assert_ne!(
+            base,
+            compute_link_solana(&enc_key, &handles, &pubkey, chain_id + 1)
+        );
     }
 
     #[test]

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -136,9 +136,7 @@ zeroize.workspace = true
 # Maintain alphabetical order
 assert_cmd.workspace = true
 backward-compatibility = { workspace = true, features = ["load", "tests"] }
-bs58.workspace = true
 cargo_metadata = { workspace = true }
-ed25519-dalek.workspace = true
 reqwest.workspace = true
 threshold-execution = { workspace = true, features = ["testing", "malicious_strategies"] }
 # Self-import for integration tests

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -136,7 +136,10 @@ zeroize.workspace = true
 # Maintain alphabetical order
 assert_cmd.workspace = true
 backward-compatibility = { workspace = true, features = ["load", "tests"] }
+bs58.workspace = true
 cargo_metadata = { workspace = true }
+ed25519-dalek.workspace = true
+reqwest.workspace = true
 threshold-execution = { workspace = true, features = ["testing", "malicious_strategies"] }
 # Self-import for integration tests
 kms = { workspace = true, features = ["insecure", "testing"] }

--- a/core/service/src/client/user_decryption_wasm.rs
+++ b/core/service/src/client/user_decryption_wasm.rs
@@ -25,6 +25,7 @@ use itertools::Itertools;
 use kms_grpc::kms::v1::{
     TypedPlaintext, UserDecryptionRequest, UserDecryptionResponse, UserDecryptionResponsePayload,
 };
+use kms_grpc::rpc_types::compute_link_solana;
 use kms_grpc::rpc_types::fhe_types_to_num_blocks;
 use kms_grpc::solidity_types::UserDecryptionLinker;
 use std::num::Wrapping;
@@ -202,6 +203,97 @@ impl Client {
             })?;
         }
         let receiver_id = self.client_address.to_vec();
+        let unsign_key =
+            UnifiedUnsigncryptionKey::new(dec_key, enc_key, &cur_verf_key, &receiver_id);
+
+        payload
+            .signcrypted_ciphertexts
+            .into_iter()
+            .map(|ct| {
+                unsign_key
+                    .unsigncrypt_plaintext(&DSEP_USER_DECRYPTION, &ct.signcrypted_ciphertext, &link)
+                    .map(|res| res.plaintext)
+                    .map_err(|e| anyhow::anyhow!("unsigncrypt_plaintext failed: {}", e))
+            })
+            .collect()
+    }
+
+    /// Solana (RFC-021) centralized de-signcryption.
+    ///
+    /// Identical to [`Self::centralized_user_decryption_resp`] except for the request<->response
+    /// binding `link`: on Solana it is the opaque keccak [`compute_link_solana`] digest over
+    /// `(host_chain_id, solana_user_pubkey, handles, enc_key)`, not the EVM `UserDecryptionLinker`
+    /// EIP-712 hash. The KMS signcrypts against this same link and the derived signcryption
+    /// `receiver_id = keccak256(solana_user_pubkey)[12..]` (see the Solana branch in
+    /// `validation_non_wasm`), so the client reproduces both here. The link is opaque AAD to the
+    /// signcryption layer, so the unsigncryption is mechanically the EVM path with a different link.
+    ///
+    /// Server authenticity is checked via the internal ECDSA signature over the response payload;
+    /// the external EIP-712 certificate is the on-chain-consumable artifact and is not needed to
+    /// recover the plaintext client-side.
+    pub fn process_user_decryption_resp_solana(
+        &self,
+        request: &ParsedUserDecryptionRequest,
+        solana_user_pubkey: &[u8; 32],
+        host_chain_id: u64,
+        enc_key: &UnifiedPublicEncKey,
+        dec_key: &UnifiedPrivateEncKey,
+        agg_resp: &[UserDecryptionResponse],
+    ) -> anyhow::Result<Vec<TypedPlaintext>> {
+        let resp = some_or_err(agg_resp.last(), "Response does not exist".to_owned())?;
+        let payload = some_or_err(resp.payload.clone(), "Payload does not exist".to_owned())?;
+
+        // Handles are 32 bytes on Solana; left-pad defensively to mirror the EVM consistency check.
+        let handles: Vec<[u8; 32]> = request
+            .ciphertext_handles
+            .iter()
+            .map(|c| {
+                let mut h = [0u8; 32];
+                let src = &c.0;
+                let take = src.len().min(32);
+                h[32 - take..].copy_from_slice(&src[src.len() - take..]);
+                h
+            })
+            .collect();
+        let link =
+            compute_link_solana(&request.enc_key, &handles, solana_user_pubkey, host_chain_id);
+        if link != payload.digest {
+            return Err(anyhow_error_and_log(format!(
+                "solana link mismatch ({} != {})",
+                hex::encode(&link),
+                hex::encode(&payload.digest),
+            )));
+        }
+
+        let stored_server_addrs = &self.get_server_addrs();
+        if stored_server_addrs.len() != 1 {
+            return Err(anyhow_error_and_log("incorrect length for addresses"));
+        }
+        let cur_verf_key: PublicSigKey = bc2wrap::deserialize_safe(&payload.verification_key)?;
+        match stored_server_addrs.get(&1) {
+            Some(server_addr) if *server_addr == cur_verf_key.address() => {}
+            Some(_) => return Err(anyhow_error_and_log("server address is not consistent")),
+            None => return Err(anyhow_error_and_log("missing server address at ID 1")),
+        }
+
+        if resp.signature.is_empty() {
+            return Err(anyhow_error_and_log(
+                "empty server signature on solana user-decrypt response",
+            ));
+        }
+        let sig = Signature {
+            sig: k256::ecdsa::Signature::from_slice(&resp.signature)?,
+        };
+        internal_verify_sig(
+            &DSEP_USER_DECRYPTION,
+            &bc2wrap::serialize(&payload)?,
+            &sig,
+            &cur_verf_key,
+        )
+        .inspect_err(|e| tracing::warn!("solana user-decrypt response signature invalid ({e})"))?;
+
+        // receiver_id mirrors the server's `solana_user_decrypt_client_id`: keccak256(pubkey)[12..].
+        let receiver_id = alloy_primitives::keccak256(solana_user_pubkey)[12..].to_vec();
         let unsign_key =
             UnifiedUnsigncryptionKey::new(dec_key, enc_key, &cur_verf_key, &receiver_id);
 

--- a/core/service/src/client/user_decryption_wasm.rs
+++ b/core/service/src/client/user_decryption_wasm.rs
@@ -255,8 +255,12 @@ impl Client {
                 h
             })
             .collect();
-        let link =
-            compute_link_solana(&request.enc_key, &handles, solana_user_pubkey, host_chain_id);
+        let link = compute_link_solana(
+            &request.enc_key,
+            &handles,
+            solana_user_pubkey,
+            host_chain_id,
+        );
         if link != payload.digest {
             return Err(anyhow_error_and_log(format!(
                 "solana link mismatch ({} != {})",

--- a/core/service/src/client/user_decryption_wasm.rs
+++ b/core/service/src/client/user_decryption_wasm.rs
@@ -276,21 +276,32 @@ impl Client {
             None => return Err(anyhow_error_and_log("missing server address at ID 1")),
         }
 
+        // Authenticity: the relayer/gateway path carries only the KMS external (EIP-712) signature,
+        // already verified on-chain by gateway consensus, with the internal ECDSA `signature` empty;
+        // the direct-gRPC path carries the internal ECDSA signature. Verify the internal signature
+        // when present; otherwise rely on the gateway-verified external signature plus the link/AEAD
+        // binding below (the opaque `link` must equal payload.digest, and unsigncryption is an AEAD
+        // keyed to the server verf key + receiver id, so a forged response cannot be unsigncrypted).
         if resp.signature.is_empty() {
-            return Err(anyhow_error_and_log(
-                "empty server signature on solana user-decrypt response",
-            ));
+            if resp.external_signature.is_empty() {
+                return Err(anyhow_error_and_log(
+                    "solana user-decrypt response has neither internal nor external signature",
+                ));
+            }
+        } else {
+            let sig = Signature {
+                sig: k256::ecdsa::Signature::from_slice(&resp.signature)?,
+            };
+            internal_verify_sig(
+                &DSEP_USER_DECRYPTION,
+                &bc2wrap::serialize(&payload)?,
+                &sig,
+                &cur_verf_key,
+            )
+            .inspect_err(|e| {
+                tracing::warn!("solana user-decrypt response signature invalid ({e})")
+            })?;
         }
-        let sig = Signature {
-            sig: k256::ecdsa::Signature::from_slice(&resp.signature)?,
-        };
-        internal_verify_sig(
-            &DSEP_USER_DECRYPTION,
-            &bc2wrap::serialize(&payload)?,
-            &sig,
-            &cur_verf_key,
-        )
-        .inspect_err(|e| tracing::warn!("solana user-decrypt response signature invalid ({e})"))?;
 
         // receiver_id mirrors the server's `solana_user_decrypt_client_id`: keccak256(pubkey)[12..].
         let receiver_id = alloy_primitives::keccak256(solana_user_pubkey)[12..].to_vec();

--- a/core/service/src/engine/validation_non_wasm.rs
+++ b/core/service/src/engine/validation_non_wasm.rs
@@ -27,7 +27,7 @@ use kms_grpc::{
         PublicDecryptionRequest, PublicDecryptionResponse, PublicDecryptionResponsePayload,
         TypedCiphertext, TypedPlaintext, UserDecryptionRequest,
     },
-    rpc_types::optional_protobuf_to_alloy_domain,
+    rpc_types::{compute_link_solana, optional_protobuf_to_alloy_domain},
 };
 use observability::metrics_names::{
     OP_KEYGEN_PREPROC_REQUEST, OP_NEW_EPOCH, OP_PUBLIC_DECRYPT_REQUEST, OP_USER_DECRYPT_REQUEST,
@@ -182,6 +182,27 @@ pub(crate) fn parse_grpc_request_id<'a, O: TryFrom<&'a kms_grpc::kms::v1::Reques
     })
 }
 
+/// Parses a Solana-native user-decryption client identity carried as
+/// `"solana:<64 lowercase hex chars>"` in [`UserDecryptionRequest::client_address`].
+///
+/// Solana users authenticate with an ed25519 `signMessage` over a 32-byte pubkey rather
+/// than an EVM EIP-712 wallet signature over a 20-byte address, so the standard checksummed
+/// `Address` parse cannot represent them. Returns `None` for an ordinary EVM client address,
+/// which takes the unchanged EIP-712 path.
+fn parse_solana_user_decrypt_pubkey(client_address: &str) -> Option<[u8; 32]> {
+    let hex = client_address.strip_prefix("solana:")?;
+    let bytes = alloy_primitives::hex::decode(hex).ok()?;
+    <[u8; 32]>::try_from(bytes.as_slice()).ok()
+}
+
+/// Derives the stable 20-byte signcryption `client_id` from a 32-byte Solana pubkey as
+/// `keccak256(pubkey)[12..]`, mirroring EVM address derivation. The client reproduces this
+/// to de-signcrypt the response; it is a deterministic label, not an authorization input
+/// (Solana user-decrypt authorization is enforced by the kms-connector before this call).
+fn solana_user_decrypt_client_id(solana_pubkey: &[u8; 32]) -> alloy_primitives::Address {
+    alloy_primitives::Address::from_slice(&alloy_primitives::keccak256(solana_pubkey)[12..])
+}
+
 /// Validates and unpacks a user decryption request and returns ciphertext, FheType, request digest, client
 /// encryption key, client verification key, key_id and request_id if valid.
 ///
@@ -251,6 +272,56 @@ fn unpack_user_decrypt_req(
     sanity_check_extra_data(&req.extra_data, &epoch_id, &context_id);
     if req.typed_ciphertexts.is_empty() {
         return Err(anyhow::anyhow!(ERR_VALIDATE_USER_DECRYPTION_EMPTY_CTS).into());
+    }
+
+    // Solana-native user decryption: the client identity is a 32-byte ed25519 pubkey carried
+    // as "solana:<hex>" (the EVM checksum parse below cannot represent it) and there is no EVM
+    // verifying contract. Authorization (RPC-verified on-chain ACL + ed25519 signMessage) is
+    // enforced by the kms-connector before this call — exactly as the gateway enforces the EVM
+    // ACL before the EVM path — so here we only bind the response to the request via the Solana
+    // link (`compute_link_solana`). The link is passed opaquely into signcryption, so the
+    // binding is sound as long as the client recomputes the same link; the EIP-712 domain is
+    // response metadata only in the centralized path, so a placeholder domain is used.
+    if let Some(solana_pubkey) = parse_solana_user_decrypt_pubkey(&req.client_address) {
+        let mut handles = Vec::with_capacity(req.typed_ciphertexts.len());
+        for c in &req.typed_ciphertexts {
+            if c.external_handle.len() > 32 {
+                return Err(anyhow::anyhow!(
+                    "Solana user-decrypt external_handle too long: {} bytes (max 32)",
+                    c.external_handle.len()
+                )
+                .into());
+            }
+            let mut handle = [0u8; 32];
+            handle[32 - c.external_handle.len()..].copy_from_slice(&c.external_handle);
+            handles.push(handle);
+        }
+        // Handle byte-layout (canonical fhevm): chain id at bytes [22..30], big-endian.
+        let first = &handles[0];
+        let mut chain_id_bytes = [0u8; 8];
+        chain_id_bytes.copy_from_slice(&first[22..30]);
+        let host_chain_id = u64::from_be_bytes(chain_id_bytes);
+
+        let link = compute_link_solana(&req.enc_key, &handles, &solana_pubkey, host_chain_id);
+        let client_verf_key = solana_user_decrypt_client_id(&solana_pubkey);
+        let _client_enc_key =
+            UnifiedPublicEncKey::deserialize_and_validate(&req.enc_key).map_err(|e| {
+                anyhow::anyhow!(
+                    "Error deserializing UnifiedPublicEncKey from Solana UserDecryptionRequest: {e}"
+                )
+            })?;
+        return Ok((
+            req.typed_ciphertexts.clone(),
+            link,
+            req.enc_key.clone(),
+            client_verf_key,
+            request_id,
+            key_id,
+            context_id,
+            epoch_id,
+            crate::dummy_domain(),
+            req.extra_data.clone(),
+        ));
     }
 
     let client_verf_key = alloy_primitives::Address::parse_checksummed(&req.client_address, None)
@@ -984,6 +1055,39 @@ fn unpack_new_mpc_epoch_req(req: NewMpcEpochRequest) -> anyhow::Result<VerifiedN
         resharing,
         extra_data: req.extra_data,
     })
+}
+
+#[cfg(test)]
+mod solana_user_decrypt_tests {
+    use super::{parse_solana_user_decrypt_pubkey, solana_user_decrypt_client_id};
+
+    #[test]
+    fn parses_solana_client_address_and_rejects_evm() {
+        let pubkey = [0x11u8; 32];
+        let addr = format!("solana:{}", alloy_primitives::hex::encode(pubkey));
+        assert_eq!(parse_solana_user_decrypt_pubkey(&addr), Some(pubkey));
+
+        // Ordinary EVM checksummed address → None (takes the unchanged EIP-712 path).
+        assert_eq!(
+            parse_solana_user_decrypt_pubkey("0x66f9664f97F2b50F62D13eA064982f936dE76657"),
+            None
+        );
+        // Malformed Solana payloads → None.
+        assert_eq!(parse_solana_user_decrypt_pubkey("solana:zz"), None);
+        assert_eq!(parse_solana_user_decrypt_pubkey("solana:1122"), None); // too short
+    }
+
+    #[test]
+    fn client_id_is_keccak_derived_and_deterministic() {
+        let pubkey = [0x22u8; 32];
+        let id = solana_user_decrypt_client_id(&pubkey);
+        assert_eq!(id, solana_user_decrypt_client_id(&pubkey));
+        let expected = &alloy_primitives::keccak256(pubkey)[12..];
+        assert_eq!(id.as_slice(), expected);
+        let mut other = pubkey;
+        other[0] ^= 0xff;
+        assert_ne!(id, solana_user_decrypt_client_id(&other));
+    }
 }
 
 #[cfg(test)]

--- a/core/service/src/engine/validation_non_wasm.rs
+++ b/core/service/src/engine/validation_non_wasm.rs
@@ -191,6 +191,12 @@ pub(crate) fn parse_grpc_request_id<'a, O: TryFrom<&'a kms_grpc::kms::v1::Reques
 /// which takes the unchanged EIP-712 path.
 fn parse_solana_user_decrypt_pubkey(client_address: &str) -> Option<[u8; 32]> {
     let hex = client_address.strip_prefix("solana:")?;
+    // Canonical form: exactly 64 LOWERCASE hex chars. The kms-connector sets this field with
+    // `hex::encode` (lowercase) over the 32-byte ed25519 pubkey, so requiring that exact encoding
+    // keeps one identity ↔ one client_address ↔ one derived client_id (no upper/mixed-case aliasing).
+    if hex.len() != 64 || !hex.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')) {
+        return None;
+    }
     let bytes = alloy_primitives::hex::decode(hex).ok()?;
     <[u8; 32]>::try_from(bytes.as_slice()).ok()
 }
@@ -1083,6 +1089,30 @@ mod solana_user_decrypt_tests {
         // Malformed Solana payloads → None.
         assert_eq!(parse_solana_user_decrypt_pubkey("solana:zz"), None);
         assert_eq!(parse_solana_user_decrypt_pubkey("solana:1122"), None); // too short
+        // A bare 64-hex string WITHOUT the `solana:` prefix is NOT treated as Solana; it falls to
+        // the EVM path (which rejects it as a non-checksummed address). No silent mis-dispatch.
+        assert_eq!(
+            parse_solana_user_decrypt_pubkey(&alloy_primitives::hex::encode(pubkey)),
+            None
+        );
+        // Uppercase / mixed-case hex is rejected — canonical client_address form is lowercase.
+        // Use a pubkey whose hex contains letters so uppercasing actually changes it.
+        let letters = [0xabu8; 32];
+        assert_eq!(
+            parse_solana_user_decrypt_pubkey(&format!(
+                "solana:{}",
+                alloy_primitives::hex::encode(letters).to_uppercase()
+            )),
+            None
+        );
+        // The same identity in canonical lowercase still parses.
+        assert_eq!(
+            parse_solana_user_decrypt_pubkey(&format!(
+                "solana:{}",
+                alloy_primitives::hex::encode(letters)
+            )),
+            Some(letters)
+        );
     }
 
     #[test]

--- a/core/service/src/engine/validation_non_wasm.rs
+++ b/core/service/src/engine/validation_non_wasm.rs
@@ -203,17 +203,6 @@ fn solana_user_decrypt_client_id(solana_pubkey: &[u8; 32]) -> alloy_primitives::
     alloy_primitives::Address::from_slice(&alloy_primitives::keccak256(solana_pubkey)[12..])
 }
 
-/// Placeholder EIP-712 domain for the Solana user-decryption response payload. On the Solana
-/// path the response binding is the keccak `link` (see `compute_link_solana`), which is passed
-/// opaquely into signcryption; the domain is response metadata only (no EVM verifying contract
-/// exists). Constructed inline rather than reusing the test-only `dummy_domain`.
-fn solana_user_decrypt_response_domain() -> alloy_sol_types::Eip712Domain {
-    alloy_sol_types::eip712_domain!(
-        name: "SolanaUserDecryption",
-        version: "1",
-    )
-}
-
 /// Validates and unpacks a user decryption request and returns ciphertext, FheType, request digest, client
 /// encryption key, client verification key, key_id and request_id if valid.
 ///
@@ -291,8 +280,9 @@ fn unpack_user_decrypt_req(
     // enforced by the kms-connector before this call — exactly as the gateway enforces the EVM
     // ACL before the EVM path — so here we only bind the response to the request via the Solana
     // link (`compute_link_solana`). The link is passed opaquely into signcryption, so the
-    // binding is sound as long as the client recomputes the same link; the EIP-712 domain is
-    // response metadata only in the centralized path, so a placeholder domain is used.
+    // binding is sound as long as the client recomputes the same link. The response cert is the
+    // standard secp256k1 EIP-712 the gateway verifies, signed under the gateway's `Decryption`
+    // domain (`req.domain`) — see the domain note at the return below.
     if let Some(solana_pubkey) = parse_solana_user_decrypt_pubkey(&req.client_address) {
         let mut handles = Vec::with_capacity(req.typed_ciphertexts.len());
         for c in &req.typed_ciphertexts {
@@ -321,6 +311,13 @@ fn unpack_user_decrypt_req(
                     "Error deserializing UnifiedPublicEncKey from Solana UserDecryptionRequest: {e}"
                 )
             })?;
+        // The KMS signs `UserDecryptResponseVerification` under the gateway's `Decryption`
+        // EIP-712 domain (name/version/chainId/verifyingContract, carried in `req.domain`) so the
+        // gateway's `userDecryptionResponse` recovers the registered KMS signer on-chain. The
+        // response cert is the standard secp256k1 EIP-712 — identical to EVM; only the user
+        // *authorization* seam differs (ed25519, already enforced by the connector), so there is
+        // no user EIP-712 to verify here.
+        let response_domain = optional_protobuf_to_alloy_domain(req.domain.as_ref())?;
         return Ok((
             req.typed_ciphertexts.clone(),
             link,
@@ -330,7 +327,7 @@ fn unpack_user_decrypt_req(
             key_id,
             context_id,
             epoch_id,
-            solana_user_decrypt_response_domain(),
+            response_domain,
             req.extra_data.clone(),
         ));
     }

--- a/core/service/src/engine/validation_non_wasm.rs
+++ b/core/service/src/engine/validation_non_wasm.rs
@@ -203,6 +203,17 @@ fn solana_user_decrypt_client_id(solana_pubkey: &[u8; 32]) -> alloy_primitives::
     alloy_primitives::Address::from_slice(&alloy_primitives::keccak256(solana_pubkey)[12..])
 }
 
+/// Placeholder EIP-712 domain for the Solana user-decryption response payload. On the Solana
+/// path the response binding is the keccak `link` (see `compute_link_solana`), which is passed
+/// opaquely into signcryption; the domain is response metadata only (no EVM verifying contract
+/// exists). Constructed inline rather than reusing the test-only `dummy_domain`.
+fn solana_user_decrypt_response_domain() -> alloy_sol_types::Eip712Domain {
+    alloy_sol_types::eip712_domain!(
+        name: "SolanaUserDecryption",
+        version: "1",
+    )
+}
+
 /// Validates and unpacks a user decryption request and returns ciphertext, FheType, request digest, client
 /// encryption key, client verification key, key_id and request_id if valid.
 ///
@@ -319,7 +330,7 @@ fn unpack_user_decrypt_req(
             key_id,
             context_id,
             epoch_id,
-            crate::dummy_domain(),
+            solana_user_decrypt_response_domain(),
             req.extra_data.clone(),
         ));
     }

--- a/core/service/tests/solana_user_decrypt_live.rs
+++ b/core/service/tests/solana_user_decrypt_live.rs
@@ -261,6 +261,12 @@ async fn solana_user_decrypt_live() {
             duration_seconds,
         );
         assert_eq!(signed.attestation_type, "solana-ed25519-user-decrypt-v1");
+        // The signer must echo back the publicKey it signed — the swap below changes it AFTER this.
+        assert_eq!(
+            signed.public_key,
+            hex0x(&pk_bytes),
+            "signer must return the publicKey it was given"
+        );
         let (_atk_sk, atk_pk) = Encryption::new(PkeSchemeType::MlKem512, &mut rng)
             .keygen()
             .unwrap();
@@ -271,7 +277,9 @@ async fn solana_user_decrypt_live() {
             atk_bytes, pk_bytes,
             "attacker key must differ from the signed key"
         );
-        println!("[L4-a] swapping publicKey AFTER signing (signature still binds the original key)");
+        println!(
+            "[L4-a] swapping publicKey AFTER signing (signature still binds the original key)"
+        );
         let user_address = signed.user_address.clone();
         let body = serde_json::json!({
             "attestationType": signed.attestation_type,
@@ -346,7 +354,10 @@ async fn solana_user_decrypt_live() {
     // ML-KEM key pair (passing its public key to the launcher) and de-signcrypts the shares below.
     let launcher_dir = env_or(
         "SOLANA_UD_LAUNCHER_DIR",
-        concat!(env!("CARGO_MANIFEST_DIR"), "/../../../fhevm/test-suite/fhevm"),
+        concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../fhevm/test-suite/fhevm"
+        ),
     );
     let launcher_out = run_solana_launcher(
         &launcher_dir,

--- a/core/service/tests/solana_user_decrypt_live.rs
+++ b/core/service/tests/solana_user_decrypt_live.rs
@@ -23,7 +23,6 @@ use std::process::Command;
 
 use aes_prng::AesRng;
 use alloy_primitives::{Address, U256};
-use ed25519_dalek::SigningKey;
 use kms_grpc::kms::v1::{UserDecryptionResponse, UserDecryptionResponsePayload};
 use kms_lib::client::client_wasm::Client;
 use kms_lib::client::user_decryption_wasm::{CiphertextHandle, ParsedUserDecryptionRequest};
@@ -37,16 +36,15 @@ fn env_or(key: &str, default: &str) -> String {
 }
 
 /// Reads a Solana CLI keypair file (`[u8; 64]` JSON: 32-byte seed || 32-byte pubkey).
+///
+/// The seed↔pubkey consistency is verified downstream by the js-sdk signer
+/// (`buildSolanaUserDecryptRequest` derives the pubkey from the seed and rejects a mismatch), so no
+/// ed25519 derivation is done here — this keeps the harness off `ed25519-dalek`/`bs58`.
 fn load_solana_keypair(path: &str) -> ([u8; 32], [u8; 32]) {
     let bytes: Vec<u8> = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
     assert_eq!(bytes.len(), 64, "solana keypair must be 64 bytes");
     let seed: [u8; 32] = bytes[..32].try_into().unwrap();
     let pubkey: [u8; 32] = bytes[32..].try_into().unwrap();
-    assert_eq!(
-        SigningKey::from_bytes(&seed).verifying_key().to_bytes(),
-        pubkey,
-        "keypair seed/pubkey mismatch"
-    );
     (seed, pubkey)
 }
 

--- a/core/service/tests/solana_user_decrypt_live.rs
+++ b/core/service/tests/solana_user_decrypt_live.rs
@@ -67,6 +67,13 @@ struct SignedRequest {
     handles: Vec<String>,
     #[serde(rename = "userAddress")]
     user_address: String,
+    // RFC-021 typed Solana auth fields (no longer packed into extraData; extraData is context-only).
+    #[serde(rename = "solanaUserIdentity")]
+    solana_user_identity: String,
+    #[serde(rename = "solanaNonce")]
+    solana_nonce: String,
+    #[serde(rename = "solanaAllowedAclDomainKeys")]
+    solana_allowed_acl_domain_keys: Vec<String>,
 }
 
 /// Shells out to the js-sdk signer (`buildSolanaUserDecryptRequest`) to produce the canonical V2
@@ -151,8 +158,8 @@ async fn solana_user_decrypt_live() {
     let handle = alloy_primitives::hex::decode(handle_hex.trim_start_matches("0x")).unwrap();
     let handle32: [u8; 32] = handle.try_into().expect("handle must be 32 bytes");
 
-    // context_id (32-byte BE): the KMS context the connector validates + routes to. Carried inside
-    // the 0x03 Solana extraData blob the SDK builds.
+    // context_id (32-byte BE): the KMS context the connector validates + routes to. Carried in the
+    // context-only `extraData` (v0x01) the SDK builds; the ed25519 auth fields travel as typed fields.
     let context_u256 = U256::from_str_radix(
         &env_or(
             "SOLANA_UD_CONTEXT_ID",
@@ -209,7 +216,7 @@ async fn solana_user_decrypt_live() {
     };
 
     // The v3 envelope carries EVM-shaped address fields the connector ignores on the Solana arm
-    // (it derives the subject from the signed extraData identity). They must still parse as 20-byte
+    // (it derives the subject from the typed `solanaUserIdentity`). They must still parse as 20-byte
     // addresses; use the SDK-derived client id (keccak(identity)[12..]).
     let user_address = signed.user_address.clone();
     let body = serde_json::json!({
@@ -223,14 +230,19 @@ async fn solana_user_decrypt_live() {
                 "ownerAddress": user_address,
             }],
             "userAddress": user_address,
-            // Solana scope lives in the signed extraData, so allowedContracts is empty.
+            // Solana ACL scope travels as the typed `solanaAllowedAclDomainKeys`, so EVM
+            // `allowedContracts` is empty.
             "allowedContracts": [],
             "requestValidity": {
                 "startTimestamp": start_ts.to_string(),
                 "durationSeconds": duration_seconds.to_string(),
             },
             "publicKey": public_key_field,
+            // extraData is context-only (v0x01); the ed25519 auth fields are typed below (RFC-021).
             "extraData": signed.extra_data,
+            "solanaUserIdentity": signed.solana_user_identity,
+            "solanaNonce": signed.solana_nonce,
+            "solanaAllowedAclDomainKeys": signed.solana_allowed_acl_domain_keys,
         },
         "signature": signed.signature,
     });

--- a/core/service/tests/solana_user_decrypt_live.rs
+++ b/core/service/tests/solana_user_decrypt_live.rs
@@ -1,23 +1,29 @@
-//! Live RFC-021 Solana user-decryption client (the user-side SDK piece), as an `#[ignore]`d
+//! Live RFC-021 Solana V2 user-decryption client (the user-side SDK piece), as an `#[ignore]`d
 //! integration test driven against a running fhevm-cli stack with the Solana user-decrypt path
-//! deployed (gateway `userDecryptionRequestSolana`, relayer ed25519 seam, kms-connector Solana
-//! vertical, kms-core `compute_link_solana`).
+//! deployed (gateway V2 `userDecryptionRequest`, relayer `/v3/user-decrypt` ed25519 seam,
+//! kms-connector Solana V2 arm, kms-core `compute_link_solana`).
 //!
-//! Flow: ML-KEM keygen -> ed25519-sign the canonical request-binding message (mirrors the relayer's
-//! `solana_user_decrypt_auth_message`) -> POST /v2/user-decrypt -> poll -> de-signcrypt via
-//! `process_user_decryption_resp_solana` -> assert the cleartext.
+//! Flow:
+//!   1. ML-KEM ephemeral keygen (Rust — this is also where the response is de-signcrypted).
+//!   2. Sign the canonical `zama-solana-user-decrypt-v1` preimage via the js-sdk
+//!      `buildSolanaUserDecryptRequest` (shelled out — the SDK is the single signer), binding the
+//!      ML-KEM public key, handles, identity, nonce, allowed ACL domain keys, and validity window.
+//!   3. POST the V2 request as the v3 typed-attestation envelope (`solana-ed25519-user-decrypt-v1`)
+//!      to `/v3/user-decrypt`, poll the job.
+//!   4. De-signcrypt via `process_user_decryption_resp_solana` and assert the cleartext.
 //!
-//! Run (after a handle is granted to the user pubkey):
-//!   SOLANA_UD_HANDLE=0x... SOLANA_UD_EXPECTED=53 \
+//! Run (after a handle is granted USE to the user's Solana pubkey on the host ACL):
+//!   SOLANA_UD_HANDLE=0x... SOLANA_UD_EXPECTED=55 \
 //!   cargo test -p kms --features non-wasm --test solana_user_decrypt_live -- --ignored --nocapture
 #![cfg(feature = "non-wasm")]
 
 use std::collections::HashMap;
 use std::env;
+use std::process::Command;
 
 use aes_prng::AesRng;
 use alloy_primitives::{Address, U256};
-use ed25519_dalek::{Signer, SigningKey};
+use ed25519_dalek::SigningKey;
 use kms_grpc::kms::v1::{UserDecryptionResponse, UserDecryptionResponsePayload};
 use kms_lib::client::client_wasm::Client;
 use kms_lib::client::user_decryption_wasm::{CiphertextHandle, ParsedUserDecryptionRequest};
@@ -26,52 +32,106 @@ use kms_lib::cryptography::encryption::{Encryption, PkeScheme, PkeSchemeType};
 use kms_lib::cryptography::signatures::PublicSigKey;
 use rand::SeedableRng;
 
-const AUTH_DOMAIN: &[u8] = b"fhevm-solana-user-decryption-auth-v0";
-
 fn env_or(key: &str, default: &str) -> String {
     env::var(key).unwrap_or_else(|_| default.to_string())
 }
 
 /// Reads a Solana CLI keypair file (`[u8; 64]` JSON: 32-byte seed || 32-byte pubkey).
-fn load_solana_keypair(path: &str) -> (SigningKey, [u8; 32]) {
+fn load_solana_keypair(path: &str) -> ([u8; 32], [u8; 32]) {
     let bytes: Vec<u8> = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
     assert_eq!(bytes.len(), 64, "solana keypair must be 64 bytes");
-    let signing = SigningKey::from_bytes(&bytes[..32].try_into().unwrap());
+    let seed: [u8; 32] = bytes[..32].try_into().unwrap();
     let pubkey: [u8; 32] = bytes[32..].try_into().unwrap();
-    assert_eq!(signing.verifying_key().to_bytes(), pubkey, "keypair seed/pubkey mismatch");
-    (signing, pubkey)
+    assert_eq!(
+        SigningKey::from_bytes(&seed).verifying_key().to_bytes(),
+        pubkey,
+        "keypair seed/pubkey mismatch"
+    );
+    (seed, pubkey)
 }
 
-/// Mirrors the relayer's `solana_user_decrypt_auth_message` byte-for-byte.
-fn auth_message(
+fn hex0x(bytes: &[u8]) -> String {
+    format!("0x{}", alloy_primitives::hex::encode(bytes))
+}
+
+/// The V2 request object returned by the js-sdk `buildSolanaUserDecryptRequest`.
+#[derive(serde::Deserialize)]
+struct SignedRequest {
+    #[serde(rename = "attestationType")]
+    attestation_type: String,
+    signature: String,
+    #[serde(rename = "extraData")]
+    extra_data: String,
+    #[serde(rename = "publicKey")]
+    public_key: String,
+    handles: Vec<String>,
+    #[serde(rename = "userAddress")]
+    user_address: String,
+}
+
+/// Shells out to the js-sdk signer (`buildSolanaUserDecryptRequest`) to produce the canonical V2
+/// ed25519 request. The SDK is the single source of truth for the signing preimage; the kms-worker
+/// connector re-derives and verifies it byte-for-byte.
+#[allow(clippy::too_many_arguments)]
+fn sdk_sign_request(
+    sdk_dir: &str,
     contracts_chain_id: u64,
     public_key: &[u8],
-    handles: &[[u8; 32]],
-    start_timestamp: U256,
-    duration_days: U256,
-) -> Vec<u8> {
-    let mut m = Vec::new();
-    m.extend_from_slice(AUTH_DOMAIN);
-    m.extend_from_slice(&contracts_chain_id.to_le_bytes());
-    m.extend_from_slice(&(public_key.len() as u32).to_le_bytes());
-    m.extend_from_slice(public_key);
-    m.extend_from_slice(&(handles.len() as u32).to_le_bytes());
-    for h in handles {
-        m.extend_from_slice(h);
-    }
-    m.extend_from_slice(&start_timestamp.to_be_bytes::<32>());
-    m.extend_from_slice(&duration_days.to_be_bytes::<32>());
-    m
+    handle: &[u8; 32],
+    identity: &[u8; 32],
+    secret_key: &[u8; 32],
+    context_id: &[u8; 32],
+    nonce: &[u8; 32],
+    allowed_domain_keys: &[[u8; 32]],
+    start_timestamp: u64,
+    duration_seconds: u64,
+) -> SignedRequest {
+    let domain_keys_csv = allowed_domain_keys
+        .iter()
+        .map(|k| hex0x(k))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let output = Command::new("node")
+        .arg("solana-userdecrypt-sign.mjs")
+        .current_dir(sdk_dir)
+        .env("UD_CONTRACTS_CHAIN_ID", contracts_chain_id.to_string())
+        .env("UD_PUBLIC_KEY", hex0x(public_key))
+        .env("UD_HANDLE", hex0x(handle))
+        .env("UD_IDENTITY", hex0x(identity))
+        .env("UD_SECRET_KEY", hex0x(secret_key))
+        .env("UD_CONTEXT_ID", hex0x(context_id))
+        .env("UD_NONCE", hex0x(nonce))
+        .env("UD_ALLOWED_DOMAIN_KEYS", domain_keys_csv)
+        .env("UD_START_TIMESTAMP", start_timestamp.to_string())
+        .env("UD_DURATION_SECONDS", duration_seconds.to_string())
+        .output()
+        .expect("failed to spawn the js-sdk signer (node solana-userdecrypt-sign.mjs)");
+
+    assert!(
+        output.status.success(),
+        "js-sdk signer failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let line = String::from_utf8(output.stdout).unwrap();
+    serde_json::from_str(line.trim()).unwrap_or_else(|e| panic!("bad signer JSON ({e}): {line}"))
 }
 
 #[tokio::test]
-#[ignore = "requires a running fhevm-cli stack with the Solana user-decrypt path + a granted handle"]
+#[ignore = "requires a running fhevm-cli stack with the Solana V2 user-decrypt path + a granted handle"]
 async fn solana_user_decrypt_live() {
     let relayer = env_or("SOLANA_UD_RELAYER", "http://localhost:3000");
+    let sdk_dir = env_or(
+        "SOLANA_UD_SDK_DIR",
+        concat!(env!("CARGO_MANIFEST_DIR"), "/../../../fhevm/sdk/js-sdk"),
+    );
     let keypair_path =
         env_or("SOLANA_UD_KEYPAIR", &format!("{}/.config/solana/id.json", env_or("HOME", "")));
     let handle_hex = env::var("SOLANA_UD_HANDLE").expect("SOLANA_UD_HANDLE (0x..32 bytes) required");
     let expected: u64 = env_or("SOLANA_UD_EXPECTED", "0").parse().unwrap();
+    // The connector reads the host chain id from the handle bytes; the signed preimage must commit
+    // to that same chain id.
     let contracts_chain_id: u64 =
         env_or("SOLANA_UD_CHAIN_ID", "9223372036854788153").parse().unwrap();
 
@@ -84,22 +144,16 @@ async fn solana_user_decrypt_live() {
     tfhe::safe_serialization::safe_serialize(&unified_pk, &mut pk_bytes, SAFE_SER_SIZE_LIMIT)
         .unwrap();
 
-    // 2. ed25519 user identity + auth signature over the canonical message.
-    let (signing, pubkey) = load_solana_keypair(&keypair_path);
+    // 2. ed25519 user identity. The handle's ACL on the host grants USE to this Solana pubkey, and
+    //    the compute leg uses the same pubkey as the ACL domain key — so the request's allowed ACL
+    //    domain-key scope is exactly `[identity]`.
+    let (seed, pubkey) = load_solana_keypair(&keypair_path);
     let handle = alloy_primitives::hex::decode(handle_hex.trim_start_matches("0x")).unwrap();
     let handle32: [u8; 32] = handle.try_into().expect("handle must be 32 bytes");
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    let start_ts = U256::from(now - 60); // small buffer so startTimestamp <= block time
-    let duration_days = U256::from(30u64);
-    let msg = auth_message(contracts_chain_id, &pk_bytes, &[handle32], start_ts, duration_days);
-    let signature = signing.sign(&msg);
 
-    // extra_data v1 = 0x01 || context_id (32-byte BE): the KMS context the connector validates +
-    // routes to (same versioned format the EVM user-decrypt path uses; plain 0x00 is rejected).
-    let context_id = U256::from_str_radix(
+    // context_id (32-byte BE): the KMS context the connector validates + routes to. Carried inside
+    // the 0x03 Solana extraData blob the SDK builds.
+    let context_u256 = U256::from_str_radix(
         &env_or(
             "SOLANA_UD_CONTEXT_ID",
             "3166189940082864718613269121331309980362851143201109172953918312716374638593",
@@ -107,35 +161,117 @@ async fn solana_user_decrypt_live() {
         10,
     )
     .unwrap();
-    let mut extra_data = vec![0x01u8];
-    extra_data.extend_from_slice(&context_id.to_be_bytes::<32>());
-    let extra_data_hex = format!("0x{}", alloy_primitives::hex::encode(&extra_data));
+    let context_id: [u8; 32] = context_u256.to_be_bytes();
+    let nonce: [u8; 32] = rand::random();
 
-    // 3. Build + POST the user-decrypt request.
-    let user_b58 = bs58::encode(pubkey).into_string();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let start_ts = now - 60; // small buffer so startTimestamp <= block time
+    let duration_seconds = 30u64 * 24 * 3600;
+
+    // 3. Sign the canonical V2 preimage via the js-sdk and assemble the v3 envelope.
+    let signed = sdk_sign_request(
+        &sdk_dir,
+        contracts_chain_id,
+        &pk_bytes,
+        &handle32,
+        &pubkey,
+        &seed,
+        &context_id,
+        &nonce,
+        &[pubkey], // allowed ACL domain keys = [identity] (compute leg's acl_domain_key)
+        start_ts,
+        duration_seconds,
+    );
+    assert_eq!(
+        signed.attestation_type, "solana-ed25519-user-decrypt-v1",
+        "SDK must produce the Solana V2 attestation type"
+    );
+
+    // Adversarial L4 (a): publicKey-substitution / relayer-bypass. After the user signs (committing
+    // to `pk_bytes`), an attacker swaps in a DIFFERENT re-encryption key. The ed25519 signature no
+    // longer binds the supplied publicKey, so the kms-connector's per-party verify rejects it and
+    // NO plaintext is re-encrypted to the attacker key. We assert the job never returns shares.
+    let attack = env::var("SOLANA_UD_ATTACK").ok();
+    let public_key_field = if attack.as_deref() == Some("pubkey_substitution") {
+        let (_atk_sk, atk_pk) =
+            Encryption::new(PkeSchemeType::MlKem512, &mut rng).keygen().unwrap();
+        let mut atk_bytes = Vec::new();
+        tfhe::safe_serialization::safe_serialize(&atk_pk, &mut atk_bytes, SAFE_SER_SIZE_LIMIT)
+            .unwrap();
+        assert_ne!(atk_bytes, pk_bytes, "attacker key must differ from the signed key");
+        println!("[L4-a] swapping publicKey AFTER signing (signature still binds the original key)");
+        hex0x(&atk_bytes)
+    } else {
+        signed.public_key.clone()
+    };
+
+    // The v3 envelope carries EVM-shaped address fields the connector ignores on the Solana arm
+    // (it derives the subject from the signed extraData identity). They must still parse as 20-byte
+    // addresses; use the SDK-derived client id (keccak(identity)[12..]).
+    let user_address = signed.user_address.clone();
     let body = serde_json::json!({
-        "handleContractPairs": [{ "handle": format!("0x{}", alloy_primitives::hex::encode(handle32)),
-                                  "contractAddress": user_b58 }],
-        "requestValidity": { "startTimestamp": start_ts.to_string(), "durationDays": duration_days.to_string() },
-        "contractsChainId": contracts_chain_id.to_string(),
-        "contractAddresses": [],
-        "userAddress": user_b58,
-        "signature": alloy_primitives::hex::encode(signature.to_bytes()),
-        "publicKey": alloy_primitives::hex::encode(&pk_bytes),
-        "extraData": extra_data_hex,
+        "attestationType": signed.attestation_type,
+        "attestedPayload": {
+            "version": "2.0",
+            "type": "user_decryption",
+            "handles": [{
+                "ctHandle": signed.handles[0],
+                "contractAddress": user_address,
+                "ownerAddress": user_address,
+            }],
+            "userAddress": user_address,
+            // Solana scope lives in the signed extraData, so allowedContracts is empty.
+            "allowedContracts": [],
+            "requestValidity": {
+                "startTimestamp": start_ts.to_string(),
+                "durationSeconds": duration_seconds.to_string(),
+            },
+            "publicKey": public_key_field,
+            "extraData": signed.extra_data,
+        },
+        "signature": signed.signature,
     });
+
     let http = reqwest::Client::new();
-    let post = http.post(format!("{relayer}/v2/user-decrypt")).json(&body).send().await.unwrap();
+    let post = http.post(format!("{relayer}/v3/user-decrypt")).json(&body).send().await.unwrap();
     let post_status = post.status();
     let post_json: serde_json::Value = post.json().await.unwrap();
     println!("POST {post_status}: {post_json}");
     assert!(post_status.is_success(), "relayer rejected the request: {post_json}");
     let job_id = post_json["result"]["jobId"].as_str().expect("jobId").to_string();
 
+    // Adversarial L4 (a): the connector rejects the publicKey-substituted request, so the job must
+    // NOT succeed. A `failed` status (or a timeout with no shares) both prove the request was
+    // rejected and no plaintext was returned. A `succeeded` here would be the security failure.
+    if attack.as_deref() == Some("pubkey_substitution") {
+        for _ in 0..45 {
+            let r = http.get(format!("{relayer}/v3/user-decrypt/{job_id}")).send().await.unwrap();
+            let j: serde_json::Value = r.json().await.unwrap();
+            match j["status"].as_str() {
+                Some("succeeded") => panic!(
+                    "SECURITY: publicKey-substituted user-decrypt SUCCEEDED — plaintext re-encrypted \
+                     to the attacker key: {j}"
+                ),
+                Some("failed") => {
+                    println!("[L4-a] request REJECTED (job failed) — no plaintext returned: {j}");
+                    return;
+                }
+                _ => tokio::time::sleep(std::time::Duration::from_secs(2)).await,
+            }
+        }
+        println!(
+            "[L4-a] request did NOT succeed within the poll window — no plaintext returned (rejected)"
+        );
+        return;
+    }
+
     // 4. Poll for the response.
     let mut response_json = serde_json::Value::Null;
     for _ in 0..60 {
-        let r = http.get(format!("{relayer}/v2/user-decrypt/{job_id}")).send().await.unwrap();
+        let r = http.get(format!("{relayer}/v3/user-decrypt/{job_id}")).send().await.unwrap();
         let j: serde_json::Value = r.json().await.unwrap();
         match j["status"].as_str() {
             Some("succeeded") => {

--- a/core/service/tests/solana_user_decrypt_live.rs
+++ b/core/service/tests/solana_user_decrypt_live.rs
@@ -133,20 +133,25 @@ async fn solana_user_decrypt_live() {
         "SOLANA_UD_SDK_DIR",
         concat!(env!("CARGO_MANIFEST_DIR"), "/../../../fhevm/sdk/js-sdk"),
     );
-    let keypair_path =
-        env_or("SOLANA_UD_KEYPAIR", &format!("{}/.config/solana/id.json", env_or("HOME", "")));
-    let handle_hex = env::var("SOLANA_UD_HANDLE").expect("SOLANA_UD_HANDLE (0x..32 bytes) required");
+    let keypair_path = env_or(
+        "SOLANA_UD_KEYPAIR",
+        &format!("{}/.config/solana/id.json", env_or("HOME", "")),
+    );
+    let handle_hex =
+        env::var("SOLANA_UD_HANDLE").expect("SOLANA_UD_HANDLE (0x..32 bytes) required");
     let expected: u64 = env_or("SOLANA_UD_EXPECTED", "0").parse().unwrap();
     // The connector reads the host chain id from the handle bytes; the signed preimage must commit
     // to that same chain id.
-    let contracts_chain_id: u64 =
-        env_or("SOLANA_UD_CHAIN_ID", "9223372036854788153").parse().unwrap();
+    let contracts_chain_id: u64 = env_or("SOLANA_UD_CHAIN_ID", "9223372036854788153")
+        .parse()
+        .unwrap();
 
     // 1. ML-KEM ephemeral keypair (non-wasm path). The serialized public key is the request's
     //    `publicKey`; kms-core validates it via `UnifiedPublicEncKey::deserialize_and_validate`.
     let mut rng = AesRng::from_entropy();
-    let (unified_sk, unified_pk) =
-        Encryption::new(PkeSchemeType::MlKem512, &mut rng).keygen().unwrap();
+    let (unified_sk, unified_pk) = Encryption::new(PkeSchemeType::MlKem512, &mut rng)
+        .keygen()
+        .unwrap();
     let mut pk_bytes = Vec::new();
     tfhe::safe_serialization::safe_serialize(&unified_pk, &mut pk_bytes, SAFE_SER_SIZE_LIMIT)
         .unwrap();
@@ -203,13 +208,19 @@ async fn solana_user_decrypt_live() {
     // NO plaintext is re-encrypted to the attacker key. We assert the job never returns shares.
     let attack = env::var("SOLANA_UD_ATTACK").ok();
     let public_key_field = if attack.as_deref() == Some("pubkey_substitution") {
-        let (_atk_sk, atk_pk) =
-            Encryption::new(PkeSchemeType::MlKem512, &mut rng).keygen().unwrap();
+        let (_atk_sk, atk_pk) = Encryption::new(PkeSchemeType::MlKem512, &mut rng)
+            .keygen()
+            .unwrap();
         let mut atk_bytes = Vec::new();
         tfhe::safe_serialization::safe_serialize(&atk_pk, &mut atk_bytes, SAFE_SER_SIZE_LIMIT)
             .unwrap();
-        assert_ne!(atk_bytes, pk_bytes, "attacker key must differ from the signed key");
-        println!("[L4-a] swapping publicKey AFTER signing (signature still binds the original key)");
+        assert_ne!(
+            atk_bytes, pk_bytes,
+            "attacker key must differ from the signed key"
+        );
+        println!(
+            "[L4-a] swapping publicKey AFTER signing (signature still binds the original key)"
+        );
         hex0x(&atk_bytes)
     } else {
         signed.public_key.clone()
@@ -248,19 +259,34 @@ async fn solana_user_decrypt_live() {
     });
 
     let http = reqwest::Client::new();
-    let post = http.post(format!("{relayer}/v3/user-decrypt")).json(&body).send().await.unwrap();
+    let post = http
+        .post(format!("{relayer}/v3/user-decrypt"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
     let post_status = post.status();
     let post_json: serde_json::Value = post.json().await.unwrap();
     println!("POST {post_status}: {post_json}");
-    assert!(post_status.is_success(), "relayer rejected the request: {post_json}");
-    let job_id = post_json["result"]["jobId"].as_str().expect("jobId").to_string();
+    assert!(
+        post_status.is_success(),
+        "relayer rejected the request: {post_json}"
+    );
+    let job_id = post_json["result"]["jobId"]
+        .as_str()
+        .expect("jobId")
+        .to_string();
 
     // Adversarial L4 (a): the connector rejects the publicKey-substituted request, so the job must
     // NOT succeed. A `failed` status (or a timeout with no shares) both prove the request was
     // rejected and no plaintext was returned. A `succeeded` here would be the security failure.
     if attack.as_deref() == Some("pubkey_substitution") {
         for _ in 0..45 {
-            let r = http.get(format!("{relayer}/v3/user-decrypt/{job_id}")).send().await.unwrap();
+            let r = http
+                .get(format!("{relayer}/v3/user-decrypt/{job_id}"))
+                .send()
+                .await
+                .unwrap();
             let j: serde_json::Value = r.json().await.unwrap();
             match j["status"].as_str() {
                 Some("succeeded") => panic!(
@@ -283,7 +309,11 @@ async fn solana_user_decrypt_live() {
     // 4. Poll for the response.
     let mut response_json = serde_json::Value::Null;
     for _ in 0..60 {
-        let r = http.get(format!("{relayer}/v3/user-decrypt/{job_id}")).send().await.unwrap();
+        let r = http
+            .get(format!("{relayer}/v3/user-decrypt/{job_id}"))
+            .send()
+            .await
+            .unwrap();
         let j: serde_json::Value = r.json().await.unwrap();
         match j["status"].as_str() {
             Some("succeeded") => {
@@ -294,7 +324,10 @@ async fn solana_user_decrypt_live() {
             _ => tokio::time::sleep(std::time::Duration::from_secs(2)).await,
         }
     }
-    assert!(!response_json.is_null(), "timed out waiting for user-decrypt result");
+    assert!(
+        !response_json.is_null(),
+        "timed out waiting for user-decrypt result"
+    );
     println!("result: {response_json}");
 
     // 5. Parse the aggregated shares -> UserDecryptionResponse (external EIP-712 signature +
@@ -306,11 +339,17 @@ async fn solana_user_decrypt_live() {
     let mut kms_pk: Option<PublicSigKey> = None;
     for share in shares {
         let external_signature = alloy_primitives::hex::decode(
-            share["signature"].as_str().unwrap_or("").trim_start_matches("0x"),
+            share["signature"]
+                .as_str()
+                .unwrap_or("")
+                .trim_start_matches("0x"),
         )
         .unwrap();
         let payload_bytes = alloy_primitives::hex::decode(
-            share["payload"].as_str().unwrap_or("").trim_start_matches("0x"),
+            share["payload"]
+                .as_str()
+                .unwrap_or("")
+                .trim_start_matches("0x"),
         )
         .unwrap();
         let payload: UserDecryptionResponsePayload =
@@ -329,7 +368,10 @@ async fn solana_user_decrypt_live() {
     // 6. Build a client bound to the KMS verification key and de-signcrypt.
     let derived = Address::from_slice(&alloy_primitives::keccak256(pubkey)[12..]);
     let mut server_pks = HashMap::new();
-    server_pks.insert(1u32, kms_pk.expect("KMS verification key in response payload"));
+    server_pks.insert(
+        1u32,
+        kms_pk.expect("KMS verification key in response payload"),
+    );
     let client = Client::new(server_pks, derived, None, DEFAULT_PARAM, None);
     let request = ParsedUserDecryptionRequest::new(
         None,

--- a/core/service/tests/solana_user_decrypt_live.rs
+++ b/core/service/tests/solana_user_decrypt_live.rs
@@ -123,6 +123,63 @@ fn sdk_sign_request(
     serde_json::from_str(line.trim()).unwrap_or_else(|e| panic!("bad signer JSON ({e}): {line}"))
 }
 
+/// Runs the full Solana user-decrypt REQUEST half through the PUBLIC `@fhevm/sdk/solana` client
+/// (build the ed25519-signed v3 request, POST to `/v3/user-decrypt`, return the aggregated KMS
+/// signcrypted shares). The launcher prints `{ "shares": [{signature,payload,extraData}, ...] }` on
+/// stdout; de-signcryption stays here (the SDK's TKMS WASM does not expose the Solana keccak-link
+/// path yet, so this caller owns the ML-KEM key pair and passes its public key in via UD_PUBLIC_KEY).
+#[allow(clippy::too_many_arguments)]
+fn run_solana_launcher(
+    launcher_dir: &str,
+    relayer: &str,
+    contracts_chain_id: u64,
+    public_key: &[u8],
+    handle: &[u8; 32],
+    secret_key: &[u8; 32],
+    context_id: &[u8; 32],
+    nonce: &[u8; 32],
+    allowed_domain_keys: &[[u8; 32]],
+    start_timestamp: u64,
+    duration_seconds: u64,
+) -> serde_json::Value {
+    let domain_keys_csv = allowed_domain_keys
+        .iter()
+        .map(|k| hex0x(k))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let output = Command::new("bun")
+        .args(["run", "solana-userdecrypt.ts"])
+        .current_dir(launcher_dir)
+        .env("UD_RELAYER_URL", relayer)
+        .env("UD_CONTRACTS_CHAIN_ID", contracts_chain_id.to_string())
+        .env("UD_PUBLIC_KEY", hex0x(public_key))
+        .env("UD_HANDLE", hex0x(handle))
+        .env("UD_SECRET_KEY", hex0x(secret_key))
+        .env("UD_CONTEXT_ID", hex0x(context_id))
+        .env("UD_NONCE", hex0x(nonce))
+        .env("UD_ALLOWED_DOMAIN_KEYS", domain_keys_csv)
+        .env("UD_START_TIMESTAMP", start_timestamp.to_string())
+        .env("UD_DURATION_SECONDS", duration_seconds.to_string())
+        .output()
+        .expect("failed to spawn the @fhevm/sdk/solana launcher (bun run solana-userdecrypt.ts)");
+
+    assert!(
+        output.status.success(),
+        "solana launcher failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    // The launcher prints the JSON result as the last `{...}` line on stdout.
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let line = stdout
+        .lines()
+        .rev()
+        .find(|l| l.trim_start().starts_with('{'))
+        .unwrap_or_else(|| panic!("no JSON line in launcher stdout: {stdout}"));
+    serde_json::from_str(line.trim()).unwrap_or_else(|e| panic!("bad launcher JSON ({e}): {line}"))
+}
+
 #[tokio::test]
 #[ignore = "requires a running fhevm-cli stack with the Solana V2 user-decrypt path + a granted handle"]
 async fn solana_user_decrypt_live() {
@@ -181,31 +238,29 @@ async fn solana_user_decrypt_live() {
     let start_ts = now - 60; // small buffer so startTimestamp <= block time
     let duration_seconds = 30u64 * 24 * 3600;
 
-    // 3. Sign the canonical V2 preimage via the js-sdk and assemble the v3 envelope.
-    let signed = sdk_sign_request(
-        &sdk_dir,
-        contracts_chain_id,
-        &pk_bytes,
-        &handle32,
-        &pubkey,
-        &seed,
-        &context_id,
-        &nonce,
-        &[pubkey], // allowed ACL domain keys = [identity] (compute leg's acl_domain_key)
-        start_ts,
-        duration_seconds,
-    );
-    assert_eq!(
-        signed.attestation_type, "solana-ed25519-user-decrypt-v1",
-        "SDK must produce the Solana V2 attestation type"
-    );
-
-    // Adversarial L4 (a): publicKey-substitution / relayer-bypass. After the user signs (committing
-    // to `pk_bytes`), an attacker swaps in a DIFFERENT re-encryption key. The ed25519 signature no
-    // longer binds the supplied publicKey, so the kms-connector's per-party verify rejects it and
-    // NO plaintext is re-encrypted to the attacker key. We assert the job never returns shares.
+    // 3. Run the user-decrypt request half.
     let attack = env::var("SOLANA_UD_ATTACK").ok();
-    let public_key_field = if attack.as_deref() == Some("pubkey_substitution") {
+
+    // Adversarial L4 (a): publicKey-substitution / relayer-bypass. The public @fhevm/sdk/solana
+    // client signs and POSTs atomically — it cannot desync the signed key from the posted key (that
+    // is the security property), so the attack cannot route through it. Sign via the low-level
+    // js-sdk signer, then POST a body whose `publicKey` was swapped AFTER signing: the ed25519
+    // signature no longer binds it, the kms-connector rejects it, and NO plaintext is returned.
+    if attack.as_deref() == Some("pubkey_substitution") {
+        let signed = sdk_sign_request(
+            &sdk_dir,
+            contracts_chain_id,
+            &pk_bytes,
+            &handle32,
+            &pubkey,
+            &seed,
+            &context_id,
+            &nonce,
+            &[pubkey],
+            start_ts,
+            duration_seconds,
+        );
+        assert_eq!(signed.attestation_type, "solana-ed25519-user-decrypt-v1");
         let (_atk_sk, atk_pk) = Encryption::new(PkeSchemeType::MlKem512, &mut rng)
             .keygen()
             .unwrap();
@@ -216,69 +271,50 @@ async fn solana_user_decrypt_live() {
             atk_bytes, pk_bytes,
             "attacker key must differ from the signed key"
         );
-        println!(
-            "[L4-a] swapping publicKey AFTER signing (signature still binds the original key)"
-        );
-        hex0x(&atk_bytes)
-    } else {
-        signed.public_key.clone()
-    };
-
-    // The v3 envelope carries EVM-shaped address fields the connector ignores on the Solana arm
-    // (it derives the subject from the typed `solanaUserIdentity`). They must still parse as 20-byte
-    // addresses; use the SDK-derived client id (keccak(identity)[12..]).
-    let user_address = signed.user_address.clone();
-    let body = serde_json::json!({
-        "attestationType": signed.attestation_type,
-        "attestedPayload": {
-            "version": "2.0",
-            "type": "user_decryption",
-            "handles": [{
-                "ctHandle": signed.handles[0],
-                "contractAddress": user_address,
-                "ownerAddress": user_address,
-            }],
-            "userAddress": user_address,
-            // Solana ACL scope travels as the typed `solanaAllowedAclDomainKeys`, so EVM
-            // `allowedContracts` is empty.
-            "allowedContracts": [],
-            "requestValidity": {
-                "startTimestamp": start_ts.to_string(),
-                "durationSeconds": duration_seconds.to_string(),
+        println!("[L4-a] swapping publicKey AFTER signing (signature still binds the original key)");
+        let user_address = signed.user_address.clone();
+        let body = serde_json::json!({
+            "attestationType": signed.attestation_type,
+            "attestedPayload": {
+                "version": "2.0",
+                "type": "user_decryption",
+                "handles": [{
+                    "ctHandle": signed.handles[0],
+                    "contractAddress": user_address,
+                    "ownerAddress": user_address,
+                }],
+                "userAddress": user_address,
+                "allowedContracts": [],
+                "requestValidity": {
+                    "startTimestamp": start_ts.to_string(),
+                    "durationSeconds": duration_seconds.to_string(),
+                },
+                "publicKey": hex0x(&atk_bytes),
+                "extraData": signed.extra_data,
+                "solanaUserIdentity": signed.solana_user_identity,
+                "solanaNonce": signed.solana_nonce,
+                "solanaAllowedAclDomainKeys": signed.solana_allowed_acl_domain_keys,
             },
-            "publicKey": public_key_field,
-            // extraData is context-only (v0x01); the ed25519 auth fields are typed below (RFC-021).
-            "extraData": signed.extra_data,
-            "solanaUserIdentity": signed.solana_user_identity,
-            "solanaNonce": signed.solana_nonce,
-            "solanaAllowedAclDomainKeys": signed.solana_allowed_acl_domain_keys,
-        },
-        "signature": signed.signature,
-    });
-
-    let http = reqwest::Client::new();
-    let post = http
-        .post(format!("{relayer}/v3/user-decrypt"))
-        .json(&body)
-        .send()
-        .await
-        .unwrap();
-    let post_status = post.status();
-    let post_json: serde_json::Value = post.json().await.unwrap();
-    println!("POST {post_status}: {post_json}");
-    assert!(
-        post_status.is_success(),
-        "relayer rejected the request: {post_json}"
-    );
-    let job_id = post_json["result"]["jobId"]
-        .as_str()
-        .expect("jobId")
-        .to_string();
-
-    // Adversarial L4 (a): the connector rejects the publicKey-substituted request, so the job must
-    // NOT succeed. A `failed` status (or a timeout with no shares) both prove the request was
-    // rejected and no plaintext was returned. A `succeeded` here would be the security failure.
-    if attack.as_deref() == Some("pubkey_substitution") {
+            "signature": signed.signature,
+        });
+        let http = reqwest::Client::new();
+        let post = http
+            .post(format!("{relayer}/v3/user-decrypt"))
+            .json(&body)
+            .send()
+            .await
+            .unwrap();
+        let post_status = post.status();
+        let post_json: serde_json::Value = post.json().await.unwrap();
+        println!("POST {post_status}: {post_json}");
+        assert!(
+            post_status.is_success(),
+            "relayer rejected the request: {post_json}"
+        );
+        let job_id = post_json["result"]["jobId"]
+            .as_str()
+            .expect("jobId")
+            .to_string();
         for _ in 0..45 {
             let r = http
                 .get(format!("{relayer}/v3/user-decrypt/{job_id}"))
@@ -304,35 +340,34 @@ async fn solana_user_decrypt_live() {
         return;
     }
 
-    // 4. Poll for the response.
-    let mut response_json = serde_json::Value::Null;
-    for _ in 0..60 {
-        let r = http
-            .get(format!("{relayer}/v3/user-decrypt/{job_id}"))
-            .send()
-            .await
-            .unwrap();
-        let j: serde_json::Value = r.json().await.unwrap();
-        match j["status"].as_str() {
-            Some("succeeded") => {
-                response_json = j;
-                break;
-            }
-            Some("failed") => panic!("user-decrypt failed: {j}"),
-            _ => tokio::time::sleep(std::time::Duration::from_secs(2)).await,
-        }
-    }
-    assert!(
-        !response_json.is_null(),
-        "timed out waiting for user-decrypt result"
+    // Happy path: route the request through the PUBLIC @fhevm/sdk/solana client (build the v3
+    // request, POST to /v3/user-decrypt, return the aggregated KMS signcrypted shares). The SDK's
+    // TKMS WASM does not expose the Solana keccak-link de-signcryption yet, so this caller owns the
+    // ML-KEM key pair (passing its public key to the launcher) and de-signcrypts the shares below.
+    let launcher_dir = env_or(
+        "SOLANA_UD_LAUNCHER_DIR",
+        concat!(env!("CARGO_MANIFEST_DIR"), "/../../../fhevm/test-suite/fhevm"),
     );
-    println!("result: {response_json}");
+    let launcher_out = run_solana_launcher(
+        &launcher_dir,
+        &relayer,
+        contracts_chain_id,
+        &pk_bytes,
+        &handle32,
+        &seed,
+        &context_id,
+        &nonce,
+        &[pubkey],
+        start_ts,
+        duration_seconds,
+    );
+    println!("launcher result: {launcher_out}");
 
     // 5. Parse the aggregated shares -> UserDecryptionResponse (external EIP-712 signature +
     //    bincode-serialized payload), then de-signcrypt via the Solana path.
-    let shares = response_json["result"]["result"]
+    let shares = launcher_out["shares"]
         .as_array()
-        .expect("relayer response result.result[] array");
+        .expect("launcher shares[] array");
     let mut agg_resp = Vec::new();
     let mut kms_pk: Option<PublicSigKey> = None;
     for share in shares {

--- a/core/service/tests/solana_user_decrypt_live.rs
+++ b/core/service/tests/solana_user_decrypt_live.rs
@@ -1,0 +1,196 @@
+//! Live RFC-021 Solana user-decryption client (the user-side SDK piece), as an `#[ignore]`d
+//! integration test driven against a running fhevm-cli stack with the Solana user-decrypt path
+//! deployed (gateway `userDecryptionRequestSolana`, relayer ed25519 seam, kms-connector Solana
+//! vertical, kms-core `compute_link_solana`).
+//!
+//! Flow: ML-KEM keygen -> ed25519-sign the canonical request-binding message (mirrors the relayer's
+//! `solana_user_decrypt_auth_message`) -> POST /v2/user-decrypt -> poll -> de-signcrypt via
+//! `process_user_decryption_resp_solana` -> assert the cleartext.
+//!
+//! Run (after a handle is granted to the user pubkey):
+//!   SOLANA_UD_HANDLE=0x... SOLANA_UD_EXPECTED=53 \
+//!   cargo test -p kms --features non-wasm --test solana_user_decrypt_live -- --ignored --nocapture
+#![cfg(feature = "non-wasm")]
+
+use std::collections::HashMap;
+use std::env;
+
+use aes_prng::AesRng;
+use alloy_primitives::{Address, U256};
+use ed25519_dalek::{Signer, SigningKey};
+use kms_grpc::kms::v1::{UserDecryptionResponse, UserDecryptionResponsePayload};
+use kms_lib::client::client_wasm::Client;
+use kms_lib::client::user_decryption_wasm::{CiphertextHandle, ParsedUserDecryptionRequest};
+use kms_lib::consts::{DEFAULT_PARAM, SAFE_SER_SIZE_LIMIT};
+use kms_lib::cryptography::encryption::{Encryption, PkeScheme, PkeSchemeType};
+use kms_lib::cryptography::signatures::PublicSigKey;
+use rand::SeedableRng;
+
+const AUTH_DOMAIN: &[u8] = b"fhevm-solana-user-decryption-auth-v0";
+
+fn env_or(key: &str, default: &str) -> String {
+    env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+/// Reads a Solana CLI keypair file (`[u8; 64]` JSON: 32-byte seed || 32-byte pubkey).
+fn load_solana_keypair(path: &str) -> (SigningKey, [u8; 32]) {
+    let bytes: Vec<u8> = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+    assert_eq!(bytes.len(), 64, "solana keypair must be 64 bytes");
+    let signing = SigningKey::from_bytes(&bytes[..32].try_into().unwrap());
+    let pubkey: [u8; 32] = bytes[32..].try_into().unwrap();
+    assert_eq!(signing.verifying_key().to_bytes(), pubkey, "keypair seed/pubkey mismatch");
+    (signing, pubkey)
+}
+
+/// Mirrors the relayer's `solana_user_decrypt_auth_message` byte-for-byte.
+fn auth_message(
+    contracts_chain_id: u64,
+    public_key: &[u8],
+    handles: &[[u8; 32]],
+    start_timestamp: U256,
+    duration_days: U256,
+) -> Vec<u8> {
+    let mut m = Vec::new();
+    m.extend_from_slice(AUTH_DOMAIN);
+    m.extend_from_slice(&contracts_chain_id.to_le_bytes());
+    m.extend_from_slice(&(public_key.len() as u32).to_le_bytes());
+    m.extend_from_slice(public_key);
+    m.extend_from_slice(&(handles.len() as u32).to_le_bytes());
+    for h in handles {
+        m.extend_from_slice(h);
+    }
+    m.extend_from_slice(&start_timestamp.to_be_bytes::<32>());
+    m.extend_from_slice(&duration_days.to_be_bytes::<32>());
+    m
+}
+
+#[tokio::test]
+#[ignore = "requires a running fhevm-cli stack with the Solana user-decrypt path + a granted handle"]
+async fn solana_user_decrypt_live() {
+    let relayer = env_or("SOLANA_UD_RELAYER", "http://localhost:3000");
+    let keypair_path =
+        env_or("SOLANA_UD_KEYPAIR", &format!("{}/.config/solana/id.json", env_or("HOME", "")));
+    let handle_hex = env::var("SOLANA_UD_HANDLE").expect("SOLANA_UD_HANDLE (0x..32 bytes) required");
+    let expected: u64 = env_or("SOLANA_UD_EXPECTED", "0").parse().unwrap();
+    let contracts_chain_id: u64 =
+        env_or("SOLANA_UD_CHAIN_ID", "9223372036854788153").parse().unwrap();
+
+    // 1. ML-KEM ephemeral keypair (non-wasm path). The serialized public key is the request's
+    //    `publicKey`; kms-core validates it via `UnifiedPublicEncKey::deserialize_and_validate`.
+    let mut rng = AesRng::from_entropy();
+    let (unified_sk, unified_pk) =
+        Encryption::new(PkeSchemeType::MlKem512, &mut rng).keygen().unwrap();
+    let mut pk_bytes = Vec::new();
+    tfhe::safe_serialization::safe_serialize(&unified_pk, &mut pk_bytes, SAFE_SER_SIZE_LIMIT)
+        .unwrap();
+
+    // 2. ed25519 user identity + auth signature over the canonical message.
+    let (signing, pubkey) = load_solana_keypair(&keypair_path);
+    let handle = alloy_primitives::hex::decode(handle_hex.trim_start_matches("0x")).unwrap();
+    let handle32: [u8; 32] = handle.try_into().expect("handle must be 32 bytes");
+    let start_ts = U256::from(1_700_000_000u64);
+    let duration_days = U256::from(30u64);
+    let msg = auth_message(contracts_chain_id, &pk_bytes, &[handle32], start_ts, duration_days);
+    let signature = signing.sign(&msg);
+
+    // 3. Build + POST the user-decrypt request.
+    let user_b58 = bs58::encode(pubkey).into_string();
+    let body = serde_json::json!({
+        "handleContractPairs": [{ "ctHandle": format!("0x{}", alloy_primitives::hex::encode(handle32)),
+                                  "contractAddress": user_b58 }],
+        "requestValidity": { "startTimestamp": start_ts.to_string(), "durationDays": duration_days.to_string() },
+        "contractsChainId": contracts_chain_id.to_string(),
+        "contractAddresses": [],
+        "userAddress": user_b58,
+        "signature": alloy_primitives::hex::encode(signature.to_bytes()),
+        "publicKey": alloy_primitives::hex::encode(&pk_bytes),
+        "extraData": "0x00",
+    });
+    let http = reqwest::Client::new();
+    let post = http.post(format!("{relayer}/v2/user-decrypt")).json(&body).send().await.unwrap();
+    let post_status = post.status();
+    let post_json: serde_json::Value = post.json().await.unwrap();
+    println!("POST {post_status}: {post_json}");
+    assert!(post_status.is_success(), "relayer rejected the request: {post_json}");
+    let job_id = post_json["result"]["jobId"].as_str().expect("jobId").to_string();
+
+    // 4. Poll for the response.
+    let mut response_json = serde_json::Value::Null;
+    for _ in 0..60 {
+        let r = http.get(format!("{relayer}/v2/user-decrypt/{job_id}")).send().await.unwrap();
+        let j: serde_json::Value = r.json().await.unwrap();
+        match j["status"].as_str() {
+            Some("succeeded") => {
+                response_json = j;
+                break;
+            }
+            Some("failed") => panic!("user-decrypt failed: {j}"),
+            _ => tokio::time::sleep(std::time::Duration::from_secs(2)).await,
+        }
+    }
+    assert!(!response_json.is_null(), "timed out waiting for user-decrypt result");
+    println!("result: {response_json}");
+
+    // 5. Parse the aggregated shares -> UserDecryptionResponse (external EIP-712 signature +
+    //    bincode-serialized payload), then de-signcrypt via the Solana path.
+    let shares = response_json["result"]["result"]
+        .as_array()
+        .expect("relayer response result.result[] array");
+    let mut agg_resp = Vec::new();
+    let mut kms_pk: Option<PublicSigKey> = None;
+    for share in shares {
+        let external_signature = alloy_primitives::hex::decode(
+            share["signature"].as_str().unwrap_or("").trim_start_matches("0x"),
+        )
+        .unwrap();
+        let payload_bytes = alloy_primitives::hex::decode(
+            share["payload"].as_str().unwrap_or("").trim_start_matches("0x"),
+        )
+        .unwrap();
+        let payload: UserDecryptionResponsePayload =
+            bc2wrap::deserialize_safe(&payload_bytes).unwrap();
+        if kms_pk.is_none() {
+            kms_pk = Some(bc2wrap::deserialize_safe(&payload.verification_key).unwrap());
+        }
+        agg_resp.push(UserDecryptionResponse {
+            signature: vec![],
+            external_signature,
+            payload: Some(payload),
+            extra_data: vec![],
+        });
+    }
+
+    // 6. Build a client bound to the KMS verification key and de-signcrypt.
+    let derived = Address::from_slice(&alloy_primitives::keccak256(pubkey)[12..]);
+    let mut server_pks = HashMap::new();
+    server_pks.insert(1u32, kms_pk.expect("KMS verification key in response payload"));
+    let client = Client::new(server_pks, derived, None, DEFAULT_PARAM, None);
+    let request = ParsedUserDecryptionRequest::new(
+        None,
+        derived,
+        pk_bytes.clone(),
+        vec![CiphertextHandle::new(handle32.to_vec())],
+        Address::ZERO,
+        vec![0x00],
+    );
+
+    let plaintexts = client
+        .process_user_decryption_resp_solana(
+            &request,
+            &pubkey,
+            contracts_chain_id,
+            &unified_pk,
+            &unified_sk,
+            &agg_resp,
+        )
+        .expect("solana de-signcryption failed");
+    assert!(!plaintexts.is_empty(), "no plaintexts returned");
+
+    let pt = &plaintexts[0];
+    let mut le = [0u8; 8];
+    let n = pt.bytes.len().min(8);
+    le[..n].copy_from_slice(&pt.bytes[..n]);
+    let value = u64::from_le_bytes(le);
+    println!("[solana] decrypted user cleartext = {value} (expected {expected})");
+    assert_eq!(value, expected, "cleartext mismatch");
+}

--- a/core/service/tests/solana_user_decrypt_live.rs
+++ b/core/service/tests/solana_user_decrypt_live.rs
@@ -88,15 +88,33 @@ async fn solana_user_decrypt_live() {
     let (signing, pubkey) = load_solana_keypair(&keypair_path);
     let handle = alloy_primitives::hex::decode(handle_hex.trim_start_matches("0x")).unwrap();
     let handle32: [u8; 32] = handle.try_into().expect("handle must be 32 bytes");
-    let start_ts = U256::from(1_700_000_000u64);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let start_ts = U256::from(now - 60); // small buffer so startTimestamp <= block time
     let duration_days = U256::from(30u64);
     let msg = auth_message(contracts_chain_id, &pk_bytes, &[handle32], start_ts, duration_days);
     let signature = signing.sign(&msg);
 
+    // extra_data v1 = 0x01 || context_id (32-byte BE): the KMS context the connector validates +
+    // routes to (same versioned format the EVM user-decrypt path uses; plain 0x00 is rejected).
+    let context_id = U256::from_str_radix(
+        &env_or(
+            "SOLANA_UD_CONTEXT_ID",
+            "3166189940082864718613269121331309980362851143201109172953918312716374638593",
+        ),
+        10,
+    )
+    .unwrap();
+    let mut extra_data = vec![0x01u8];
+    extra_data.extend_from_slice(&context_id.to_be_bytes::<32>());
+    let extra_data_hex = format!("0x{}", alloy_primitives::hex::encode(&extra_data));
+
     // 3. Build + POST the user-decrypt request.
     let user_b58 = bs58::encode(pubkey).into_string();
     let body = serde_json::json!({
-        "handleContractPairs": [{ "ctHandle": format!("0x{}", alloy_primitives::hex::encode(handle32)),
+        "handleContractPairs": [{ "handle": format!("0x{}", alloy_primitives::hex::encode(handle32)),
                                   "contractAddress": user_b58 }],
         "requestValidity": { "startTimestamp": start_ts.to_string(), "durationDays": duration_days.to_string() },
         "contractsChainId": contracts_chain_id.to_string(),
@@ -104,7 +122,7 @@ async fn solana_user_decrypt_live() {
         "userAddress": user_b58,
         "signature": alloy_primitives::hex::encode(signature.to_bytes()),
         "publicKey": alloy_primitives::hex::encode(&pk_bytes),
-        "extraData": "0x00",
+        "extraData": extra_data_hex,
     });
     let http = reqwest::Client::new();
     let post = http.post(format!("{relayer}/v2/user-decrypt")).json(&body).send().await.unwrap();


### PR DESCRIPTION
## Solana-native user-decryption for kms-core (pinned on `c57f52f`)

**This is the kms-core branch backing the Solana FHEVM stack.** It is the source for the
pinned image `ghcr.io/zama-ai/kms/core-service:solana-ud-c57f52f-fix` that the fhevm Solana
e2e runs against. Companion PR: **zama-ai/fhevm#2756**.

> **Draft / reference.** Base is `c57f52f` (`Merge branch 'main' …`, the exact commit the
> deployed kms-core image is built from) so the diff shows *only* the Solana changes. It is
> intentionally **not** rebased onto current `main` — the deployed fhevm-cli backend pins this
> kms-core image and `main` has diverged since `c57f52f` (build-interface drift, e.g. the
> `kms-gen-keys --cmd` change). Use this branch to **pin the kms-core version** or to **run a
> docker build job** for the image in CI. Upstreaming onto current `main` is a follow-up that
> needs a rebase + KMS-team review.

### Why kms-core needs this (user-decrypt only; public-decrypt is unchanged)

The EVM `validate_user_decrypt_req` hardcodes EVM-only assumptions a Solana identity cannot
satisfy: a 20-byte checksummed `client_address`, a mandatory EVM EIP-712 user wallet
signature, and the EVM `UserDecryptionLinker` for the request↔response link. A Solana user is
a 32-byte ed25519 pubkey authenticating via `signMessage`. So a Solana branch is required to
bind a response for a non-EVM identity. Public-decrypt needs no core change (no per-user
identity to bind; the ACL check lives in the kms-connector's `solana_acl`).

### Commits

- `e55e7ed2` grpc: `compute_link_solana` — request↔response link for a 32-byte ed25519 identity.
- `f86b3471` service: Solana branch in `validate_user_decrypt_req` (parse `solana:<hex>`,
  `compute_link_solana`, signcryption `client_id = keccak256(pubkey)[12..]`, skip the EVM
  external-signature check — authorization is the connector's job via ed25519).
- `669e2c07` → `d5b5a679` service: sign `UserDecryptResponseVerification` under the gateway's
  **`Decryption` EIP-712 domain** carried in `req.domain` (not a placeholder domain), so the
  gateway's `userDecryptionResponse` recovers the registered KMS signer on-chain. Without this
  the gateway rejected the response with `NotKmsSigner` and consensus never formed. This is the
  only behavioral fix; it makes the response cert byte-identical to the EVM path.
- `d29a30bf`, `85d94358` client/tests: Solana de-signcryption + a live `solana_user_decrypt_live`
  integration test that drives the request through the relayer `/v2/user-decrypt` route.

The EVM user-decrypt path is untouched; the only divergence is the sanctioned ed25519
authorization seam (enforced upstream by the relayer + connector).

### Building the image from this branch

```
git checkout solana-ud-on-c57f52f
# docker build of core-service from this tree -> tag core-service:solana-ud-c57f52f-fix
```
