### PR TITLE
[chore] Retire `threshold_tests`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,7 +199,7 @@ jobs:
       # nightly_* and nightly_full_gen_tests_* are intentionally included here
       # (they're skipped only in the regular-CI profile via --skip).
       args-tests: >-
-        --features threshold_tests -- --skip k8s_ --skip isolated_test_example
+        --features slow_tests -- --skip k8s_ --skip isolated_test_example
         --skip test_threshold_mpc_context_switch_6_docker
       nextest-profile: 'ci-nightly'
       runs-on: '64cpu-linux-x64'

--- a/.github/workflows/parallel-testing.yml
+++ b/.github/workflows/parallel-testing.yml
@@ -122,32 +122,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Core client - aggressively sharded.
-          - job_name: core-client-threshold-p1
+          # Core client - threshold tests. Built with `slow_tests` so the heavy
+          # threshold tests (insecure, default preproc-keygen, 6-party context
+          # switch) run per-PR.
+          - job_name: core-client-threshold
             crate_names: '-p kms-core-client'
-            args_tests: '--features threshold_tests --partition count:1/3 -- threshold --skip full_gen_tests --skip nightly --skip k8s_ --skip centralized --skip isolated_test_example --skip test_threshold_mpc_context_switch_6_docker --skip test_threshold_insecure'
-            run_minio: false
-            run_redis: false
-            skip_test_material: false
-            lfs: false
-            runs_on: '64cpu-linux-x64'
-            runner_volume: '200gb'
-            rust_log_level: 'error'
-            nextest_threads: '4'
-          - job_name: core-client-threshold-p2
-            crate_names: '-p kms-core-client'
-            args_tests: '--features threshold_tests --partition count:2/3 -- threshold --skip full_gen_tests --skip nightly --skip k8s_ --skip centralized --skip isolated_test_example --skip test_threshold_mpc_context_switch_6_docker --skip test_threshold_insecure'
-            run_minio: false
-            run_redis: false
-            skip_test_material: false
-            lfs: false
-            runs_on: '64cpu-linux-x64'
-            runner_volume: '200gb'
-            rust_log_level: 'error'
-            nextest_threads: '4'
-          - job_name: core-client-threshold-p3
-            crate_names: '-p kms-core-client'
-            args_tests: '--features threshold_tests --partition count:3/3 -- threshold --skip full_gen_tests --skip nightly --skip k8s_ --skip centralized --skip isolated_test_example --skip test_threshold_mpc_context_switch_6_docker --skip test_threshold_insecure'
+            args_tests: '--features slow_tests -- threshold --skip full_gen_tests --skip nightly --skip k8s_ --skip isolated_test_example --skip test_threshold_mpc_context_switch_6_docker'
             run_minio: false
             run_redis: false
             skip_test_material: false
@@ -224,22 +204,6 @@ jobs:
             runner_volume: '200gb'
             rust_log_level: 'error'
             nextest_threads: '4'
-          #======================================================================
-          # `test_threshold_insecure_default_keygen` is intentionally NOT run
-          # per-PR (skipped here, and the threshold-* partitions skip the whole
-          # `test_threshold_insecure` group). It is still covered by the nightly
-          # `test-core-client-nightly` job in main.yml.
-          - job_name: core-client-insecure
-            crate_names: '-p kms-core-client'
-            args_tests: '--features threshold_tests --partition count:1/1 -- test_threshold_insecure --skip test_threshold_insecure_default_keygen --skip test_threshold_mpc_context_switch_6_docker'
-            run_minio: false
-            run_redis: false
-            skip_test_material: false
-            lfs: false
-            runs_on: '64cpu-linux-x64'
-            runner_volume: '200gb'
-            rust_log_level: 'error'
-            nextest_threads: '1'
           #======================================================================
           # Core service - aggressively sharded by family and partition.
           - job_name: core-service-lib-p1

--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -98,10 +98,10 @@ ignored = ["kms", "strum"]
 # (see core/service, core/threshold-execution). CI opts in via `-F slow_tests`.
 #
 # This flag only gates code/tests; it does NOT generate key material by itself.
-# The gated tests use Default params, which require pre-generated material in
+# Some gated tests use Default params, which require pre-generated material in
 # `test-material/default` (run
 # `cargo run -p generate-test-material -- --output ./test-material --profile secure --parties 4,13`);
