### PR TITLE
perf: batch reconstruction with hints + more par iter

### DIFF
--- a/core/experiments/benches/decoding.rs
+++ b/core/experiments/benches/decoding.rs
@@ -71,7 +71,7 @@ fn bench_decode_z128(c: &mut Criterion) {
             let sharing = ShamirSharings::share(&mut rng, secret, num_parties, threshold).unwrap();
 
             b.iter(|| {
-                let f_zero = sharing.err_reconstruct(threshold, max_err).unwrap();
+                let f_zero = sharing.error_reconstruct(threshold, max_err).unwrap();
                 assert_eq!(f_zero, secret);
             });
         });
@@ -94,7 +94,7 @@ fn bench_decode_z64(c: &mut Criterion) {
             let sharing = ShamirSharings::share(&mut rng, secret, num_parties, threshold).unwrap();
 
             b.iter(|| {
-                let f_zero = sharing.err_reconstruct(threshold, max_err).unwrap();
+                let f_zero = sharing.error_reconstruct(threshold, max_err).unwrap();
                 assert_eq!(f_zero, secret);
             });
         });
@@ -141,14 +141,18 @@ fn bench_decode_par_z64(c: &mut Criterion) {
                         None => {
                             sharings
                                 .iter()
-                                .map(|sharing| sharing.err_reconstruct(threshold, max_err).unwrap())
+                                .map(|sharing| {
+                                    sharing.error_reconstruct(threshold, max_err).unwrap()
+                                })
                                 .collect_vec();
                         }
                         Some(chunk_size) => {
                             sharings
                                 .par_iter()
                                 .with_min_len(chunk_size)
-                                .map(|sharing| sharing.err_reconstruct(threshold, max_err).unwrap())
+                                .map(|sharing| {
+                                    sharing.error_reconstruct(threshold, max_err).unwrap()
+                                })
                                 .collect_into_vec(&mut f_zero);
                         }
                     }
@@ -173,7 +177,7 @@ fn bench_decode_large_field(c: &mut Criterion) {
             let secret = LevelOne::from_u128(2345);
             let sharing = ShamirSharings::share(&mut rng, secret, num_parties, threshold).unwrap();
             b.iter(|| {
-                let f_zero = sharing.err_reconstruct(threshold, max_err).unwrap();
+                let f_zero = sharing.error_reconstruct(threshold, max_err).unwrap();
                 assert_eq!(f_zero, secret);
             });
         });

--- a/core/service/src/client/user_decryption_wasm.rs
+++ b/core/service/src/client/user_decryption_wasm.rs
@@ -12,6 +12,7 @@ use crate::engine::validation::{
     validate_user_decrypt_responses_against_request,
 };
 use crate::{anyhow_error_and_log, some_or_err};
+use algebra::error_correction::ReconstructionHints;
 use algebra::{
     base_ring::{Z64, Z128},
     error_correction::MemoizedExceptionals,
@@ -301,6 +302,12 @@ impl Client {
                         )));
                     }
                     let mut decrypted_blocks = Vec::new();
