### PR TITLE
Move `safe_serialize_hash_element_versioned` to `threshold-hashing` and rename to `hash_versioned`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7676,6 +7676,8 @@ dependencies = [
  "bc2wrap",
  "serde",
  "sha3",
+ "tfhe-safe-serialize",
+ "tfhe-versionable",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,7 @@ test-context = "=0.4.1"  # Test context utilities - MEDIUM RISK: Individual main
 # NOTE: when changing the tfhe dependency, consider also updating the pinned version of dylint lints from tfhe (see dylint.toml)
 tfhe = "=1.6.2"  # Fully Homomorphic Encryption library - LOW RISK: Zama
 tfhe-csprng = "=0.9.1"  # Cryptographically secure PRNG for TFHE - LOW RISK: Zama
+tfhe-safe-serialize = "0.1.1" # TFHE safe serialization - LOW RISK: Zama
 tfhe-versionable = "=0.8.0"  # TFHE versioning support - LOW RISK: Zama
 tfhe-zk-pok = "=0.8.2"  # Zero-knowledge proofs for TFHE - LOW RISK: Zama
 thiserror = "=2.0.12"  # Error derive macro - MEDIUM RISK: Reputable individual maintainer (dtolnay), 545M downloads

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,7 @@ test-context = "=0.4.1"  # Test context utilities - MEDIUM RISK: Individual main
 # NOTE: when changing the tfhe dependency, consider also updating the pinned version of dylint lints from tfhe (see dylint.toml)
 tfhe = "=1.6.2"  # Fully Homomorphic Encryption library - LOW RISK: Zama
 tfhe-csprng = "=0.9.1"  # Cryptographically secure PRNG for TFHE - LOW RISK: Zama
-tfhe-safe-serialize = "0.1.1" # TFHE safe serialization - LOW RISK: Zama
+tfhe-safe-serialize = "=0.1.1" # TFHE safe serialization - LOW RISK: Zama
 tfhe-versionable = "=0.8.0"  # TFHE versioning support - LOW RISK: Zama
 tfhe-zk-pok = "=0.8.2"  # Zero-knowledge proofs for TFHE - LOW RISK: Zama
 thiserror = "=2.0.12"  # Error derive macro - MEDIUM RISK: Reputable individual maintainer (dtolnay), 545M downloads

--- a/core-client/src/crsgen.rs
+++ b/core-client/src/crsgen.rs
@@ -1,7 +1,9 @@
 use crate::s3_operations::fetch_public_elements;
 use crate::{CmdConfig, CoreClientConfig, CoreConf, SLEEP_TIME_BETWEEN_REQUESTS_MS, dummy_domain};
+
 use aes_prng::AesRng;
 use alloy_sol_types::Eip712Domain;
+use hashing::hash_versioned;
 use kms_grpc::kms::v1::{CrsGenResult, FheParameter};
 use kms_grpc::kms_service::v1::core_service_endpoint_client::CoreServiceEndpointClient;
 use kms_grpc::rpc_types::{PubDataType, protobuf_to_alloy_domain};
@@ -9,7 +11,7 @@ use kms_grpc::solidity_types::CrsgenVerification;
 use kms_grpc::{ContextId, EpochId, RequestId};
 use kms_lib::client::client_wasm::Client;
 use kms_lib::cryptography::signatures::recover_address_from_ext_signature;
-use kms_lib::engine::base::{DSEP_PUBDATA_CRS, safe_serialize_hash_element_versioned};
+use kms_lib::engine::base::DSEP_PUBDATA_CRS;
 use kms_lib::util::key_setup::test_tools::load_material_from_pub_storage;
 use std::collections::HashMap;
 use std::path::Path;
@@ -312,7 +314,7 @@ fn check_crsgen_ext_signature(
     extra_data: Vec<u8>,
     kms_addrs: &[alloy_primitives::Address],
 ) -> anyhow::Result<()> {
-    let crs_digest = safe_serialize_hash_element_versioned(&DSEP_PUBDATA_CRS, crs)?;
+    let crs_digest = hash_versioned(&DSEP_PUBDATA_CRS, crs)?;
 
     tracing::info!(
         "Checking external signature on CRS gen result. crs_id={},digest={}",
@@ -475,8 +477,8 @@ mod tests {
         );
 
         let max_num_bits = max_num_bits_from_crs(&crs);
-        let crs_digest = safe_serialize_hash_element_versioned(&DSEP_PUBDATA_CRS, &crs)
-            .expect("serialization should succeed");
+        let crs_digest =
+            hash_versioned(&DSEP_PUBDATA_CRS, &crs).expect("serialization should succeed");
         let crs_sol_struct =
             CrsgenVerification::new(crs_id, max_num_bits, crs_digest.clone(), vec![]);
         let crs_sol_struct_extra_data =

--- a/core-client/src/keygen.rs
+++ b/core-client/src/keygen.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use aes_prng::AesRng;
 use alloy_sol_types::Eip712Domain;
+use hashing::hash_versioned;
 use kms_grpc::identifiers::EpochId;
 use kms_grpc::kms::v1::{FheParameter, KeyGenPreprocResult, KeyGenResult};
 use kms_grpc::kms_service::v1::core_service_endpoint_client::CoreServiceEndpointClient;
@@ -13,7 +14,7 @@ use kms_grpc::solidity_types::KeygenVerification;
 use kms_grpc::{ContextId, RequestId};
 use kms_lib::client::client_wasm::Client;
 use kms_lib::cryptography::signatures::recover_address_from_ext_signature;
-use kms_lib::engine::base::{DSEP_PUBDATA_KEY, safe_serialize_hash_element_versioned};
+use kms_lib::engine::base::DSEP_PUBDATA_KEY;
 use kms_lib::util::key_setup::test_tools::{
     load_material_from_pub_storage, load_pk_from_pub_storage,
 };
@@ -520,8 +521,8 @@ pub(crate) fn check_uncompressed_keyset_ext_signature(
     extra_data: Vec<u8>,
     kms_addrs: &[alloy_primitives::Address],
 ) -> anyhow::Result<()> {
-    let server_key_digest = safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, server_key)?;
-    let public_key_digest = safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, public_key)?;
+    let server_key_digest = hash_versioned(&DSEP_PUBDATA_KEY, server_key)?;
+    let public_key_digest = hash_versioned(&DSEP_PUBDATA_KEY, public_key)?;
 
     tracing::info!(
         "Checking external signature for standard keyset: key_id={},preproc_id={},server_key_digest={},public_key_digest={}",
@@ -562,9 +563,8 @@ pub(crate) fn check_compressed_keyset_ext_signature(
     extra_data: Vec<u8>,
     kms_addrs: &[alloy_primitives::Address],
 ) -> anyhow::Result<()> {
-    let keyset_digest =
-        safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, compressed_keyset)?;
-    let public_key_digest = safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, public_key)?;
+    let keyset_digest = hash_versioned(&DSEP_PUBDATA_KEY, compressed_keyset)?;
+    let public_key_digest = hash_versioned(&DSEP_PUBDATA_KEY, public_key)?;
 
     tracing::info!(
         "Checking external signature for compressed keyset: key_id={},preproc_id={},xof_keyset_digest={},public_key_digest={}",
@@ -901,9 +901,8 @@ mod tests {
 
         // === compressed keyset signatures ===
         let compressed_keyset_digest =
-            safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &compressed_keyset).unwrap();
-        let public_key_digest =
-            safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &compact_public_key).unwrap();
+            hash_versioned(&DSEP_PUBDATA_KEY, &compressed_keyset).unwrap();
+        let public_key_digest = hash_versioned(&DSEP_PUBDATA_KEY, &compact_public_key).unwrap();
         let compressed_sol_struct = KeygenVerification::new_compressed(
             prep_id,
             key_id,

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -40,9 +40,9 @@ use tfhe::safe_serialization::safe_serialize;
 
 // Additional imports for reshare test (only needed with threshold_tests feature)
 #[cfg(feature = "threshold_tests")]
-use kms_lib::engine::base::{
-    DSEP_PUBDATA_CRS, DSEP_PUBDATA_KEY, safe_serialize_hash_element_versioned,
-};
+use hashing::hash_versioned;
+#[cfg(feature = "threshold_tests")]
+use kms_lib::engine::base::{DSEP_PUBDATA_CRS, DSEP_PUBDATA_KEY};
 #[cfg(feature = "threshold_tests")]
 use kms_lib::util::key_setup::test_tools::load_material_from_pub_storage;
 
@@ -3102,10 +3102,8 @@ async fn test_threshold_reshare() -> Result<()> {
     )
     .await;
 
-    let compressed_keyset_digest = hex::encode(safe_serialize_hash_element_versioned(
-        &DSEP_PUBDATA_KEY,
-        &compressed_keyset,
-    )?);
+    let compressed_keyset_digest =
+        hex::encode(hash_versioned(&DSEP_PUBDATA_KEY, &compressed_keyset)?);
 
     let _ids =
         fetch_public_elements(&crs_id, &[PubDataType::CRS], &cc_conf, test_path, false).await?;
@@ -3119,10 +3117,7 @@ async fn test_threshold_reshare() -> Result<()> {
     )
     .await;
 
-    let crs_digest = hex::encode(safe_serialize_hash_element_versioned(
-        &DSEP_PUBDATA_CRS,
-        &crs,
-    )?);
+    let crs_digest = hex::encode(hash_versioned(&DSEP_PUBDATA_CRS, &crs)?);
 
     // Step 8: Execute resharing (must use a NEW epoch ID, different from the one created in Step 3)
     let new_epoch_id = derive_request_id("EPOCH_RESHARE_NEW")?.into();

--- a/core/service/src/backup/operator.rs
+++ b/core/service/src/backup/operator.rs
@@ -16,7 +16,6 @@ use crate::{
         Signcrypt, UnifiedSigncryption, UnifiedSigncryptionKey, UnifiedUnsigncryptionKey,
         Unsigncrypt,
     },
-    engine::base::safe_serialize_hash_element_versioned,
 };
 use crate::{
     backup::custodian::DSEP_BACKUP_CUSTODIAN,
@@ -26,7 +25,7 @@ use algebra::{
     galois_rings::degree_4::ResiduePolyF4Z64,
     sharing::{shamir::ShamirSharings, share::Share},
 };
-use hashing::DomainSep;
+use hashing::{DomainSep, hash_versioned};
 use kms_grpc::{
     ContextId, RequestId,
     kms::v1::{OperatorBackupOutput, RecoveryRequest},
@@ -587,9 +586,8 @@ impl Operator {
             // we simply use the digest as the commitment
             // since the share should have enough entropy
             // is simply a sha3 hash with some metadata of the share
-            let msg_digest =
-                safe_serialize_hash_element_versioned(&DSEP_BACKUP_COMMITMENT, &backup_material)
-                    .map_err(|e| BackupError::OperatorError(e.to_string()))?;
+            let msg_digest = hash_versioned(&DSEP_BACKUP_COMMITMENT, &backup_material)
+                .map_err(|e| BackupError::OperatorError(e.to_string()))?;
 
             // 5. The ciphertext is stored by `Pij`, or stored on a non-malleable storage, e.g. a blockchain or a secure bank vault.
             ct_shares.insert(role_j, InnerOperatorBackupOutput { signcryption });
@@ -693,14 +691,13 @@ impl Operator {
             return Err(e);
         }
         let actual_commitment =
-            safe_serialize_hash_element_versioned(&DSEP_BACKUP_COMMITMENT, &backup_material)
-                .map_err(|e| {
-                    tracing::warn!(
-                        "Could not hash BackupMaterial for commitment check (role {}): {e}",
-                        output.custodian_role
-                    );
-                    RecoverySkipReason::ParseError
-                })?;
+            hash_versioned(&DSEP_BACKUP_COMMITMENT, &backup_material).map_err(|e| {
+                tracing::warn!(
+                    "Could not hash BackupMaterial for commitment check (role {}): {e}",
+                    output.custodian_role
+                );
+                RecoverySkipReason::ParseError
+            })?;
         let expected_commitment = recovery_material.get(&output.custodian_role).map_err(|_| {
             tracing::warn!(
                 "No stored commitment for custodian role {}",

--- a/core/service/src/client/crs_gen.rs
+++ b/core/service/src/client/crs_gen.rs
@@ -3,13 +3,14 @@ use std::collections::HashMap;
 use crate::client::client_wasm::Client;
 use crate::consts::{DEFAULT_EPOCH_ID, DEFAULT_MPC_CONTEXT};
 use crate::engine::base::DSEP_PUBDATA_CRS;
-use crate::engine::base::safe_serialize_hash_element_versioned;
 use crate::engine::utils::make_extra_data;
 use crate::engine::validation::RequestIdParsingErr;
 use crate::engine::validation::parse_optional_grpc_request_id;
 use crate::vault::storage::StorageReader;
 use crate::{anyhow_error_and_log, some_or_err};
+
 use alloy_sol_types::Eip712Domain;
+use hashing::hash_versioned;
 use kms_grpc::ContextId;
 use kms_grpc::EpochId;
 use kms_grpc::RequestId;
@@ -107,7 +108,7 @@ impl Client {
             }
 
             // check the digest
-            let actual_digest = safe_serialize_hash_element_versioned(&DSEP_PUBDATA_CRS, &pp)?;
+            let actual_digest = hash_versioned(&DSEP_PUBDATA_CRS, &pp)?;
             if result.crs_digest != actual_digest {
                 tracing::warn!(
                     "crs_handle {} does not match the computed digest {}; discarding the CRS",
@@ -204,7 +205,7 @@ impl Client {
         .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
         let pp = self.get_crs(&request_id, storage).await?;
-        let actual_digest = safe_serialize_hash_element_versioned(&DSEP_PUBDATA_CRS, &pp)?;
+        let actual_digest = hash_versioned(&DSEP_PUBDATA_CRS, &pp)?;
         if actual_digest != crs_gen_result.crs_digest {
             tracing::warn!(
                 "Computed crs handle {} of retrieved crs does not match expected crs handle {}",
@@ -341,7 +342,7 @@ pub(crate) mod tests {
         let crs = CompactPkeCrs::from_config(config, 2048).unwrap();
 
         // Create a CrsGenResult with an invalid signature
-        let crs_digest = safe_serialize_hash_element_versioned(&DSEP_PUBDATA_CRS, &crs).unwrap();
+        let crs_digest = hash_versioned(&DSEP_PUBDATA_CRS, &crs).unwrap();
         let result = CrsGenResult {
             request_id: Some(request_id.into()),
             crs_digest: crs_digest.clone(),

--- a/core/service/src/client/key_gen.rs
+++ b/core/service/src/client/key_gen.rs
@@ -3,15 +3,14 @@ use std::io::Cursor;
 use crate::client::client_wasm::Client;
 use crate::consts::{DEFAULT_EPOCH_ID, DEFAULT_MPC_CONTEXT};
 use crate::engine::base::DSEP_PUBDATA_KEY;
-use crate::engine::base::safe_serialize_hash_element_versioned;
 use crate::engine::utils::make_extra_data;
 use crate::engine::validation::RequestIdParsingErr;
 use crate::engine::validation::parse_optional_grpc_request_id;
 use crate::vault::storage::StorageReader;
 use crate::{anyhow_error_and_log, some_or_err};
+
 use alloy_sol_types::Eip712Domain;
-use hashing::SAFE_SER_SIZE_LIMIT;
-use hashing::hash_element;
+use hashing::{SAFE_SER_SIZE_LIMIT, hash_element, hash_versioned};
 use kms_grpc::ContextId;
 use kms_grpc::RequestId;
 use kms_grpc::identifiers::EpochId;
@@ -395,7 +394,7 @@ impl Client {
         .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
         let key: S = self.get_key(&request_id, key_type, storage).await?;
-        let actual_digest = safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &key)?;
+        let actual_digest = hash_versioned(&DSEP_PUBDATA_KEY, &key)?;
 
         if actual_digest != *key_digest.digest {
             return Err(anyhow::anyhow!(

--- a/core/service/src/client/tests/centralized/crs_gen_tests.rs
+++ b/core/service/src/client/tests/centralized/crs_gen_tests.rs
@@ -1,5 +1,4 @@
 use crate::client::client_wasm::Client;
-use crate::engine::base::safe_serialize_hash_element_versioned;
 use crate::testing::setup::CentralizedTestEnv;
 use crate::vault::storage::{StorageType, file::FileStorage};
 use crate::{
@@ -10,7 +9,9 @@ use crate::{
     util::rate_limiter::RateLimiterConfig,
     vault::storage::StorageReader,
 };
+
 use anyhow::Result;
+use hashing::hash_versioned;
 use kms_grpc::kms_service::v1::core_service_endpoint_client::CoreServiceEndpointClient;
 use kms_grpc::solidity_types::CrsgenVerification;
 use kms_grpc::{
@@ -123,8 +124,7 @@ async fn crs_gen_centralized_manual(
         .await
         .unwrap();
 
-    let actual_digest =
-        safe_serialize_hash_element_versioned(&DSEP_PUBDATA_CRS, &crs_unversioned).unwrap();
+    let actual_digest = hash_versioned(&DSEP_PUBDATA_CRS, &crs_unversioned).unwrap();
     assert_eq!(actual_digest, resp.crs_digest);
 
     let max_num_bits = max_num_bits_from_crs(&crs_unversioned);

--- a/core/service/src/client/tests/centralized/key_gen_tests.rs
+++ b/core/service/src/client/tests/centralized/key_gen_tests.rs
@@ -4,11 +4,14 @@ use crate::client::tests::common::keygen_config;
 use crate::consts::DEFAULT_EPOCH_ID;
 use crate::cryptography::internal_crypto_types::WrappedDKGParams;
 use crate::dummy_domain;
+use crate::engine::base::DSEP_PUBDATA_KEY;
 use crate::engine::base::derive_request_id;
 use crate::util::rate_limiter::RateLimiterConfig;
 use crate::vault::storage::StorageReaderExt;
 use crate::vault::storage::{StorageType, file::FileStorage};
+
 use alloy_dyn_abi::Eip712Domain;
+use hashing::hash_versioned;
 use kms_grpc::identifiers::EpochId;
 use kms_grpc::kms::v1::{Empty, FheParameter, KeySetAddedInfo, KeySetConfig, KeySetType};
 use kms_grpc::kms_service::v1::core_service_endpoint_client::CoreServiceEndpointClient;
@@ -18,9 +21,8 @@ use kms_grpc::{ContextId, RequestId};
 use std::path::Path;
 use std::str::FromStr;
 use tfhe::prelude::Tagged;
-use tonic::transport::Channel;
-
 use threshold_execution::tfhe_internals::test_feature::run_decompression_test;
+use tonic::transport::Channel;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_key_gen_centralized() -> anyhow::Result<()> {
@@ -329,16 +331,8 @@ pub async fn run_key_gen_centralized(
             // from the compressed keyset (migration flow would differ, but this test path is
             // always a fresh keygen). CompactPublicKey does not implement PartialEq, so we
             // compare via domain-separated digests.
-            let stored_digest = crate::engine::base::safe_serialize_hash_element_versioned(
-                &crate::engine::base::DSEP_PUBDATA_KEY,
-                &stored_public_key,
-            )
-            .unwrap();
-            let derived_digest = crate::engine::base::safe_serialize_hash_element_versioned(
-                &crate::engine::base::DSEP_PUBDATA_KEY,
-                &derived_public_key,
-            )
-            .unwrap();
+            let stored_digest = hash_versioned(&DSEP_PUBDATA_KEY, &stored_public_key).unwrap();
+            let derived_digest = hash_versioned(&DSEP_PUBDATA_KEY, &derived_public_key).unwrap();
             assert_eq!(stored_digest, derived_digest);
             (server_key, stored_public_key)
         } else {

--- a/core/service/src/client/tests/threshold/custodian_backup_tests.rs
+++ b/core/service/src/client/tests/threshold/custodian_backup_tests.rs
@@ -19,10 +19,7 @@ use crate::cryptography::internal_crypto_types::WrappedDKGParams;
 use crate::cryptography::signatures::PrivateSigKey;
 use crate::cryptography::signatures::PublicSigKey;
 use crate::engine::base::derive_request_id;
-use crate::engine::base::{
-    CrsGenMetadata, DSEP_PUBDATA_KEY, INSECURE_PREPROCESSING_ID,
-    safe_serialize_hash_element_versioned,
-};
+use crate::engine::base::{CrsGenMetadata, DSEP_PUBDATA_KEY, INSECURE_PREPROCESSING_ID};
 use crate::engine::context::ContextInfo;
 use crate::testing::setup::ThresholdTestEnv;
 use crate::util::key_setup::test_tools::EncryptionConfig;
@@ -38,8 +35,10 @@ use crate::vault::storage::file::FileStorage;
 use crate::vault::storage::read_context_at_id;
 use crate::vault::storage::read_versioned_at_request_and_epoch_id;
 use crate::vault::storage::read_versioned_at_request_id;
+
 use aes_prng::AesRng;
 use alloy_primitives::Address;
+use hashing::hash_versioned;
 use kms_grpc::identifiers::EpochId;
 use kms_grpc::kms::v1::{
     CrsInfo, CustodianRecoveryInitRequest, CustodianRecoveryOutput, CustodianRecoveryRequest,
@@ -914,10 +913,8 @@ async fn test_backup_after_reshare_threshold() {
 
     // Compute key digests needed for the reshare request
     let (_, public_key, server_key) = keyset.get_uncompressed();
-    let server_key_digest =
-        safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &server_key).unwrap();
-    let public_key_digest =
-        safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &public_key).unwrap();
+    let server_key_digest = hash_versioned(&DSEP_PUBDATA_KEY, &server_key).unwrap();
+    let public_key_digest = hash_versioned(&DSEP_PUBDATA_KEY, &public_key).unwrap();
 
     // Generate CRS (so we have CRS to reshare)
     let crs_info_vec = run_crs(

--- a/core/service/src/client/tests/threshold/key_gen_tests.rs
+++ b/core/service/src/client/tests/threshold/key_gen_tests.rs
@@ -1867,8 +1867,10 @@ async fn run_secure_threshold_compressed_keygen_from_existing(
     // from keygen_id_1 (migration semantics), not the one obtained by decompressing the
     // newly-generated CompressedXofKeySet.
     {
-        use crate::engine::base::{DSEP_PUBDATA_KEY, safe_serialize_hash_element_versioned};
+        use crate::engine::base::DSEP_PUBDATA_KEY;
         use crate::vault::storage::crypto_material::CryptoMaterialReader;
+        use hashing::hash_versioned;
+
         let expected_tag: tfhe::Tag = keygen_id_1.into();
         for (&party_id, storage) in &pub_storage_map {
             let compressed_keyset: tfhe::xof_key_set::CompressedXofKeySet =
@@ -1899,12 +1901,9 @@ async fn run_secure_threshold_compressed_keygen_from_existing(
                 CryptoMaterialReader::read_from_storage(storage, &keygen_id_1).await?;
 
             // CompactPublicKey does not implement PartialEq, so compare via digests.
-            let digest_stored_new =
-                safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &stored_pk_new).unwrap();
-            let digest_stored_old =
-                safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &stored_pk_old).unwrap();
-            let digest_derived_from_new_keyset =
-                safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &pk).unwrap();
+            let digest_stored_new = hash_versioned(&DSEP_PUBDATA_KEY, &stored_pk_new).unwrap();
+            let digest_stored_old = hash_versioned(&DSEP_PUBDATA_KEY, &stored_pk_old).unwrap();
+            let digest_derived_from_new_keyset = hash_versioned(&DSEP_PUBDATA_KEY, &pk).unwrap();
 
             assert_eq!(
                 digest_stored_new, digest_stored_old,

--- a/core/service/src/client/tests/threshold/mpc_epoch_tests.rs
+++ b/core/service/src/client/tests/threshold/mpc_epoch_tests.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use hashing::hash_versioned;
 use itertools::Itertools;
 use kms_grpc::{
     ContextId, RequestId,
@@ -33,7 +34,7 @@ use crate::{
     cryptography::internal_crypto_types::WrappedDKGParams,
     dummy_domain,
     engine::{
-        base::{DSEP_PUBDATA_KEY, derive_request_id, safe_serialize_hash_element_versioned},
+        base::{DSEP_PUBDATA_KEY, derive_request_id},
         threshold::service::ThresholdFheKeys,
         validation::ResharingParams,
     },
@@ -165,7 +166,7 @@ pub(crate) async fn new_epoch_with_reshare_and_crs(
 
         // compute the key digest for compressed keyset
         let compressed_keyset_digest =
-            safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &compressed_keyset).unwrap();
+            hash_versioned(&DSEP_PUBDATA_KEY, &compressed_keyset).unwrap();
         keys_info.push(KeyInfo {
             key_id: Some((*key_req_id).into()),
             preproc_id: Some((*preproc_req_id).into()),
@@ -482,10 +483,9 @@ async fn run_new_epoch(
             // secret shares, so its stored CompactPublicKey must match the one obtained
             // by decompressing the keyset (resharing derives the PK from the new keyset,
             // per epoch_manager.rs). CompactPublicKey has no PartialEq, compare digests.
-            let stored_pk_digest =
-                safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &pk).unwrap();
+            let stored_pk_digest = hash_versioned(&DSEP_PUBDATA_KEY, &pk).unwrap();
             let decompressed_pk_digest =
-                safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &decompressed_pk).unwrap();
+                hash_versioned(&DSEP_PUBDATA_KEY, &decompressed_pk).unwrap();
             assert_eq!(
                 stored_pk_digest, decompressed_pk_digest,
                 "stored CompactPublicKey must equal the one derived from the reshared compressed keyset"

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -14,10 +14,7 @@ use alloy_dyn_abi::DynSolValue;
 use alloy_primitives::U256;
 use alloy_primitives::{Bytes, FixedBytes, Uint};
 use alloy_sol_types::Eip712Domain;
-use hashing::DomainSep;
-use hashing::HashingWriter;
-use hashing::hash_element;
-use hashing::serialize_hash_element;
+use hashing::{DomainSep, hash_element, hash_versioned, serialize_hash_element};
 use kms_grpc::RequestId;
 use kms_grpc::kms::v1::{
     CiphertextFormat, FheParameter, TypedPlaintext, UserDecryptionResponsePayload,
@@ -246,7 +243,7 @@ pub(crate) fn compute_info_crs(
     domain: &alloy_sol_types::Eip712Domain,
     extra_data: Vec<u8>,
 ) -> anyhow::Result<CrsGenMetadata> {
-    let crs_digest = safe_serialize_hash_element_versioned(domain_separator, pp)?;
+    let crs_digest = hash_versioned(domain_separator, pp)?;
     let max_num_bits = max_num_bits_from_crs(pp);
     compute_info_crs_from_digest(sk, crs_id, crs_digest, max_num_bits, domain, extra_data)
 }
@@ -310,10 +307,8 @@ pub(crate) fn compute_keygen_digests(
     domain_separator: &DomainSep,
     keyset: &FhePubKeySet,
 ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
-    let server_key_digest =
-        safe_serialize_hash_element_versioned(domain_separator, &keyset.server_key)?;
-    let public_key_digest =
-        safe_serialize_hash_element_versioned(domain_separator, &keyset.public_key)?;
+    let server_key_digest = hash_versioned(domain_separator, &keyset.server_key)?;
+    let public_key_digest = hash_versioned(domain_separator, &keyset.public_key)?;
 
     tracing::info!(
         "Computed server key digest: {} and public key digest: {}",
@@ -364,7 +359,7 @@ pub(crate) fn compute_info_decompression_keygen(
     domain: &alloy_sol_types::Eip712Domain,
     extra_data: Vec<u8>,
 ) -> anyhow::Result<KeyGenMetadata> {
-    let key_digest = safe_serialize_hash_element_versioned(domain_separator, decompression_key)?;
+    let key_digest = hash_versioned(domain_separator, decompression_key)?;
 
     let sol_type = FheDecompressionUpgradeKey {
         decompressionUpgradeKeyDigest: key_digest.to_vec().into(),
@@ -394,10 +389,8 @@ pub(crate) fn compute_info_compressed_keygen(
     domain: &alloy_sol_types::Eip712Domain,
     extra_data: Vec<u8>,
 ) -> anyhow::Result<KeyGenMetadata> {
-    let compressed_keyset_digest =
-        safe_serialize_hash_element_versioned(domain_separator, compressed_keyset)?;
-    let public_key_digest =
-        safe_serialize_hash_element_versioned(domain_separator, compact_public_key)?;
+    let compressed_keyset_digest = hash_versioned(domain_separator, compressed_keyset)?;
+    let public_key_digest = hash_versioned(domain_separator, compact_public_key)?;
     compute_info_compressed_keygen_from_digests(
         sk,
         prep_id,
@@ -460,7 +453,7 @@ pub fn compute_handle<S>(element: &S) -> anyhow::Result<String>
 where
     S: Serialize + Versionize + Named,
 {
-    let mut digest = safe_serialize_hash_element_versioned(&DSEP_HANDLE, element)?;
+    let mut digest = hash_versioned(&DSEP_HANDLE, element)?;
     // Truncate and convert to hex
     digest.truncate(ID_LENGTH);
     Ok(hex::encode(digest))
@@ -662,21 +655,6 @@ pub fn deserialize_to_low_level(
         }
     };
     Ok(radix_ct)
-}
-
-/// Serialize and hash a versioned element using tfhe-rs' `safe_serialize` function.
-pub fn safe_serialize_hash_element_versioned<T>(
-    domain_separator: &DomainSep,
-    msg: &T,
-) -> anyhow::Result<Vec<u8>>
-where
-    T: Serialize + tfhe::Versionize + tfhe::named::Named,
-{
-    let mut writer = HashingWriter::new(domain_separator);
-
-    tfhe::safe_serialization::safe_serialize(msg, &mut writer, SAFE_SER_SIZE_LIMIT)
-        .map_err(|e| anyhow::anyhow!("Could not serialize&hash element. Error: {e}"))?;
-    Ok(writer.finalize())
 }
 
 /// take external handles and plaintext in the form of bytes, convert them to the required solidity types and sign them using EIP-712 for external verification (e.g. in fhevm).
@@ -1190,7 +1168,7 @@ pub(crate) mod tests {
             base::{
                 DSEP_PUBDATA_CRS, DSEP_PUBDATA_KEY, compute_external_signature_preprocessing,
                 compute_info_uncompressed_keygen, compute_public_decryption_message,
-                safe_serialize_hash_element_versioned,
+                hash_versioned,
             },
             centralized::central_kms::{
                 gen_centralized_crs, generate_client_fhe_key, generate_uncompressed_fhe_keys,
@@ -1583,10 +1561,8 @@ pub(crate) mod tests {
         let server_key = client_key.generate_server_key();
         let public_key = FhePublicKey::new(&client_key);
 
-        let server_key_digest =
-            safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &server_key).unwrap();
-        let public_key_digest =
-            safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &public_key).unwrap();
+        let server_key_digest = hash_versioned(&DSEP_PUBDATA_KEY, &server_key).unwrap();
+        let public_key_digest = hash_versioned(&DSEP_PUBDATA_KEY, &public_key).unwrap();
 
         let keyset = FhePubKeySet {
             public_key,
@@ -1783,7 +1759,7 @@ pub(crate) mod tests {
         )
         .unwrap();
 
-        let crs_digest = safe_serialize_hash_element_versioned(&DSEP_PUBDATA_CRS, &crs).unwrap();
+        let crs_digest = hash_versioned(&DSEP_PUBDATA_CRS, &crs).unwrap();
 
         {
             // do the verification correctly
@@ -1902,8 +1878,7 @@ pub(crate) mod tests {
                 &mut rng,
             )
             .unwrap();
-            let crs_digest =
-                safe_serialize_hash_element_versioned(&DSEP_PUBDATA_CRS, &crs).unwrap();
+            let crs_digest = hash_versioned(&DSEP_PUBDATA_CRS, &crs).unwrap();
 
             let sol_struct = CrsgenVerification::new(
                 &crs_id,

--- a/core/service/src/engine/threshold/service/reshare_utils.rs
+++ b/core/service/src/engine/threshold/service/reshare_utils.rs
@@ -602,7 +602,6 @@ mod tests {
     use std::cell::RefCell;
     use std::collections::HashMap;
 
-    use crate::engine::base::safe_serialize_hash_element_versioned;
     use crate::engine::context::ContextInfo;
     use crate::engine::context::NodeInfo;
     use crate::engine::context::SoftwareVersion;
@@ -615,7 +614,9 @@ mod tests {
     use crate::vault::storage::s3::DummyReadOnlyS3Storage;
     use crate::vault::storage::s3::DummyReadOnlyS3StorageGetter;
     use crate::vault::storage::store_versioned_at_request_id;
+
     use aes_prng::AesRng;
+    use hashing::hash_versioned;
     use kms_grpc::ContextId;
     use kms_grpc::RequestId;
     use kms_grpc::rpc_types::PubDataType;
@@ -691,16 +692,10 @@ mod tests {
         let public_key = CompactPublicKey::new(&client_key);
 
         // generate digests
-        let server_key_digest = safe_serialize_hash_element_versioned(
-            &crate::engine::base::DSEP_PUBDATA_KEY,
-            &server_key,
-        )
-        .unwrap();
-        let public_key_digest = safe_serialize_hash_element_versioned(
-            &crate::engine::base::DSEP_PUBDATA_KEY,
-            &public_key,
-        )
-        .unwrap();
+        let server_key_digest =
+            hash_versioned(&crate::engine::base::DSEP_PUBDATA_KEY, &server_key).unwrap();
+        let public_key_digest =
+            hash_versioned(&crate::engine::base::DSEP_PUBDATA_KEY, &public_key).unwrap();
         let key_digests: HashMap<PubDataType, Vec<u8>> = HashMap::from_iter([
             (PubDataType::ServerKey, server_key_digest),
             (PubDataType::PublicKey, public_key_digest),
@@ -1042,11 +1037,8 @@ mod tests {
                 .unwrap();
 
         // generate digest
-        let compressed_keyset_digest = safe_serialize_hash_element_versioned(
-            &crate::engine::base::DSEP_PUBDATA_KEY,
-            &compressed_keyset,
-        )
-        .unwrap();
+        let compressed_keyset_digest =
+            hash_versioned(&crate::engine::base::DSEP_PUBDATA_KEY, &compressed_keyset).unwrap();
         let key_digests: HashMap<PubDataType, Vec<u8>> =
             HashMap::from_iter([(PubDataType::CompressedXofKeySet, compressed_keyset_digest)]);
 

--- a/core/service/src/engine/utils.rs
+++ b/core/service/src/engine/utils.rs
@@ -646,11 +646,13 @@ thread_local! {
 mod tests {
     use super::*;
     use crate::cryptography::signatures::gen_sig_keys;
-    use crate::engine::base::{KeyGenMetadataInner, safe_serialize_hash_element_versioned};
+    use crate::engine::base::KeyGenMetadataInner;
     use crate::engine::centralized::central_kms::gen_centralized_crs;
     use crate::vault::storage::ram::RamStorage;
     use crate::vault::storage::{delete_at_request_id, store_versioned_at_request_id};
+
     use aes_prng::AesRng;
+    use hashing::hash_versioned;
     use kms_grpc::rpc_types::{PubDataType, SignedPubDataHandleInternal};
     use rand::SeedableRng;
     use std::collections::{BTreeMap, HashMap};
@@ -1250,16 +1252,10 @@ mod tests {
         let server_key = client_key.generate_server_key();
         let public_key = tfhe::CompactPublicKey::new(&client_key);
 
-        let server_key_digest = safe_serialize_hash_element_versioned(
-            &crate::engine::base::DSEP_PUBDATA_KEY,
-            &server_key,
-        )
-        .unwrap();
-        let public_key_digest = safe_serialize_hash_element_versioned(
-            &crate::engine::base::DSEP_PUBDATA_KEY,
-            &public_key,
-        )
-        .unwrap();
+        let server_key_digest =
+            hash_versioned(&crate::engine::base::DSEP_PUBDATA_KEY, &server_key).unwrap();
+        let public_key_digest =
+            hash_versioned(&crate::engine::base::DSEP_PUBDATA_KEY, &public_key).unwrap();
 
         store_versioned_at_request_id(
             storage,
@@ -1318,16 +1314,10 @@ mod tests {
             .into_raw_parts()
             .0;
 
-        let compressed_keyset_digest = safe_serialize_hash_element_versioned(
-            &crate::engine::base::DSEP_PUBDATA_KEY,
-            &compressed_keyset,
-        )
-        .unwrap();
-        let public_key_digest = safe_serialize_hash_element_versioned(
-            &crate::engine::base::DSEP_PUBDATA_KEY,
-            &compact_public_key,
-        )
-        .unwrap();
+        let compressed_keyset_digest =
+            hash_versioned(&crate::engine::base::DSEP_PUBDATA_KEY, &compressed_keyset).unwrap();
+        let public_key_digest =
+            hash_versioned(&crate::engine::base::DSEP_PUBDATA_KEY, &compact_public_key).unwrap();
 
         store_versioned_at_request_id(
             storage,

--- a/core/service/src/util/key_setup/mod.rs
+++ b/core/service/src/util/key_setup/mod.rs
@@ -8,7 +8,7 @@ cfg_if::cfg_if! {
             compute_info_compressed_keygen_from_digests, compute_info_crs_from_digest,
             CrsGenMetadata,
         };
-        use crate::engine::base::{DSEP_PUBDATA_CRS, DSEP_PUBDATA_KEY, safe_serialize_hash_element_versioned};
+        use crate::engine::base::{DSEP_PUBDATA_CRS, DSEP_PUBDATA_KEY};
         use crate::engine::centralized::central_kms::{gen_centralized_crs, generate_fhe_keys};
         use crate::engine::threshold::service::{PublicKeyMaterial, ThresholdFheKeys};
         use crate::vault::storage::crypto_material::{
@@ -16,6 +16,8 @@ cfg_if::cfg_if! {
         };
         use crate::vault::storage::crypto_material::check_data_exists_at_epoch;
         use crate::vault::storage::{delete_at_request_and_epoch_id, delete_at_request_id, store_versioned_at_request_and_epoch_id, StorageExt};
+
+        use hashing::hash_versioned;
         use futures_util::future;
         use itertools::Itertools;
         use kms_grpc::identifiers::EpochId;
@@ -1114,14 +1116,13 @@ where
     };
 
     // Hash the compressed keyset once; reuse per party.
-    let compressed_digest =
-        match safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &compressed_keyset) {
-            Ok(digest) => digest,
-            Err(e) => {
-                tracing::error!("Failed to hash compressed keyset: {}", e);
-                return false;
-            }
-        };
+    let compressed_digest = match hash_versioned(&DSEP_PUBDATA_KEY, &compressed_keyset) {
+        Ok(digest) => digest,
+        Err(e) => {
+            tracing::error!("Failed to hash compressed keyset: {}", e);
+            return false;
+        }
+    };
 
     // Derive the CompactPublicKey from the compressed keyset once; store and sign it
     // along with the compressed keyset for each party.
@@ -1134,14 +1135,13 @@ where
     };
 
     // Hash the compact public key once; reuse per party.
-    let public_key_digest =
-        match safe_serialize_hash_element_versioned(&DSEP_PUBDATA_KEY, &compact_public_key) {
-            Ok(digest) => digest,
-            Err(e) => {
-                tracing::error!("Failed to hash compact public key: {}", e);
-                return false;
-            }
-        };
+    let public_key_digest = match hash_versioned(&DSEP_PUBDATA_KEY, &compact_public_key) {
+        Ok(digest) => digest,
+        Err(e) => {
+            tracing::error!("Failed to hash compact public key: {}", e);
+            return false;
+        }
+    };
 
     // Wrap the compressed keyset, public key, and per-party shares once; futures hold cheap Arc clones.
     let compressed_keyset = Arc::new(compressed_keyset);
@@ -1364,7 +1364,7 @@ where
         });
 
     // Hash pp once; reused per party.
-    let crs_digest = safe_serialize_hash_element_versioned(&DSEP_PUBDATA_CRS, &pp)
+    let crs_digest = hash_versioned(&DSEP_PUBDATA_CRS, &pp)
         .expect("serializing and hashing a CompactPkCrs works");
     let crs_max_num_bits = max_num_bits_from_crs(&pp);
 

--- a/core/service/tests/backward_compatibility_kms.rs
+++ b/core/service/tests/backward_compatibility_kms.rs
@@ -21,6 +21,7 @@ use backward_compatibility::{
     tests::{TestedModule, run_all_tests},
 };
 use common::{load_and_unversionize, load_and_unversionize_auxiliary};
+use hashing::hash_versioned;
 use kms_grpc::{
     RequestId,
     kms::v1::TypedPlaintext,
@@ -53,10 +54,7 @@ use kms_lib::{
         },
     },
     engine::{
-        base::{
-            CrsGenMetadata, KeyGenMetadata, KeyGenMetadataInner, KmsFheKeyHandles,
-            safe_serialize_hash_element_versioned,
-        },
+        base::{CrsGenMetadata, KeyGenMetadata, KeyGenMetadataInner, KmsFheKeyHandles},
         context::{ContextInfo, NodeInfo, SoftwareVersion},
         threshold::service::{PublicKeyMaterial, ThresholdFheKeys, session::PRSSSetupCombined},
     },
@@ -197,10 +195,8 @@ fn test_key_gen_metadata(
 
     let mut key_digest_map: BTreeMap<PubDataType, Vec<u8>> = BTreeMap::new();
     let mut new_legacy: HashMap<PubDataType, SignedPubDataHandleInternal> = HashMap::new();
-    let server_key_digest =
-        safe_serialize_hash_element_versioned(b"TESTTEST", &pretend_server_key).unwrap();
-    let pub_key_digest =
-        safe_serialize_hash_element_versioned(b"TESTTEST", &pretend_public_key).unwrap();
+    let server_key_digest = hash_versioned(b"TESTTEST", &pretend_server_key).unwrap();
+    let pub_key_digest = hash_versioned(b"TESTTEST", &pretend_public_key).unwrap();
     let sol_type = KeygenVerificationQ126::new_standard(
         &preprocessing_id,
         &key_id,
@@ -355,10 +351,8 @@ fn test_key_gen_metadata_with_extra_data(
 
     let extra_data = test.extra_data.to_vec();
     let mut key_digest_map: BTreeMap<PubDataType, Vec<u8>> = BTreeMap::new();
-    let server_key_digest =
-        safe_serialize_hash_element_versioned(b"TESTTEST", &pretend_server_key).unwrap();
-    let pub_key_digest =
-        safe_serialize_hash_element_versioned(b"TESTTEST", &pretend_public_key).unwrap();
+    let server_key_digest = hash_versioned(b"TESTTEST", &pretend_server_key).unwrap();
+    let pub_key_digest = hash_versioned(b"TESTTEST", &pretend_public_key).unwrap();
     let sol_type = KeygenVerification::new_uncompressed(
         &preprocessing_id,
         &key_id,
@@ -851,9 +845,7 @@ fn test_recovery_material(
             operator_pk: operator_pk.clone(),
             shares: Vec::new(),
         };
-        let msg_digest =
-            safe_serialize_hash_element_versioned(&DSEP_BACKUP_COMMITMENT, &backup_material)
-                .unwrap();
+        let msg_digest = hash_versioned(&DSEP_BACKUP_COMMITMENT, &backup_material).unwrap();
         commitments.insert(cus_role, msg_digest);
         let mut payload = [0_u8; 32];
         rng.fill_bytes(&mut payload);

--- a/core/threshold-hashing/Cargo.toml
+++ b/core/threshold-hashing/Cargo.toml
@@ -12,3 +12,5 @@ anyhow.workspace = true
 serde.workspace = true
 sha3.workspace = true
 bc2wrap.workspace = true
+tfhe-versionable.workspace = true
+tfhe-safe-serialize.workspace = true

--- a/core/threshold-hashing/src/lib.rs
+++ b/core/threshold-hashing/src/lib.rs
@@ -85,8 +85,8 @@ where
     Ok(writer.finalize())
 }
 
-/// Compute the SHAKE-256 hash of a [`Versionize`]'d piece of data `T` using tfhe-rs's [`safe_serialize`] function.
-/// The call will fail if the serialized size of `T` is larger than [`SAFE_SER_SIZE_LIMIT`], currently set to 2Gb.
+/// Compute the SHAKE-256 hash of a [`Versionize`]'d value `T` using [`tfhe_safe_serialize::safe_serialize`].
+/// The call will fail if the serialized size of `T` is larger than [`SAFE_SER_SIZE_LIMIT`] (currently 2 GB).
 pub fn hash_versioned<T>(domain_sep: &DomainSep, msg: &T) -> anyhow::Result<Vec<u8>>
 where
     T: Serialize + Versionize + Named,

--- a/core/threshold-hashing/src/lib.rs
+++ b/core/threshold-hashing/src/lib.rs
@@ -3,6 +3,8 @@ use sha3::{
     Shake256,
     digest::{ExtendableOutput, Update, XofReader},
 };
+use tfhe_safe_serialize::{Named, safe_serialize};
+use tfhe_versionable::Versionize;
 
 /// Domain separator for hashing elements.
 /// This is used to ensure that the hash is unique to the context in which it is used.
@@ -80,6 +82,17 @@ where
     let mut writer = HashingWriter::new(domain_separator);
 
     let _hashed_bytes = bc2wrap::serialize_into(msg, &mut writer)?;
+    Ok(writer.finalize())
+}
+
+/// Compute the SHAKE-256 hash of a [`Versionize`]'d piece of data `T` using tfhe-rs's [`safe_serialize`] function.
+/// The call will fail if the serialized size of `T` is larger than [`SAFE_SER_SIZE_LIMIT`], currently set to 2Gb.
+pub fn hash_versioned<T>(domain_sep: &DomainSep, msg: &T) -> anyhow::Result<Vec<u8>>
+where
+    T: Serialize + Versionize + Named,
+{
+    let mut writer = HashingWriter::new(domain_sep);
+    safe_serialize(msg, &mut writer, SAFE_SER_SIZE_LIMIT)?;
     Ok(writer.finalize())
 }
 


### PR DESCRIPTION
Consolidate hashing work into the `threshold-hashing` crate, now that `tfhe-safe-serialize` can be used independently.

The rename is the source of noise here.

Core changes are:

- removal [here](https://github.com/zama-ai/kms/pull/640/changes#diff-99ef0e8eb0ec9d1c2ccb456bad0e0f846a4c43f3b0e462e5e5722a8bfec447a6L667-L681)
- addition&rename [here](https://github.com/zama-ai/kms/pull/640/changes#diff-59d2f21beef3078407a98f3ef45931ea2eace917bb7675c423b079b251da317eR88-R98)

Fixes https://github.com/zama-ai/kms-internal/issues/2969