-# missing PRSS is a hard error.
+# missing Default material is a hard error.
 # Does NOT enable Kind/Kubernetes tests (use `kind_tests` for those).
 slow_tests = ["testing"]
 # Enable tests that require a running Kind/Kubernetes cluster.

--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -92,22 +92,18 @@ tonic-prost-build.workspace = true
 ignored = ["kms", "strum"]
 
 [features]
-# Enables threshold PRSS tests in `integration_test`.
-# These are the threshold tests that require PRSS infrastructure:
-#   preproc+keygen, MPC context init/switch, reshare, full-gen preproc.
-# Un-ignores tests guarded with `#[cfg_attr(not(feature = "threshold_tests"), ignore)]`.
-# Compiles setup helpers that run threshold servers with `ensure_default_prss=true`.
+# Compiles + runs the handful of threshold integration tests that are too slow
+# to run locally by default (full preproc+keygen, 6-party MPC context switch,
+# nightly preproc-keygen). Follows the workspace-wide `slow_tests` convention
+# (see core/service, core/threshold-execution). CI opts in via `-F slow_tests`.
 #
 # This flag only gates code/tests; it does NOT generate key material by itself.
-# Material requirements:
-# - Test params: missing PRSS can be initialized live at server startup.
-# - Default params: pre-generated PRSS is required in `test-material/default`
-#   (run `cargo run -p generate-test-material -- --output ./test-material --profile secure --parties 4,13`);
-#   missing PRSS is a hard error.
-# - Some tests generate PRSS during the test itself (via NewEpoch/new_prss_isolated)
-#   and therefore do not require pre-generated startup PRSS.
+# The gated tests use Default params, which require pre-generated material in
+# `test-material/default` (run
+# `cargo run -p generate-test-material -- --output ./test-material --profile secure --parties 4,13`);
+# missing PRSS is a hard error.
 # Does NOT enable Kind/Kubernetes tests (use `kind_tests` for those).
-threshold_tests = ["testing"]
+slow_tests = ["testing"]
 # Enable tests that require a running Kind/Kubernetes cluster.
 kind_tests = ["testing"]
 testing = ["threshold-execution/testing"]

--- a/core-client/tests/README.md
+++ b/core-client/tests/README.md
@@ -5,7 +5,7 @@
 | Test Type | Command |
 |-----------|---------|
 | **Native (fast)** | `cargo test --test integration_test --features testing` |
-| **Native (slow threshold tests)** | `cargo nextest run --test integration_test --features slow_tests` |
+| **Native (slow threshold tests)** | `cargo nextest run --test integration_test --features slow_tests -- threshold` |
 | **K8s Threshold (kind)** | `cargo test --test kubernetes_test_threshold --features kind_tests` |
 | **K8s Centralized (kind)** | `cargo test --test kubernetes_test_centralized --features kind_tests` |
 