+                    let pivot = if let Some(pivot) = sharings.first() {
+                        pivot
+                    } else {
+                        return Ok(Vec::new());
+                    };
+                    let hints = ReconstructionHints::new(pivot, degree)?;
                     for cur_block_shares in sharings {
                         // NOTE: this performs optimistic reconstruction
                         match reconstruct_w_errors_sync(
@@ -309,6 +316,7 @@ impl Client {
                             degree,
                             num_parties - amount_shares,
                             &cur_block_shares,
+                            &hints,
                         ) {
                             Ok(Some(r)) => decrypted_blocks.push(r),
                             Ok(None) => {
@@ -356,6 +364,12 @@ impl Client {
                             "Too many errors in share recovery / signcryption: {recovery_errors} (threshold {degree})"
                         )));
                     }
+                    let pivot = if let Some(pivot) = sharings.first() {
+                        pivot
+                    } else {
+                        return Ok(Vec::new());
+                    };
+                    let hints = ReconstructionHints::new(pivot, degree)?;
 
                     let mut decrypted_blocks = Vec::new();
                     for cur_block_shares in sharings {
@@ -366,6 +380,7 @@ impl Client {
                             degree,
                             num_parties - amount_shares,
                             &cur_block_shares,
+                            &hints,
                         ) {
                             Ok(Some(r)) => decrypted_blocks.push(r),
                             Ok(None) => {
@@ -526,6 +541,12 @@ impl Client {
             }
 
             let mut decrypted_blocks = Vec::new();
+            let pivot = if let Some(pivot) = sharings.first() {
+                pivot
+            } else {
+                return Ok(Vec::new());
+            };
+            let hints = ReconstructionHints::new(pivot, degree)?;
             for cur_block_shares in sharings {
                 // NOTE: this performs optimistic reconstruction
                 match reconstruct_w_errors_sync(
@@ -534,6 +555,7 @@ impl Client {
                     degree,
                     num_parties - amount_shares,
                     &cur_block_shares,
+                    &hints,
                 ) {
                     Ok(Some(r)) => decrypted_blocks.push(r),
                     Ok(None) => {

--- a/core/service/src/testing/utils.rs
+++ b/core/service/src/testing/utils.rs
@@ -371,7 +371,6 @@ pub async fn compute_cipher_from_stored_key(
     // the server key which is a thread global variable using RefCell in tfhe
     // and if the key is reset in another rayon thread while compute_cipher is running,
     // it can cause a panic due to the RefCell borrow rules.
-    // By using spawn_blocking, we ensure that compute_cipher runs in a dedicated tokio thread where the server key won't be reset by other threads.
     tokio::task::spawn_blocking(move || compute_cipher(msg, &pk, Some(server_key), enc_config))
         .await
         .unwrap()

--- a/core/service/src/testing/utils.rs
+++ b/core/service/src/testing/utils.rs
@@ -367,11 +367,14 @@ pub async fn compute_cipher_from_stored_key(
     };
 
     // compute_cipher can take a long time since it may do SnS
-    let (send, recv) = tokio::sync::oneshot::channel();
-    rayon::spawn_fifo(move || {
-        let _ = send.send(compute_cipher(msg, &pk, Some(server_key), enc_config));
-    });
-    recv.await.unwrap()
+    // Use a tokio spawn_blocking instead of rayon because computer_cipher sets
+    // the server key which is a thread global variable using RefCell in tfhe
+    // and if the key is reset in another rayon thread while compute_cipher is running,
+    // it can cause a panic due to the RefCell borrow rules.
+    // By using spawn_blocking, we ensure that compute_cipher runs in a dedicated tokio thread where the server key won't be reset by other threads.
+    tokio::task::spawn_blocking(move || compute_cipher(msg, &pk, Some(server_key), enc_config))
+        .await
+        .unwrap()
 }
 
 /// Helper method to construct a backup vault for testing. That is either without encryption (no `Keychain`) or using custodians.

--- a/core/service/src/util/key_setup/test_tools.rs
+++ b/core/service/src/util/key_setup/test_tools.rs
@@ -376,7 +376,6 @@ pub async fn compute_cipher_from_stored_key(
     // the server key which is a thread global variable using RefCell in tfhe
     // and if the key is reset in another rayon thread while compute_cipher is running,
     // it can cause a panic due to the RefCell borrow rules.
-    // By using spawn_blocking, we ensure that compute_cipher runs in a dedicated tokio thread where the server key won't be reset by other threads.
     tokio::task::spawn_blocking(move || compute_cipher(msg, &pk, Some(server_key), enc_config))
         .await
         .unwrap()

--- a/core/service/src/util/key_setup/test_tools.rs
+++ b/core/service/src/util/key_setup/test_tools.rs
@@ -372,11 +372,14 @@ pub async fn compute_cipher_from_stored_key(
     };
 
     // compute_cipher can take a long time since it may do SnS
-    let (send, recv) = tokio::sync::oneshot::channel();
-    rayon::spawn_fifo(move || {
-        let _ = send.send(compute_cipher(msg, &pk, Some(server_key), enc_config));
-    });
-    recv.await.unwrap()
+    // Use a tokio spawn_blocking instead of rayon because computer_cipher sets
+    // the server key which is a thread global variable using RefCell in tfhe
+    // and if the key is reset in another rayon thread while compute_cipher is running,
+    // it can cause a panic due to the RefCell borrow rules.
+    // By using spawn_blocking, we ensure that compute_cipher runs in a dedicated tokio thread where the server key won't be reset by other threads.
+    tokio::task::spawn_blocking(move || compute_cipher(msg, &pk, Some(server_key), enc_config))
+        .await
+        .unwrap()
 }
 
 /// Purge any kind of public or private data, regardless of type, for a specific request ID.

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -160,39 +160,6 @@ impl<Z: ErrorCorrect> ReconstructionHints<Z> {
     }
 }
 
-impl<Z: ErrorCorrect + MemoizedExceptionals> ReconstructionHints<Z> {
-    /// Like [`Self::from_parties`] but fetches exceptional powers from the
-    /// [`MemoizedExceptionals`] cache instead of recomputing them.
-    pub fn from_parties_sorted_cached(parties: &[Role], degree: usize) -> anyhow::Result<Self> {
-        let embedded_points: Vec<Z> = parties
-            .iter()
-            .map(|p| Z::embed_role_to_exceptional_sequence(p))
-            .try_collect()?;
-        let exceptional_powers: Vec<Vec<Z>> = parties
-            .iter()
-            .map(|p| Z::exceptional_set(p.one_based(), degree))
-            .collect::<anyhow::Result<Vec<_>>>()?;
-        let field_hints = FieldHints::new(parties)?;
-        Ok(Self {
-            parties: parties.to_vec(),
-            degree,
-            embedded_points,
-            exceptional_powers,
-            field_hints,
-        })
-    }
-
-    /// Like [`Self::from_parties`] but fetches exceptional powers from the
-    /// [`MemoizedExceptionals`] cache instead of recomputing them.
-    ///
-    /// Parties are not required to be pre-sorted, but they will be sorted internally
-    pub fn from_parties_cached(parties: &[Role], degree: usize) -> anyhow::Result<Self> {
-        // Roles are always sorted when creating a ShamirSharing, so sort it here too
-        let parties = parties.iter().sorted().cloned().collect_vec();
-        Self::from_parties_sorted_cached(&parties, degree)
-    }
-}
-
 /// Lifts binary polynomial p to the big ring and accumulates 2^amount * p into res
 fn accumulate_and_lift_bitwise_poly<Z: BaseRing, const EXTENSION_DEGREE: usize>(
     res: &mut Poly<ResiduePoly<Z, EXTENSION_DEGREE>>,

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -339,6 +339,21 @@ where
         From<Poly<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>>,
     BitwisePoly: BitWiseEval<Z, EXTENSION_DEGREE>,
 {
+    if hints.degree != degree {
+        return Err(anyhow_error_and_log(format!(
+            "ReconstructionHints degree {} does not match the provided degree {}",
+            hints.degree, degree
+        )));
+    }
+
+    let sharing_parties: Vec<Role> = sharing.shares.iter().map(|s| s.owner()).collect();
+    if hints.parties != sharing_parties {
+        return Err(anyhow_error_and_log(format!(
+            "ReconstructionHints parties {:?} do not match the sharing's owner set {:?}",
+            hints.parties, sharing_parties
+        )));
+    }
+
     let ring_size: usize = Z::BIT_LENGTH;
 
     let mut shares_with_validity = sharing
@@ -500,12 +515,17 @@ mod tests {
     use aes_prng::AesRng;
     use rand::SeedableRng;
 
-    use crate::error_correction::{FieldHints, error_correction_with_field_hints};
+    use crate::error_correction::{
+        FieldHints, ReconstructionHints, error_correction_with_field_hints,
+        shamir_error_correct_with_hints,
+    };
     use crate::galois_fields::gf8::GF8;
     use crate::galois_fields::gf32::GF32;
     use crate::galois_fields::gf64::GF64;
     use crate::galois_fields::gf128::GF128;
     use crate::galois_fields::gf256::GF256;
+    use crate::galois_rings::degree_3::ResiduePolyF3Z128;
+    use crate::structure_traits::Sample;
     use crate::{
         base_ring::Z64,
         error_correction::{error_correction, shamir_error_correct},
@@ -662,5 +682,53 @@ mod tests {
         let secret_poly_with_hints =
             error_correction_with_field_hints(shares, threshold, max_errors, &hints).unwrap();
         assert_eq!(secret_poly_with_hints, f);
+    }
+
+    #[test]
+    fn test_error_correction_with_hints() {
+        let num_parties = 4;
+        let mut rng = AesRng::seed_from_u64(0);
+        let secret = ResiduePolyF3Z128::sample(&mut rng);
+        let threshold = 1;
+        let sharings =
+            ShamirSharings::share(&mut rng, secret.clone(), num_parties, threshold).unwrap();
+
+        let hint = ReconstructionHints::new(&sharings, threshold).unwrap();
+
+        let result =
+            shamir_error_correct_with_hints(&sharings, threshold, threshold, &hint).unwrap();
+        assert_eq!(result.eval(&ResiduePolyF3Z128::ZERO), secret);
+    }
+
+    // Test that error correction with hints fails when hint is wrong
+    // Using polynomial over ResiduePolyZ128F4
+    #[test]
+    fn test_error_correction_with_wrong_hints() {
+        let num_parties = 4;
+        let mut rng = AesRng::seed_from_u64(0);
+        let secret = ResiduePolyF3Z128::sample(&mut rng);
+        let threshold = 1;
+        let sharings = ShamirSharings::share(&mut rng, secret, num_parties, threshold).unwrap();
+
+        let hint_wrong_degree = ReconstructionHints::new(&sharings, 2).unwrap();
+
+        let result =
+            shamir_error_correct_with_hints(&sharings, threshold, threshold, &hint_wrong_degree);
+        assert!(result.is_err());
+
+        let mut parties = sharings
+            .shares
+            .iter()
+            .map(|s| s.owner())
+            .collect::<Vec<_>>();
+
+        // Remove a party to create a wrong hint
+        parties.pop();
+
+        let hint_wrong_parties = ReconstructionHints::from_parties(parties, threshold).unwrap();
+
+        let result =
+            shamir_error_correct_with_hints(&sharings, threshold, threshold, &hint_wrong_parties);
+        assert!(result.is_err());
     }
 }

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -212,6 +212,75 @@ fn accumulate_and_lift_bitwise_poly<Z: BaseRing, const EXTENSION_DEGREE: usize>(
     }
 }
 
+/// Compose the `bit_idx`-th bit of every still-valid share into the reconstruction
+/// (quotient) field. Shared by the hinted and non-hinted Hensel lift.
+fn compute_binary_shares<Z: BaseRing, const EXTENSION_DEGREE: usize>(
+    shares_with_validity: &[(Share<ResiduePoly<Z, EXTENSION_DEGREE>>, bool)],
+    bit_idx: usize,
+) -> Vec<Share<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>>
+where
+    ResiduePoly<Z, EXTENSION_DEGREE>: QuotientMaximalIdeal,
+{
+    shares_with_validity
+        .iter()
+        .filter_map(|(sh, is_valid)| {
+            if *is_valid {
+                Some(Share::<
+                    <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput,
+                >::new(
+                    sh.owner(), sh.value().bit_compose(bit_idx)
+                ))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// One Hensel-lift correction step shared by the hinted and non-hinted reconstruction:
+/// subtract the contribution of the GF error-corrected bit polynomial `fi_mod2` (evaluated at
+/// each party's exceptional point) from every still-valid share, refresh that share's validity,
+/// and accumulate the lifted bits into `res`. Returns the owners of the shares that became
+/// invalid during this step.
+fn apply_bit_correction<Z: BaseRing, const EXTENSION_DEGREE: usize>(
+    shares_with_validity: &mut [(Share<ResiduePoly<Z, EXTENSION_DEGREE>>, bool)],
+    ordered_powers: &[Vec<ResiduePoly<Z, EXTENSION_DEGREE>>],
+    fi_mod2: &Poly<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>,
+    bit_idx: usize,
+    res: &mut Poly<ResiduePoly<Z, EXTENSION_DEGREE>>,
+) -> Vec<Role>
+where
+    ResiduePoly<Z, EXTENSION_DEGREE>: MemoizedExceptionals,
+    ResiduePoly<Z, EXTENSION_DEGREE>: RingWithExceptionalSequence,
+    ResiduePoly<Z, EXTENSION_DEGREE>: QuotientMaximalIdeal,
+    ResiduePoly<Z, EXTENSION_DEGREE>: LutMulReduction<Z>,
+    BitwisePoly:
+        From<Poly<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>>,
+    BitwisePoly: BitWiseEval<Z, EXTENSION_DEGREE>,
+{
+    let bitwise = BitwisePoly::from(fi_mod2.clone());
+    let mut evicted = Vec::new();
+    // remove the LSBs computed from error correction in the quotient field
+    for (j, (share, is_valid)) in shares_with_validity.iter_mut().enumerate() {
+        if *is_valid {
+            // compute fi(\gamma_1) ..., fi(\gamma_n) \in GR[Z = {2^64/2^128}]
+            let offset = bitwise.lazy_eval(&ordered_powers[j]) << bit_idx;
+            *share -= offset;
+
+            // divisibility check of pi; only needed while the share is still valid
+            *is_valid = share.value().multiple_pow2(bit_idx + 1);
+
+            // Log at most once, when the share becomes invalid
+            if !*is_valid {
+                tracing::warn!("Share at index {j} is invalid after iteration {bit_idx}");
+                evicted.push(share.owner());
+            }
+        }
+    }
+    accumulate_and_lift_bitwise_poly(res, fi_mod2, bit_idx);
+    evicted
+}
+
 fn shamir_error_correct<Z: BaseRing, const EXTENSION_DEGREE: usize>(
     sharing: &ShamirSharings<ResiduePoly<Z, EXTENSION_DEGREE>>,
     degree: usize,
@@ -227,7 +296,6 @@ where
         From<Poly<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>>,
     BitwisePoly: BitWiseEval<Z, EXTENSION_DEGREE>,
 {
-    // threshold is the degree of the shamir polynomial
     let ring_size: usize = Z::BIT_LENGTH;
 
     //Start with all values being valid (none of them are Bot)
@@ -239,66 +307,44 @@ where
 
     let initial_length = shares_with_validity.len();
 
+    // Exceptional powers fetched (per party) from the memoized store.
     let parties: Vec<_> = sharing
         .shares
         .iter()
         .map(|x| x.owner().one_based())
         .collect();
-
     let ordered_powers: Vec<Vec<ResiduePoly<Z, EXTENSION_DEGREE>>> = parties
         .iter()
         .map(|party_id| ResiduePoly::<Z, EXTENSION_DEGREE>::exceptional_set(*party_id, degree))
         .collect::<anyhow::Result<Vec<_>>>()?;
 
     let mut res = Poly::<ResiduePoly<Z, EXTENSION_DEGREE>>::zero();
+    // (owner, iteration) of shares that became invalid, for test-side bookkeeping only.
+    #[cfg(test)]
+    let mut all_evicted: Vec<(Role, usize)> = Vec::new();
 
     for bit_idx in 0..ring_size {
-        //Compute z = pi(y/2^i), where Bots are filtered out
-        let binary_shares: Vec<
-            Share<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>,
-        > = shares_with_validity
-            .iter()
-            .filter_map(|(sh, is_valid)| {
-                if *is_valid {
-                    Some(Share::<
-                        <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput,
-                    >::new(
-                        sh.owner(), sh.value().bit_compose(bit_idx)
-                    ))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
+        // z = pi(y/2^i), Bots filtered out
+        let binary_shares = compute_binary_shares(&shares_with_validity, bit_idx);
         let num_new_bot = initial_length - binary_shares.len();
-        // apply error correction on z
+
         // fi(X) = a0 + ... a_t * X^t where a0 is the secret bit corresponding to position i
         let fi_mod2 = error_correction(binary_shares, degree, max_errs - num_new_bot)?;
-        let bitwise = BitwisePoly::from(fi_mod2.clone());
 
-        // remove LSBs computed from error correction in GF(256)
-        for (j, (share, is_valid)) in shares_with_validity.iter_mut().enumerate() {
-            if *is_valid {
-                // compute fi(\gamma_1) ..., fi(\gamma_n) \in GR[Z = {2^64/2^128}]
-                let offset = bitwise.lazy_eval(&ordered_powers[j]) << bit_idx;
-                *share -= offset;
+        let _evicted = apply_bit_correction(
+            &mut shares_with_validity,
+            &ordered_powers,
+            &fi_mod2,
+            bit_idx,
+            &mut res,
+        );
+        #[cfg(test)]
+        all_evicted.extend(_evicted.into_iter().map(|owner| (owner, bit_idx)));
+    }
 
-                //Do the divisibility check of pi, only need to do it if the share is currently valid
-                *is_valid = share.value().multiple_pow2(bit_idx + 1);
-
-                //Log at most once, when share becomes invalid
-                if !*is_valid {
-                    #[cfg(test)]
-                    if let Some(&mut ref mut indices) = err_indices {
-                        indices.push((share.owner(), bit_idx));
-                    }
-                    tracing::warn!("Share at index {j} is invalid after iteration {bit_idx}");
-                }
-            }
-        }
-
-        accumulate_and_lift_bitwise_poly(&mut res, &fi_mod2, bit_idx);
+    #[cfg(test)]
+    if let Some(indices) = err_indices {
+        indices.extend(all_evicted);
     }
 
     Ok(res)
@@ -350,23 +396,7 @@ where
     > = None;
 
     for bit_idx in 0..ring_size {
-        let binary_shares: Vec<
-            Share<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>,
-        > = shares_with_validity
-            .iter()
-            .filter_map(|(sh, is_valid)| {
-                if *is_valid {
-                    Some(Share::<
-                        <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput,
-                    >::new(
-                        sh.owner(), sh.value().bit_compose(bit_idx)
-                    ))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
+        let binary_shares = compute_binary_shares(&shares_with_validity, bit_idx);
         let num_new_bot = initial_length - binary_shares.len();
 
         let fi_mod2 = if !validity_changed {
@@ -379,7 +409,7 @@ where
             )?
         } else {
             // Some parties were evicted — recompute field hints for the new valid set
-            // (or reuse previously computed fallback if validity hasn't changed again).
+            // (or reuse the previously computed fallback if validity hasn't changed again).
             if fallback_field_hints.is_none() {
                 let valid_parties: Vec<Role> = shares_with_validity
                     .iter()
@@ -394,30 +424,19 @@ where
                 fallback_field_hints.as_ref().unwrap(),
             )?
         };
-        let bitwise = BitwisePoly::from(fi_mod2.clone());
 
-        let mut evicted_this_round = false;
-        for (j, (share, is_valid)) in shares_with_validity.iter_mut().enumerate() {
-            if *is_valid {
-                let offset = bitwise.lazy_eval(&ordered_powers[j]) << bit_idx;
-                *share -= offset;
-
-                *is_valid = share.value().multiple_pow2(bit_idx + 1);
-
-                if !*is_valid {
-                    tracing::warn!("Share at index {j} is invalid after iteration {bit_idx}");
-                    evicted_this_round = true;
-                }
-            }
-        }
-
-        if evicted_this_round {
+        let evicted = apply_bit_correction(
+            &mut shares_with_validity,
+            ordered_powers,
+            &fi_mod2,
+            bit_idx,
+            &mut res,
+        );
+        if !evicted.is_empty() {
             validity_changed = true;
             // Invalidate fallback hints so they get recomputed for the new valid set.
             fallback_field_hints = None;
         }
-
-        accumulate_and_lift_bitwise_poly(&mut res, &fi_mod2, bit_idx);
     }
 
     Ok(res)

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -251,7 +251,7 @@ where
 fn shamir_error_correct<Z: BaseRing, const EXTENSION_DEGREE: usize>(
     sharing: &ShamirSharings<ResiduePoly<Z, EXTENSION_DEGREE>>,
     degree: usize,
-    max_errs: usize,
+    max_errorsors: usize,
     #[cfg(test)] err_indices: Option<&mut Vec<(threshold_types::role::Role, usize)>>,
 ) -> anyhow::Result<Poly<ResiduePoly<Z, EXTENSION_DEGREE>>>
 where
@@ -296,7 +296,7 @@ where
         let num_new_bot = initial_length - binary_shares.len();
 
         // fi(X) = a0 + ... a_t * X^t where a0 is the secret bit corresponding to position i
-        let fi_mod2 = error_correction(binary_shares, degree, max_errs - num_new_bot)?;
+        let fi_mod2 = error_correction(binary_shares, degree, max_errorsors - num_new_bot)?;
 
         let _evicted = apply_bit_correction(
             &mut shares_with_validity,
@@ -325,7 +325,7 @@ where
 fn shamir_error_correct_with_hints<Z: BaseRing, const EXTENSION_DEGREE: usize>(
     sharing: &ShamirSharings<ResiduePoly<Z, EXTENSION_DEGREE>>,
     degree: usize,
-    max_errs: usize,
+    max_errorsors: usize,
     hints: &ReconstructionHints<ResiduePoly<Z, EXTENSION_DEGREE>>,
 ) -> anyhow::Result<Poly<ResiduePoly<Z, EXTENSION_DEGREE>>>
 where
@@ -371,7 +371,7 @@ where
             error_correction_with_field_hints(
                 binary_shares,
                 degree,
-                max_errs - num_new_bot,
+                max_errorsors - num_new_bot,
                 &hints.field_hints,
             )?
         } else {
@@ -387,7 +387,7 @@ where
             error_correction_with_field_hints(
                 binary_shares,
                 degree,
-                max_errs - num_new_bot,
+                max_errorsors - num_new_bot,
                 fallback_field_hints.as_ref().unwrap(),
             )?
         };
@@ -427,38 +427,38 @@ where
     ///
     /// - sharing is the set of shares we try to reconstruct the secret from
     /// - degree is the degree of the sharing polynomial (either threshold or `2*threshold`)
-    /// - max_errs is the maximum number of errors we try to correct for (most often threshold - len(corrupt_set), but can be less than this if degree is `2*threshold`)
+    /// - max_errorsors is the maximum number of errors we try to correct for (most often threshold - len(corrupt_set), but can be less than this if degree is `2*threshold`)
     ///
     /// __NOTE__ : We assume values coming from known malicious parties have been excluded by the caller (i.e. values denoted Bot in NIST doc)
     fn error_correct(
         sharing: &ShamirSharings<Self>,
         degree: usize,
-        max_errs: usize,
+        max_errorsors: usize,
     ) -> anyhow::Result<Poly<Self>> {
         #[cfg(not(test))]
         {
-            shamir_error_correct(sharing, degree, max_errs)
+            shamir_error_correct(sharing, degree, max_errorsors)
         }
         #[cfg(test)]
         {
-            shamir_error_correct(sharing, degree, max_errs, None)
+            shamir_error_correct(sharing, degree, max_errorsors, None)
         }
     }
 
     fn error_correct_with_hints(
         sharing: &ShamirSharings<Self>,
         degree: usize,
-        max_errs: usize,
+        max_errorsors: usize,
         hints: &ReconstructionHints<Self>,
     ) -> anyhow::Result<Poly<Self>> {
-        shamir_error_correct_with_hints(sharing, degree, max_errs, hints)
+        shamir_error_correct_with_hints(sharing, degree, max_errorsors, hints)
     }
 }
 
 pub fn error_correction<F: Field>(
     shares: Vec<Share<F>>,
     degree: usize,
-    max_errs: usize,
+    max_errorsors: usize,
 ) -> anyhow::Result<ShamirFieldPoly<F>> {
     let xs: Vec<F> = shares
         .iter()
@@ -467,7 +467,7 @@ pub fn error_correction<F: Field>(
     let ys: Vec<F> = shares.into_iter().map(|s| s.take_value()).collect();
 
     // call Gao decoding with the shares as points/values, set Gao parameter k = v = degree+1
-    gao_decoding(&xs, &ys, degree + 1, max_errs)
+    gao_decoding(&xs, &ys, degree + 1, max_errorsors)
 }
 
 /// Like [`error_correction`] but reuses precomputed [`FieldHints`] to avoid redundant
@@ -477,7 +477,7 @@ pub fn error_correction<F: Field>(
 pub fn error_correction_with_field_hints<F: Field>(
     shares: Vec<Share<F>>,
     degree: usize,
-    max_errs: usize,
+    max_errorsors: usize,
     field_hints: &FieldHints<F>,
 ) -> anyhow::Result<ShamirFieldPoly<F>> {
     let ys: Vec<F> = shares.into_iter().map(|s| s.take_value()).collect();
@@ -486,7 +486,7 @@ pub fn error_correction_with_field_hints<F: Field>(
         &field_hints.embedded_points,
         &ys,
         degree + 1,
-        max_errs,
+        max_errorsors,
         &field_hints.lagrange_polys,
         &field_hints.vanishing_poly,
     )
@@ -640,7 +640,7 @@ mod tests {
 
         let num_parties = 7;
         let threshold = f.coefs().len() - 1; // = 2 here
-        let max_err = (num_parties - threshold) / 2; // = 2 here
+        let max_errors = (num_parties - threshold) / 2; // = 2 here
 
         let mut shares: Vec<_> = (1..=num_parties)
             .map(|x| {
@@ -654,13 +654,13 @@ mod tests {
         shares[1] += BaseField::from_u128(9);
         shares[2] += BaseField::from_u128(254);
 
-        let secret_poly = error_correction(shares.clone(), threshold, max_err).unwrap();
+        let secret_poly = error_correction(shares.clone(), threshold, max_errors).unwrap();
         assert_eq!(secret_poly, f);
 
         let parties = shares.iter().map(|s| s.owner()).collect::<Vec<_>>();
         let hints = FieldHints::new(&parties).unwrap();
         let secret_poly_with_hints =
-            error_correction_with_field_hints(shares, threshold, max_err, &hints).unwrap();
+            error_correction_with_field_hints(shares, threshold, max_errors, &hints).unwrap();
         assert_eq!(secret_poly_with_hints, f);
     }
 }

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -125,7 +125,7 @@ impl<Z: ErrorCorrect> ReconstructionHints<Z> {
     pub fn new(sharing: &ShamirSharings<Z>, degree: usize) -> anyhow::Result<Self> {
         // ShamirSharings are always sorted by owner Role, so the parties are already sorted here.
         let parties: Vec<Role> = sharing.shares.iter().map(|s| s.owner()).collect();
-        Self::from_parties_sorted(&parties, degree)
+        Self::from_parties_sorted(parties, degree)
     }
 
     /// Build hints from an explicit list of parties and a degree.
@@ -133,25 +133,25 @@ impl<Z: ErrorCorrect> ReconstructionHints<Z> {
     /// Computes exceptional powers directly from the embedded points.
     ///
     /// Parties are not required to be pre-sorted, but they will be sorted internally
-    pub fn from_parties(parties: &[Role], degree: usize) -> anyhow::Result<Self> {
+    pub fn from_parties(parties: Vec<Role>, degree: usize) -> anyhow::Result<Self> {
         // Roles are always sorted when creating a ShamirSharing, so sort it here too
-        let parties = parties.iter().sorted().cloned().collect_vec();
-        Self::from_parties_sorted(&parties, degree)
+        let parties = parties.into_iter().sorted_unstable().collect_vec();
+        Self::from_parties_sorted(parties, degree)
     }
 
     /// Build hints from an explicit list of parties and a degree.
     ///
     /// Computes exceptional powers directly from the embedded points.
-    pub fn from_parties_sorted(parties: &[Role], degree: usize) -> anyhow::Result<Self> {
+    fn from_parties_sorted(parties: Vec<Role>, degree: usize) -> anyhow::Result<Self> {
         let embedded_points: Vec<Z> = parties
             .iter()
             .map(|p| Z::embed_role_to_exceptional_sequence(p))
             .try_collect()?;
         let exceptional_powers: Vec<Vec<Z>> = compute_powers_list(&embedded_points, degree);
 
-        let field_hints = FieldHints::new(parties)?;
+        let field_hints = FieldHints::new(&parties)?;
         Ok(Self {
-            parties: parties.to_vec(),
+            parties,
             degree,
             embedded_points,
             exceptional_powers,

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -473,7 +473,7 @@ pub fn error_correction<F: Field>(
 /// Like [`error_correction`] but reuses precomputed [`FieldHints`] to avoid redundant
 /// embedding, Lagrange polynomial, and vanishing polynomial computations.
 ///
-/// `field_hints` must have been built from the same set of parties that own the `shares`.
+/// `field_hints` must have been built from the same __ordered list__ of parties that own the `shares`.
 pub fn error_correction_with_field_hints<F: Field>(
     shares: Vec<Share<F>>,
     degree: usize,

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -500,6 +500,7 @@ mod tests {
     use aes_prng::AesRng;
     use rand::SeedableRng;
 
+    use crate::error_correction::{FieldHints, error_correction_with_field_hints};
     use crate::galois_fields::gf8::GF8;
     use crate::galois_fields::gf32::GF32;
     use crate::galois_fields::gf64::GF64;
@@ -653,7 +654,13 @@ mod tests {
         shares[1] += BaseField::from_u128(9);
         shares[2] += BaseField::from_u128(254);
 
-        let secret_poly = error_correction(shares, threshold, max_err).unwrap();
+        let secret_poly = error_correction(shares.clone(), threshold, max_err).unwrap();
         assert_eq!(secret_poly, f);
+
+        let parties = shares.iter().map(|s| s.owner()).collect::<Vec<_>>();
+        let hints = FieldHints::new(&parties).unwrap();
+        let secret_poly_with_hints =
+            error_correction_with_field_hints(shares, threshold, max_err, &hints).unwrap();
+        assert_eq!(secret_poly_with_hints, f);
     }
 }

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -1,6 +1,6 @@
 use super::{
     galois_rings::common::{LutMulReduction, ResiduePoly},
-    poly::{BitWiseEval, Poly, gao_decoding},
+    poly::{BitWiseEval, Poly, gao_decoding, gao_decoding_with_field_hints, lagrange_polynomials},
     structure_traits::{
         BaseRing, ErrorCorrect, Field, QuotientMaximalIdeal, RingWithExceptionalSequence,
     },
@@ -10,10 +10,11 @@ use error_utils::anyhow_error_and_log;
 use super::sharing::shamir::ShamirFieldPoly;
 use super::sharing::shamir::ShamirSharings;
 use super::sharing::share::Share;
-use crate::poly::BitwisePoly;
+use crate::{matrix::compute_powers_list, poly::BitwisePoly};
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::sync::RwLock;
+use threshold_types::role::Role;
 
 /// Trait used to speed up error correction computation.
 ///
@@ -51,6 +52,144 @@ pub trait MemoizedExceptionals: Sized + Clone + 'static {
                 "Error reading exceptional store".to_string(),
             ))
         }
+    }
+}
+
+/// Precomputed field-level data for Lagrange interpolation and Gao decoding.
+///
+/// These depend only on the set of evaluation points (i.e. the party identities),
+/// not on the actual share values, so they can be reused across many sharings.
+pub struct FieldHints<F: Field> {
+    /// Field-level embedded evaluation points: `F::embed_role_to_exceptional_sequence(party_i)`.
+    pub embedded_points: Vec<F>,
+    /// Lagrange basis polynomials `L_i(X)` for the embedded points.
+    pub lagrange_polys: Vec<Poly<F>>,
+    /// Vanishing polynomial `∏(X - x_i)`.
+    pub vanishing_poly: Poly<F>,
+}
+
+impl<F: Field> FieldHints<F> {
+    /// Build field-level hints from a set of parties.
+    pub fn new(parties: &[Role]) -> anyhow::Result<Self> {
+        let embedded_points: Vec<F> = parties
+            .iter()
+            .map(|p| F::embed_role_to_exceptional_sequence(p))
+            .try_collect()?;
+        let lagrange_polys = if let Some(cached) = F::cached_lagrange_polys(&embedded_points) {
+            cached.to_vec()
+        } else {
+            lagrange_polynomials(&embedded_points)
+        };
+        let vanishing_poly = Self::compute_vanishing_poly(&embedded_points);
+        Ok(Self {
+            embedded_points,
+            lagrange_polys,
+            vanishing_poly,
+        })
+    }
+
+    fn compute_vanishing_poly(points: &[F]) -> Poly<F> {
+        let mut g = Poly::one();
+        for xi in points.iter() {
+            g = g * Poly::from_coefs(vec![-*xi, F::ONE]);
+        }
+        g
+    }
+}
+
+/// Precomputed data that depends only on the set of contributing parties
+/// and the degree of the sharing polynomial — not on any share values.
+///
+/// When reconstructing many [`ShamirSharings`] that share the same owner set
+/// and degree, build this once and pass it to each reconstruction call.
+pub struct ReconstructionHints<Z: ErrorCorrect> {
+    /// The sorted set of party roles that contributed shares.
+    pub parties: Vec<Role>,
+    /// The degree of the sharing polynomial (threshold or 2×threshold).
+    pub degree: usize,
+    /// Ring-level embedded evaluation points: `Z::embed_role_to_exceptional_sequence(party_i)`.
+    pub embedded_points: Vec<Z>,
+    /// `exceptional_powers[i][j]` = `embedded_points[i]^j` for `j` in `0..=degree`.
+    ///
+    /// Used in the Hensel-lift loop of `shamir_error_correct`.
+    pub exceptional_powers: Vec<Vec<Z>>,
+    /// Field-level hints for Lagrange interpolation / Gao decoding.
+    pub field_hints: FieldHints<Z::ReconstructionField>,
+}
+
+impl<Z: ErrorCorrect> ReconstructionHints<Z> {
+    /// Build hints from the owner set of a sharing and a degree.
+    ///
+    /// Typically called once before iterating over a batch of sharings.
+    /// Computes exceptional powers directly from the embedded points.
+    pub fn new(sharing: &ShamirSharings<Z>, degree: usize) -> anyhow::Result<Self> {
+        // ShamirSharings are always sorted by owner Role, so the parties are already sorted here.
+        let parties: Vec<Role> = sharing.shares.iter().map(|s| s.owner()).collect();
+        Self::from_parties_sorted(&parties, degree)
+    }
+
+    /// Build hints from an explicit list of parties and a degree.
+    ///
+    /// Computes exceptional powers directly from the embedded points.
+    ///
+    /// Parties are not required to be pre-sorted, but they will be sorted internally
+    pub fn from_parties(parties: &[Role], degree: usize) -> anyhow::Result<Self> {
+        // Roles are always sorted when creating a ShamirSharing, so sort it here too
+        let parties = parties.iter().sorted().cloned().collect_vec();
+        Self::from_parties_sorted(&parties, degree)
+    }
+
+    /// Build hints from an explicit list of parties and a degree.
+    ///
+    /// Computes exceptional powers directly from the embedded points.
+    pub fn from_parties_sorted(parties: &[Role], degree: usize) -> anyhow::Result<Self> {
+        let embedded_points: Vec<Z> = parties
+            .iter()
+            .map(|p| Z::embed_role_to_exceptional_sequence(p))
+            .try_collect()?;
+        let exceptional_powers: Vec<Vec<Z>> = compute_powers_list(&embedded_points, degree);
+
+        let field_hints = FieldHints::new(parties)?;
+        Ok(Self {
+            parties: parties.to_vec(),
+            degree,
+            embedded_points,
+            exceptional_powers,
+            field_hints,
+        })
+    }
+}
+
+impl<Z: ErrorCorrect + MemoizedExceptionals> ReconstructionHints<Z> {
+    /// Like [`Self::from_parties`] but fetches exceptional powers from the
+    /// [`MemoizedExceptionals`] cache instead of recomputing them.
+    pub fn from_parties_sorted_cached(parties: &[Role], degree: usize) -> anyhow::Result<Self> {
+        let embedded_points: Vec<Z> = parties
+            .iter()
+            .map(|p| Z::embed_role_to_exceptional_sequence(p))
+            .try_collect()?;
+        let exceptional_powers: Vec<Vec<Z>> = parties
+            .iter()
+            .map(|p| Z::exceptional_set(p.one_based(), degree))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let field_hints = FieldHints::new(parties)?;
+        Ok(Self {
+            parties: parties.to_vec(),
+            degree,
+            embedded_points,
+            exceptional_powers,
+            field_hints,
+        })
+    }
+
+    /// Like [`Self::from_parties`] but fetches exceptional powers from the
+    /// [`MemoizedExceptionals`] cache instead of recomputing them.
+    ///
+    /// Parties are not required to be pre-sorted, but they will be sorted internally
+    pub fn from_parties_cached(parties: &[Role], degree: usize) -> anyhow::Result<Self> {
+        // Roles are always sorted when creating a ShamirSharing, so sort it here too
+        let parties = parties.iter().sorted().cloned().collect_vec();
+        Self::from_parties_sorted_cached(&parties, degree)
     }
 }
 
@@ -165,6 +304,125 @@ where
     Ok(res)
 }
 
+/// Like [`shamir_error_correct`] but reuses precomputed [`ReconstructionHints`].
+///
+/// The exceptional powers and field hints are taken from the hints structure instead of being
+/// recomputed, and the field hints are reused across Hensel-lift iterations as long as no
+/// party is evicted.
+fn shamir_error_correct_with_hints<Z: BaseRing, const EXTENSION_DEGREE: usize>(
+    sharing: &ShamirSharings<ResiduePoly<Z, EXTENSION_DEGREE>>,
+    degree: usize,
+    max_errs: usize,
+    hints: &ReconstructionHints<ResiduePoly<Z, EXTENSION_DEGREE>>,
+) -> anyhow::Result<Poly<ResiduePoly<Z, EXTENSION_DEGREE>>>
+where
+    ResiduePoly<Z, EXTENSION_DEGREE>: MemoizedExceptionals,
+    ResiduePoly<Z, EXTENSION_DEGREE>:
+        ErrorCorrect<ReconstructionField = <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>,
+    ResiduePoly<Z, EXTENSION_DEGREE>: RingWithExceptionalSequence,
+    ResiduePoly<Z, EXTENSION_DEGREE>: QuotientMaximalIdeal,
+    ResiduePoly<Z, EXTENSION_DEGREE>: LutMulReduction<Z>,
+    BitwisePoly:
+        From<Poly<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>>,
+    BitwisePoly: BitWiseEval<Z, EXTENSION_DEGREE>,
+{
+    let ring_size: usize = Z::BIT_LENGTH;
+
+    let mut shares_with_validity = sharing
+        .shares
+        .iter()
+        .map(|x| (*x, true))
+        .collect::<Vec<_>>();
+
+    let initial_length = shares_with_validity.len();
+
+    // Use exceptional powers from hints (avoids RwLock + clone per party).
+    let ordered_powers = &hints.exceptional_powers;
+
+    let mut res = Poly::<ResiduePoly<Z, EXTENSION_DEGREE>>::zero();
+
+    // Track whether any party has been evicted. As long as no eviction has happened
+    // the field hints (Lagrange polys, vanishing poly) remain valid.
+    let mut validity_changed = false;
+    // Lazily computed field hints for the reduced valid set after evictions.
+    let mut fallback_field_hints: Option<
+        FieldHints<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>,
+    > = None;
+
+    for bit_idx in 0..ring_size {
+        let binary_shares: Vec<
+            Share<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>,
+        > = shares_with_validity
+            .iter()
+            .filter_map(|(sh, is_valid)| {
+                if *is_valid {
+                    Some(Share::<
+                        <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput,
+                    >::new(
+                        sh.owner(), sh.value().bit_compose(bit_idx)
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let num_new_bot = initial_length - binary_shares.len();
+
+        let fi_mod2 = if !validity_changed {
+            // All parties still valid — use the precomputed field hints.
+            error_correction_with_field_hints(
+                binary_shares,
+                degree,
+                max_errs - num_new_bot,
+                &hints.field_hints,
+            )?
+        } else {
+            // Some parties were evicted — recompute field hints for the new valid set
+            // (or reuse previously computed fallback if validity hasn't changed again).
+            if fallback_field_hints.is_none() {
+                let valid_parties: Vec<Role> = shares_with_validity
+                    .iter()
+                    .filter_map(|(sh, valid)| if *valid { Some(sh.owner()) } else { None })
+                    .collect();
+                fallback_field_hints = Some(FieldHints::new(&valid_parties)?);
+            }
+            error_correction_with_field_hints(
+                binary_shares,
+                degree,
+                max_errs - num_new_bot,
+                fallback_field_hints.as_ref().unwrap(),
+            )?
+        };
+        let bitwise = BitwisePoly::from(fi_mod2.clone());
+
+        let mut evicted_this_round = false;
+        for (j, (share, is_valid)) in shares_with_validity.iter_mut().enumerate() {
+            if *is_valid {
+                let offset = bitwise.lazy_eval(&ordered_powers[j]) << bit_idx;
+                *share -= offset;
+
+                *is_valid = share.value().multiple_pow2(bit_idx + 1);
+
+                if !*is_valid {
+                    tracing::warn!("Share at index {j} is invalid after iteration {bit_idx}");
+                    evicted_this_round = true;
+                }
+            }
+        }
+
+        if evicted_this_round {
+            validity_changed = true;
+            // Invalidate fallback hints so they get recomputed for the new valid set.
+            fallback_field_hints = None;
+        }
+
+        accumulate_and_lift_bitwise_poly(&mut res, &fi_mod2, bit_idx);
+    }
+
+    Ok(res)
+}
+
 impl<Z: BaseRing, const EXTENSION_DEGREE: usize> ErrorCorrect for ResiduePoly<Z, EXTENSION_DEGREE>
 where
     ResiduePoly<Z, EXTENSION_DEGREE>: MemoizedExceptionals,
@@ -175,6 +433,9 @@ where
         From<Poly<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>>,
     BitwisePoly: BitWiseEval<Z, EXTENSION_DEGREE>,
 {
+    type ReconstructionField =
+        <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput;
+
     //NIST: Level Zero Operation
     ///Perform error correction for the extension ring.
     ///
@@ -197,6 +458,15 @@ where
             shamir_error_correct(sharing, degree, max_errs, None)
         }
     }
+
+    fn error_correct_with_hints(
+        sharing: &ShamirSharings<Self>,
+        degree: usize,
+        max_errs: usize,
+        hints: &ReconstructionHints<Self>,
+    ) -> anyhow::Result<Poly<Self>> {
+        shamir_error_correct_with_hints(sharing, degree, max_errs, hints)
+    }
 }
 
 pub fn error_correction<F: Field>(
@@ -212,6 +482,28 @@ pub fn error_correction<F: Field>(
 
     // call Gao decoding with the shares as points/values, set Gao parameter k = v = degree+1
     gao_decoding(&xs, &ys, degree + 1, max_errs)
+}
+
+/// Like [`error_correction`] but reuses precomputed [`FieldHints`] to avoid redundant
+/// embedding, Lagrange polynomial, and vanishing polynomial computations.
+///
+/// `field_hints` must have been built from the same set of parties that own the `shares`.
+pub fn error_correction_with_field_hints<F: Field>(
+    shares: Vec<Share<F>>,
+    degree: usize,
+    max_errs: usize,
+    field_hints: &FieldHints<F>,
+) -> anyhow::Result<ShamirFieldPoly<F>> {
+    let ys: Vec<F> = shares.into_iter().map(|s| s.take_value()).collect();
+
+    gao_decoding_with_field_hints(
+        &field_hints.embedded_points,
+        &ys,
+        degree + 1,
+        max_errs,
+        &field_hints.lagrange_polys,
+        &field_hints.vanishing_poly,
+    )
 }
 
 #[cfg(test)]

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -690,8 +690,7 @@ mod tests {
         let mut rng = AesRng::seed_from_u64(0);
         let secret = ResiduePolyF3Z128::sample(&mut rng);
         let threshold = 1;
-        let sharings =
-            ShamirSharings::share(&mut rng, secret.clone(), num_parties, threshold).unwrap();
+        let sharings = ShamirSharings::share(&mut rng, secret, num_parties, threshold).unwrap();
 
         let hint = ReconstructionHints::new(&sharings, threshold).unwrap();
 

--- a/core/threshold-algebra/src/poly.rs
+++ b/core/threshold-algebra/src/poly.rs
@@ -636,42 +636,25 @@ fn partial_xgcd<F: Field>(a: Poly<F>, b: Poly<F>, stop: usize) -> (Poly<F>, Poly
     (r1, t1)
 }
 
-//NIST: Level Zero Operation
-/// Runs Gao decoding algorithm.
+/// Common tail of [`gao_decoding`] and [`gao_decoding_with_field_hints`].
 ///
-/// - `points` holds the x-coordinates
-/// - `values` holds the y-coordinates
-/// - `k` such that we apply error correction to a polynomial of degree < k
-///   (usually degree = threshold in our scheme, but it can be 2*threshold in some cases)
-/// - `max_errs` is the maximum number of errors we try to correct for (most often threshold - len(corrupt_set), but can be less than this if degree is 2*threshold)
-///
-/// __NOTE__ : We assume values already identified as errors have been excluded by the caller (i.e. values denoted Bot in NIST doc)
-pub fn gao_decoding<F: Field>(
-    points: &[F],
-    values: &[F],
+/// Given the interpolation polynomial `r` (through the points/values) and the vanishing
+/// polynomial `g = prod(X - xi)` — however they were obtained — run the partial extended
+/// Euclidean algorithm and recover the message polynomial, with the usual error/degree checks.
+/// `n` is the number of evaluation points and `k` the RS dimension (`degree + 1`).
+fn gao_decoding_common<F: Field>(
+    n: usize,
     k: usize,
     max_errs: usize,
+    r: Poly<F>,
+    g: Poly<F>,
 ) -> anyhow::Result<Poly<F>> {
-    // in the literature we find (n, k, d) codes
-    // parameter k is called v in the NIST doc (the RS dimension)
-    // this means that n is the number of points xi for which we have some values yi
-    // yi ~= G(xi))
-    // where deg(G) <= k-1
-    let n = points.len();
-
-    // d = n-k+1
+    // d = n - k + 1
     let d = (n + 1)
         .checked_sub(k)
         .ok_or_else(|| anyhow_error_and_log("Gao decoding failure: overflow computing d"))?;
 
-    // sanity checks for parameter sizes
-    if values.len() != points.len() {
-        return Err(anyhow_error_and_log(
-            "Gao decoding failure: mismatch between number of values and points".to_string(),
-        ));
-    }
-
-    // We are expecting to correct more than what can be done
+    // We are expecting to correct more than what can be done:
     // Gao can only correct up to (d-1)/2 errors
     if 2 * max_errs >= d {
         return Err(anyhow_error_and_log(
@@ -679,24 +662,10 @@ pub fn gao_decoding<F: Field>(
         ));
     }
 
-    // R \in GF(256)[X] such that R(xi) = yi. Called g_1(x) in the Gao paper.
-    let r = lagrange_interpolation(points, values)?;
-
-    // G = prod(X - xi) where xi is party i's index. Called g_0(x) in the Gao paper.
-    // note that deg(G) >= deg(R)
-    let mut g = Poly::one();
-    for xi in points.iter() {
-        let fi = Poly {
-            coefs: vec![-*xi, F::ONE],
-        };
-        g = g * fi;
-    }
-
     // apply EEA to compute q0, q1 such that
-    // q1 = gcd(g, r) = g * t + r * q0
-    // q1 | g, q1 | r
-    // q1 and q0 are called g(x) and v(x), respectively in the Gao paper.
-    // q0 = v(x) is the error locator polynomial. Its roots are the error positions xi.
+    // q1 = gcd(g, r) = g * t + r * q0, with q1 | g and q1 | r.
+    // q1 and q0 are called g(x) and v(x), respectively, in the Gao paper.
+    // q0 = v(x) is the error locator polynomial; its roots are the error positions xi.
     let gcd_stop = (n + k) / 2;
     let (q1, q0) = partial_xgcd(g, r, gcd_stop);
 
@@ -726,6 +695,51 @@ pub fn gao_decoding<F: Field>(
     }
 }
 
+//NIST: Level Zero Operation
+/// Runs Gao decoding algorithm.
+///
+/// - `points` holds the x-coordinates
+/// - `values` holds the y-coordinates
+/// - `k` such that we apply error correction to a polynomial of degree < k
+///   (usually degree = threshold in our scheme, but it can be 2*threshold in some cases)
+/// - `max_errs` is the maximum number of errors we try to correct for (most often threshold - len(corrupt_set), but can be less than this if degree is 2*threshold)
+///
+/// __NOTE__ : We assume values already identified as errors have been excluded by the caller (i.e. values denoted Bot in NIST doc)
+pub fn gao_decoding<F: Field>(
+    points: &[F],
+    values: &[F],
+    k: usize,
+    max_errs: usize,
+) -> anyhow::Result<Poly<F>> {
+    // in the literature we find (n, k, d) codes
+    // parameter k is called v in the NIST doc (the RS dimension)
+    // this means that n is the number of points xi for which we have some values yi
+    // yi ~= G(xi)), where deg(G) <= k-1
+    let n = points.len();
+
+    // sanity check for parameter sizes
+    if values.len() != points.len() {
+        return Err(anyhow_error_and_log(
+            "Gao decoding failure: mismatch between number of values and points".to_string(),
+        ));
+    }
+
+    // R \in F[X] such that R(xi) = yi. Called g_1(x) in the Gao paper.
+    let r = lagrange_interpolation(points, values)?;
+
+    // G = prod(X - xi) where xi is party i's index. Called g_0(x) in the Gao paper.
+    // note that deg(G) >= deg(R)
+    let mut g = Poly::one();
+    for xi in points.iter() {
+        let fi = Poly {
+            coefs: vec![-*xi, F::ONE],
+        };
+        g = g * fi;
+    }
+
+    gao_decoding_common(n, k, max_errs, r, g)
+}
+
 /// Like [`gao_decoding`] but reuses precomputed Lagrange polynomials and the vanishing polynomial
 /// from [`FieldHints`](crate::error_correction::FieldHints).
 ///
@@ -741,53 +755,19 @@ pub fn gao_decoding_with_field_hints<F: Field>(
 ) -> anyhow::Result<Poly<F>> {
     let n = points.len();
 
-    let d = (n + 1)
-        .checked_sub(k)
-        .ok_or_else(|| anyhow_error_and_log("Gao decoding failure: overflow computing d"))?;
-
     if values.len() != points.len() {
         return Err(anyhow_error_and_log(
             "Gao decoding failure: mismatch between number of values and points".to_string(),
         ));
     }
 
-    if 2 * max_errs >= d {
-        return Err(anyhow_error_and_log(
-            "Gao decoding failure: expected max number of errors is too large for given code parameters".to_string(),
-        ));
-    }
-
-    // R = interpolation polynomial through (points, values).
+    // R = interpolation polynomial through (points, values), using the precomputed Lagrange basis.
     let r = lagrange_interpolation_with_polys(lagrange_polys, values)?;
 
     // G = vanishing polynomial (precomputed).
     let g = vanishing_poly.clone();
 
-    let gcd_stop = (n + k) / 2;
-    let (q1, q0) = partial_xgcd(g, r, gcd_stop);
-
-    if q0.deg() > max_errs {
-        return Err(anyhow_error_and_log(format!(
-            "Gao decoding failure: Allowed at most {max_errs} errors but xgcd factor degree indicates {}.",
-            q0.deg()
-        )));
-    }
-
-    let (h, rem) = q1 / &q0;
-
-    if !rem.is_zero() {
-        Err(anyhow_error_and_log(format!(
-            "Gao decoding failure: Division remainder is not zero but {rem:?}."
-        )))
-    } else if h.deg() >= k {
-        Err(anyhow_error_and_log(format!(
-            "Gao decoding failure: Division result is of too high degree {}, but should be at most {}.",
-            h.deg(),
-            k - 1
-        )))
-    } else {
-        Ok(h)
-    }
+    gao_decoding_common(n, k, max_errs, r, g)
 }
 
 #[cfg(test)]

--- a/core/threshold-algebra/src/poly.rs
+++ b/core/threshold-algebra/src/poly.rs
@@ -773,11 +773,12 @@ pub fn gao_decoding_with_field_hints<F: Field>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error_correction::MemoizedExceptionals;
+    use crate::error_correction::{FieldHints, MemoizedExceptionals};
     use crate::galois_fields::gf16::GF16;
     use crate::galois_rings::degree_4::ResiduePolyF4Z128;
     use proptest::prelude::*;
     use rstest::rstest;
+    use threshold_types::role::Role;
 
     #[test]
     fn test_lagrange_mod2() {
@@ -855,15 +856,21 @@ mod tests {
         let f = Poly {
             coefs: vec![GF16::from(7), GF16::from(13), GF16::from(2)],
         };
-        let xs = vec![
-            GF16::from(2),
-            GF16::from(3),
-            GF16::from(4),
-            GF16::from(5),
-            GF16::from(6),
-            GF16::from(7),
-            GF16::from(8),
+        let roles = vec![
+            Role::indexed_from_one(2),
+            Role::indexed_from_one(3),
+            Role::indexed_from_one(4),
+            Role::indexed_from_one(5),
+            Role::indexed_from_one(6),
+            Role::indexed_from_one(7),
+            Role::indexed_from_one(8),
         ];
+
+        let xs = roles
+            .iter()
+            .map(|r| GF16::from(r.one_based() as u8))
+            .collect::<Vec<_>>();
+
         let mut ys: Vec<_> = xs.iter().map(|x| f.eval(x)).collect();
 
         tracing::debug!(
@@ -879,6 +886,18 @@ mod tests {
         ys[1] += GF16::from(4);
         let polynomial = gao_decoding(&xs, &ys, f.coefs.len(), 2).unwrap();
         assert_eq!(polynomial.eval(&GF16::from(0)), GF16::from(7));
+
+        let field_hint = FieldHints::new(&roles).unwrap();
+        let polynomial_with_hint = gao_decoding_with_field_hints(
+            &xs,
+            &ys,
+            f.coefs.len(),
+            2,
+            &field_hint.lagrange_polys,
+            &field_hint.vanishing_poly,
+        )
+        .unwrap();
+        assert_eq!(polynomial_with_hint.eval(&GF16::from(0)), GF16::from(7));
     }
 
     #[test]
@@ -886,20 +905,41 @@ mod tests {
         let f = Poly {
             coefs: vec![GF16::from(7), GF16::from(3), GF16::from(8)],
         };
-        let xs = vec![
-            GF16::from(2),
-            GF16::from(3),
-            GF16::from(4),
-            GF16::from(5),
-            GF16::from(6),
-            GF16::from(7),
+        let roles = vec![
+            Role::indexed_from_one(2),
+            Role::indexed_from_one(3),
+            Role::indexed_from_one(4),
+            Role::indexed_from_one(5),
+            Role::indexed_from_one(6),
+            Role::indexed_from_one(7),
         ];
+
+        let xs = roles
+            .iter()
+            .map(|r| GF16::from(r.one_based() as u8))
+            .collect::<Vec<_>>();
+
         let mut ys: Vec<_> = xs.iter().map(|x| f.eval(x)).collect();
         // adding two errors
         ys[0] += GF16::from(2);
         ys[1] += GF16::from(5);
         let r = gao_decoding(&xs, &ys, 3, 1).unwrap_err().to_string();
         assert!(r.contains(
+            "Gao decoding failure: Allowed at most 1 errors but xgcd factor degree indicates 2."
+        ));
+
+        let field_hint = FieldHints::new(&roles).unwrap();
+        let r_with_hint = gao_decoding_with_field_hints(
+            &xs,
+            &ys,
+            3,
+            1,
+            &field_hint.lagrange_polys,
+            &field_hint.vanishing_poly,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(r_with_hint.contains(
             "Gao decoding failure: Allowed at most 1 errors but xgcd factor degree indicates 2."
         ));
     }

--- a/core/threshold-algebra/src/poly.rs
+++ b/core/threshold-algebra/src/poly.rs
@@ -726,6 +726,70 @@ pub fn gao_decoding<F: Field>(
     }
 }
 
+/// Like [`gao_decoding`] but reuses precomputed Lagrange polynomials and the vanishing polynomial
+/// from [`FieldHints`](crate::error_correction::FieldHints).
+///
+/// The caller must ensure that `lagrange_polys` and `vanishing_poly` were built from the same
+/// `points` slice passed here.
+pub fn gao_decoding_with_field_hints<F: Field>(
+    points: &[F],
+    values: &[F],
+    k: usize,
+    max_errs: usize,
+    lagrange_polys: &[Poly<F>],
+    vanishing_poly: &Poly<F>,
+) -> anyhow::Result<Poly<F>> {
+    let n = points.len();
+
+    let d = (n + 1)
+        .checked_sub(k)
+        .ok_or_else(|| anyhow_error_and_log("Gao decoding failure: overflow computing d"))?;
+
+    if values.len() != points.len() {
+        return Err(anyhow_error_and_log(
+            "Gao decoding failure: mismatch between number of values and points".to_string(),
+        ));
+    }
+
+    if 2 * max_errs >= d {
+        return Err(anyhow_error_and_log(
+            "Gao decoding failure: expected max number of errors is too large for given code parameters".to_string(),
+        ));
+    }
+
+    // R = interpolation polynomial through (points, values).
+    let r = lagrange_interpolation_with_polys(lagrange_polys, values)?;
+
+    // G = vanishing polynomial (precomputed).
+    let g = vanishing_poly.clone();
+
+    let gcd_stop = (n + k) / 2;
+    let (q1, q0) = partial_xgcd(g, r, gcd_stop);
+
+    if q0.deg() > max_errs {
+        return Err(anyhow_error_and_log(format!(
+            "Gao decoding failure: Allowed at most {max_errs} errors but xgcd factor degree indicates {}.",
+            q0.deg()
+        )));
+    }
+
+    let (h, rem) = q1 / &q0;
+
+    if !rem.is_zero() {
+        Err(anyhow_error_and_log(format!(
+            "Gao decoding failure: Division remainder is not zero but {rem:?}."
+        )))
+    } else if h.deg() >= k {
+        Err(anyhow_error_and_log(format!(
+            "Gao decoding failure: Division result is of too high degree {}, but should be at most {}.",
+            h.deg(),
+            k - 1
+        )))
+    } else {
+        Ok(h)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/threshold-algebra/src/poly.rs
+++ b/core/threshold-algebra/src/poly.rs
@@ -645,7 +645,7 @@ fn partial_xgcd<F: Field>(a: Poly<F>, b: Poly<F>, stop: usize) -> (Poly<F>, Poly
 fn gao_decoding_common<F: Field>(
     n: usize,
     k: usize,
-    max_errs: usize,
+    max_errors: usize,
     r: Poly<F>,
     g: Poly<F>,
 ) -> anyhow::Result<Poly<F>> {
@@ -656,7 +656,7 @@ fn gao_decoding_common<F: Field>(
 
     // We are expecting to correct more than what can be done:
     // Gao can only correct up to (d-1)/2 errors
-    if 2 * max_errs >= d {
+    if 2 * max_errors >= d {
         return Err(anyhow_error_and_log(
             "Gao decoding failure: expected max number of errors is too large for given code parameters".to_string(),
         ));
@@ -670,9 +670,9 @@ fn gao_decoding_common<F: Field>(
     let (q1, q0) = partial_xgcd(g, r, gcd_stop);
 
     // abort early if we have too many errors
-    if q0.deg() > max_errs {
+    if q0.deg() > max_errors {
         return Err(anyhow_error_and_log(format!(
-            "Gao decoding failure: Allowed at most {max_errs} errors but xgcd factor degree indicates {}.",
+            "Gao decoding failure: Allowed at most {max_errors} errors but xgcd factor degree indicates {}.",
             q0.deg()
         )));
     }
@@ -702,14 +702,14 @@ fn gao_decoding_common<F: Field>(
 /// - `values` holds the y-coordinates
 /// - `k` such that we apply error correction to a polynomial of degree < k
 ///   (usually degree = threshold in our scheme, but it can be 2*threshold in some cases)
-/// - `max_errs` is the maximum number of errors we try to correct for (most often threshold - len(corrupt_set), but can be less than this if degree is 2*threshold)
+/// - `max_errors` is the maximum number of errors we try to correct for (most often threshold - len(corrupt_set), but can be less than this if degree is 2*threshold)
 ///
 /// __NOTE__ : We assume values already identified as errors have been excluded by the caller (i.e. values denoted Bot in NIST doc)
 pub fn gao_decoding<F: Field>(
     points: &[F],
     values: &[F],
     k: usize,
-    max_errs: usize,
+    max_errors: usize,
 ) -> anyhow::Result<Poly<F>> {
     // in the literature we find (n, k, d) codes
     // parameter k is called v in the NIST doc (the RS dimension)
@@ -737,7 +737,7 @@ pub fn gao_decoding<F: Field>(
         g = g * fi;
     }
 
-    gao_decoding_common(n, k, max_errs, r, g)
+    gao_decoding_common(n, k, max_errors, r, g)
 }
 
 /// Like [`gao_decoding`] but reuses precomputed Lagrange polynomials and the vanishing polynomial
@@ -749,7 +749,7 @@ pub fn gao_decoding_with_field_hints<F: Field>(
     points: &[F],
     values: &[F],
     k: usize,
-    max_errs: usize,
+    max_errors: usize,
     lagrange_polys: &[Poly<F>],
     vanishing_poly: &Poly<F>,
 ) -> anyhow::Result<Poly<F>> {
@@ -767,7 +767,7 @@ pub fn gao_decoding_with_field_hints<F: Field>(
     // G = vanishing polynomial (precomputed).
     let g = vanishing_poly.clone();
 
-    gao_decoding_common(n, k, max_errs, r, g)
+    gao_decoding_common(n, k, max_errors, r, g)
 }
 
 #[cfg(test)]

--- a/core/threshold-algebra/src/sharing/shamir.rs
+++ b/core/threshold-algebra/src/sharing/shamir.rs
@@ -277,7 +277,7 @@ pub fn fill_indexed_shares<Z: Ring>(
 /// Returns either the result or None if there are not enough shares to do reconstruction yet
 /// This assumes that sharing contains all the shares the current party know of, including its own if relevant
 /// thus we always perform the check "case B".
-/// This error out only if reconstruction is impossible given the parameters, it does not error out if we just do not have enough shares yet.
+/// This errors out only if reconstruction is impossible given the parameters, it does not error out if we just do not have enough shares yet.
 pub fn reconstruct_w_errors_sync<Z>(
     num_parties: usize,
     degree: usize,
@@ -331,7 +331,7 @@ where
 /// This assumes that sharing contains all the shares the current party know of, including its own if relevant
 /// thus we always perform the check "case B".
 ///
-/// This error out only if reconstruction is impossible given the parameters, it does not error out if we just do not have enough shares yet.
+/// This errors out only if reconstruction is impossible given the parameters, it does not error out if we just do not have enough shares yet.
 pub fn reconstruct_w_errors_async<Z>(
     num_parties: usize,
     degree: usize,

--- a/core/threshold-algebra/src/sharing/shamir.rs
+++ b/core/threshold-algebra/src/sharing/shamir.rs
@@ -278,13 +278,13 @@ pub fn fill_indexed_shares<Z: Ring>(
 /// This assumes that sharing contains all the shares the current party know of, including its own if relevant
 /// thus we always perform the check "case B".
 /// This error out only if reconstruction is impossible given the parameters, it does not error out if we just do not have enough shares yet.
-fn reconstruct_w_errors_sync_common<Z>(
+pub fn reconstruct_w_errors_sync<Z>(
     num_parties: usize,
     degree: usize,
     threshold: usize,
     num_bots: usize,
     sharing: &ShamirSharings<Z>,
-    hints: Option<&ReconstructionHints<Z>>,
+    hints: &ReconstructionHints<Z>,
 ) -> anyhow::Result<Option<Z>>
 where
     Z: Ring + ErrorCorrect,
@@ -302,11 +302,7 @@ where
             ))
         })?;
 
-        let opened = if let Some(hints) = hints {
-            sharing.err_reconstruct_with_hints(degree, max_errs, hints)?
-        } else {
-            sharing.err_reconstruct(degree, max_errs)?
-        };
+        let opened = sharing.err_reconstruct_with_hints(degree, max_errs, hints)?;
         return Ok(Some(opened));
     }
 
@@ -320,44 +316,6 @@ where
 
     // Not enough shares to reconstruct (yet)
     Ok(None)
-}
-
-/// [`reconstruct_w_errors_sync_common`] without precomputed [`ReconstructionHints`].
-pub fn reconstruct_w_errors_sync<Z>(
-    num_parties: usize,
-    degree: usize,
-    threshold: usize,
-    num_bots: usize,
-    sharing: &ShamirSharings<Z>,
-) -> anyhow::Result<Option<Z>>
-where
-    Z: Ring + ErrorCorrect,
-    ShamirSharings<Z>: RevealOp<Z>,
-{
-    reconstruct_w_errors_sync_common(num_parties, degree, threshold, num_bots, sharing, None)
-}
-
-/// [`reconstruct_w_errors_sync_common`] with precomputed [`ReconstructionHints`].
-pub fn reconstruct_w_errors_sync_with_hints<Z>(
-    num_parties: usize,
-    degree: usize,
-    threshold: usize,
-    num_bots: usize,
-    sharing: &ShamirSharings<Z>,
-    hints: &ReconstructionHints<Z>,
-) -> anyhow::Result<Option<Z>>
-where
-    Z: Ring + ErrorCorrect,
-    ShamirSharings<Z>: RevealOp<Z>,
-{
-    reconstruct_w_errors_sync_common(
-        num_parties,
-        degree,
-        threshold,
-        num_bots,
-        sharing,
-        Some(hints),
-    )
 }
 
 /// Core algorithm for robust reconstructions which tries to reconstruct from a collection of shares
@@ -374,13 +332,13 @@ where
 /// thus we always perform the check "case B".
 ///
 /// This error out only if reconstruction is impossible given the parameters, it does not error out if we just do not have enough shares yet.
-fn reconstruct_w_errors_async_common<Z>(
+pub fn reconstruct_w_errors_async<Z>(
     num_parties: usize,
     degree: usize,
     threshold: usize,
     num_bots: usize,
     sharing: &ShamirSharings<Z>,
-    hints: Option<&ReconstructionHints<Z>>,
+    hints: &ReconstructionHints<Z>,
 ) -> anyhow::Result<Option<Z>>
 where
     Z: Ring + ErrorCorrect,
@@ -396,11 +354,7 @@ where
                 ))
             })?;
 
-            let opened = if let Some(hints) = hints {
-                sharing.err_reconstruct_with_hints(degree, max_errs, hints)?
-            } else {
-                sharing.err_reconstruct(degree, max_errs)?
-            };
+            let opened = sharing.err_reconstruct_with_hints(degree, max_errs, hints)?;
             Ok(Some(opened))
         } else {
             //We do not have enough shares yet
@@ -409,11 +363,7 @@ where
     } else if degree + 2 * threshold < num_parties {
         if num_heard_from > degree + threshold {
             let r: usize = num_heard_from - (degree + threshold + 1);
-            let opened_poly = if let Some(hints) = hints {
-                Z::error_correct_with_hints(sharing, degree, r, hints)
-            } else {
-                Z::error_correct(sharing, degree, r)
-            };
+            let opened_poly = Z::error_correct_with_hints(sharing, degree, r, hints);
             if let Ok(opened_poly) = opened_poly {
                 if opened_poly.deg() <= degree {
                     //Check how many shares lie on the polynomial
@@ -448,44 +398,6 @@ where
             "Can NOT reconstruct with degree {degree}, threshold {threshold} and num_parties {num_parties}"
         )))
     }
-}
-
-/// [`reconstruct_w_errors_async_common`] without precomputed [`ReconstructionHints`].
-pub fn reconstruct_w_errors_async<Z>(
-    num_parties: usize,
-    degree: usize,
-    threshold: usize,
-    num_bots: usize,
-    sharing: &ShamirSharings<Z>,
-) -> anyhow::Result<Option<Z>>
-where
-    Z: Ring + ErrorCorrect,
-    ShamirSharings<Z>: RevealOp<Z>,
-{
-    reconstruct_w_errors_async_common(num_parties, degree, threshold, num_bots, sharing, None)
-}
-
-/// [`reconstruct_w_errors_async_common`] with precomputed [`ReconstructionHints`].
-pub fn reconstruct_w_errors_async_with_hints<Z>(
-    num_parties: usize,
-    degree: usize,
-    threshold: usize,
-    num_bots: usize,
-    sharing: &ShamirSharings<Z>,
-    hints: &ReconstructionHints<Z>,
-) -> anyhow::Result<Option<Z>>
-where
-    Z: Ring + ErrorCorrect,
-    ShamirSharings<Z>: RevealOp<Z>,
-{
-    reconstruct_w_errors_async_common(
-        num_parties,
-        degree,
-        threshold,
-        num_bots,
-        sharing,
-        Some(hints),
-    )
 }
 
 #[cfg(test)]
@@ -594,9 +506,11 @@ mod tests {
             ShamirSharings::<ResiduePolyF4<Z128>>::share(&mut rng, secret, num_parties, threshold)
                 .unwrap();
 
-        let opened = reconstruct_w_errors_async(num_parties, threshold, threshold, 0, &sharings)
-            .unwrap()
-            .unwrap();
+        let hints = ReconstructionHints::new(&sharings, threshold).unwrap();
+        let opened =
+            reconstruct_w_errors_async(num_parties, threshold, threshold, 0, &sharings, &hints)
+                .unwrap()
+                .unwrap();
 
         assert_eq!(opened, secret);
     }
@@ -631,9 +545,16 @@ mod tests {
         for i in threshold..3 * threshold {
             contribution.push(sharings.shares[i]);
             let faulty_shares = ShamirSharings::create(contribution.clone());
-            let opened =
-                reconstruct_w_errors_async(num_parties, threshold, threshold, 0, &faulty_shares)
-                    .unwrap();
+            let hints = ReconstructionHints::new(&faulty_shares, threshold).unwrap();
+            let opened = reconstruct_w_errors_async(
+                num_parties,
+                threshold,
+                threshold,
+                0,
+                &faulty_shares,
+                &hints,
+            )
+            .unwrap();
 
             assert!(opened.is_none());
         }
@@ -641,9 +562,11 @@ mod tests {
         //With all shares we should be able to decode
         contribution.push(*sharings.shares.last().unwrap());
         let shares = ShamirSharings::create(contribution.clone());
-        let opened = reconstruct_w_errors_async(num_parties, threshold, threshold, 0, &shares)
-            .unwrap()
-            .unwrap();
+        let hints = ReconstructionHints::new(&shares, threshold).unwrap();
+        let opened =
+            reconstruct_w_errors_async(num_parties, threshold, threshold, 0, &shares, &hints)
+                .unwrap()
+                .unwrap();
 
         assert_eq!(opened, secret);
     }
@@ -736,10 +659,17 @@ mod tests {
             }
         }
 
-        let opened =
-            reconstruct_w_errors_sync(num_parties, threshold, threshold, 0, &packed_sharmir_shares)
-                .unwrap()
-                .unwrap();
+        let hints = ReconstructionHints::new(&packed_sharmir_shares, threshold).unwrap();
+        let opened = reconstruct_w_errors_sync(
+            num_parties,
+            threshold,
+            threshold,
+            0,
+            &packed_sharmir_shares,
+            &hints,
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(opened.at(0), secret1.at(0));
         assert_eq!(opened.at(1), secret2.at(0));
     }

--- a/core/threshold-algebra/src/sharing/shamir.rs
+++ b/core/threshold-algebra/src/sharing/shamir.rs
@@ -192,22 +192,22 @@ where
 
 pub trait RevealOp<Z> {
     fn reconstruct(&self, degree: usize) -> anyhow::Result<Z> {
-        self.err_reconstruct(degree, 0)
+        self.error_reconstruct(degree, 0)
     }
 
-    fn err_reconstruct(&self, degree: usize, max_errs: usize) -> anyhow::Result<Z>;
+    fn error_reconstruct(&self, degree: usize, max_errors: usize) -> anyhow::Result<Z>;
 
-    fn err_reconstruct_with_hints(
+    fn error_reconstruct_with_hints(
         &self,
         degree: usize,
-        max_errs: usize,
+        max_errors: usize,
         _hints: &ReconstructionHints<Z>,
     ) -> anyhow::Result<Z>
     where
         Z: ErrorCorrect,
     {
         // Default: ignore hints
-        self.err_reconstruct(degree, max_errs)
+        self.error_reconstruct(degree, max_errors)
     }
 }
 
@@ -215,18 +215,18 @@ impl<Z> RevealOp<Z> for ShamirSharings<Z>
 where
     Z: ErrorCorrect,
 {
-    fn err_reconstruct(&self, degree: usize, max_errs: usize) -> anyhow::Result<Z> {
-        let recon = <Z as ErrorCorrect>::error_correct(self, degree, max_errs)?;
+    fn error_reconstruct(&self, degree: usize, max_errors: usize) -> anyhow::Result<Z> {
+        let recon = <Z as ErrorCorrect>::error_correct(self, degree, max_errors)?;
         Ok(recon.eval(&Z::ZERO))
     }
 
-    fn err_reconstruct_with_hints(
+    fn error_reconstruct_with_hints(
         &self,
         degree: usize,
-        max_errs: usize,
+        max_errors: usize,
         hints: &ReconstructionHints<Z>,
     ) -> anyhow::Result<Z> {
-        let recon = Z::error_correct_with_hints(self, degree, max_errs, hints)?;
+        let recon = Z::error_correct_with_hints(self, degree, max_errors, hints)?;
         Ok(recon.eval(&Z::ZERO))
     }
 }
@@ -295,14 +295,14 @@ where
     //Make sure we have enough shares already to try and reconstrcut
     if degree + 2 * threshold < num_parties && num_heard_from > degree + 2 * threshold {
         // the maximum number of errors we can correct is threshold minus the number of bots
-        // max_errs = threshold - num_bots
-        let max_errs = threshold.checked_sub(num_bots).ok_or_else(|| {
+        // max_errors = threshold - num_bots
+        let max_errorss = threshold.checked_sub(num_bots).ok_or_else(|| {
             anyhow_error_and_warn_log(format!(
-                "Underflow in reconstruction computing max_errs:  num_bots ({num_bots}) > threshold ({threshold})"
+                "Underflow in reconstruction computing max_errors:  num_bots ({num_bots}) > threshold ({threshold})"
             ))
         })?;
 
-        let opened = sharing.err_reconstruct_with_hints(degree, max_errs, hints)?;
+        let opened = sharing.error_reconstruct_with_hints(degree, max_errorss, hints)?;
         return Ok(Some(opened));
     }
 
@@ -348,13 +348,13 @@ where
     let num_heard_from = sharing.shares.len() + num_bots;
     if degree + 3 * threshold < num_parties {
         if num_heard_from > degree + 2 * threshold {
-            let max_errs = threshold.checked_sub(num_bots).ok_or_else(|| {
+            let max_errors = threshold.checked_sub(num_bots).ok_or_else(|| {
                 anyhow_error_and_warn_log(format!(
-                    "Underflow in reconstruction computing max_errs:  num_bots ({num_bots}) > threshold ({threshold})"
+                    "Underflow in reconstruction computing max_errors:  num_bots ({num_bots}) > threshold ({threshold})"
                 ))
             })?;
 
-            let opened = sharing.err_reconstruct_with_hints(degree, max_errs, hints)?;
+            let opened = sharing.error_reconstruct_with_hints(degree, max_errors, hints)?;
             Ok(Some(opened))
         } else {
             //We do not have enough shares yet

--- a/core/threshold-algebra/src/sharing/shamir.rs
+++ b/core/threshold-algebra/src/sharing/shamir.rs
@@ -1,6 +1,7 @@
 use threshold_types::role::Role;
 
 use crate::{
+    error_correction::ReconstructionHints,
     poly::Poly,
     sharing::share::Share,
     structure_traits::{ErrorCorrect, Ring, RingWithExceptionalSequence},
@@ -195,6 +196,19 @@ pub trait RevealOp<Z> {
     }
 
     fn err_reconstruct(&self, degree: usize, max_errs: usize) -> anyhow::Result<Z>;
+
+    fn err_reconstruct_with_hints(
+        &self,
+        degree: usize,
+        max_errs: usize,
+        _hints: &ReconstructionHints<Z>,
+    ) -> anyhow::Result<Z>
+    where
+        Z: ErrorCorrect,
+    {
+        // Default: ignore hints
+        self.err_reconstruct(degree, max_errs)
+    }
 }
 
 impl<Z> RevealOp<Z> for ShamirSharings<Z>
@@ -203,6 +217,16 @@ where
 {
     fn err_reconstruct(&self, degree: usize, max_errs: usize) -> anyhow::Result<Z> {
         let recon = <Z as ErrorCorrect>::error_correct(self, degree, max_errs)?;
+        Ok(recon.eval(&Z::ZERO))
+    }
+
+    fn err_reconstruct_with_hints(
+        &self,
+        degree: usize,
+        max_errs: usize,
+        hints: &ReconstructionHints<Z>,
+    ) -> anyhow::Result<Z> {
+        let recon = Z::error_correct_with_hints(self, degree, max_errs, hints)?;
         Ok(recon.eval(&Z::ZERO))
     }
 }
@@ -253,12 +277,14 @@ pub fn fill_indexed_shares<Z: Ring>(
 /// Returns either the result or None if there are not enough shares to do reconstruction yet
 /// This assumes that sharing contains all the shares the current party know of, including its own if relevant
 /// thus we always perform the check "case B".
-pub fn reconstruct_w_errors_sync<Z>(
+/// This error out only if reconstruction is impossible given the parameters, it does not error out if we just do not have enough shares yet.
+fn reconstruct_w_errors_sync_common<Z>(
     num_parties: usize,
     degree: usize,
     threshold: usize,
     num_bots: usize,
     sharing: &ShamirSharings<Z>,
+    hints: Option<&ReconstructionHints<Z>>,
 ) -> anyhow::Result<Option<Z>>
 where
     Z: Ring + ErrorCorrect,
@@ -276,7 +302,11 @@ where
             ))
         })?;
 
-        let opened = sharing.err_reconstruct(degree, max_errs)?;
+        let opened = if let Some(hints) = hints {
+            sharing.err_reconstruct_with_hints(degree, max_errs, hints)?
+        } else {
+            sharing.err_reconstruct(degree, max_errs)?
+        };
         return Ok(Some(opened));
     }
 
@@ -292,6 +322,44 @@ where
     Ok(None)
 }
 
+/// [`reconstruct_w_errors_sync_common`] without precomputed [`ReconstructionHints`].
+pub fn reconstruct_w_errors_sync<Z>(
+    num_parties: usize,
+    degree: usize,
+    threshold: usize,
+    num_bots: usize,
+    sharing: &ShamirSharings<Z>,
+) -> anyhow::Result<Option<Z>>
+where
+    Z: Ring + ErrorCorrect,
+    ShamirSharings<Z>: RevealOp<Z>,
+{
+    reconstruct_w_errors_sync_common(num_parties, degree, threshold, num_bots, sharing, None)
+}
+
+/// [`reconstruct_w_errors_sync_common`] with precomputed [`ReconstructionHints`].
+pub fn reconstruct_w_errors_sync_with_hints<Z>(
+    num_parties: usize,
+    degree: usize,
+    threshold: usize,
+    num_bots: usize,
+    sharing: &ShamirSharings<Z>,
+    hints: &ReconstructionHints<Z>,
+) -> anyhow::Result<Option<Z>>
+where
+    Z: Ring + ErrorCorrect,
+    ShamirSharings<Z>: RevealOp<Z>,
+{
+    reconstruct_w_errors_sync_common(
+        num_parties,
+        degree,
+        threshold,
+        num_bots,
+        sharing,
+        Some(hints),
+    )
+}
+
 /// Core algorithm for robust reconstructions which tries to reconstruct from a collection of shares
 /// in an async network
 /// Takes as input:
@@ -304,12 +372,15 @@ where
 ///  Returns either the result or None if there are not enough shares to do reconstruction yet
 /// This assumes that sharing contains all the shares the current party know of, including its own if relevant
 /// thus we always perform the check "case B".
-pub fn reconstruct_w_errors_async<Z>(
+///
+/// This error out only if reconstruction is impossible given the parameters, it does not error out if we just do not have enough shares yet.
+fn reconstruct_w_errors_async_common<Z>(
     num_parties: usize,
     degree: usize,
     threshold: usize,
     num_bots: usize,
     sharing: &ShamirSharings<Z>,
+    hints: Option<&ReconstructionHints<Z>>,
 ) -> anyhow::Result<Option<Z>>
 where
     Z: Ring + ErrorCorrect,
@@ -319,13 +390,17 @@ where
     let num_heard_from = sharing.shares.len() + num_bots;
     if degree + 3 * threshold < num_parties {
         if num_heard_from > degree + 2 * threshold {
-            // max_errs = threshold - num_bots
             let max_errs = threshold.checked_sub(num_bots).ok_or_else(|| {
                 anyhow_error_and_warn_log(format!(
-                "Underflow in reconstruction computing max_errs:  num_bots ({num_bots}) > threshold ({threshold})"
-            ))
+                    "Underflow in reconstruction computing max_errs:  num_bots ({num_bots}) > threshold ({threshold})"
+                ))
             })?;
-            let opened = sharing.err_reconstruct(degree, max_errs)?;
+
+            let opened = if let Some(hints) = hints {
+                sharing.err_reconstruct_with_hints(degree, max_errs, hints)?
+            } else {
+                sharing.err_reconstruct(degree, max_errs)?
+            };
             Ok(Some(opened))
         } else {
             //We do not have enough shares yet
@@ -334,12 +409,13 @@ where
     } else if degree + 2 * threshold < num_parties {
         if num_heard_from > degree + threshold {
             let r: usize = num_heard_from - (degree + threshold + 1);
-            let opened_poly = Z::error_correct(sharing, degree, r);
+            let opened_poly = if let Some(hints) = hints {
+                Z::error_correct_with_hints(sharing, degree, r, hints)
+            } else {
+                Z::error_correct(sharing, degree, r)
+            };
             if let Ok(opened_poly) = opened_poly {
                 if opened_poly.deg() <= degree {
-                    //Note: Not entirely certain we really need all this checking mechanism.
-                    //If error_correct succeeded, why isnt it enough?
-
                     //Check how many shares lie on the polynomial
                     let mut num_shares_on_poly = 0;
                     for share in sharing.shares.iter() {
@@ -349,7 +425,6 @@ where
                         {
                             num_shares_on_poly += 1;
                         }
-
                         //If enough, return the result
                         if num_shares_on_poly > degree + threshold {
                             return Ok(Some(opened_poly.eval(&(Z::ZERO))));
@@ -367,12 +442,50 @@ where
             //We do not have enough shares yet
             Ok(None)
         }
-    //Make sure there's hope to ever have enough shares to try and reconstruct
+        //Make sure there's hope to ever have enough shares to try and reconstruct
     } else {
         Err(anyhow_error_and_warn_log(format!(
             "Can NOT reconstruct with degree {degree}, threshold {threshold} and num_parties {num_parties}"
         )))
     }
+}
+
+/// [`reconstruct_w_errors_async_common`] without precomputed [`ReconstructionHints`].
+pub fn reconstruct_w_errors_async<Z>(
+    num_parties: usize,
+    degree: usize,
+    threshold: usize,
+    num_bots: usize,
+    sharing: &ShamirSharings<Z>,
+) -> anyhow::Result<Option<Z>>
+where
+    Z: Ring + ErrorCorrect,
+    ShamirSharings<Z>: RevealOp<Z>,
+{
+    reconstruct_w_errors_async_common(num_parties, degree, threshold, num_bots, sharing, None)
+}
+
+/// [`reconstruct_w_errors_async_common`] with precomputed [`ReconstructionHints`].
+pub fn reconstruct_w_errors_async_with_hints<Z>(
+    num_parties: usize,
+    degree: usize,
+    threshold: usize,
+    num_bots: usize,
+    sharing: &ShamirSharings<Z>,
+    hints: &ReconstructionHints<Z>,
+) -> anyhow::Result<Option<Z>>
+where
+    Z: Ring + ErrorCorrect,
+    ShamirSharings<Z>: RevealOp<Z>,
+{
+    reconstruct_w_errors_async_common(
+        num_parties,
+        degree,
+        threshold,
+        num_bots,
+        sharing,
+        Some(hints),
+    )
 }
 
 #[cfg(test)]

--- a/core/threshold-algebra/src/structure_traits.rs
+++ b/core/threshold-algebra/src/structure_traits.rs
@@ -1,3 +1,4 @@
+use super::error_correction::ReconstructionHints;
 use super::poly::Poly;
 use super::sharing::shamir::ShamirSharings;
 use hashing::DomainSep;
@@ -145,6 +146,13 @@ pub trait RingWithExceptionalSequence: Ring + Sized {
 }
 
 pub trait ErrorCorrect: RingWithExceptionalSequence {
+    /// The field over which Lagrange interpolation and Gao decoding operate.
+    ///
+    /// For Galois rings this is `<Self as QuotientMaximalIdeal>::QuotientOutput`
+    /// (e.g. `GF16` for `ResiduePolyF4`).
+    /// For types that are already a `Field` (e.g. BGV levels), this is `Self`.
+    type ReconstructionField: Field;
+
     ///Perform error correction.
     /// degree is the degree of the sharing polynomial (either threshold or 2*threshold)
     /// max_errs is the maximum number of errors we try to correct for (most often threshold - len(corrupt_set), but can be less than this if degree is 2*threshold)
@@ -155,6 +163,19 @@ pub trait ErrorCorrect: RingWithExceptionalSequence {
         degree: usize,
         max_errs: usize,
     ) -> anyhow::Result<Poly<Self>>;
+
+    /// Like [`Self::error_correct`] but accepts precomputed [`ReconstructionHints`] to avoid
+    /// redundant work when reconstructing many sharings with the same owner set and degree.
+    ///
+    /// The default implementation ignores the hints and falls back to [`Self::error_correct`].
+    fn error_correct_with_hints(
+        sharing: &ShamirSharings<Self>,
+        degree: usize,
+        max_errs: usize,
+        _hints: &ReconstructionHints<Self>,
+    ) -> anyhow::Result<Poly<Self>> {
+        Self::error_correct(sharing, degree, max_errs)
+    }
 }
 
 pub trait Derive: Sized {

--- a/core/threshold-algebra/src/structure_traits.rs
+++ b/core/threshold-algebra/src/structure_traits.rs
@@ -155,13 +155,13 @@ pub trait ErrorCorrect: RingWithExceptionalSequence {
 
     ///Perform error correction.
     /// degree is the degree of the sharing polynomial (either threshold or 2*threshold)
-    /// max_errs is the maximum number of errors we try to correct for (most often threshold - len(corrupt_set), but can be less than this if degree is 2*threshold)
+    /// max_errors is the maximum number of errors we try to correct for (most often threshold - len(corrupt_set), but can be less than this if degree is 2*threshold)
     ///
     /// __NOTE__ : We assume values coming from known malicious parties have been excluded by the caller (i.e. values denoted Bot in NIST doc)
     fn error_correct(
         sharing: &ShamirSharings<Self>,
         degree: usize,
-        max_errs: usize,
+        max_errors: usize,
     ) -> anyhow::Result<Poly<Self>>;
 
     /// Like [`Self::error_correct`] but accepts precomputed [`ReconstructionHints`] to avoid
@@ -171,10 +171,10 @@ pub trait ErrorCorrect: RingWithExceptionalSequence {
     fn error_correct_with_hints(
         sharing: &ShamirSharings<Self>,
         degree: usize,
-        max_errs: usize,
+        max_errors: usize,
         _hints: &ReconstructionHints<Self>,
     ) -> anyhow::Result<Poly<Self>> {
-        Self::error_correct(sharing, degree, max_errs)
+        Self::error_correct(sharing, degree, max_errors)
     }
 }
 

--- a/core/threshold-bgv/src/algebra/levels.rs
+++ b/core/threshold-bgv/src/algebra/levels.rs
@@ -379,6 +379,8 @@ macro_rules! impl_field_level {
             }
 
             impl ErrorCorrect for $name {
+                type ReconstructionField = $name;
+
                 fn error_correct(
                     sharing: &ShamirSharings<$name>,
                     threshold: usize,
@@ -399,6 +401,10 @@ impl RingWithExceptionalSequence for LevelKsw {
 }
 
 impl ErrorCorrect for LevelKsw {
+    // LevelKsw decomposes via CRT into individual fields; FieldR is used as a
+    // representative but the hints path is not exercised for this type.
+    type ReconstructionField = FieldR;
+
     fn error_correct(
         sharing: &ShamirSharings<Self>,
         threshold: usize,

--- a/core/threshold-bgv/src/algebra/levels.rs
+++ b/core/threshold-bgv/src/algebra/levels.rs
@@ -384,9 +384,9 @@ macro_rules! impl_field_level {
                 fn error_correct(
                     sharing: &ShamirSharings<$name>,
                     threshold: usize,
-                    max_errs: usize,
+                    max_errorsors: usize,
                 ) -> anyhow::Result<Poly<$name>> {
-                    error_correction(sharing.shares.clone(), threshold, max_errs)
+                    error_correction(sharing.shares.clone(), threshold, max_errorsors)
                 }
             }
             }
@@ -408,7 +408,7 @@ impl ErrorCorrect for LevelKsw {
     fn error_correct(
         sharing: &ShamirSharings<Self>,
         threshold: usize,
-        max_errs: usize,
+        max_errorsors: usize,
     ) -> anyhow::Result<Poly<Self>> {
         //Apply CRT decomposition to all the shares
         let crt_shares = sharing
@@ -423,7 +423,7 @@ impl ErrorCorrect for LevelKsw {
                 .map(|crt_share| Share::new(crt_share.1, crt_share.0.value_level_r))
                 .collect_vec(),
         };
-        let mut res_level_r = FieldR::error_correct(&shamir_level_r, threshold, max_errs)?;
+        let mut res_level_r = FieldR::error_correct(&shamir_level_r, threshold, max_errorsors)?;
 
         let shamir_level_one = ShamirSharings {
             shares: crt_shares
@@ -431,7 +431,8 @@ impl ErrorCorrect for LevelKsw {
                 .map(|crt_share| Share::new(crt_share.1, crt_share.0.value_level_one))
                 .collect_vec(),
         };
-        let mut res_level_one = FieldOne::error_correct(&shamir_level_one, threshold, max_errs)?;
+        let mut res_level_one =
+            FieldOne::error_correct(&shamir_level_one, threshold, max_errorsors)?;
 
         let shamir_level_two = ShamirSharings {
             shares: crt_shares
@@ -439,7 +440,8 @@ impl ErrorCorrect for LevelKsw {
                 .map(|crt_share| Share::new(crt_share.1, crt_share.0.value_level_two))
                 .collect_vec(),
         };
-        let mut res_level_two = FieldTwo::error_correct(&shamir_level_two, threshold, max_errs)?;
+        let mut res_level_two =
+            FieldTwo::error_correct(&shamir_level_two, threshold, max_errorsors)?;
 
         let shamir_level_three = ShamirSharings {
             shares: crt_shares
@@ -448,7 +450,7 @@ impl ErrorCorrect for LevelKsw {
                 .collect_vec(),
         };
         let mut res_level_three =
-            FieldThree::error_correct(&shamir_level_three, threshold, max_errs)?;
+            FieldThree::error_correct(&shamir_level_three, threshold, max_errorsors)?;
 
         let shamir_level_four = ShamirSharings {
             shares: crt_shares
@@ -456,7 +458,8 @@ impl ErrorCorrect for LevelKsw {
                 .map(|crt_share| Share::new(crt_share.1, crt_share.0.value_level_four))
                 .collect_vec(),
         };
-        let mut res_level_four = FieldFour::error_correct(&shamir_level_four, threshold, max_errs)?;
+        let mut res_level_four =
+            FieldFour::error_correct(&shamir_level_four, threshold, max_errorsors)?;
 
         let shamir_level_five = ShamirSharings {
             shares: crt_shares
@@ -464,7 +467,8 @@ impl ErrorCorrect for LevelKsw {
                 .map(|crt_share| Share::new(crt_share.1, crt_share.0.value_level_five))
                 .collect_vec(),
         };
-        let mut res_level_five = FieldFive::error_correct(&shamir_level_five, threshold, max_errs)?;
+        let mut res_level_five =
+            FieldFive::error_correct(&shamir_level_five, threshold, max_errorsors)?;
 
         let shamir_level_six = ShamirSharings {
             shares: crt_shares
@@ -472,7 +476,8 @@ impl ErrorCorrect for LevelKsw {
                 .map(|crt_share| Share::new(crt_share.1, crt_share.0.value_level_six))
                 .collect_vec(),
         };
-        let mut res_level_six = FieldSix::error_correct(&shamir_level_six, threshold, max_errs)?;
+        let mut res_level_six =
+            FieldSix::error_correct(&shamir_level_six, threshold, max_errorsors)?;
 
         let shamir_level_seven = ShamirSharings {
             shares: crt_shares
@@ -481,7 +486,7 @@ impl ErrorCorrect for LevelKsw {
                 .collect_vec(),
         };
         let mut res_level_seven =
-            FieldSeven::error_correct(&shamir_level_seven, threshold, max_errs)?;
+            FieldSeven::error_correct(&shamir_level_seven, threshold, max_errorsors)?;
 
         let shamir_level_eight = ShamirSharings {
             shares: crt_shares
@@ -490,7 +495,7 @@ impl ErrorCorrect for LevelKsw {
                 .collect_vec(),
         };
         let mut res_level_eight =
-            FieldEight::error_correct(&shamir_level_eight, threshold, max_errs)?;
+            FieldEight::error_correct(&shamir_level_eight, threshold, max_errorsors)?;
 
         let shamir_level_nine = ShamirSharings {
             shares: crt_shares
@@ -498,7 +503,8 @@ impl ErrorCorrect for LevelKsw {
                 .map(|crt_share| Share::new(crt_share.1, crt_share.0.value_level_nine))
                 .collect_vec(),
         };
-        let mut res_level_nine = FieldNine::error_correct(&shamir_level_nine, threshold, max_errs)?;
+        let mut res_level_nine =
+            FieldNine::error_correct(&shamir_level_nine, threshold, max_errorsors)?;
 
         let shamir_level_ten = ShamirSharings {
             shares: crt_shares
@@ -506,7 +512,8 @@ impl ErrorCorrect for LevelKsw {
                 .map(|crt_share| Share::new(crt_share.1, crt_share.0.value_level_ten))
                 .collect_vec(),
         };
-        let mut res_level_ten = FieldTen::error_correct(&shamir_level_ten, threshold, max_errs)?;
+        let mut res_level_ten =
+            FieldTen::error_correct(&shamir_level_ten, threshold, max_errorsors)?;
 
         let shamir_level_eleven = ShamirSharings {
             shares: crt_shares
@@ -515,7 +522,7 @@ impl ErrorCorrect for LevelKsw {
                 .collect_vec(),
         };
         let mut res_level_eleven =
-            FieldEleven::error_correct(&shamir_level_eleven, threshold, max_errs)?;
+            FieldEleven::error_correct(&shamir_level_eleven, threshold, max_errorsors)?;
 
         let shamir_level_twelve = ShamirSharings {
             shares: crt_shares
@@ -524,7 +531,7 @@ impl ErrorCorrect for LevelKsw {
                 .collect_vec(),
         };
         let mut res_level_twelve =
-            FieldTwelve::error_correct(&shamir_level_twelve, threshold, max_errs)?;
+            FieldTwelve::error_correct(&shamir_level_twelve, threshold, max_errorsors)?;
 
         let shamir_level_thirteen = ShamirSharings {
             shares: crt_shares
@@ -533,7 +540,7 @@ impl ErrorCorrect for LevelKsw {
                 .collect_vec(),
         };
         let mut res_level_thirteen =
-            FieldThirteen::error_correct(&shamir_level_thirteen, threshold, max_errs)?;
+            FieldThirteen::error_correct(&shamir_level_thirteen, threshold, max_errorsors)?;
 
         let shamir_level_fourteen = ShamirSharings {
             shares: crt_shares
@@ -542,7 +549,7 @@ impl ErrorCorrect for LevelKsw {
                 .collect_vec(),
         };
         let mut res_level_fourteen =
-            FieldFourteen::error_correct(&shamir_level_fourteen, threshold, max_errs)?;
+            FieldFourteen::error_correct(&shamir_level_fourteen, threshold, max_errorsors)?;
 
         let shamir_level_fifteen = ShamirSharings {
             shares: crt_shares
@@ -551,7 +558,7 @@ impl ErrorCorrect for LevelKsw {
                 .collect_vec(),
         };
         let mut res_level_fifteen =
-            FieldFifteen::error_correct(&shamir_level_fifteen, threshold, max_errs)?;
+            FieldFifteen::error_correct(&shamir_level_fifteen, threshold, max_errorsors)?;
 
         //All the level polynomial have max degree threshold, so we will crt reconstruct a polynomial of degree threshold
         let mut coefs: Vec<Self> = Vec::new();
@@ -1533,7 +1540,7 @@ mod tests {
 
         let num_parties = 7;
         let threshold = f.coefs().len() - 1; // = 2 here
-        let max_err = (num_parties - threshold) / 2; // = 2 here
+        let max_errors = (num_parties - threshold) / 2; // = 2 here
 
         let mut shares: Vec<_> = (1..=num_parties)
             .map(|x| {
@@ -1547,7 +1554,7 @@ mod tests {
         shares[1] += LevelOne::from_u128(10);
         shares[2] += LevelOne::from_u128(254);
 
-        let secret_poly = error_correction(shares, threshold, max_err).unwrap();
+        let secret_poly = error_correction(shares, threshold, max_errors).unwrap();
         assert_eq!(secret_poly, f);
     }
 
@@ -1557,9 +1564,9 @@ mod tests {
         let secret = LevelOne::from_u128(2345);
         let num_parties = 8;
         let threshold = 2;
-        let max_err = 0;
+        let max_errors = 0;
         let sharing = ShamirSharings::share(&mut rng, secret, num_parties, threshold).unwrap();
-        let f_zero = sharing.err_reconstruct(threshold, max_err).unwrap();
+        let f_zero = sharing.error_reconstruct(threshold, max_errors).unwrap();
         assert_eq!(f_zero, secret);
     }
 
@@ -1569,9 +1576,9 @@ mod tests {
         let secret = LevelKsw::sample(&mut rng);
         let num_parties = 8;
         let threshold = 2;
-        let max_err = 0;
+        let max_errors = 0;
         let sharing = ShamirSharings::share(&mut rng, secret, num_parties, threshold).unwrap();
-        let f_zero = sharing.err_reconstruct(threshold, max_err).unwrap();
+        let f_zero = sharing.error_reconstruct(threshold, max_errors).unwrap();
         assert_eq!(f_zero, secret);
     }
 
@@ -1584,7 +1591,7 @@ mod tests {
         let mut sharing = ShamirSharings::share(&mut rng, secret, num_parties, threshold).unwrap();
         sharing.shares[0] = Share::new(sharing.shares[0].owner(), LevelKsw::sample(&mut rng));
         sharing.shares[3] = Share::new(sharing.shares[3].owner(), LevelKsw::sample(&mut rng));
-        let f_zero = sharing.err_reconstruct(threshold, threshold).unwrap();
+        let f_zero = sharing.error_reconstruct(threshold, threshold).unwrap();
         assert_eq!(f_zero, secret);
     }
 

--- a/core/threshold-bgv/src/bgv/dkg_orchestrator.rs
+++ b/core/threshold-bgv/src/bgv/dkg_orchestrator.rs
@@ -80,7 +80,8 @@ impl BGVPreprocessingOrchestrator {
             ProgressTracker::new("TripleGen", num_triples, *TRACKER_LOG_PERCENTAGE);
         let random_progress_tracker =
             ProgressTracker::new("RandomGen", num_randomness, *TRACKER_LOG_PERCENTAGE);
-        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
+        let bit_progress_tracker =
+            ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
 
         Self {
             poly_size,

--- a/core/threshold-bgv/src/bgv/dkg_orchestrator.rs
+++ b/core/threshold-bgv/src/bgv/dkg_orchestrator.rs
@@ -21,9 +21,9 @@ use algebra::sharing::share::Share;
 use error_utils::anyhow_error_and_log;
 use threshold_execution::{
     config::BatchParams,
+    constants::TRACKER_LOG_PERCENTAGE,
     online::{
         preprocessing::{
-            constants::TRACKER_LOG_PERCENTAGE,
             memory::InMemoryBitPreprocessing,
             orchestration::{
                 consumers::{
@@ -77,10 +77,10 @@ impl BGVPreprocessingOrchestrator {
         let (num_bits, num_triples, num_randomness) =
             get_num_correlated_randomness_required(poly_size);
         let triple_progress_tracker =
-            ProgressTracker::new("TripleGen", num_triples, TRACKER_LOG_PERCENTAGE);
+            ProgressTracker::new("TripleGen", num_triples, *TRACKER_LOG_PERCENTAGE);
         let random_progress_tracker =
-            ProgressTracker::new("RandomGen", num_randomness, TRACKER_LOG_PERCENTAGE);
-        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, TRACKER_LOG_PERCENTAGE);
+            ProgressTracker::new("RandomGen", num_randomness, *TRACKER_LOG_PERCENTAGE);
+        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
 
         Self {
             poly_size,

--- a/core/threshold-execution/src/constants.rs
+++ b/core/threshold-execution/src/constants.rs
@@ -34,7 +34,10 @@ cfg_if::cfg_if! {
                         default
                     })
                 },
-                Err(_) => default,
+                Err(_) => {
+                    tracing::warn!("Env var {name} not set; using default {default}");
+                    default
+                },
             };
             tracing::info!("Using tuning value {value} from env var {name} ");
             value

--- a/core/threshold-execution/src/constants.rs
+++ b/core/threshold-execution/src/constants.rs
@@ -16,15 +16,11 @@ cfg_if::cfg_if! {
         pub(crate) const PHI_XOR_CONSTANT: u8 = 2;
         pub(crate) const CHI_XOR_CONSTANT: u8 = 1;
 
-        // ---- DKG preprocessing tuning knobs ----
+        // ---- MPC tuning knobs ----
         //
         // Each value is configurable at runtime via an environment variable and
         // read once on first access (`LazyLock`). When the variable is unset or
         // cannot be parsed as a `usize`, the documented default is used.
-        //
-        // Because they are read once and cached, set the variables before the DKG
-        // preprocessing starts (e.g. in the process environment); changing them
-        // afterwards has no effect.
 
         /// Reads a `usize` tuning value from environment variable `name`, falling
         /// back to `default` when unset or unparseable.
@@ -66,8 +62,8 @@ cfg_if::cfg_if! {
         // Tuning knobs for the parallel preprocessing loops: large enough to
         // amortize rayon's split/join overhead and to avoid oversubscription
         // under the orchestrator's session-level parallelism, small enough to
-        // still parallelize the large DKG batches. These are starting points and
-        // should be benchmarked.
+        // still parallelize some tasks.
+        // NOTE: These are starting points and should be benchmarked and adjusted as needed.
 
         /// TUniform noise assembly: very cheap per item (~`bound + 2` ring ops).
         /// Env: `MPC_DKG_TUNIFORM_PAR_MIN_CHUNK` (default 4096).
@@ -84,8 +80,7 @@ cfg_if::cfg_if! {
             std::sync::LazyLock::new(|| {
                 env_usize("MPC_D_VALUE_RECONSTRUCTION_PAR_MIN_CHUNK", 256)
             });
-        /// Robust-open reconstruction (`sharing::open`): kept large so that only
-        /// the big DKG opens parallelize and ordinary small opens stay sequential.
+        /// Robust-open reconstruction (`sharing::open`).
         /// Env: `MPC_ROBUST_OPEN_PAR_MIN_CHUNK` (default 256).
         pub(crate) static ROBUST_OPEN_RECONSTRUCTION_PAR_MIN_CHUNK: std::sync::LazyLock<usize> =
             std::sync::LazyLock::new(|| {

--- a/core/threshold-execution/src/constants.rs
+++ b/core/threshold-execution/src/constants.rs
@@ -34,8 +34,8 @@ cfg_if::cfg_if! {
                         default
                     })
                 },
-                Err(_) => {
-                    tracing::warn!("Env var {name} not set; using default {default}");
+                Err(e) => {
+                    tracing::warn!("Error reading env var {name}: {e:?}; using default {default}");
                     default
                 },
             };

--- a/core/threshold-execution/src/constants.rs
+++ b/core/threshold-execution/src/constants.rs
@@ -15,6 +15,82 @@ cfg_if::cfg_if! {
         /// constants for key separation in PRSS/PRZS
         pub(crate) const PHI_XOR_CONSTANT: u8 = 2;
         pub(crate) const CHI_XOR_CONSTANT: u8 = 1;
+
+        // ---- DKG preprocessing tuning knobs ----
+        //
+        // Each value is configurable at runtime via an environment variable and
+        // read once on first access (`LazyLock`). When the variable is unset or
+        // cannot be parsed as a `usize`, the documented default is used.
+        //
+        // Because they are read once and cached, set the variables before the DKG
+        // preprocessing starts (e.g. in the process environment); changing them
+        // afterwards has no effect.
+
+        /// Reads a `usize` tuning value from environment variable `name`, falling
+        /// back to `default` when unset or unparseable.
+        fn env_usize(name: &str, default: usize) -> usize {
+            match std::env::var(name) {
+                Ok(raw) =>{ let parsed = raw.trim().parse::<usize>().unwrap_or_else(|_| {
+                    tracing::warn!(
+                        "Invalid usize value {raw:?} for env var {name}; using default {default}"
+                    );
+                    default
+                });
+                tracing::info!("Using tuning value {parsed} from env var {name} ");
+                parsed
+            },
+                Err(_) => default,
+            }
+        }
+
+        /// Amount of triples generated in one batch by the orchestrator.
+        /// Env: `MPC_DKG_BATCH_SIZE_TRIPLES` (default 10000).
+        pub(crate) static BATCH_SIZE_TRIPLES: std::sync::LazyLock<usize> =
+            std::sync::LazyLock::new(|| env_usize("MPC_DKG_BATCH_SIZE_TRIPLES", 10000));
+        /// Amount of bits generated in one batch by the orchestrator.
+        /// Env: `MPC_DKG_BATCH_SIZE_BITS` (default 10000).
+        pub(crate) static BATCH_SIZE_BITS: std::sync::LazyLock<usize> =
+            std::sync::LazyLock::new(|| env_usize("MPC_DKG_BATCH_SIZE_BITS", 10000));
+        /// Number of batches that can be queued per producer thread in the
+        /// orchestrator. A value of 2 enables double-buffering: a producer can
+        /// prepare the next batch while the consumer drains the current one.
+        /// Env: `MPC_DKG_CHANNEL_BUFFER_SIZE` (default 2).
+        pub(crate) static CHANNEL_BUFFER_SIZE: std::sync::LazyLock<usize> =
+            std::sync::LazyLock::new(|| env_usize("MPC_DKG_CHANNEL_BUFFER_SIZE", 2));
+        /// Progress tracker reports every `TRACKER_LOG_PERCENTAGE` percent.
+        /// Env: `MPC_DKG_TRACKER_LOG_PERCENTAGE` (default 5).
+        pub static TRACKER_LOG_PERCENTAGE: std::sync::LazyLock<usize> =
+            std::sync::LazyLock::new(|| env_usize("MPC_DKG_TRACKER_LOG_PERCENTAGE", 5));
+
+        // ---- Minimum rayon chunk sizes (minimum items per parallel task) ----
+        // Tuning knobs for the parallel preprocessing loops: large enough to
+        // amortize rayon's split/join overhead and to avoid oversubscription
+        // under the orchestrator's session-level parallelism, small enough to
+        // still parallelize the large DKG batches. These are starting points and
+        // should be benchmarked.
+
+        /// TUniform noise assembly: very cheap per item (~`bound + 2` ring ops).
+        /// Env: `MPC_DKG_TUNIFORM_PAR_MIN_CHUNK` (default 4096).
+        pub(crate) static TUNIFORM_GEN_PAR_MIN_CHUNK: std::sync::LazyLock<usize> =
+            std::sync::LazyLock::new(|| env_usize("MPC_DKG_TUNIFORM_PAR_MIN_CHUNK", 4096));
+        /// PRSS / PRZS / mask batch generation: a few AES-PRF evaluations per item.
+        /// Env: `MPC_PRSS_PAR_MIN_CHUNK` (default 1024).
+        pub(crate) static PRSS_GEN_PAR_MIN_CHUNK: std::sync::LazyLock<usize> =
+            std::sync::LazyLock::new(|| env_usize("MPC_PRSS_PAR_MIN_CHUNK", 1024));
+        /// d-value reconstruction in triple/square generation: heavy per item
+        /// (a Shamir reconstruction).
+        /// Env: `MPC_D_VALUE_RECONSTRUCTION_PAR_MIN_CHUNK` (default 256).
+        pub(crate) static D_VALUE_RECONSTRUCTION_PAR_MIN_CHUNK: std::sync::LazyLock<usize> =
+            std::sync::LazyLock::new(|| {
+                env_usize("MPC_D_VALUE_RECONSTRUCTION_PAR_MIN_CHUNK", 256)
+            });
+        /// Robust-open reconstruction (`sharing::open`): kept large so that only
+        /// the big DKG opens parallelize and ordinary small opens stay sequential.
+        /// Env: `MPC_ROBUST_OPEN_PAR_MIN_CHUNK` (default 256).
+        pub(crate) static ROBUST_OPEN_RECONSTRUCTION_PAR_MIN_CHUNK: std::sync::LazyLock<usize> =
+            std::sync::LazyLock::new(|| {
+                env_usize("MPC_ROBUST_OPEN_PAR_MIN_CHUNK", 256)
+            });
     }
 }
 

--- a/core/threshold-execution/src/constants.rs
+++ b/core/threshold-execution/src/constants.rs
@@ -25,19 +25,19 @@ cfg_if::cfg_if! {
         /// Reads a `usize` tuning value from environment variable `name`, falling
         /// back to `default` when unset or unparseable.
         fn env_usize(name: &str, default: usize) -> usize {
-            match std::env::var(name) {
+            let value = match std::env::var(name) {
                 Ok(raw) => {
-                    let parsed = raw.trim().parse::<usize>().unwrap_or_else(|_| {
+                    raw.trim().parse::<usize>().unwrap_or_else(|_| {
                         tracing::warn!(
                             "Invalid usize value {raw:?} for env var {name}; using default {default}"
                         );
                         default
-                    });
-                    tracing::info!("Using tuning value {parsed} from env var {name} ");
-                    parsed
+                    })
                 },
                 Err(_) => default,
-            }
+            };
+            tracing::info!("Using tuning value {value} from env var {name} ");
+            value
         }
 
         /// Amount of triples generated in one batch by the orchestrator.

--- a/core/threshold-execution/src/constants.rs
+++ b/core/threshold-execution/src/constants.rs
@@ -26,15 +26,16 @@ cfg_if::cfg_if! {
         /// back to `default` when unset or unparseable.
         fn env_usize(name: &str, default: usize) -> usize {
             match std::env::var(name) {
-                Ok(raw) =>{ let parsed = raw.trim().parse::<usize>().unwrap_or_else(|_| {
-                    tracing::warn!(
-                        "Invalid usize value {raw:?} for env var {name}; using default {default}"
-                    );
-                    default
-                });
-                tracing::info!("Using tuning value {parsed} from env var {name} ");
-                parsed
-            },
+                Ok(raw) => {
+                    let parsed = raw.trim().parse::<usize>().unwrap_or_else(|_| {
+                        tracing::warn!(
+                            "Invalid usize value {raw:?} for env var {name}; using default {default}"
+                        );
+                        default
+                    });
+                    tracing::info!("Using tuning value {parsed} from env var {name} ");
+                    parsed
+                },
                 Err(_) => default,
             }
         }
@@ -73,7 +74,7 @@ cfg_if::cfg_if! {
         /// Env: `MPC_PRSS_PAR_MIN_CHUNK` (default 1024).
         pub(crate) static PRSS_GEN_PAR_MIN_CHUNK: std::sync::LazyLock<usize> =
             std::sync::LazyLock::new(|| env_usize("MPC_PRSS_PAR_MIN_CHUNK", 1024));
-        /// d-value reconstruction in triple/square generation: heavy per item
+        /// d-value reconstruction in triple/square generation (nsmall offline) : heavy per item
         /// (a Shamir reconstruction).
         /// Env: `MPC_D_VALUE_RECONSTRUCTION_PAR_MIN_CHUNK` (default 256).
         pub(crate) static D_VALUE_RECONSTRUCTION_PAR_MIN_CHUNK: std::sync::LazyLock<usize> =

--- a/core/threshold-execution/src/endpoints/decryption_non_wasm.rs
+++ b/core/threshold-execution/src/endpoints/decryption_non_wasm.rs
@@ -1355,7 +1355,7 @@ mod tests {
             ));
         });
         let first_bit_sharing = ShamirSharings::create(first_bit_shares);
-        let rec = first_bit_sharing.err_reconstruct(1, 0).unwrap();
+        let rec = first_bit_sharing.error_reconstruct(1, 0).unwrap();
         let inner_rec = rec.to_scalar().unwrap();
         assert_eq!(
             keyset

--- a/core/threshold-execution/src/endpoints/reshare_sk.rs
+++ b/core/threshold-execution/src/endpoints/reshare_sk.rs
@@ -1429,7 +1429,7 @@ mod tests {
             });
             let first_bit_sharing = ShamirSharings::create(bit_shares);
             let rec = first_bit_sharing
-                .err_reconstruct(threshold, max_errors)
+                .error_reconstruct(threshold, max_errors)
                 .unwrap();
             let inner_rec = rec.to_scalar().unwrap();
             out.push(inner_rec)

--- a/core/threshold-execution/src/large_execution/double_sharing.rs
+++ b/core/threshold-execution/src/large_execution/double_sharing.rs
@@ -384,7 +384,7 @@ pub(crate) mod tests {
             let shamir_sharing_t = ShamirSharings::create(res_vec_t);
             let shamir_sharing_2t = ShamirSharings::create(res_vec_2t);
             //Expect at most 1 error from the dropout party
-            let res_t = shamir_sharing_t.err_reconstruct(threshold, 1);
+            let res_t = shamir_sharing_t.error_reconstruct(threshold, 1);
             //Here we needed to remove the corrupt party's share because of the pol. degree
             let res_2t = shamir_sharing_2t.reconstruct(2 * threshold);
             assert!(res_t.is_ok());

--- a/core/threshold-execution/src/large_execution/local_single_share.rs
+++ b/core/threshold-execution/src/large_execution/local_single_share.rs
@@ -377,7 +377,7 @@ pub(crate) fn verify_sender_challenge<Z: Ring + ErrorCorrect, L: LargeSessionHan
                     .map(|(role, share)| Share::new(*role, *share))
                     .collect_vec();
                 let sharing = ShamirSharings::create(sharing);
-                let try_reconstruct = sharing.err_reconstruct(threshold, 0);
+                let try_reconstruct = sharing.error_reconstruct(threshold, 0);
 
                 if let Ok(value) = try_reconstruct {
                     if let Some(result_map) = result_map {

--- a/core/threshold-execution/src/large_execution/share_dispute.rs
+++ b/core/threshold-execution/src/large_execution/share_dispute.rs
@@ -772,7 +772,7 @@ pub(crate) mod tests {
         let sham = ShamirSharings::create(points);
         // Reconstruct the message and check it is as expected
         let ref_msg = sham
-            .err_reconstruct(threshold, dispute_ids.len())
+            .error_reconstruct(threshold, dispute_ids.len())
             .unwrap()
             .coefs[0];
         assert_eq!(msg, ref_msg.0);

--- a/core/threshold-execution/src/large_execution/single_sharing.rs
+++ b/core/threshold-execution/src/large_execution/single_sharing.rs
@@ -339,7 +339,7 @@ pub(crate) mod tests {
             }
             let shamir_sharing = ShamirSharings::create(res_vec);
             //Expect max 1 error coming from dropout
-            let res = shamir_sharing.err_reconstruct(threshold, 1);
+            let res = shamir_sharing.error_reconstruct(threshold, 1);
             assert!(res.is_ok());
         }
     }

--- a/core/threshold-execution/src/online/preprocessing/constants.rs
+++ b/core/threshold-execution/src/online/preprocessing/constants.rs
@@ -3,7 +3,11 @@
 pub(crate) const BATCH_SIZE_TRIPLES: usize = 10000;
 ///Amount of bits generated in one batch by the orchestrator
 pub(crate) const BATCH_SIZE_BITS: usize = 10000;
-///Number of batches of bits that can be queued per thread in the orchestrator
-pub(crate) const CHANNEL_BUFFER_SIZE: usize = 1;
+///Number of batches of bits that can be queued per thread in the orchestrator.
+///A value of 2 enables double-buffering: a producer can prepare the next batch
+///while the consumer drains the current one, instead of stalling on a 1-slot
+///channel. Kept small to bound memory (each queued batch is BATCH_SIZE_* shares
+///per producer thread).
+pub(crate) const CHANNEL_BUFFER_SIZE: usize = 2;
 ///Progress tracker will automatically report every TRACKER_LOG_PERCENTAGE percent
 pub const TRACKER_LOG_PERCENTAGE: usize = 5;

--- a/core/threshold-execution/src/online/preprocessing/constants.rs
+++ b/core/threshold-execution/src/online/preprocessing/constants.rs
@@ -1,4 +1,0 @@
-//! The DKG preprocessing batch-size and parallel-chunk constants previously
-//! defined here now live in the crate-level [`crate::constants`] module so that
-//! all tuning knobs (batch sizes, channel depth, rayon minimum chunk sizes) sit
-//! in one place. Import them from `crate::constants` instead.

--- a/core/threshold-execution/src/online/preprocessing/constants.rs
+++ b/core/threshold-execution/src/online/preprocessing/constants.rs
@@ -1,13 +1,4 @@
-// TODO: Make those configurable ?
-///Amount of triples generated in one batch by the orchestrator
-pub(crate) const BATCH_SIZE_TRIPLES: usize = 10000;
-///Amount of bits generated in one batch by the orchestrator
-pub(crate) const BATCH_SIZE_BITS: usize = 10000;
-///Number of batches of bits that can be queued per thread in the orchestrator.
-///A value of 2 enables double-buffering: a producer can prepare the next batch
-///while the consumer drains the current one, instead of stalling on a 1-slot
-///channel. Kept small to bound memory (each queued batch is BATCH_SIZE_* shares
-///per producer thread).
-pub(crate) const CHANNEL_BUFFER_SIZE: usize = 2;
-///Progress tracker will automatically report every TRACKER_LOG_PERCENTAGE percent
-pub const TRACKER_LOG_PERCENTAGE: usize = 5;
+//! The DKG preprocessing batch-size and parallel-chunk constants previously
+//! defined here now live in the crate-level [`crate::constants`] module so that
+//! all tuning knobs (batch sizes, channel depth, rayon minimum chunk sizes) sit
+//! in one place. Import them from `crate::constants` instead.

--- a/core/threshold-execution/src/online/preprocessing/mod.rs
+++ b/core/threshold-execution/src/online/preprocessing/mod.rs
@@ -409,7 +409,6 @@ where
     redis_factory::<EXTENSION_DEGREE>(key_prefix, redis_conf)
 }
 
-pub mod constants;
 pub mod dummy;
 pub mod memory;
 pub mod orchestration;

--- a/core/threshold-execution/src/online/preprocessing/mod.rs
+++ b/core/threshold-execution/src/online/preprocessing/mod.rs
@@ -89,7 +89,9 @@ mock! {
 
 pub trait BitPreprocessing<Z: Clone>: Send + Sync {
     fn append_bits(&mut self, bits: Vec<Share<Z>>);
+    /// Must return an error if there are no bits available
     fn next_bit(&mut self) -> anyhow::Result<Share<Z>>;
+    /// Must return an error if there are not enough bits available
     fn next_bit_vec(&mut self, amount: usize) -> anyhow::Result<Vec<Share<Z>>>;
     fn bits_len(&self) -> usize;
 }

--- a/core/threshold-execution/src/online/preprocessing/orchestration/dkg_orchestrator.rs
+++ b/core/threshold-execution/src/online/preprocessing/orchestration/dkg_orchestrator.rs
@@ -7,13 +7,11 @@ use super::{
     progress_tracker::ProgressTracker,
 };
 use crate::{
+    constants::{BATCH_SIZE_BITS, BATCH_SIZE_TRIPLES, CHANNEL_BUFFER_SIZE, TRACKER_LOG_PERCENTAGE},
     keyset_config::KeySetConfig,
     online::{
         preprocessing::{
             DKGPreprocessing, PreprocessorFactory,
-            constants::{
-                BATCH_SIZE_BITS, BATCH_SIZE_TRIPLES, CHANNEL_BUFFER_SIZE, TRACKER_LOG_PERCENTAGE,
-            },
             orchestration::producer_traits::ProducerFactory,
         },
         triple::Triple,
@@ -132,10 +130,10 @@ impl<const EXTENSION_DEGREE: usize> PreprocessingOrchestrator<ResiduePoly<Z64, E
         );
 
         let triple_progress_tracker =
-            ProgressTracker::new("TripleGen", num_triples, TRACKER_LOG_PERCENTAGE);
+            ProgressTracker::new("TripleGen", num_triples, *TRACKER_LOG_PERCENTAGE);
         let random_progress_tracker =
-            ProgressTracker::new("RandomGen", num_randomness, TRACKER_LOG_PERCENTAGE);
-        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, TRACKER_LOG_PERCENTAGE);
+            ProgressTracker::new("RandomGen", num_randomness, *TRACKER_LOG_PERCENTAGE);
+        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
 
         Ok(Self {
             params,
@@ -166,10 +164,10 @@ impl<const EXTENSION_DEGREE: usize> PreprocessingOrchestrator<ResiduePoly<Z64, E
             get_num_correlated_randomness_required(&params, keyset_config, percentage_offline);
 
         let triple_progress_tracker =
-            ProgressTracker::new("TripleGen", num_triples, TRACKER_LOG_PERCENTAGE);
+            ProgressTracker::new("TripleGen", num_triples, *TRACKER_LOG_PERCENTAGE);
         let random_progress_tracker =
-            ProgressTracker::new("RandomGen", num_randomness, TRACKER_LOG_PERCENTAGE);
-        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, TRACKER_LOG_PERCENTAGE);
+            ProgressTracker::new("RandomGen", num_randomness, *TRACKER_LOG_PERCENTAGE);
+        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
 
         Ok(Self {
             params,
@@ -209,10 +207,10 @@ impl<const EXTENSION_DEGREE: usize> PreprocessingOrchestrator<ResiduePoly<Z128, 
         );
 
         let triple_progress_tracker =
-            ProgressTracker::new("TripleGen", num_triples, TRACKER_LOG_PERCENTAGE);
+            ProgressTracker::new("TripleGen", num_triples, *TRACKER_LOG_PERCENTAGE);
         let random_progress_tracker =
-            ProgressTracker::new("RandomGen", num_randomness, TRACKER_LOG_PERCENTAGE);
-        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, TRACKER_LOG_PERCENTAGE);
+            ProgressTracker::new("RandomGen", num_randomness, *TRACKER_LOG_PERCENTAGE);
+        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
 
         Ok(Self {
             params,
@@ -245,10 +243,10 @@ impl<const EXTENSION_DEGREE: usize> PreprocessingOrchestrator<ResiduePoly<Z128, 
             get_num_correlated_randomness_required(&params, keyset_config, percentage_offline);
 
         let triple_progress_tracker =
-            ProgressTracker::new("TripleGen", num_triples, TRACKER_LOG_PERCENTAGE);
+            ProgressTracker::new("TripleGen", num_triples, *TRACKER_LOG_PERCENTAGE);
         let random_progress_tracker =
-            ProgressTracker::new("RandomGen", num_randomness, TRACKER_LOG_PERCENTAGE);
-        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, TRACKER_LOG_PERCENTAGE);
+            ProgressTracker::new("RandomGen", num_randomness, *TRACKER_LOG_PERCENTAGE);
+        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
 
         Ok(Self {
             params,
@@ -283,7 +281,7 @@ pub fn create_channels<R: Clone>(
     let mut triple_sender_channels = Vec::new();
     let mut triple_receiver_channels = Vec::new();
     for _ in 0..num_triple_sessions {
-        let (tx, rx) = channel::<Vec<Triple<R>>>(CHANNEL_BUFFER_SIZE);
+        let (tx, rx) = channel::<Vec<Triple<R>>>(*CHANNEL_BUFFER_SIZE);
         triple_sender_channels.push(tx);
         triple_receiver_channels.push(Mutex::new(rx));
     }
@@ -292,7 +290,7 @@ pub fn create_channels<R: Clone>(
     let mut random_sender_channels = Vec::new();
     let mut random_receiver_channels = Vec::new();
     for _ in 0..num_random_sessions {
-        let (tx, rx) = channel::<Vec<Share<R>>>(CHANNEL_BUFFER_SIZE);
+        let (tx, rx) = channel::<Vec<Share<R>>>(*CHANNEL_BUFFER_SIZE);
         random_sender_channels.push(tx);
         random_receiver_channels.push(Mutex::new(rx));
     }
@@ -300,7 +298,7 @@ pub fn create_channels<R: Clone>(
     let mut bit_sender_channels = Vec::new();
     let mut bit_receiver_channels = Vec::new();
     for _ in 0..num_bits_sessions {
-        let (tx, rx) = channel::<Vec<Share<R>>>(CHANNEL_BUFFER_SIZE);
+        let (tx, rx) = channel::<Vec<Share<R>>>(*CHANNEL_BUFFER_SIZE);
         bit_sender_channels.push(tx);
         bit_receiver_channels.push(Mutex::new(rx));
     }
@@ -391,7 +389,7 @@ where
 
         //Start the producers
         let triple_producer = P::TripleProducer::new(
-            BATCH_SIZE_TRIPLES,
+            *BATCH_SIZE_TRIPLES,
             num_triples,
             basic_sessions,
             triple_sender_channels,
@@ -400,7 +398,7 @@ where
         let mut triple_producer_handles = triple_producer.start_triple_production();
 
         let bit_producer = P::BitProducer::new(
-            BATCH_SIZE_BITS,
+            *BATCH_SIZE_BITS,
             num_bits,
             sessions,
             bit_sender_channels,

--- a/core/threshold-execution/src/online/preprocessing/orchestration/dkg_orchestrator.rs
+++ b/core/threshold-execution/src/online/preprocessing/orchestration/dkg_orchestrator.rs
@@ -11,8 +11,7 @@ use crate::{
     keyset_config::KeySetConfig,
     online::{
         preprocessing::{
-            DKGPreprocessing, PreprocessorFactory,
-            orchestration::producer_traits::ProducerFactory,
+            DKGPreprocessing, PreprocessorFactory, orchestration::producer_traits::ProducerFactory,
         },
         triple::Triple,
     },
@@ -133,7 +132,8 @@ impl<const EXTENSION_DEGREE: usize> PreprocessingOrchestrator<ResiduePoly<Z64, E
             ProgressTracker::new("TripleGen", num_triples, *TRACKER_LOG_PERCENTAGE);
         let random_progress_tracker =
             ProgressTracker::new("RandomGen", num_randomness, *TRACKER_LOG_PERCENTAGE);
-        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
+        let bit_progress_tracker =
+            ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
 
         Ok(Self {
             params,
@@ -167,7 +167,8 @@ impl<const EXTENSION_DEGREE: usize> PreprocessingOrchestrator<ResiduePoly<Z64, E
             ProgressTracker::new("TripleGen", num_triples, *TRACKER_LOG_PERCENTAGE);
         let random_progress_tracker =
             ProgressTracker::new("RandomGen", num_randomness, *TRACKER_LOG_PERCENTAGE);
-        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
+        let bit_progress_tracker =
+            ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
 
         Ok(Self {
             params,
@@ -210,7 +211,8 @@ impl<const EXTENSION_DEGREE: usize> PreprocessingOrchestrator<ResiduePoly<Z128, 
             ProgressTracker::new("TripleGen", num_triples, *TRACKER_LOG_PERCENTAGE);
         let random_progress_tracker =
             ProgressTracker::new("RandomGen", num_randomness, *TRACKER_LOG_PERCENTAGE);
-        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
+        let bit_progress_tracker =
+            ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
 
         Ok(Self {
             params,
@@ -246,7 +248,8 @@ impl<const EXTENSION_DEGREE: usize> PreprocessingOrchestrator<ResiduePoly<Z128, 
             ProgressTracker::new("TripleGen", num_triples, *TRACKER_LOG_PERCENTAGE);
         let random_progress_tracker =
             ProgressTracker::new("RandomGen", num_randomness, *TRACKER_LOG_PERCENTAGE);
-        let bit_progress_tracker = ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
+        let bit_progress_tracker =
+            ProgressTracker::new("BitGen", num_bits, *TRACKER_LOG_PERCENTAGE);
 
         Ok(Self {
             params,

--- a/core/threshold-execution/src/online/secret_distributions.rs
+++ b/core/threshold-execution/src/online/secret_distributions.rs
@@ -1,3 +1,4 @@
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tracing::instrument;
 
 use super::preprocessing::BitPreprocessing;
@@ -59,24 +60,27 @@ impl SecretDistributions for RealSecretDistributions {
         let bound = bound.0;
         let required_bits = n * (bound + 2);
 
-        let mut b = preproc.next_bit_vec(required_bits)?;
+        let b = preproc.next_bit_vec(required_bits)?;
 
-        let mut res = Vec::with_capacity(n);
+        // Each of the `n` samples consumes a disjoint window of `bound + 2` bits,
+        // so the samples can be assembled in parallel.
+        // Note: the ith window is taken from bits [i*(bound+2), (i+1)*(bound+2)), so the top bit of the window is at index (i+1)*(bound+2) - 1 = required_bits - 1 - i*(bound+2)
+        // windows are traversed in reverse to emulate popping bits (historical implementation)
+        let res = (0..n)
+            .into_par_iter()
+            .map(|e| {
+                let top = required_bits - 1 - e * (bound + 2);
+                //Start with next_random_bit() - 2^bound
+                let mut ei = b[top] - Z::from_u128(1 << bound);
 
-        //No need to compute indexes, simply pop the shared bits
-        for _ in 1..=n {
-            //Start with next_random_bit() - 2^bound
-            let first_bit = b.pop().expect("validated sufficient bits");
-            let mut ei = first_bit - Z::from_u128(1 << bound);
-
-            //for j in [1,bound+1], add next_random_bit() << (j-1)
-            //(could do j in [0,bound], but we keep it closer to NIST doc notation)
-            for j in 1..=bound + 1 {
-                let next_bit = b.pop().expect("validated sufficient bits");
-                ei += next_bit * (1 << (j - 1));
-            }
-            res.push(ei);
-        }
+                //for j in [1,bound+1], add next_random_bit() << (j-1)
+                //(could do j in [0,bound], but we keep it closer to NIST doc notation)
+                for j in 1..=bound + 1 {
+                    ei += b[top - j] * (1 << (j - 1));
+                }
+                ei
+            })
+            .collect();
 
         Ok(res)
     }

--- a/core/threshold-execution/src/online/secret_distributions.rs
+++ b/core/threshold-execution/src/online/secret_distributions.rs
@@ -69,7 +69,7 @@ impl SecretDistributions for RealSecretDistributions {
         let res = (0..n)
             .into_par_iter()
             // Per-sample work is tiny (~bound+2 ring ops); see the constant's doc.
-            .with_min_len(crate::constants::TUNIFORM_GEN_PAR_MIN_CHUNK)
+            .with_min_len(*crate::constants::TUNIFORM_GEN_PAR_MIN_CHUNK)
             .map(|e| {
                 let top = required_bits - 1 - e * (bound + 2);
                 //Start with next_random_bit() - 2^bound

--- a/core/threshold-execution/src/online/secret_distributions.rs
+++ b/core/threshold-execution/src/online/secret_distributions.rs
@@ -1,4 +1,4 @@
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use tracing::instrument;
 
 use super::preprocessing::BitPreprocessing;
@@ -68,6 +68,8 @@ impl SecretDistributions for RealSecretDistributions {
         // windows are traversed in reverse to emulate popping bits (historical implementation)
         let res = (0..n)
             .into_par_iter()
+            // Per-sample work is tiny (~bound+2 ring ops); see the constant's doc.
+            .with_min_len(crate::constants::TUNIFORM_GEN_PAR_MIN_CHUNK)
             .map(|e| {
                 let top = required_bits - 1 - e * (bound + 2);
                 //Start with next_random_bit() - 2^bound

--- a/core/threshold-execution/src/sharing/open.rs
+++ b/core/threshold-execution/src/sharing/open.rs
@@ -20,10 +20,12 @@ use crate::{
     },
 };
 use algebra::{
+    error_correction::ReconstructionHints,
     sharing::{
         shamir::{
             ShamirSharings, fill_indexed_shares, reconstruct_w_errors_async,
-            reconstruct_w_errors_sync,
+            reconstruct_w_errors_async_with_hints, reconstruct_w_errors_sync,
+            reconstruct_w_errors_sync_with_hints,
         },
         share::Share,
     },
@@ -266,6 +268,10 @@ impl RobustOpen for SecureRobustOpen {
                 NetworkMode::Sync => reconstruct_w_errors_sync,
                 NetworkMode::Async => reconstruct_w_errors_async,
             };
+            let reconstruct_fn_with_hints = match session.network().get_network_mode() {
+                NetworkMode::Sync => reconstruct_w_errors_sync_with_hints,
+                NetworkMode::Async => reconstruct_w_errors_async_with_hints,
+            };
 
             let num_parties = session.num_parties();
             let threshold = session.threshold();
@@ -278,6 +284,7 @@ impl RobustOpen for SecureRobustOpen {
                 degree,
                 jobs,
                 reconstruct_fn,
+                reconstruct_fn_with_hints,
             )
             .await?
         } else {
@@ -388,6 +395,10 @@ impl RobustOpen for SecureRobustOpen {
                 NetworkMode::Sync => reconstruct_w_errors_sync,
                 NetworkMode::Async => reconstruct_w_errors_async,
             };
+            let reconstruct_fn_with_hints = match session.network().get_network_mode() {
+                NetworkMode::Sync => reconstruct_w_errors_sync_with_hints,
+                NetworkMode::Async => reconstruct_w_errors_async_with_hints,
+            };
 
             // Use my own share if ever I am in both sets
             let sharings = if let Some(my_shares) = my_shares {
@@ -413,6 +424,7 @@ impl RobustOpen for SecureRobustOpen {
                 degree,
                 jobs,
                 reconstruct_fn,
+                reconstruct_fn_with_hints,
             )
             .await;
         }
@@ -428,6 +440,14 @@ type ReconsFunc<Z> = fn(
     num_bots: usize,
     sharing: &ShamirSharings<Z>,
 ) -> anyhow::Result<Option<Z>>;
+type ReconsFuncWithHints<Z> = fn(
+    num_parties: usize,
+    degree: usize,
+    threshold: usize,
+    num_bots: usize,
+    sharing: &ShamirSharings<Z>,
+    hints: &ReconstructionHints<Z>,
+) -> anyhow::Result<Option<Z>>;
 /// Helper function of robust reconstructions which collect the shares and tries to reconstruct
 ///
 /// Takes as input:
@@ -437,6 +457,7 @@ type ReconsFunc<Z> = fn(
 /// - degree as the degree of the secret sharing
 /// - max_num_errors as the max. number of errors we allow (this is session.threshold)
 /// - a set of jobs to receive the shares from the other parties
+#[expect(clippy::too_many_arguments)]
 async fn try_reconstruct_from_shares<Z: ErrorCorrect>(
     num_parties: usize,
     threshold: u8,
@@ -445,6 +466,7 @@ async fn try_reconstruct_from_shares<Z: ErrorCorrect>(
     degree: usize,
     mut jobs: JoinSet<Result<JobResultType<Role, Z>, Elapsed>>,
     reconstruct_fn: ReconsFunc<Z>,
+    reconstruct_fn_with_hints: ReconsFuncWithHints<Z>,
 ) -> anyhow::Result<Option<Vec<Z>>> {
     // OPTIMIZATION: Collect shares concurrently with batched reconstruction
     // Instead of processing one party at a time, collect multiple responses
@@ -458,27 +480,27 @@ async fn try_reconstruct_from_shares<Z: ErrorCorrect>(
     //Start awaiting on receive jobs to retrieve the shares
     while let Some(v) = jobs.join_next().await {
         let sharings = sharings.clone();
-        let joined_result = if let Ok(v) = v {
+        let opening_contribution = if let Ok(v) = v {
             v
         } else {
             tracing::warn!("(Share reconstruction) A receive job failed during reconstruction.");
             num_bots += 1;
             continue;
         };
-        match joined_result {
-            Ok((party_id, data)) => {
-                if let Ok(values) = data {
+        match opening_contribution {
+            Ok((contributor, partial_openings)) => {
+                if let Ok(partial_openings) = partial_openings {
                     fill_indexed_shares(
                         &mut sharings
                             .lock()
                             .map_err(|_| anyhow_error_and_log("Poisoned lock"))?,
-                        values,
-                        party_id,
+                        partial_openings,
+                        contributor,
                     );
                     collected_shares += 1;
-                } else if let Err(e) = data {
+                } else if let Err(e) = partial_openings {
                     tracing::warn!(
-                        "(Share reconstruction) Received malformed data from {party_id}:  {:?}",
+                        "(Share reconstruction) Received malformed data from {contributor}:  {:?}",
                         e
                     );
                     num_bots += 1;
@@ -505,20 +527,55 @@ async fn try_reconstruct_from_shares<Z: ErrorCorrect>(
 
             // Spawn a task on rayon.
             let res: Option<Vec<_>> = spawn_compute_bound(move || -> anyhow::Result<_> {
+                let locked_sharings = sharings
+                    .lock()
+                    .map_err(|_| anyhow_error_and_log("Poisoned lock"))?;
+
+                // Build reconstruction hints once from the current owner set.
+                // All sharings in the batch have the same owners (filled identically).
+                let hints = if let Some(first) = locked_sharings.first() {
+                    ReconstructionHints::new(first, degree).ok()
+                } else {
+                    None
+                };
+
                 //Note: here we keep waiting on new shares until we have all of the values opened.
                 // Here we want to use par_iter for opening the huge batches
                 // present in DKG, but we want to avoid using it for
                 // other tasks.
-                Ok(sharings
-                    .lock()
-                    .map_err(|_| anyhow_error_and_log("Poisoned lock"))?
-                    .par_iter()
-                    .with_min_len(2 * BATCH_SIZE_BITS)
-                    .map(|sharing| {
-                        reconstruct_fn(num_parties, degree, threshold as usize, num_bots, sharing)
+                let result: Option<Vec<_>> = if let Some(hints) = &hints {
+                    locked_sharings
+                        .par_iter()
+                        .with_min_len(2 * BATCH_SIZE_BITS)
+                        .map(|sharing| {
+                            reconstruct_fn_with_hints(
+                                num_parties,
+                                degree,
+                                threshold as usize,
+                                num_bots,
+                                sharing,
+                                hints,
+                            )
                             .unwrap_or_default()
-                    })
-                    .collect())
+                        })
+                        .collect()
+                } else {
+                    locked_sharings
+                        .par_iter()
+                        .with_min_len(2 * BATCH_SIZE_BITS)
+                        .map(|sharing| {
+                            reconstruct_fn(
+                                num_parties,
+                                degree,
+                                threshold as usize,
+                                num_bots,
+                                sharing,
+                            )
+                            .unwrap_or_default()
+                        })
+                        .collect()
+                };
+                Ok(result)
             })
             .await??;
 

--- a/core/threshold-execution/src/sharing/open.rs
+++ b/core/threshold-execution/src/sharing/open.rs
@@ -15,7 +15,7 @@ use crate::{
             generic_receive_from_all, generic_receive_from_all_senders_with_role_transform,
             send_to_all,
         },
-        online::preprocessing::constants::BATCH_SIZE_BITS,
+        constants::ROBUST_OPEN_RECONSTRUCTION_PAR_MIN_CHUNK,
         runtime::sessions::base_session::{BaseSessionHandles, GenericBaseSessionHandles},
     },
 };
@@ -546,7 +546,7 @@ async fn try_reconstruct_from_shares<Z: ErrorCorrect>(
                 let result: Option<Vec<_>> = if let Some(hints) = &hints {
                     locked_sharings
                         .par_iter()
-                        .with_min_len(2 * BATCH_SIZE_BITS)
+                        .with_min_len(*ROBUST_OPEN_RECONSTRUCTION_PAR_MIN_CHUNK)
                         .map(|sharing| {
                             reconstruct_fn_with_hints(
                                 num_parties,
@@ -562,7 +562,7 @@ async fn try_reconstruct_from_shares<Z: ErrorCorrect>(
                 } else {
                     locked_sharings
                         .par_iter()
-                        .with_min_len(2 * BATCH_SIZE_BITS)
+                        .with_min_len(*ROBUST_OPEN_RECONSTRUCTION_PAR_MIN_CHUNK)
                         .map(|sharing| {
                             reconstruct_fn(
                                 num_parties,

--- a/core/threshold-execution/src/sharing/open.rs
+++ b/core/threshold-execution/src/sharing/open.rs
@@ -24,8 +24,7 @@ use algebra::{
     sharing::{
         shamir::{
             ShamirSharings, fill_indexed_shares, reconstruct_w_errors_async,
-            reconstruct_w_errors_async_with_hints, reconstruct_w_errors_sync,
-            reconstruct_w_errors_sync_with_hints,
+            reconstruct_w_errors_sync,
         },
         share::Share,
     },
@@ -268,10 +267,6 @@ impl RobustOpen for SecureRobustOpen {
                 NetworkMode::Sync => reconstruct_w_errors_sync,
                 NetworkMode::Async => reconstruct_w_errors_async,
             };
-            let reconstruct_fn_with_hints = match session.network().get_network_mode() {
-                NetworkMode::Sync => reconstruct_w_errors_sync_with_hints,
-                NetworkMode::Async => reconstruct_w_errors_async_with_hints,
-            };
 
             let num_parties = session.num_parties();
             let threshold = session.threshold();
@@ -284,7 +279,6 @@ impl RobustOpen for SecureRobustOpen {
                 degree,
                 jobs,
                 reconstruct_fn,
-                reconstruct_fn_with_hints,
             )
             .await?
         } else {
@@ -395,10 +389,6 @@ impl RobustOpen for SecureRobustOpen {
                 NetworkMode::Sync => reconstruct_w_errors_sync,
                 NetworkMode::Async => reconstruct_w_errors_async,
             };
-            let reconstruct_fn_with_hints = match session.network().get_network_mode() {
-                NetworkMode::Sync => reconstruct_w_errors_sync_with_hints,
-                NetworkMode::Async => reconstruct_w_errors_async_with_hints,
-            };
 
             // Use my own share if ever I am in both sets
             let sharings = if let Some(my_shares) = my_shares {
@@ -424,7 +414,6 @@ impl RobustOpen for SecureRobustOpen {
                 degree,
                 jobs,
                 reconstruct_fn,
-                reconstruct_fn_with_hints,
             )
             .await;
         }
@@ -439,15 +428,9 @@ type ReconsFunc<Z> = fn(
     threshold: usize,
     num_bots: usize,
     sharing: &ShamirSharings<Z>,
-) -> anyhow::Result<Option<Z>>;
-type ReconsFuncWithHints<Z> = fn(
-    num_parties: usize,
-    degree: usize,
-    threshold: usize,
-    num_bots: usize,
-    sharing: &ShamirSharings<Z>,
     hints: &ReconstructionHints<Z>,
 ) -> anyhow::Result<Option<Z>>;
+
 /// Helper function of robust reconstructions which collect the shares and tries to reconstruct
 ///
 /// Takes as input:
@@ -457,7 +440,6 @@ type ReconsFuncWithHints<Z> = fn(
 /// - degree as the degree of the secret sharing
 /// - max_num_errors as the max. number of errors we allow (this is session.threshold)
 /// - a set of jobs to receive the shares from the other parties
-#[expect(clippy::too_many_arguments)]
 async fn try_reconstruct_from_shares<Z: ErrorCorrect>(
     num_parties: usize,
     threshold: u8,
@@ -466,7 +448,6 @@ async fn try_reconstruct_from_shares<Z: ErrorCorrect>(
     degree: usize,
     mut jobs: JoinSet<Result<JobResultType<Role, Z>, Elapsed>>,
     reconstruct_fn: ReconsFunc<Z>,
-    reconstruct_fn_with_hints: ReconsFuncWithHints<Z>,
 ) -> anyhow::Result<Option<Vec<Z>>> {
     // OPTIMIZATION: Collect shares concurrently with batched reconstruction
     // Instead of processing one party at a time, collect multiple responses
@@ -534,47 +515,31 @@ async fn try_reconstruct_from_shares<Z: ErrorCorrect>(
                 // Build reconstruction hints once from the current owner set.
                 // All sharings in the batch have the same owners (filled identically).
                 let hints = if let Some(first) = locked_sharings.first() {
-                    ReconstructionHints::new(first, degree).ok()
+                    ReconstructionHints::new(first, degree)?
                 } else {
-                    None
+                    // If there's not even a single sharing, we can return directly
+                    return Ok(Some(vec![]));
                 };
 
                 //Note: here we keep waiting on new shares until we have all of the values opened.
                 // Here we want to use par_iter for opening the huge batches
                 // present in DKG, but we want to avoid using it for
                 // other tasks.
-                let result: Option<Vec<_>> = if let Some(hints) = &hints {
-                    locked_sharings
-                        .par_iter()
-                        .with_min_len(*ROBUST_OPEN_RECONSTRUCTION_PAR_MIN_CHUNK)
-                        .map(|sharing| {
-                            reconstruct_fn_with_hints(
-                                num_parties,
-                                degree,
-                                threshold as usize,
-                                num_bots,
-                                sharing,
-                                hints,
-                            )
-                            .unwrap_or_default()
-                        })
-                        .collect()
-                } else {
-                    locked_sharings
-                        .par_iter()
-                        .with_min_len(*ROBUST_OPEN_RECONSTRUCTION_PAR_MIN_CHUNK)
-                        .map(|sharing| {
-                            reconstruct_fn(
-                                num_parties,
-                                degree,
-                                threshold as usize,
-                                num_bots,
-                                sharing,
-                            )
-                            .unwrap_or_default()
-                        })
-                        .collect()
-                };
+                let result: Option<Vec<_>> = locked_sharings
+                    .par_iter()
+                    .with_min_len(*ROBUST_OPEN_RECONSTRUCTION_PAR_MIN_CHUNK)
+                    .map(|sharing| {
+                        reconstruct_fn(
+                            num_parties,
+                            degree,
+                            threshold as usize,
+                            num_bots,
+                            sharing,
+                            &hints,
+                        )
+                        .unwrap_or_default()
+                    })
+                    .collect();
                 Ok(result)
             })
             .await??;

--- a/core/threshold-execution/src/small_execution/offline.rs
+++ b/core/threshold-execution/src/small_execution/offline.rs
@@ -305,7 +305,7 @@ where
                     .map(|(cur_role, cur_values)| Share::new(*cur_role, cur_values[i]))
                     .collect_vec();
                 ShamirSharings::create(shares)
-                    .err_reconstruct_with_hints(degree, max_errors, &hints)
+                    .error_reconstruct_with_hints(degree, max_errors, &hints)
                     .ok()
             })
             .collect::<Vec<_>>()
@@ -600,7 +600,7 @@ mod test {
                         .unwrap_or_else(|_| Share::new(*role, Z::ZERO)),
                 );
             }
-            let random = shares.err_reconstruct(params.threshold, num_malicious);
+            let random = shares.error_reconstruct(params.threshold, num_malicious);
             assert!(random.is_ok(), "Failed to reconstruct random: {random:?}");
             reconstructed_randoms.push(random.unwrap());
         }
@@ -636,9 +636,9 @@ mod test {
                 shares_z.add_share(z);
             }
             let (x, y, z) = (
-                shares_x.err_reconstruct(params.threshold, num_malicious),
-                shares_y.err_reconstruct(params.threshold, num_malicious),
-                shares_z.err_reconstruct(params.threshold, num_malicious),
+                shares_x.error_reconstruct(params.threshold, num_malicious),
+                shares_y.error_reconstruct(params.threshold, num_malicious),
+                shares_z.error_reconstruct(params.threshold, num_malicious),
             );
             assert!(
                 x.is_ok(),

--- a/core/threshold-execution/src/small_execution/offline.rs
+++ b/core/threshold-execution/src/small_execution/offline.rs
@@ -302,7 +302,7 @@ where
         (0..amount)
             .into_par_iter()
             // Each item is a full (heavy) Shamir reconstruction; see the constant's doc.
-            .with_min_len(crate::constants::D_VALUE_RECONSTRUCTION_PAR_MIN_CHUNK)
+            .with_min_len(*crate::constants::D_VALUE_RECONSTRUCTION_PAR_MIN_CHUNK)
             .map(|i| {
                 let shares = party_vectors
                     .iter()

--- a/core/threshold-execution/src/small_execution/offline.rs
+++ b/core/threshold-execution/src/small_execution/offline.rs
@@ -246,11 +246,6 @@ where
     // Validate each party's broadcast and keep the per-party value vectors.
     // Done sequentially because it mutates the session's corrupt set; this pass
     // is cheap (length/type checks only, no per-value work).
-    //
-    // We deliberately do NOT build a full transposed `amount`-long vector of
-    // share-vectors up front anymore (the previous `vec![Vec; amount]` +
-    // per-party push transpose). Instead we keep the per-party vectors and index
-    // into them inside the parallel reconstruction below.
     let mut party_vectors: Vec<(Role, Vec<Z>)> = Vec::with_capacity(session.num_parties());
     for (cur_role, cur_values) in d_recons {
         match cur_values {

--- a/core/threshold-execution/src/small_execution/offline.rs
+++ b/core/threshold-execution/src/small_execution/offline.rs
@@ -288,7 +288,7 @@ where
     let max_errors = (session.num_parties() - session.corrupt_roles().len() - (degree + 1)) / 2;
 
     let roles = party_vectors.iter().map(|(role, _)| *role).collect_vec();
-    let hints = ReconstructionHints::from_parties(&roles, degree);
+    let hints = ReconstructionHints::from_parties(&roles, degree)?;
 
     // Reconstruct the `amount` values in parallel: value `i` is reconstructed
     // from share `i` of every party, indexed directly out of the kept per-party
@@ -304,15 +304,9 @@ where
                     // Direct indexing is safe because we checked the length of the vector above
                     .map(|(cur_role, cur_values)| Share::new(*cur_role, cur_values[i]))
                     .collect_vec();
-                if let Ok(hints) = &hints {
-                    ShamirSharings::create(shares)
-                        .err_reconstruct_with_hints(degree, max_errors, hints)
-                        .ok()
-                } else {
-                    ShamirSharings::create(shares)
-                        .err_reconstruct(degree, max_errors)
-                        .ok()
-                }
+                ShamirSharings::create(shares)
+                    .err_reconstruct_with_hints(degree, max_errors, &hints)
+                    .ok()
             })
             .collect::<Vec<_>>()
     })

--- a/core/threshold-execution/src/small_execution/offline.rs
+++ b/core/threshold-execution/src/small_execution/offline.rs
@@ -288,7 +288,7 @@ where
     let max_errors = (session.num_parties() - session.corrupt_roles().len() - (degree + 1)) / 2;
 
     let roles = party_vectors.iter().map(|(role, _)| *role).collect_vec();
-    let hints = ReconstructionHints::from_parties(&roles, degree)?;
+    let hints = ReconstructionHints::from_parties(roles, degree)?;
 
     // Reconstruct the `amount` values in parallel: value `i` is reconstructed
     // from share `i` of every party, indexed directly out of the kept per-party

--- a/core/threshold-execution/src/small_execution/offline.rs
+++ b/core/threshold-execution/src/small_execution/offline.rs
@@ -1,5 +1,7 @@
+use algebra::error_correction::ReconstructionHints;
 use anyhow::Context;
 use itertools::Itertools;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::collections::HashMap;
 use tonic::async_trait;
 use tracing::instrument;
@@ -241,9 +243,15 @@ async fn reconstruct_d_values<Z, Ses: BaseSessionHandles>(
 where
     Z: ErrorCorrect,
 {
-    let mut collected_shares = vec![Vec::with_capacity(session.num_parties()); amount];
-    // Go through the Role/value map of a broadcast of vectors of values and turn them into a vector of vectors of indexed values.
-    // I.e. transpose the result and convert the role and value into indexed values
+    // Validate each party's broadcast and keep the per-party value vectors.
+    // Done sequentially because it mutates the session's corrupt set; this pass
+    // is cheap (length/type checks only, no per-value work).
+    //
+    // We deliberately do NOT build a full transposed `amount`-long vector of
+    // share-vectors up front anymore (the previous `vec![Vec; amount]` +
+    // per-party push transpose). Instead we keep the per-party vectors and index
+    // into them inside the parallel reconstruction below.
+    let mut party_vectors: Vec<(Role, Vec<Z>)> = Vec::with_capacity(session.num_parties());
     for (cur_role, cur_values) in d_recons {
         match cur_values {
             BroadcastValue::RingVector(cur_values) => {
@@ -256,10 +264,7 @@ where
                     session.add_corrupt(cur_role);
                     continue;
                 }
-                // No need for zip_eq as we just checked the length
-                for (cur_collect_share, cur_value) in collected_shares.iter_mut().zip(cur_values) {
-                    cur_collect_share.push(Share::new(cur_role, cur_value));
-                }
+                party_vectors.push((cur_role, cur_values));
             }
             _ => {
                 tracing::warn!(
@@ -287,14 +292,32 @@ where
     let degree = 2 * session.threshold() as usize;
     let max_errors = (session.num_parties() - session.corrupt_roles().len() - (degree + 1)) / 2;
 
+    let roles = party_vectors.iter().map(|(role, _)| *role).collect_vec();
+    let hints = ReconstructionHints::from_parties(&roles, degree);
+
+    // Reconstruct the `amount` values in parallel: value `i` is reconstructed
+    // from share `i` of every party, indexed directly out of the kept per-party
+    // vectors.
     spawn_compute_bound(move || {
-        collected_shares
-            .into_iter()
-            .map(|cur_collection| {
-                let sharing = ShamirSharings::create(cur_collection);
-                sharing.err_reconstruct(degree, max_errors).ok()
+        (0..amount)
+            .into_par_iter()
+            .map(|i| {
+                let shares = party_vectors
+                    .iter()
+                    // Direct indexing is safe because we checked the length of the vector above
+                    .map(|(cur_role, cur_values)| Share::new(*cur_role, cur_values[i]))
+                    .collect_vec();
+                if let Ok(hints) = &hints {
+                    ShamirSharings::create(shares)
+                        .err_reconstruct_with_hints(degree, max_errors, hints)
+                        .ok()
+                } else {
+                    ShamirSharings::create(shares)
+                        .err_reconstruct(degree, max_errors)
+                        .ok()
+                }
             })
-            .collect_vec()
+            .collect::<Vec<_>>()
     })
     .await
 }

--- a/core/threshold-execution/src/small_execution/offline.rs
+++ b/core/threshold-execution/src/small_execution/offline.rs
@@ -1,7 +1,7 @@
 use algebra::error_correction::ReconstructionHints;
 use anyhow::Context;
 use itertools::Itertools;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use std::collections::HashMap;
 use tonic::async_trait;
 use tracing::instrument;
@@ -301,6 +301,8 @@ where
     spawn_compute_bound(move || {
         (0..amount)
             .into_par_iter()
+            // Each item is a full (heavy) Shamir reconstruction; see the constant's doc.
+            .with_min_len(crate::constants::D_VALUE_RECONSTRUCTION_PAR_MIN_CHUNK)
             .map(|i| {
                 let shares = party_vectors
                     .iter()

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -25,6 +25,7 @@ use algebra::{
 use anyhow::Context;
 use error_utils::{anyhow_error_and_log, log_error_wrapper};
 use itertools::Itertools;
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -627,8 +628,12 @@ where
         let prss_setup = self.prss_setup.clone();
         let mask_ctr = self.counters.mask_ctr;
 
+        // Each element is computed from an independent counter, so the batch is
+        // assembled in parallel. Element `idx` uses `ctr = mask_ctr + idx` (and
+        // `ctr + 1`).
         let res = spawn_compute_bound(move || {
-        (mask_ctr..mask_ctr + (amount as u128)).map(|ctr| {
+        (0..amount).into_par_iter().with_min_len(crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
+        let ctr = mask_ctr + idx as u128;
         let mut res = Z::ZERO;
         for (i, set) in prss_setup.sets.iter().enumerate() {
             if set.parties.contains(&party_role) {
@@ -651,7 +656,7 @@ where
                 return Err(anyhow_error_and_log(format!("Called prss.mask_next() with party role {party_role} that is not in a precomputed set of parties!")));
             }
         }
-            Ok(res)}).try_collect()
+            Ok(res)}).collect::<anyhow::Result<Vec<_>>>()
     }).instrument(tracing::Span::current()).await??;
 
         // increase counter by two for each element generated, since we have two phi calls above
@@ -671,8 +676,11 @@ where
         let prss_setup = self.prss_setup.clone();
         let prss_ctr = self.counters.prss_ctr;
 
+        // Independent per-counter elements, assembled in parallel. Element `idx`
+        // uses `ctr = prss_ctr + idx`.
         let res = spawn_compute_bound(move ||{
-            (prss_ctr..prss_ctr + (amount as u128)).map(|ctr| {
+            (0..amount).into_par_iter().with_min_len(crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
+        let ctr = prss_ctr + idx as u128;
         let mut res = Z::ZERO;
         for (i, set) in prss_setup.sets.iter().enumerate() {
             if set.parties.contains(&party_role) {
@@ -692,7 +700,7 @@ where
                 return Err(anyhow_error_and_log(format!("Called prss.next() with party role {party_role} that is not in a precomputed set of parties!")));
             }
         }
-        Ok(res)}).try_collect()
+        Ok(res)}).collect::<anyhow::Result<Vec<_>>>()
     }).instrument(tracing::Span::current()).await??;
 
         self.counters.prss_ctr += amount as u128;
@@ -718,8 +726,11 @@ where
         let prss_setup = self.prss_setup.clone();
         let przs_ctr = self.counters.przs_ctr;
 
+        // Independent per-counter elements, assembled in parallel. Element `idx`
+        // uses `ctr = przs_ctr + idx`.
         let res = spawn_compute_bound(move ||{
-            (przs_ctr..przs_ctr + (amount as u128)).map(|ctr| {
+            (0..amount).into_par_iter().with_min_len(crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
+        let ctr = przs_ctr + idx as u128;
         let mut res = Z::ZERO;
         for (i, set) in prss_setup.sets.iter().enumerate() {
             if set.parties.contains(&party_role) {
@@ -741,7 +752,7 @@ where
                 return Err(anyhow_error_and_log(format!("Called przs.next() with party role {party_role} that is not in a precomputed set of parties!")));
             }
         }
-        Ok(res)}).try_collect()
+        Ok(res)}).collect::<anyhow::Result<Vec<_>>>()
 }).instrument(tracing::Span::current()).await??;
 
         self.counters.przs_ctr += amount as u128;

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -2499,7 +2499,7 @@ mod tests {
             .map(|idx| {
                 let reconstruct =
                     ShamirSharings::create(results.iter().map(|shares| shares[idx]).collect())
-                        .err_reconstruct(degree, max_error);
+                        .error_reconstruct(degree, max_error);
                 assert!(
                     reconstruct.is_ok(),
                     "Failed to reconstruct at idx {idx}: {reconstruct:?}"

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -632,7 +632,7 @@ where
         // assembled in parallel. Element `idx` uses `ctr = mask_ctr + idx` (and
         // `ctr + 1`).
         let res = spawn_compute_bound(move || {
-        (0..amount).into_par_iter().with_min_len(crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
+        (0..amount).into_par_iter().with_min_len(*crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
         let ctr = mask_ctr + idx as u128;
         let mut res = Z::ZERO;
         for (i, set) in prss_setup.sets.iter().enumerate() {
@@ -679,7 +679,7 @@ where
         // Independent per-counter elements, assembled in parallel. Element `idx`
         // uses `ctr = prss_ctr + idx`.
         let res = spawn_compute_bound(move ||{
-            (0..amount).into_par_iter().with_min_len(crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
+            (0..amount).into_par_iter().with_min_len(*crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
         let ctr = prss_ctr + idx as u128;
         let mut res = Z::ZERO;
         for (i, set) in prss_setup.sets.iter().enumerate() {
@@ -729,7 +729,7 @@ where
         // Independent per-counter elements, assembled in parallel. Element `idx`
         // uses `ctr = przs_ctr + idx`.
         let res = spawn_compute_bound(move ||{
-            (0..amount).into_par_iter().with_min_len(crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
+            (0..amount).into_par_iter().with_min_len(*crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
         let ctr = przs_ctr + idx as u128;
         let mut res = Z::ZERO;
         for (i, set) in prss_setup.sets.iter().enumerate() {


### PR DESCRIPTION
## Description of changes
<!-- Please explain the changes you made -->
Main logic change is that when we reconstruct a batch of shares (which we know are from the same set of parties) we pre-compute once a `hint` struct which contains everything that's redundant for all reconstructions:

```rust
pub struct ReconstructionHints<Z: ErrorCorrect> {
    /// The sorted set of party roles that contributed shares.
    pub parties: Vec<Role>,
    /// The degree of the sharing polynomial (threshold or 2×threshold).
    pub degree: usize,
    /// Ring-level embedded evaluation points: `Z::embed_role_to_exceptional_sequence(party_i)`.
    pub embedded_points: Vec<Z>,
    /// `exceptional_powers[i][j]` = `embedded_points[i]^j` for `j` in `0..=degree`.
    ///
    /// Used in the Hensel-lift loop of `shamir_error_correct`.
    pub exceptional_powers: Vec<Vec<Z>>,
    /// Field-level hints for Lagrange interpolation / Gao decoding.
    pub field_hints: FieldHints<Z::ReconstructionField>,
}

pub struct FieldHints<F: Field> {
    /// Field-level embedded evaluation points: `F::embed_role_to_exceptional_sequence(party_i)`.
    pub embedded_points: Vec<F>,
    /// Lagrange basis polynomials `L_i(X)` for the embedded points.
    pub lagrange_polys: Vec<Poly<F>>,
    /// Vanishing polynomial `∏(X - x_i)`.
    pub vanishing_poly: Poly<F>,
}
```

In addition the PR also adds parallelization in a bunch of places, where the min batch size until parallelization kicks in can now be configured by env variable see `core/threshold-execution/src/constants.rs`.

## Observed performance increase

Ran DKG offline on 13P each running c7a.16xl all in same region.
10% of the offline phase in 2460s, so that's an expected total time of ~7H.
If I trust this thread:
https://zama-ai.slack.com/archives/C06D8AVHL0N/p1758007336363079
that's a nice improvement as even though we now require 850M bits instead of 790M, we have an expected ~7H instead of ~13H.


## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new pub item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