--- a/core-client/tests/README.md
+++ b/core-client/tests/README.md
@@ -106,7 +106,7 @@ async fn test_my_feature() -> Result<()> {
 - `setup_isolated_threshold_cli_test_with_backup` — with backup vault
 - `setup_isolated_threshold_cli_test_with_custodian_backup` — with custodian backup vault
 - `setup_isolated_threshold_cli_test_default` — Default FHE params, no PRSS (`ensure_default_prss=false`)
-- `setup_isolated_threshold_cli_test_with_prss_default` — Default FHE + PRSS-enabled setup (`ensure_default_prss=true`; requires `slow_tests` and pre-generated Default PRSS)
+- `setup_isolated_threshold_cli_test_with_prss_default` — Default FHE + PRSS-enabled setup (`ensure_default_prss=true`; requires `slow_tests` and pre-generated Default test material)
 
 ---
 

--- a/core-client/tests/README.md
+++ b/core-client/tests/README.md
@@ -5,7 +5,7 @@
 | Test Type | Command |
 |-----------|---------|
 | **Native (fast)** | `cargo test --test integration_test --features testing` |
-| **Native (threshold preprocessing tests)** | `cargo nextest run --test integration_test --features threshold_tests` |
+| **Native (slow threshold tests)** | `cargo nextest run --test integration_test --features slow_tests` |
 | **K8s Threshold (kind)** | `cargo test --test kubernetes_test_threshold --features kind_tests` |
 | **K8s Centralized (kind)** | `cargo test --test kubernetes_test_centralized --features kind_tests` |
 
@@ -17,24 +17,20 @@
 ## Feature flags (what they enable)
 
 - `testing`
-  - Enables test helper code used by integration tests.
-- `threshold_tests`
+  - Enables test helper code used by integration tests. Most threshold tests
+    (preproc+keygen, reshare, MPC context init/switch) run under this feature.
+- `slow_tests`
   - Implies `testing`.
-  - Enables threshold preprocessing and keygen tests in `tests/integration/integration_test.rs`.
-  - Compiles setup helpers that run threshold servers with `ensure_default_prss=true`
-    (`setup_isolated_threshold_cli_test_with_prss*`).
-  - Enables preprocessing-heavy flows/tests (preproc+keygen, MPC context init/switch,
-    reshare, full-gen default preproc).
-  - Only gates code/tests; it does **not** generate test material by itself.
+  - Compiles&runs the threshold tests that are too slow to run locally.
   - **Does not** enable Kind/Kubernetes tests.
 - `kind_tests`
   - Implies `testing`.
   - Enables Kubernetes/Kind test binaries under `tests/kind-testing/`.
   - Requires a running Kind cluster.
 
-### `threshold_tests` and pre-generated material
+### Pre-generated material
 
-- `threshold_tests` enables tests that require pre-generated material: **PRSS** (generated at server startup via `ensure_default_prss=true`) and **keygen preprocessing material** (offline DKG phase, required by `nightly_full_gen_tests_default_*`).
+- PRSS-based keygen tests require pre-generated material: **PRSS** (generated at server startup via `ensure_default_prss=true`) and **keygen preprocessing material** (offline DKG phase, required by `nightly_full_gen_tests_default_*`). This applies to both the per-PR threshold tests and the `slow_tests`-gated ones.
 - For **Test** params, missing PRSS can be initialized live. For **Default** params, both PRSS and keygen preprocessing material must be pre-generated — missing either is a hard error.
 - Some tests generate PRSS live during the test (via `new_prss`) — these do not require pre-generated PRSS. Used by MPC context init/switch and reshare tests.
 - Generate the production-like required secure material (aka "default") with:
@@ -42,10 +38,8 @@
 
 ### Test gating patterns
 
-Two patterns are used — which one to pick depends on whether the test body calls feature-gated helpers:
-
-- **`#[cfg(feature = "threshold_tests")]` on the fn** — use when the test body calls helpers that only exist with the feature (e.g. `setup_*_with_prss`, `real_preproc_and_keygen`). The test is invisible to `cargo test` without the feature.
-- **`#[cfg_attr(not(feature = "threshold_tests"), ignore)]` on the fn** — use when the test body compiles without the feature (e.g. tests using `setup_isolated_threshold_cli_test_signing_only` + `new_prss`). The test is visible but skipped without the feature.
+- **`#[cfg(feature = "slow_tests")]` on the fn** — the default for slow threshold tests. The test is invisible without the feature, so the per-PR build neither compiles nor runs it. Used when the body also calls a `slow_tests`-gated helper (e.g. `setup_isolated_threshold_cli_test_with_prss_default`).
+- **`#[cfg_attr(not(feature = "slow_tests"), ignore)]` on the fn** — only for `test_threshold_mpc_context_switch_6_docker`, whose Docker-Compose harness must keep compiling per-PR. The test is visible but skipped (and always `--skip`'d in CI; it needs a running Docker Compose).
 
 ### Test naming conventions (CI skip rules)
 
@@ -108,11 +102,11 @@ async fn test_my_feature() -> Result<()> {
 **Threshold setup variants** (all take `party_count: usize`):
 - `setup_isolated_threshold_cli_test` — basic threshold test
 - `setup_isolated_threshold_cli_test_signing_only` — signing without pre-loaded PRSS
-- `setup_isolated_threshold_cli_test_with_prss` — PRSS-enabled setup (`ensure_default_prss=true`) for preprocessing/keygen flows (requires `threshold_tests`)
+- `setup_isolated_threshold_cli_test_with_prss` — PRSS-enabled setup (`ensure_default_prss=true`) for preprocessing/keygen flows
 - `setup_isolated_threshold_cli_test_with_backup` — with backup vault
 - `setup_isolated_threshold_cli_test_with_custodian_backup` — with custodian backup vault
 - `setup_isolated_threshold_cli_test_default` — Default FHE params, no PRSS (`ensure_default_prss=false`)
-- `setup_isolated_threshold_cli_test_with_prss_default` — Default FHE + PRSS-enabled setup (`ensure_default_prss=true`; requires `threshold_tests` and pre-generated Default PRSS)
+- `setup_isolated_threshold_cli_test_with_prss_default` — Default FHE + PRSS-enabled setup (`ensure_default_prss=true`; requires `slow_tests` and pre-generated Default PRSS)
 
 ---
 

--- a/core-client/tests/README.md
+++ b/core-client/tests/README.md
@@ -30,7 +30,7 @@
 
 ### Pre-generated material
 
-- PRSS-based keygen tests require pre-generated material: **PRSS** (generated at server startup via `ensure_default_prss=true`) and **keygen preprocessing material** (offline DKG phase, required by `nightly_full_gen_tests_default_*`). This applies to both the per-PR threshold tests and the `slow_tests`-gated ones.
+- PRSS-based keygen tests require PRSS to be available at server startup (`ensure_default_prss=true` ensures it is generated/reused) and, for `nightly_full_gen_tests_default_*`, pre-generated keygen preprocessing material (offline DKG phase).
 - For **Test** params, missing PRSS can be initialized live. For **Default** params, both PRSS and keygen preprocessing material must be pre-generated — missing either is a hard error.
 - Some tests generate PRSS live during the test (via `new_prss`) — these do not require pre-generated PRSS. Used by MPC context init/switch and reshare tests.
 - Generate the production-like required secure material (aka "default") with:

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -23,7 +23,6 @@ use std::str::FromStr;
 use std::string::String;
 use tempfile::TempDir;
 use test_utils::test_logging::init_test_logging as init_logging;
-#[cfg(feature = "threshold_tests")]
 use tfhe::{xof_key_set::CompressedXofKeySet, zk::CompactPkeCrs};
 use tracing::info;
 use validator::Validate;
@@ -38,12 +37,10 @@ use std::fs::create_dir_all;
 use std::process::{Command, Output};
 use tfhe::safe_serialization::safe_serialize;
 
-// Additional imports for reshare test (only needed with threshold_tests feature)
-#[cfg(feature = "threshold_tests")]
+// Additional imports for reshare test
 use kms_lib::engine::base::{
     DSEP_PUBDATA_CRS, DSEP_PUBDATA_KEY, safe_serialize_hash_element_versioned,
 };
-#[cfg(feature = "threshold_tests")]
 use kms_lib::util::key_setup::test_tools::load_material_from_pub_storage;
 
 // ============================================================================
@@ -308,9 +305,6 @@ async fn setup_isolated_threshold_cli_test_signing_only(
 /// * `PathBuf` - Path to generated CLI config file (for --config flag)
 ///
 /// # Note
-/// Requires `threshold_tests` feature. Tests using this must be marked with:
-/// - `#[cfg_attr(not(feature = "threshold_tests"), ignore)]`
-///
 /// This helper enables `ensure_default_prss=true` during server startup. For Test params,
 /// pre-generated PRSS from `test-material` may be copied and reused when present.
 ///
@@ -320,7 +314,6 @@ async fn setup_isolated_threshold_cli_test_signing_only(
 /// # Example
 /// ```no_run
 /// #[tokio::test]
-/// #[cfg_attr(not(feature = "threshold_tests"), ignore)]
 /// async fn test_prss_feature() -> Result<()> {
 ///     let (material_dir, _servers, config_path) =
 ///         setup_isolated_threshold_cli_test_with_prss("my_prss_test", 4).await?;
@@ -328,7 +321,6 @@ async fn setup_isolated_threshold_cli_test_signing_only(
 ///     Ok(())
 /// }
 /// ```
-#[cfg(feature = "threshold_tests")]
 async fn setup_isolated_threshold_cli_test_with_prss(
     test_name: &str,
     party_count: usize,
@@ -419,7 +411,7 @@ async fn setup_isolated_threshold_cli_test_default(
 /// PRSS is ensured at server startup: if the default epoch is missing, startup initializes it;
 /// otherwise existing PRSS is reused. Default threshold context and key material still come
 /// from `test-material/default`, but `PrssSetupCombined` is not copied up front.
-#[cfg(feature = "threshold_tests")]
+#[cfg(feature = "slow_tests")]
 async fn setup_isolated_threshold_cli_test_with_prss_default(
     test_name: &str,
     party_count: usize,
@@ -612,6 +604,7 @@ async fn setup_isolated_threshold_cli_test_impl_with_spec(
 /// - Config path for context 2 (servers 5,6,4,3)
 ///
 /// TODO: add possibility for dynamic party number setup
+#[cfg(feature = "slow_tests")]
 async fn setup_party_resharing_servers(
     test_name: &str,
 ) -> Result<(
@@ -1472,9 +1465,8 @@ async fn restore_from_backup(config_path: &Path, test_path: &Path) -> Result<()>
     Ok(())
 }
 
-/// Helper to run preprocessing and keygen via CLI (isolated version)
-/// Only used by PRSS tests which are gated by threshold_tests feature
-#[cfg(feature = "threshold_tests")]
+/// Helper to run preprocessing and keygen via CLI (isolated version).
+/// Used by PRSS-based keygen tests (some run per-PR, some gated by `slow_tests`).
 async fn real_preproc_and_keygen(
     config_path: &Path,
     test_path: &Path,
@@ -1523,7 +1515,7 @@ async fn real_preproc_and_keygen(
 /// Uses `PartialPreprocKeyGen` with reduced offline generation to keep runtime
 /// manageable for Default FHE parameters in CI while still exercising the
 /// keygen flow.
-#[cfg(feature = "threshold_tests")]
+#[cfg(feature = "slow_tests")]
 async fn real_partial_preproc_and_keygen(
     config_path: &Path,
     test_path: &Path,
@@ -1682,7 +1674,6 @@ async fn real_preproc_and_keygen_with_context(
 }
 
 /// Helper to run reshare operation via CLI (isolated version)
-#[cfg(feature = "threshold_tests")]
 async fn reshare(
     config_path: &Path,
     test_path: &Path,
@@ -2241,7 +2232,7 @@ async fn test_centralized_custodian_backup() -> Result<()> {
 }
 
 /// Test threshold insecure key generation via CLI (Default FHE params, with PRSS).
-#[cfg(feature = "threshold_tests")]
+#[cfg(feature = "slow_tests")]
 #[tokio::test]
 async fn test_threshold_insecure() -> Result<()> {
     init_logging();
@@ -2260,7 +2251,7 @@ async fn test_threshold_insecure() -> Result<()> {
 }
 
 /// Nightly test - threshold sequential preprocessing and keygen with nightly parameters
-#[cfg(feature = "threshold_tests")]
+#[cfg(feature = "slow_tests")]
 #[tokio::test]
 async fn nightly_tests_threshold_sequential_preproc_keygen() -> Result<()> {
     init_logging();
@@ -2281,7 +2272,6 @@ async fn nightly_tests_threshold_sequential_preproc_keygen() -> Result<()> {
 }
 
 /// Test threshold concurrent preprocessing and keygen operations
-#[cfg(feature = "threshold_tests")]
 #[tokio::test]
 async fn test_threshold_concurrent_preproc_keygen() -> Result<()> {
     init_logging();
@@ -2410,7 +2400,6 @@ async fn test_threshold_concurrent_crs() -> Result<()> {
 /// Test threshold insecure key generation via CLI using the default key format.
 ///
 /// Mirrors `test_threshold_insecure_default_keygen` in `integration_test.rs`.
-#[cfg(feature = "threshold_tests")]
 #[tokio::test]
 async fn test_threshold_insecure_default_keygen() -> Result<()> {
     init_logging();
@@ -2430,7 +2419,7 @@ async fn test_threshold_insecure_default_keygen() -> Result<()> {
 /// Mirrors `test_threshold_default_preproc_keygen` in `integration_test.rs`.
 /// Runs two sequential preproc+keygen cycles with the default key format and asserts
 /// that both produce distinct key IDs.
-#[cfg(feature = "threshold_tests")]
+#[cfg(feature = "slow_tests")]
 #[tokio::test]
 async fn test_threshold_default_preproc_keygen() -> Result<()> {
     init_logging();
@@ -2454,7 +2443,6 @@ async fn test_threshold_default_preproc_keygen() -> Result<()> {
 /// 1. Insecure keygen produces a key
 /// 2. The context can be switched to a new context ID
 /// 3. A public-decrypt request succeeds in the new context
-#[cfg(feature = "threshold_tests")]
 #[tokio::test]
 async fn test_threshold_mpc_context_switch() -> Result<()> {
     init_logging();
@@ -2652,7 +2640,7 @@ async fn test_threshold_custodian_backup() -> Result<()> {
 // Extremely heavy test — requires dedicated infra and multi-hour runtime budget.
 // Do NOT run in regular CI or local dev.
 // Only execute when a fully prepared full-generation environment is available.
-#[cfg(feature = "threshold_tests")]
+#[cfg(feature = "slow_tests")]
 #[tokio::test]
 #[ignore]
 async fn nightly_full_gen_tests_default_threshold_sequential_preproc_keygen() -> Result<()> {
@@ -2740,7 +2728,6 @@ async fn nightly_full_gen_tests_default_threshold_sequential_crs() -> Result<()>
 ///
 /// Note: This test starts from uninitialized threshold KMS servers (no PRSS or context)
 #[tokio::test]
-#[cfg_attr(not(feature = "threshold_tests"), ignore)]
 async fn test_threshold_mpc_context_init() -> Result<()> {
     init_logging();
 
@@ -2802,8 +2789,8 @@ async fn test_threshold_mpc_context_init() -> Result<()> {
 ///
 /// **TLS Status:** Disabled (isolated test, localhost only)
 /// **For TLS testing:** use `tests/kind-testing/kubernetes_test_threshold.rs`.
+#[cfg(feature = "slow_tests")]
 #[tokio::test]
-#[cfg_attr(not(feature = "threshold_tests"), ignore)]
 async fn test_threshold_mpc_context_switch_6() -> Result<()> {
     init_logging();
 
@@ -2963,7 +2950,7 @@ mod docker_harness {
     /// **Requires:** Docker Compose + locally buildable KMS images (`DOCKER_BUILD_TEST_CORE_CLIENT=1`).
     #[test_context(DockerComposeThresholdTestNoInitSixParty)]
     #[tokio::test]
-    #[cfg_attr(not(feature = "threshold_tests"), ignore)]
+    #[cfg_attr(not(feature = "slow_tests"), ignore)]
     async fn test_threshold_mpc_context_switch_6_docker(
         ctx: &DockerComposeThresholdTestNoInitSixParty,
     ) -> Result<()> {
@@ -3028,7 +3015,6 @@ mod docker_harness {
 /// 5. Run Crs generation
 /// 6. Compute digests of the key materials
 /// 7. Execute resharing command
-#[cfg(feature = "threshold_tests")]
 #[tokio::test]
 async fn test_threshold_reshare() -> Result<()> {
     init_logging();


### PR DESCRIPTION
Before this PR the `core-client` had a bespoke `threshold_tests` feature to determin which integration tests to run. This PR retires that feature and, after measuring test run times, replaces it with `slow_tests` for tests that are effectively slow.

The number of tests that run for each PR has increased a little bit. At the same time the number of CI jobs decreases from 4 to 1. The slowest test is `test_threshold_insecure` by a **very** large margin, so 4 nextest processes is enough to parallelize that.

Part of https://github.com/zama-ai/kms-internal/issues/3017

Local test timings used to decide which tests are "slow":

```
1126.662	test_threshold_insecure
326.360	test_threshold_mpc_context_switch_6
224.047	test_threshold_default_preproc_keygen
186.076	test_threshold_concurrent_preproc_keygen
115.664	test_threshold_reshare
93.969	test_threshold_mpc_context_init
5.134	test_threshold_concurrent_crs
1.372	test_threshold_mpc_context_switch
0.874	test_threshold_custodian_backup
0.793	test_threshold_restore_from_backup
0.775	test_threshold_insecure_default_keygen
0.572	test_threshold_abort_key_gen
0.557	test_threshold_abort_crs_gen
0.007	config_conformance_client_local_threshold
```
