### PR TITLE
chore: improve verification on core-client

### DIFF
--- a/core-client/config/client_local_centralized.toml
+++ b/core-client/config/client_local_centralized.toml
@@ -23,9 +23,8 @@ fhe_params = "Test" # Small, insecure parameters for testing
 
 # Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
 # signature, used as the default when verifying fetched results (overridable per
-# invocation with `--extra-data`). When unset, each pure-fetch command uses its
-# natural default (empty for public decryption, the context/epoch-derived value
-# for keygen/CRS).
+# invocation with `--extra-data`). When unset, every pure-fetch command falls back
+# to the RFC-005 default (version 0x02: default context_id ‖ epoch_id).
 # default_extra_data = "02..."
 
 # List of connection info to each of the cores (in the centralized case, there will only be a single core)

--- a/core-client/config/client_local_centralized.toml
+++ b/core-client/config/client_local_centralized.toml
@@ -21,12 +21,6 @@ decryption_mode = "NoiseFloodSmall"
 fhe_params = "Test" # Small, insecure parameters for testing
 # fhe_params = "Default" # Large, secure parameters
 
-# Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
-# signature, used as the default when verifying fetched results (overridable per
-# invocation with `--extra-data`). When unset, every pure-fetch command falls back
-# to the RFC-005 default (version 0x02: default context_id ‖ epoch_id).
-# default_extra_data = "02..."
-
 # List of connection info to each of the cores (in the centralized case, there will only be a single core)
 [[cores]]
 # The ID of the given KMS server (monotonically increasing positive integer starting at 1)

--- a/core-client/config/client_local_centralized.toml
+++ b/core-client/config/client_local_centralized.toml
@@ -21,6 +21,13 @@ decryption_mode = "NoiseFloodSmall"
 fhe_params = "Test" # Small, insecure parameters for testing
 # fhe_params = "Default" # Large, secure parameters
 
+# Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
+# signature, used as the default when verifying fetched results (overridable per
+# invocation with `--extra-data`). When unset, each pure-fetch command uses its
+# natural default (empty for public decryption, the context/epoch-derived value
+# for keygen/CRS).
+# default_extra_data = "02..."
+
 # List of connection info to each of the cores (in the centralized case, there will only be a single core)
 [[cores]]
 # The ID of the given KMS server (monotonically increasing positive integer starting at 1)
@@ -32,3 +39,13 @@ address = "localhost:50051"
 s3_endpoint = "http://localhost:9000/kms"
 # The folder at the S3 endpoint where the data is stored
 object_folder = "PUB"
+
+# Default EIP-712 domain used both when *building* requests (full-flow commands) and
+# when *verifying* fetched results (the `*Result` commands). These values match the
+# built-in default; adjust them to match the domain used by whoever issued the request.
+[default_domain]
+name = "Authorization token"
+version = "1"
+chain_id = 8006
+verifying_contract = "0x66f9664f97F2b50F62D13eA064982f936dE76657"
+# salt = "..." # optional, hex-encoded 32 bytes

--- a/core-client/config/client_local_kind_centralized.toml
+++ b/core-client/config/client_local_kind_centralized.toml
@@ -21,6 +21,13 @@ decryption_mode = "NoiseFloodSmall"
 # fhe_params = "Test" # Small, insecure parameters for testing
 fhe_params = "Default" # Large, secure parameters
 
+# Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
+# signature, used as the default when verifying fetched results (overridable per
+# invocation with `--extra-data`). When unset, each pure-fetch command uses its
+# natural default (empty for public decryption, the context/epoch-derived value
+# for keygen/CRS).
+# default_extra_data = "02..."
+
 # List of connection info to each of the cores (in the centralized case, there will only be a single core)
 [[cores]]
 # The ID of the given KMS server (monotonically increasing positive integer starting at 1)
@@ -32,3 +39,13 @@ address = "localhost:50100"
 s3_endpoint = "http://localhost:9000/kms-public"
 # The folder at the S3 endpoint where the data is stored
 object_folder = "PUB"
+
+# Default EIP-712 domain used both when *building* requests (full-flow commands) and
+# when *verifying* fetched results (the `*Result` commands). These values match the
+# built-in default; adjust them to match the domain used by whoever issued the request.
+[default_domain]
+name = "Authorization token"
+version = "1"
+chain_id = 8006
+verifying_contract = "0x66f9664f97F2b50F62D13eA064982f936dE76657"
+# salt = "..." # optional, hex-encoded 32 bytes

--- a/core-client/config/client_local_kind_centralized.toml
+++ b/core-client/config/client_local_kind_centralized.toml
@@ -23,9 +23,8 @@ fhe_params = "Default" # Large, secure parameters
 
 # Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
 # signature, used as the default when verifying fetched results (overridable per
-# invocation with `--extra-data`). When unset, each pure-fetch command uses its
-# natural default (empty for public decryption, the context/epoch-derived value
-# for keygen/CRS).
+# invocation with `--extra-data`). When unset, every pure-fetch command falls back
+# to the RFC-005 default (version 0x02: default context_id ‖ epoch_id).
 # default_extra_data = "02..."
 
 # List of connection info to each of the cores (in the centralized case, there will only be a single core)

--- a/core-client/config/client_local_kind_centralized.toml
+++ b/core-client/config/client_local_kind_centralized.toml
@@ -21,12 +21,6 @@ decryption_mode = "NoiseFloodSmall"
 # fhe_params = "Test" # Small, insecure parameters for testing
 fhe_params = "Default" # Large, secure parameters
 
-# Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
-# signature, used as the default when verifying fetched results (overridable per
-# invocation with `--extra-data`). When unset, every pure-fetch command falls back
-# to the RFC-005 default (version 0x02: default context_id ‖ epoch_id).
-# default_extra_data = "02..."
-
 # List of connection info to each of the cores (in the centralized case, there will only be a single core)
 [[cores]]
 # The ID of the given KMS server (monotonically increasing positive integer starting at 1)

--- a/core-client/config/client_local_kind_threshold.toml
+++ b/core-client/config/client_local_kind_threshold.toml
@@ -21,6 +21,13 @@ decryption_mode="NoiseFloodSmall"
 # fhe_params = "Test" # Small, insecure parameters for testing
 fhe_params="Default" # Large, secure parameters
 
+# Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
+# signature, used as the default when verifying fetched results (overridable per
+# invocation with `--extra-data`). When unset, each pure-fetch command uses its
+# natural default (empty for public decryption, the context/epoch-derived value
+# for keygen/CRS).
+# default_extra_data = "02..."
+
 # List of connection info to each of the cores
 
 
@@ -67,3 +74,13 @@ address = "localhost:50400"
 s3_endpoint = "http://localhost:9000/kms-public"
 # The folder at the S3 endpoint where the data is stored
 object_folder = "PUB-p4"
+
+# Default EIP-712 domain used both when *building* requests (full-flow commands) and
+# when *verifying* fetched results (the `*Result` commands). These values match the
+# built-in default; adjust them to match the domain used by whoever issued the request.
+[default_domain]
+name = "Authorization token"
+version = "1"
+chain_id = 8006
+verifying_contract = "0x66f9664f97F2b50F62D13eA064982f936dE76657"
+# salt = "..." # optional, hex-encoded 32 bytes

--- a/core-client/config/client_local_kind_threshold.toml
+++ b/core-client/config/client_local_kind_threshold.toml
@@ -23,9 +23,8 @@ fhe_params="Default" # Large, secure parameters
 
 # Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
 # signature, used as the default when verifying fetched results (overridable per
-# invocation with `--extra-data`). When unset, each pure-fetch command uses its
-# natural default (empty for public decryption, the context/epoch-derived value
-# for keygen/CRS).
+# invocation with `--extra-data`). When unset, every pure-fetch command falls back
+# to the RFC-005 default (version 0x02: default context_id ‖ epoch_id).
 # default_extra_data = "02..."
 
 # List of connection info to each of the cores

--- a/core-client/config/client_local_kind_threshold.toml
+++ b/core-client/config/client_local_kind_threshold.toml
@@ -21,12 +21,6 @@ decryption_mode="NoiseFloodSmall"
 # fhe_params = "Test" # Small, insecure parameters for testing
 fhe_params="Default" # Large, secure parameters
 
-# Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
-# signature, used as the default when verifying fetched results (overridable per
-# invocation with `--extra-data`). When unset, every pure-fetch command falls back
-# to the RFC-005 default (version 0x02: default context_id ‖ epoch_id).
-# default_extra_data = "02..."
-
 # List of connection info to each of the cores
 
 

--- a/core-client/config/client_local_threshold.toml
+++ b/core-client/config/client_local_threshold.toml
@@ -21,6 +21,13 @@ decryption_mode = "NoiseFloodSmall"
 fhe_params = "Test" # Small, insecure parameters for testing
 # fhe_params = "Default" # Large, secure parameters
 
+# Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
+# signature, used as the default when verifying fetched results (overridable per
+# invocation with `--extra-data`). When unset, each pure-fetch command uses its
+# natural default (empty for public decryption, the context/epoch-derived value
+# for keygen/CRS).
+# default_extra_data = "02..."
+
 # List of connection info to each of the cores
 [[cores]]
 # The ID of the given KMS server (monotonically increasing positive integer starting at 1)
@@ -64,3 +71,13 @@ s3_endpoint = "http://localhost:9000/kms"
 object_folder = "PUB-p4"
 private_object_folder = "PRIV-p4"
 config_path = "../core/service/config/compose_4.toml"
+
+# Default EIP-712 domain used both when *building* requests (full-flow commands) and
+# when *verifying* fetched results (the `*Result` commands). These values match the
+# built-in default; adjust them to match the domain used by whoever issued the request.
+[default_domain]
+name = "Authorization token"
+version = "1"
+chain_id = 8006
+verifying_contract = "0x66f9664f97F2b50F62D13eA064982f936dE76657"
+# salt = "..." # optional, hex-encoded 32 bytes

--- a/core-client/config/client_local_threshold.toml
+++ b/core-client/config/client_local_threshold.toml
@@ -21,12 +21,6 @@ decryption_mode = "NoiseFloodSmall"
 fhe_params = "Test" # Small, insecure parameters for testing
 # fhe_params = "Default" # Large, secure parameters
 
-# Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
-# signature, used as the default when verifying fetched results (overridable per
-# invocation with `--extra-data`). When unset, every pure-fetch command falls back
-# to the RFC-005 default (version 0x02: default context_id ‖ epoch_id).
-# default_extra_data = "02..."
-
 # List of connection info to each of the cores
 [[cores]]
 # The ID of the given KMS server (monotonically increasing positive integer starting at 1)

--- a/core-client/config/client_local_threshold.toml
+++ b/core-client/config/client_local_threshold.toml
@@ -23,9 +23,8 @@ fhe_params = "Test" # Small, insecure parameters for testing
 
 # Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
 # signature, used as the default when verifying fetched results (overridable per
-# invocation with `--extra-data`). When unset, each pure-fetch command uses its
-# natural default (empty for public decryption, the context/epoch-derived value
-# for keygen/CRS).
+# invocation with `--extra-data`). When unset, every pure-fetch command falls back
+# to the RFC-005 default (version 0x02: default context_id ‖ epoch_id).
 # default_extra_data = "02..."
 
 # List of connection info to each of the cores

--- a/core-client/config/client_local_threshold_alternative.toml
+++ b/core-client/config/client_local_threshold_alternative.toml
@@ -23,12 +23,6 @@ decryption_mode = "NoiseFloodSmall"
 # fhe_params = "Test" # Small, insecure parameters for testing
 fhe_params = "Default" # Large, secure parameters
 
-# Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
-# signature, used as the default when verifying fetched results (overridable per
-# invocation with `--extra-data`). When unset, every pure-fetch command falls back
-# to the RFC-005 default (version 0x02: default context_id ‖ epoch_id).
-# default_extra_data = "02..."
-
 # List of connection info to each of the cores
 [[cores]]
 # The ID of the given KMS server (monotonically increasing positive integer starting at 1)

--- a/core-client/config/client_local_threshold_alternative.toml
+++ b/core-client/config/client_local_threshold_alternative.toml
@@ -23,6 +23,13 @@ decryption_mode = "NoiseFloodSmall"
 # fhe_params = "Test" # Small, insecure parameters for testing
 fhe_params = "Default" # Large, secure parameters
 
+# Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
+# signature, used as the default when verifying fetched results (overridable per
+# invocation with `--extra-data`). When unset, each pure-fetch command uses its
+# natural default (empty for public decryption, the context/epoch-derived value
+# for keygen/CRS).
+# default_extra_data = "02..."
+
 # List of connection info to each of the cores
 [[cores]]
 # The ID of the given KMS server (monotonically increasing positive integer starting at 1)
@@ -66,3 +73,13 @@ s3_endpoint = "http://localhost:9000/kms"
 object_folder = "PUB-p4"
 private_object_folder = "PRIV-p4"
 config_path = "../core/service/config/compose_4.toml"
+
+# Default EIP-712 domain used both when *building* requests (full-flow commands) and
+# when *verifying* fetched results (the `*Result` commands). These values match the
+# built-in default; adjust them to match the domain used by whoever issued the request.
+[default_domain]
+name = "Authorization token"
+version = "1"
+chain_id = 8006
+verifying_contract = "0x66f9664f97F2b50F62D13eA064982f936dE76657"
+# salt = "..." # optional, hex-encoded 32 bytes

--- a/core-client/config/client_local_threshold_alternative.toml
+++ b/core-client/config/client_local_threshold_alternative.toml
@@ -25,9 +25,8 @@ fhe_params = "Default" # Large, secure parameters
 
 # Optional: default extra_data (hex, with or without "0x") bound in the EIP-712
 # signature, used as the default when verifying fetched results (overridable per
-# invocation with `--extra-data`). When unset, each pure-fetch command uses its
-# natural default (empty for public decryption, the context/epoch-derived value
-# for keygen/CRS).
+# invocation with `--extra-data`). When unset, every pure-fetch command falls back
+# to the RFC-005 default (version 0x02: default context_id ‖ epoch_id).
 # default_extra_data = "02..."
 
 # List of connection info to each of the cores

--- a/core-client/src/crsgen.rs
+++ b/core-client/src/crsgen.rs
@@ -1,12 +1,12 @@
 use crate::s3_operations::fetch_public_elements;
-use crate::{CmdConfig, CoreClientConfig, CoreConf, SLEEP_TIME_BETWEEN_REQUESTS_MS, dummy_domain};
+use crate::{CmdConfig, CoreClientConfig, CoreConf, SLEEP_TIME_BETWEEN_REQUESTS_MS};
 
 use aes_prng::AesRng;
 use alloy_sol_types::Eip712Domain;
 use hashing::hash_versioned;
 use kms_grpc::kms::v1::{CrsGenResult, FheParameter};
 use kms_grpc::kms_service::v1::core_service_endpoint_client::CoreServiceEndpointClient;
-use kms_grpc::rpc_types::{PubDataType, protobuf_to_alloy_domain};
+use kms_grpc::rpc_types::PubDataType;
 use kms_grpc::solidity_types::CrsgenVerification;
 use kms_grpc::{ContextId, EpochId, RequestId};
 use kms_lib::client::client_wasm::Client;
@@ -46,23 +46,19 @@ pub(crate) async fn do_crsgen(
         cc_conf.num_majority
     };
 
+    // The EIP-712 domain comes from the config (falling back to `dummy_domain`),
+    // so the request built here and a later (Insecure)CrsGenResult fetch verify
+    // against the same domain.
+    let domain = cc_conf.default_domain()?;
     let crs_req = internal_client.crs_gen_request(
         &req_id,
         context_id.as_ref(),
         epoch_id.as_ref(),
         max_num_bits,
         Some(param),
-        &dummy_domain(),
+        &domain,
     )?;
     let extra_data = crs_req.extra_data.clone();
-
-    //NOTE: Extract domain from request for sanity, but if we don't use dummy_domain
-    //we have an issue in the (Insecure)CrsGenResult commands
-    let domain = if let Some(domain) = &crs_req.domain {
-        protobuf_to_alloy_domain(domain)?
-    } else {
-        return Err(anyhow::anyhow!("No domain provided in crsgen request"));
-    };
 
     // make parallel requests by calling insecure keygen in a thread
     let mut req_tasks = JoinSet::new();
@@ -118,8 +114,7 @@ pub(crate) async fn do_crsgen(
         kms_addrs,
         destination_prefix,
         req_id,
-        domain,
-        extra_data,
+        Some((domain, extra_data)),
         resp_response_vec,
         cmd_conf.download_all,
     )
@@ -135,8 +130,10 @@ pub(crate) async fn fetch_and_check_crsgen(
     kms_addrs: &[alloy_primitives::Address],
     destination_prefix: &Path,
     request_id: RequestId,
-    domain: Eip712Domain,
-    extra_data: Vec<u8>,
+    // EIP-712 domain + extra_data to verify the external signature against. When
+    // `None`, the CRS is still downloaded and request IDs checked, but the
+    // external signature is not verified (a warning is logged).
+    verify: Option<(Eip712Domain, Vec<u8>)>,
     responses: Vec<CrsGenResult>,
     download_all: bool,
 ) -> anyhow::Result<()> {
@@ -197,17 +194,28 @@ pub(crate) async fn fetch_and_check_crsgen(
             );
         }
 
-        check_crsgen_ext_signature(
-            &crs,
-            &request_id,
-            &response.external_signature,
-            &domain,
-            extra_data.clone(),
-            kms_addrs,
-        )
-        .inspect_err(|e| tracing::error!("CRS signature check failed: {}", e))?;
+        match verify.as_ref() {
+            Some((domain, extra_data)) => {
+                check_crsgen_ext_signature(
+                    &crs,
+                    &request_id,
+                    &response.external_signature,
+                    domain,
+                    extra_data.clone(),
+                    kms_addrs,
+                )
+                .inspect_err(|e| tracing::error!("CRS signature check failed: {}", e))?;
 
-        tracing::info!("EIP712 verification of CRS successful.");
+                tracing::info!("EIP712 verification of CRS successful.");
+            }
+            None => {
+                tracing::warn!(
+                    "CRS gen result for request {} fetched WITHOUT signature verification \
+                     (no EIP-712 domain supplied).",
+                    request_id
+                );
+            }
+        }
     }
     Ok(())
 }

--- a/core-client/src/crsgen.rs
+++ b/core-client/src/crsgen.rs
@@ -1,5 +1,7 @@
 use crate::s3_operations::fetch_public_elements;
-use crate::{CmdConfig, CoreClientConfig, CoreConf, SLEEP_TIME_BETWEEN_REQUESTS_MS};
+use crate::{
+    CmdConfig, CoreClientConfig, CoreConf, SLEEP_TIME_BETWEEN_REQUESTS_MS, SigVerificationMaterial,
+};
 
 use aes_prng::AesRng;
 use alloy_sol_types::Eip712Domain;
@@ -114,7 +116,7 @@ pub(crate) async fn do_crsgen(
         kms_addrs,
         destination_prefix,
         req_id,
-        Some((domain, extra_data)),
+        Some(SigVerificationMaterial { domain, extra_data }),
         resp_response_vec,
         cmd_conf.download_all,
     )
@@ -132,8 +134,8 @@ pub(crate) async fn fetch_and_check_crsgen(
     request_id: RequestId,
     // EIP-712 domain + extra_data to verify the external signature against. When
     // `None`, the CRS is still downloaded and request IDs checked, but the
-    // external signature is not verified (a warning is logged).
-    verify: Option<(Eip712Domain, Vec<u8>)>,
+    // external signature is not verified (an error is logged).
+    verify: Option<SigVerificationMaterial>,
     responses: Vec<CrsGenResult>,
     download_all: bool,
 ) -> anyhow::Result<()> {
@@ -195,13 +197,13 @@ pub(crate) async fn fetch_and_check_crsgen(
         }
 
         match verify.as_ref() {
-            Some((domain, extra_data)) => {
+            Some(material) => {
                 check_crsgen_ext_signature(
                     &crs,
                     &request_id,
                     &response.external_signature,
-                    domain,
-                    extra_data.clone(),
+                    &material.domain,
+                    material.extra_data.clone(),
                     kms_addrs,
                 )
                 .inspect_err(|e| tracing::error!("CRS signature check failed: {}", e))?;
@@ -209,7 +211,7 @@ pub(crate) async fn fetch_and_check_crsgen(
                 tracing::info!("EIP712 verification of CRS successful.");
             }
             None => {
-                tracing::warn!(
+                tracing::error!(
                     "CRS gen result for request {} fetched WITHOUT signature verification \
                      (no EIP-712 domain supplied).",
                     request_id

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -200,9 +200,8 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
 
             let resp_response_vec = get_public_decrypt_responses(
                 &core_endpoints_resp,
-                Some(dec_req),
+                Some(PubDecVerificationMaterial::Request(dec_req)),
                 Some(ptxt),
-                None,
                 req_id,
                 max_iter,
                 num_expected_responses,
@@ -487,15 +486,33 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
     Ok(result_vec)
 }
 
+/// Material used to verify fetched public-decryption responses.
+///
+/// The two variants are mutually exclusive by construction, replacing the previous
+/// `dec_req: Option<_>` + `ext_verify: Option<_>` pair which could represent the
+/// nonsensical "both set" state.
+pub(crate) enum PubDecVerificationMaterial {
+    /// Full-flow: verify against the original request. The EIP-712 domain, external
+    /// ciphertext handles and `extra_data` are all derived from it, and the request
+    /// itself binds the responses (internal request-binding check).
+    Request(PublicDecryptionRequest),
+    /// Pure-fetch: verify against externally-supplied material (e.g. from config +
+    /// CLI) when the original request object is not available. Responses are still
+    /// checked against the trusted KMS keys, but not bound to a specific request.
+    External {
+        domain: Eip712Domain,
+        external_handles: Vec<Vec<u8>>,
+        extra_data: Vec<u8>,
+    },
+}
+
 #[expect(clippy::too_many_arguments)]
 pub(crate) async fn get_public_decrypt_responses(
     core_endpoints: &HashMap<CoreConf, CoreServiceEndpointClient<Channel>>,
-    dec_req: Option<PublicDecryptionRequest>,
+    // Verification material for the fetched responses. `None` skips signature
+    // verification entirely (responses are returned unverified, with an error log).
+    verification: Option<PubDecVerificationMaterial>,
     expected_answer: Option<TypedPlaintext>,
-    // External-signature verification inputs (domain, external handles, extra_data),
-    // used by the pure-fetch path when no full `dec_req` is available. When both
-    // `dec_req` and this are `None`, signature verification is skipped.
-    ext_verify: Option<(Eip712Domain, Vec<Vec<u8>>, Vec<u8>)>,
     request_id: RequestId,
     max_iter: usize,
     num_expected_responses: usize,
@@ -586,31 +603,41 @@ pub(crate) async fn get_public_decrypt_responses(
         .map(|(_, resp)| resp)
         .collect();
 
-    // Determine the verification inputs (domain, external handles, extra_data).
-    // Full-flow callers pass the original `dec_req`; pure-fetch callers pass
-    // `ext_verify` (built from config + CLI). When neither is available we skip
-    // signature verification and just return the fetched responses.
-    let verify_inputs: Option<(Eip712Domain, Vec<Vec<u8>>, Vec<u8>)> =
-        if let Some(decryption_request) = dec_req.as_ref() {
-            let domain_msg = decryption_request
-                .domain
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("domain not set in decryption request"))?;
-            let domain = protobuf_to_alloy_domain(domain_msg)?;
-            // retrieve external handles from request
-            let external_handles: Vec<_> = decryption_request
-                .ciphertexts
-                .iter()
-                .map(|ct| ct.external_handle.clone())
-                .collect();
-            let extra_data = decryption_request.extra_data.clone();
-            Some((domain, external_handles, extra_data))
-        } else {
-            ext_verify
-        };
+    // Resolve the verification material into (domain, external handles, extra_data)
+    // plus the optional original request used for the internal request-binding check.
+    // Full-flow callers pass `Request(..)` (everything derived from the request);
+    // pure-fetch callers pass `External { .. }` (built from config + CLI). `None`
+    // skips signature verification and just returns the fetched responses.
+    match verification {
+        Some(material) => {
+            let (domain, external_handles, extra_data, request) = match material {
+                PubDecVerificationMaterial::Request(decryption_request) => {
+                    let domain_msg = decryption_request
+                        .domain
+                        .as_ref()
+                        .ok_or_else(|| anyhow::anyhow!("domain not set in decryption request"))?;
+                    let domain = protobuf_to_alloy_domain(domain_msg)?;
+                    // retrieve external handles from request
+                    let external_handles: Vec<_> = decryption_request
+                        .ciphertexts
+                        .iter()
+                        .map(|ct| ct.external_handle.clone())
+                        .collect();
+                    let extra_data = decryption_request.extra_data.clone();
+                    (
+                        domain,
+                        external_handles,
+                        extra_data,
+                        Some(decryption_request),
+                    )
+                }
+                PubDecVerificationMaterial::External {
+                    domain,
+                    external_handles,
+                    extra_data,
+                } => (domain, external_handles, extra_data, None),
+            };
 
-    match verify_inputs {
-        Some((domain, external_handles, extra_data)) => {
             //If an expected answer is provided, then consider it,
             //otherwise consider the first answer
             let ptxt = match expected_answer {
@@ -628,9 +655,9 @@ pub(crate) async fn get_public_decrypt_responses(
             };
 
             // check the internal signatures (verifies responses are signed by the
-            // trusted KMS keys; request-binding only applies when `dec_req` is set)
+            // trusted KMS keys; request-binding only applies for the `Request` variant)
             internal_client.process_decryption_resp(
-                dec_req,
+                request,
                 num_expected_responses as u32,
                 &resp_response_vec,
             )?;
@@ -652,9 +679,9 @@ pub(crate) async fn get_public_decrypt_responses(
             );
         }
         None => {
-            tracing::warn!(
+            tracing::error!(
                 "{:?} ###! Public decryption result fetched WITHOUT verification \
-                 (no EIP-712 domain/handles supplied). The returned plaintexts are NOT \
+                 (no verification material supplied). The returned plaintexts are NOT \
                  verified against the original request.",
                 request_id.as_str(),
             );

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -114,9 +114,13 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
     num_expected_responses: usize,
     inter_request_delay: tokio::time::Duration,
     parallel_requests: usize,
-    extra_data: Vec<u8>,
     domain: Eip712Domain,
 ) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
+    // `extra_data` is always derived from the (resolved) context/epoch via
+    // `make_extra_data` (RFC-005 v2) — never user-supplied — matching the
+    // keygen/CRS request builders.
+    let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
+
     let mut timings_start = HashMap::new();
     let mut durations = Vec::new();
 
@@ -251,9 +255,13 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
     num_expected_responses: usize,
     inter_request_delay: tokio::time::Duration,
     parallel_requests: usize,
-    extra_data: Vec<u8>,
     domain: Eip712Domain,
 ) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
+    // `extra_data` is always derived from the (resolved) context/epoch via
+    // `make_extra_data` (RFC-005 v2) — never user-supplied — matching the
+    // keygen/CRS request builders.
+    let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
+
     let mut join_set: JoinSet<Result<_, anyhow::Error>> = JoinSet::new();
     let mut timings_start = HashMap::new();
     let mut durations = Vec::new();
@@ -488,9 +496,11 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
 
 /// Material used to verify fetched public-decryption responses.
 ///
-/// The two variants are mutually exclusive by construction, replacing the previous
-/// `dec_req: Option<_>` + `ext_verify: Option<_>` pair which could represent the
-/// nonsensical "both set" state.
+/// Wrapped in an `Option` at the call sites, where `None` means "skip verification".
+/// This replaces the previous `dec_req: Option<PublicDecryptionRequest>` parameter, whose
+/// `None` case silently fell back to `dummy_domain()`/`dummy_handle()` rather than either
+/// skipping or verifying against real config/CLI material. The two variants are mutually
+/// exclusive by construction, so a caller cannot mix request-derived and external material.
 pub(crate) enum PubDecVerificationMaterial {
     /// Full-flow: verify against the original request. The EIP-712 domain, external
     /// ciphertext handles and `extra_data` are all derived from it, and the request

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -1,4 +1,4 @@
-use crate::{CoreConf, SLEEP_TIME_BETWEEN_REQUESTS_MS, dummy_domain, dummy_handle, print_timings};
+use crate::{CoreConf, SLEEP_TIME_BETWEEN_REQUESTS_MS, print_timings};
 use alloy_sol_types::Eip712Domain;
 use kms_grpc::{
     ContextId, EpochId, KeyId, RequestId,
@@ -115,6 +115,7 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
     inter_request_delay: tokio::time::Duration,
     parallel_requests: usize,
     extra_data: Vec<u8>,
+    domain: Eip712Domain,
 ) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
     let mut timings_start = HashMap::new();
     let mut durations = Vec::new();
@@ -138,6 +139,7 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
         let ptxt = ptxt.clone();
         let kms_addrs = kms_addrs.clone();
         let extra_data = extra_data.clone();
+        let domain = domain.clone();
 
         // start timing measurement for this request
         timings_start.insert(req_id, tokio::time::Instant::now()); // start timing for this request
@@ -146,7 +148,7 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
             // DECRYPTION REQUEST
             let dec_req = internal_client.write().await.public_decryption_request(
                 ct_batch,
-                &dummy_domain(),
+                &domain,
                 &req_id,
                 context_id.as_ref(),
                 &key_id.into(),
@@ -200,6 +202,7 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
                 &core_endpoints_resp,
                 Some(dec_req),
                 Some(ptxt),
+                None,
                 req_id,
                 max_iter,
                 num_expected_responses,
@@ -250,6 +253,7 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
     inter_request_delay: tokio::time::Duration,
     parallel_requests: usize,
     extra_data: Vec<u8>,
+    domain: Eip712Domain,
 ) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
     let mut join_set: JoinSet<Result<_, anyhow::Error>> = JoinSet::new();
     let mut timings_start = HashMap::new();
@@ -272,6 +276,7 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
         let core_endpoints_resp = core_endpoints_resp.clone();
         let original_plaintext = ptxt.clone();
         let extra_data = extra_data.clone();
+        let domain = domain.clone();
 
         // start timing measurement for this request
         timings_start.insert(req_id, tokio::time::Instant::now()); // start timing for this request
@@ -279,7 +284,7 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
         // USER_DECRYPTION REQUEST
         join_set.spawn(async move {
             let user_decrypt_req_tuple = internal_client.write().await.user_decryption_request(
-                &dummy_domain(),
+                &domain,
                 ct_batch,
                 &req_id,
                 &key_id.into(),
@@ -487,6 +492,10 @@ pub(crate) async fn get_public_decrypt_responses(
     core_endpoints: &HashMap<CoreConf, CoreServiceEndpointClient<Channel>>,
     dec_req: Option<PublicDecryptionRequest>,
     expected_answer: Option<TypedPlaintext>,
+    // External-signature verification inputs (domain, external handles, extra_data),
+    // used by the pure-fetch path when no full `dec_req` is available. When both
+    // `dec_req` and this are `None`, signature verification is skipped.
+    ext_verify: Option<(Eip712Domain, Vec<Vec<u8>>, Vec<u8>)>,
     request_id: RequestId,
     max_iter: usize,
     num_expected_responses: usize,
@@ -577,81 +586,80 @@ pub(crate) async fn get_public_decrypt_responses(
         .map(|(_, resp)| resp)
         .collect();
 
-    //If an expected answer is provided, then consider it,
-    //otherwise consider the first answer
-    let ptxt = match expected_answer {
-        Some(pt) => pt,
-        None => resp_response_vec
-            .first()
-            .ok_or_else(|| anyhow::anyhow!("no public decryption responses available"))?
-            .payload
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("missing payload in first decryption response"))?
-            .plaintexts
-            .first()
-            .ok_or_else(|| anyhow::anyhow!("no plaintexts in first decryption response"))?
-            .clone(),
-    };
+    // Determine the verification inputs (domain, external handles, extra_data).
+    // Full-flow callers pass the original `dec_req`; pure-fetch callers pass
+    // `ext_verify` (built from config + CLI). When neither is available we skip
+    // signature verification and just return the fetched responses.
+    let verify_inputs: Option<(Eip712Domain, Vec<Vec<u8>>, Vec<u8>)> =
+        if let Some(decryption_request) = dec_req.as_ref() {
+            let domain_msg = decryption_request
+                .domain
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("domain not set in decryption request"))?;
+            let domain = protobuf_to_alloy_domain(domain_msg)?;
+            // retrieve external handles from request
+            let external_handles: Vec<_> = decryption_request
+                .ciphertexts
+                .iter()
+                .map(|ct| ct.external_handle.clone())
+                .collect();
+            let extra_data = decryption_request.extra_data.clone();
+            Some((domain, external_handles, extra_data))
+        } else {
+            ext_verify
+        };
 
-    let (domain, external_handles, extra_data) = if let Some(decryption_request) = dec_req.as_ref()
-    {
-        let domain_msg = decryption_request
-            .domain
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("domain not set in decryption request"))?;
-        let domain = protobuf_to_alloy_domain(domain_msg)?;
-        // retrieve external handles from request
-        let external_handles: Vec<_> = decryption_request
-            .ciphertexts
-            .iter()
-            .map(|ct| ct.external_handle.clone())
-            .collect();
-        let extra_data = decryption_request.extra_data.clone();
-        (domain, external_handles, extra_data)
-    } else {
-        //If the decryption request isn't provided we assume it was dummy domains and handles
-        let num_handles = resp_response_vec
-            .first()
-            .ok_or_else(|| anyhow::anyhow!("no public decryption responses available"))?
-            .payload
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("missing payload in first decryption response"))?
-            .plaintexts
-            .len();
-        let extra_data = resp_response_vec
-            .first()
-            .ok_or_else(|| anyhow::anyhow!("no public decryption responses available"))?
-            .extra_data
-            .clone();
-        (
-            dummy_domain(),
-            vec![dummy_handle(); num_handles],
-            extra_data,
-        )
-    };
+    match verify_inputs {
+        Some((domain, external_handles, extra_data)) => {
+            //If an expected answer is provided, then consider it,
+            //otherwise consider the first answer
+            let ptxt = match expected_answer {
+                Some(pt) => pt,
+                None => resp_response_vec
+                    .first()
+                    .ok_or_else(|| anyhow::anyhow!("no public decryption responses available"))?
+                    .payload
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("missing payload in first decryption response"))?
+                    .plaintexts
+                    .first()
+                    .ok_or_else(|| anyhow::anyhow!("no plaintexts in first decryption response"))?
+                    .clone(),
+            };
 
-    // check the internal signatures
-    internal_client.process_decryption_resp(
-        dec_req,
-        num_expected_responses as u32,
-        &resp_response_vec,
-    )?;
+            // check the internal signatures (verifies responses are signed by the
+            // trusted KMS keys; request-binding only applies when `dec_req` is set)
+            internal_client.process_decryption_resp(
+                dec_req,
+                num_expected_responses as u32,
+                &resp_response_vec,
+            )?;
 
-    // check the external signatures
-    check_external_decryption_signature(
-        &resp_response_vec,
-        ptxt,
-        &external_handles,
-        &domain,
-        kms_addrs,
-        &extra_data,
-    )?;
+            // check the external signatures
+            check_external_decryption_signature(
+                &resp_response_vec,
+                ptxt,
+                &external_handles,
+                &domain,
+                kms_addrs,
+                &extra_data,
+            )?;
 
-    tracing::info!(
-        "{:?} ###! Verified public decypt responses. Since start {:?}",
-        request_id.as_str(),
-        start.elapsed()
-    );
+            tracing::info!(
+                "{:?} ###! Verified public decypt responses. Since start {:?}",
+                request_id.as_str(),
+                start.elapsed()
+            );
+        }
+        None => {
+            tracing::warn!(
+                "{:?} ###! Public decryption result fetched WITHOUT verification \
+                 (no EIP-712 domain/handles supplied). The returned plaintexts are NOT \
+                 verified against the original request.",
+                request_id.as_str(),
+            );
+        }
+    }
 
     Ok(resp_response_vec)
 }

--- a/core-client/src/keygen.rs
+++ b/core-client/src/keygen.rs
@@ -9,7 +9,7 @@ use hashing::hash_versioned;
 use kms_grpc::identifiers::EpochId;
 use kms_grpc::kms::v1::{FheParameter, KeyGenPreprocResult, KeyGenResult};
 use kms_grpc::kms_service::v1::core_service_endpoint_client::CoreServiceEndpointClient;
-use kms_grpc::rpc_types::{PubDataType, protobuf_to_alloy_domain};
+use kms_grpc::rpc_types::PubDataType;
 use kms_grpc::solidity_types::KeygenVerification;
 use kms_grpc::{ContextId, RequestId};
 use kms_lib::client::client_wasm::Client;
@@ -91,8 +91,10 @@ pub(crate) async fn do_keygen(
         cc_conf.num_majority
     };
 
-    // NOTE: If we do not use dummy_domain here, then
-    // this needs changing too in the KeyGenResult command.
+    // The EIP-712 domain comes from the config (falling back to `dummy_domain`),
+    // so the request built here and a later (Insecure)KeyGenResult fetch verify
+    // against the same domain.
+    let domain = cc_conf.default_domain()?;
     let use_existing = shared_config.existing_keyset_id.is_some();
     let keyset_config = Some(build_standard_keyset_config(
         if shared_config.uncompressed {
@@ -123,17 +125,9 @@ pub(crate) async fn do_keygen(
         Some(param),
         keyset_config,
         keyset_added_info,
-        dummy_domain(),
+        domain.clone(),
     )?;
     let extra_data = dkg_req.extra_data.clone();
-
-    //NOTE: Extract domain from request for sanity, but if we don't use dummy_domain
-    //we have an issue in the (Insecure)KeyGenResult commands
-    let domain = if let Some(domain) = &dkg_req.domain {
-        protobuf_to_alloy_domain(domain)?
-    } else {
-        return Err(anyhow::anyhow!("No domain provided in crsgen request"));
-    };
 
     // make parallel requests by calling insecure keygen in a thread
     let mut req_tasks = JoinSet::new();
@@ -193,8 +187,7 @@ pub(crate) async fn do_keygen(
         kms_addrs,
         destination_prefix,
         req_id,
-        domain,
-        extra_data,
+        Some((domain, extra_data)),
         resp_response_vec,
         cmd_conf.download_all,
         shared_config.uncompressed,
@@ -211,8 +204,10 @@ pub(crate) async fn fetch_and_check_keygen(
     kms_addrs: &[alloy_primitives::Address],
     destination_prefix: &Path,
     request_id: RequestId,
-    domain: Eip712Domain,
-    extra_data: Vec<u8>,
+    // EIP-712 domain + extra_data to verify the external signature against. When
+    // `None`, the keys are still downloaded and request IDs checked, but the
+    // external signature is not verified (a warning is logged).
+    verify: Option<(Eip712Domain, Vec<u8>)>,
     responses: Vec<KeyGenResult>,
     download_all: bool,
     uncompressed: bool,
@@ -274,25 +269,36 @@ pub(crate) async fn fetch_and_check_keygen(
                 );
             }
 
-            let external_signature = response.external_signature;
-            let prep_id = response.preprocessing_id.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "No preprocessing ID in keygen response, cannot verify external signature"
-                )
-            })?;
-            check_compressed_keyset_ext_signature(
-                &compressed_keyset,
-                &compact_public_key,
-                &prep_id.try_into()?,
-                &request_id,
-                &external_signature,
-                &domain,
-                extra_data.clone(),
-                kms_addrs,
-            )
-            .inspect_err(|e| tracing::error!("signature check failed: {}", e))?;
+            match verify.as_ref() {
+                Some((domain, extra_data)) => {
+                    let external_signature = response.external_signature;
+                    let prep_id = response.preprocessing_id.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "No preprocessing ID in keygen response, cannot verify external signature"
+                        )
+                    })?;
+                    check_compressed_keyset_ext_signature(
+                        &compressed_keyset,
+                        &compact_public_key,
+                        &prep_id.try_into()?,
+                        &request_id,
+                        &external_signature,
+                        domain,
+                        extra_data.clone(),
+                        kms_addrs,
+                    )
+                    .inspect_err(|e| tracing::error!("signature check failed: {}", e))?;
 
-            tracing::info!("EIP712 verification of CompressedXofKeySet successful.");
+                    tracing::info!("EIP712 verification of CompressedXofKeySet successful.");
+                }
+                None => {
+                    tracing::warn!(
+                        "KeyGen result for request {} fetched WITHOUT signature verification \
+                         (no EIP-712 domain supplied).",
+                        request_id
+                    );
+                }
+            }
         }
     } else {
         let public_key =
@@ -318,25 +324,36 @@ pub(crate) async fn fetch_and_check_keygen(
                 );
             }
 
-            let external_signature = response.external_signature;
-            let prep_id = response.preprocessing_id.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "No preprocessing ID in keygen response, cannot verify external signature"
-                )
-            })?;
-            check_uncompressed_keyset_ext_signature(
-                &public_key,
-                &server_key,
-                &prep_id.try_into()?,
-                &request_id,
-                &external_signature,
-                &domain,
-                extra_data.clone(),
-                kms_addrs,
-            )
-            .inspect_err(|e| tracing::error!("signature check failed: {}", e))?;
+            match verify.as_ref() {
+                Some((domain, extra_data)) => {
+                    let external_signature = response.external_signature;
+                    let prep_id = response.preprocessing_id.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "No preprocessing ID in keygen response, cannot verify external signature"
+                        )
+                    })?;
+                    check_uncompressed_keyset_ext_signature(
+                        &public_key,
+                        &server_key,
+                        &prep_id.try_into()?,
+                        &request_id,
+                        &external_signature,
+                        domain,
+                        extra_data.clone(),
+                        kms_addrs,
+                    )
+                    .inspect_err(|e| tracing::error!("signature check failed: {}", e))?;
 
-            tracing::info!("EIP712 verification of Public Key and Server Key successful.");
+                    tracing::info!("EIP712 verification of Public Key and Server Key successful.");
+                }
+                None => {
+                    tracing::warn!(
+                        "KeyGen result for request {} fetched WITHOUT signature verification \
+                         (no EIP-712 domain supplied).",
+                        request_id
+                    );
+                }
+            }
         }
     }
     Ok(())

--- a/core-client/src/keygen.rs
+++ b/core-client/src/keygen.rs
@@ -1,7 +1,7 @@
 use crate::s3_operations::fetch_public_elements;
 use crate::{
     CmdConfig, CoreClientConfig, CoreConf, PartialKeyGenPreprocParameters,
-    SLEEP_TIME_BETWEEN_REQUESTS_MS, SharedKeyGenParameters, dummy_domain,
+    SLEEP_TIME_BETWEEN_REQUESTS_MS, SharedKeyGenParameters, SigVerificationMaterial, dummy_domain,
 };
 use aes_prng::AesRng;
 use alloy_sol_types::Eip712Domain;
@@ -187,7 +187,7 @@ pub(crate) async fn do_keygen(
         kms_addrs,
         destination_prefix,
         req_id,
-        Some((domain, extra_data)),
+        Some(SigVerificationMaterial { domain, extra_data }),
         resp_response_vec,
         cmd_conf.download_all,
         shared_config.uncompressed,
@@ -206,8 +206,8 @@ pub(crate) async fn fetch_and_check_keygen(
     request_id: RequestId,
     // EIP-712 domain + extra_data to verify the external signature against. When
     // `None`, the keys are still downloaded and request IDs checked, but the
-    // external signature is not verified (a warning is logged).
-    verify: Option<(Eip712Domain, Vec<u8>)>,
+    // external signature is not verified (an error is logged).
+    verify: Option<SigVerificationMaterial>,
     responses: Vec<KeyGenResult>,
     download_all: bool,
     uncompressed: bool,
@@ -270,7 +270,7 @@ pub(crate) async fn fetch_and_check_keygen(
             }
 
             match verify.as_ref() {
-                Some((domain, extra_data)) => {
+                Some(material) => {
                     let external_signature = response.external_signature;
                     let prep_id = response.preprocessing_id.ok_or_else(|| {
                         anyhow::anyhow!(
@@ -283,8 +283,8 @@ pub(crate) async fn fetch_and_check_keygen(
                         &prep_id.try_into()?,
                         &request_id,
                         &external_signature,
-                        domain,
-                        extra_data.clone(),
+                        &material.domain,
+                        material.extra_data.clone(),
                         kms_addrs,
                     )
                     .inspect_err(|e| tracing::error!("signature check failed: {}", e))?;
@@ -292,7 +292,7 @@ pub(crate) async fn fetch_and_check_keygen(
                     tracing::info!("EIP712 verification of CompressedXofKeySet successful.");
                 }
                 None => {
-                    tracing::warn!(
+                    tracing::error!(
                         "KeyGen result for request {} fetched WITHOUT signature verification \
                          (no EIP-712 domain supplied).",
                         request_id
@@ -325,7 +325,7 @@ pub(crate) async fn fetch_and_check_keygen(
             }
 
             match verify.as_ref() {
-                Some((domain, extra_data)) => {
+                Some(material) => {
                     let external_signature = response.external_signature;
                     let prep_id = response.preprocessing_id.ok_or_else(|| {
                         anyhow::anyhow!(
@@ -338,8 +338,8 @@ pub(crate) async fn fetch_and_check_keygen(
                         &prep_id.try_into()?,
                         &request_id,
                         &external_signature,
-                        domain,
-                        extra_data.clone(),
+                        &material.domain,
+                        material.extra_data.clone(),
                         kms_addrs,
                     )
                     .inspect_err(|e| tracing::error!("signature check failed: {}", e))?;
@@ -347,7 +347,7 @@ pub(crate) async fn fetch_and_check_keygen(
                     tracing::info!("EIP712 verification of Public Key and Server Key successful.");
                 }
                 None => {
-                    tracing::warn!(
+                    tracing::error!(
                         "KeyGen result for request {} fetched WITHOUT signature verification \
                          (no EIP-712 domain supplied).",
                         request_id

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -132,14 +132,24 @@ pub struct Eip712DomainConfig {
 impl Eip712DomainConfig {
     /// Build an [`alloy_sol_types::Eip712Domain`] from the configured fields.
     pub fn to_domain(&self) -> anyhow::Result<alloy_sol_types::Eip712Domain> {
-        let verifying_contract =
-            alloy_primitives::Address::from_str(self.verifying_contract.trim_start_matches("0x"))
-                .map_err(|e| {
-                anyhow::anyhow!(
-                    "invalid verifying_contract '{}' in default_domain: {e}",
-                    self.verifying_contract
-                )
-            })?;
+        // Accept the address with or without a `0x`/`0X` prefix by going through
+        // `parse_hex` (as `salt` does below); `Address::from_str` only strips a lowercase
+        // `0x`, so a `0X`-prefixed address would otherwise be rejected.
+        let verifying_contract_bytes = parse_hex(&self.verifying_contract).map_err(|e| {
+            anyhow::anyhow!(
+                "invalid verifying_contract '{}' in default_domain: {e}",
+                self.verifying_contract
+            )
+        })?;
+        let verifying_contract = alloy_primitives::Address::try_from(
+            verifying_contract_bytes.as_slice(),
+        )
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "invalid verifying_contract '{}' in default_domain: must be exactly 20 bytes",
+                self.verifying_contract
+            )
+        })?;
         let salt = match &self.salt {
             Some(s) => {
                 let bytes = parse_hex(s)?;
@@ -1098,6 +1108,22 @@ fn dummy_handle() -> Vec<u8> {
     vec![23_u8; 32]
 }
 
+/// Distinct placeholder ciphertext handles for a public-decryption batch — one entry per
+/// ciphertext. The handles within a batch must differ because a handle identifies a
+/// specific ciphertext/plaintext. Shared by the request builder and the integration tests
+/// so both agree on the exact handle list the external signature is computed over.
+pub fn integration_test_handles(count: usize) -> Vec<Vec<u8>> {
+    (0..count)
+        .map(|i| {
+            // 32-byte placeholder, made unique by encoding the batch index into the
+            // leading bytes (kept <= 32 bytes, as required by the signing-message builder).
+            let mut handle = dummy_handle();
+            handle[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            handle
+        })
+        .collect()
+}
+
 /// Derive the `extra_data` payload from an optional context/epoch, falling back to
 /// [`DEFAULT_MPC_CONTEXT`] / [`DEFAULT_EPOCH_ID`] when not supplied. This is the single
 /// source of truth for how the core-client builds `extra_data` (RFC-005 v2), used both
@@ -1875,15 +1901,20 @@ pub async fn execute_cmd(
                 }
             };
 
-            let ct_batch = vec![
-                TypedCiphertext {
-                    ciphertext,
-                    fhe_type: ptxt.fhe_type,
-                    external_handle: dummy_handle(),
-                    ciphertext_format: ct_format.into(),
-                };
-                cipher_args.get_batch_size()
-            ];
+            // Build one ciphertext per batch entry, each with a *distinct* external handle
+            // (a handle identifies a specific ciphertext/plaintext, so they must differ).
+            let fhe_type = ptxt.fhe_type;
+            let ciphertext_format: i32 = ct_format.into();
+            let ct_batch: Vec<TypedCiphertext> =
+                integration_test_handles(cipher_args.get_batch_size())
+                    .into_iter()
+                    .map(|external_handle| TypedCiphertext {
+                        ciphertext: ciphertext.clone(),
+                        fhe_type,
+                        external_handle,
+                        ciphertext_format,
+                    })
+                    .collect();
 
             do_public_decrypt(
                 &mut rng,

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -855,8 +855,8 @@ pub struct PublicDecryptResultParameters {
     pub request_id: RequestId,
     /// External ciphertext handle(s) (hex-encoded) from the original request, used to
     /// verify the external signature. Repeat the flag once per ciphertext in the batch.
-    /// When omitted, the result is fetched but NOT verified (an error is logged), since
-    /// handles are request-specific and cannot be defaulted from the config.
+    /// Required unless `--no-verify` is set: handles are request-specific and cannot be
+    /// defaulted from the config, so the command fails when they are omitted.
     /// Can optionally have a "0x" prefix.
     #[clap(long = "handle")]
     pub external_handles: Vec<String>,
@@ -870,7 +870,8 @@ pub struct PublicDecryptResultParameters {
     /// must match the epoch of the original request or verification fails.
     #[clap(long)]
     pub epoch_id: Option<EpochId>,
-    /// Skip verification of the external signature and just return the fetched responses.
+    /// Skip all verification of the fetched responses — both the internal KMS-node
+    /// signatures and the external signature — and just return them.
     #[clap(long, default_value_t = false)]
     pub no_verify: bool,
 }
@@ -2352,20 +2353,23 @@ pub async fn execute_cmd(
 
             // External-signature verification requires the request's EIP-712 domain
             // (from config) plus the per-request ciphertext handles (from `--handle`).
-            // Without `--handle`, or with `--no-verify`, we fetch without verifying.
+            // Verification is mandatory: we only skip it when `--no-verify` is set,
+            // and otherwise fail rather than returning unverified plaintexts.
             let verification = if result_parameters.no_verify {
                 tracing::error!(
                     "--no-verify set: fetching public decryption result WITHOUT verification"
                 );
                 None
-            } else if result_parameters.external_handles.is_empty() {
-                tracing::error!(
-                    "no --handle provided: fetching public decryption result WITHOUT \
-                     verification (ciphertext handles are required to verify the external \
-                     signature)"
-                );
-                None
             } else {
+                if result_parameters.external_handles.is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "no --handle provided: ciphertext handles are required to verify the \
+                         external signature of a public decryption result. Pass --handle once \
+                         per ciphertext in the batch, or pass --no-verify to fetch without \
+                         verification."
+                    )
+                    .into());
+                }
                 let external_handles = result_parameters
                     .external_handles
                     .iter()

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -18,7 +18,9 @@ use crate::backup::{
     do_new_custodian_context, do_restore_from_backup,
 };
 use crate::crsgen::{do_abort_crs_gen, do_crsgen, fetch_and_check_crsgen, get_crsgen_responses};
-use crate::decrypt::{do_public_decrypt, do_user_decrypt, get_public_decrypt_responses};
+use crate::decrypt::{
+    PubDecVerificationMaterial, do_public_decrypt, do_user_decrypt, get_public_decrypt_responses,
+};
 use crate::keygen::{
     do_abort_key_gen, do_keygen, do_partial_preproc, do_preproc, fetch_and_check_keygen,
     get_keygen_responses, get_preproc_keygen_responses,
@@ -107,9 +109,9 @@ pub struct CoreClientConfig {
     pub fhe_params: Option<FheParameter>,
     /// Default `extra_data` (hex-encoded) bound in the EIP-712 signature, used as
     /// the default when verifying fetched results. It can be overridden per
-    /// invocation with `--extra-data`. When neither is set, each pure-fetch
-    /// command falls back to its operation-specific natural default (empty for
-    /// public decryption, [`kms_lib::consts::default_extra_data`] for keygen/CRS).
+    /// invocation with `--extra-data`. When neither is set, every pure-fetch
+    /// command falls back to [`kms_lib::consts::default_extra_data`] (RFC-005
+    /// version 0x02: default context_id ‖ epoch_id).
     // NOTE: declared before `default_domain` so TOML serialization keeps this
     // scalar value before the `default_domain` table.
     pub default_extra_data: Option<String>,
@@ -1119,18 +1121,26 @@ fn dummy_handle() -> Vec<u8> {
     vec![23_u8; 32]
 }
 
-/// Build the `(domain, extra_data)` verification context for a keygen/CRS pure-fetch
-/// command. Returns `None` (skip verification, with a warning) when `no_verify` is set.
-/// Otherwise the domain comes from the config (falling back to [`dummy_domain`]) and the
-/// `extra_data` is taken from `--extra-data`, else the config default, else the natural
-/// keygen/CRS default ([`default_extra_data`]).
+/// External-signature verification material for a keygen/CRS result fetch: the
+/// EIP-712 `domain` and the `extra_data` the signature is bound to. Wrapped in an
+/// `Option` at the call sites, where `None` means "skip verification".
+pub(crate) struct SigVerificationMaterial {
+    pub domain: alloy_sol_types::Eip712Domain,
+    pub extra_data: Vec<u8>,
+}
+
+/// Build the [`SigVerificationMaterial`] for a keygen/CRS pure-fetch command. Returns
+/// `None` (skip verification, with an error log) when `no_verify` is set. Otherwise the
+/// domain comes from the config (falling back to [`dummy_domain`]) and the `extra_data`
+/// is taken from `--extra-data`, else the config default, else the natural keygen/CRS
+/// default ([`default_extra_data`]).
 fn keygen_crs_verify_ctx(
     cc_conf: &CoreClientConfig,
     no_verify: bool,
     extra_data_cli: &Option<String>,
-) -> anyhow::Result<Option<(alloy_sol_types::Eip712Domain, Vec<u8>)>> {
+) -> anyhow::Result<Option<SigVerificationMaterial>> {
     if no_verify {
-        tracing::warn!("--no-verify set: fetching result WITHOUT external-signature verification");
+        tracing::error!("--no-verify set: fetching result WITHOUT external-signature verification");
         return Ok(None);
     }
     let extra_data = match extra_data_cli {
@@ -1139,7 +1149,10 @@ fn keygen_crs_verify_ctx(
             .default_extra_data()?
             .unwrap_or_else(default_extra_data),
     };
-    Ok(Some((cc_conf.default_domain()?, extra_data)))
+    Ok(Some(SigVerificationMaterial {
+        domain: cc_conf.default_domain()?,
+        extra_data,
+    }))
 }
 
 pub struct EncryptionResult {
@@ -2321,36 +2334,45 @@ pub async fn execute_cmd(
             // External-signature verification requires the request's EIP-712 domain
             // (from config) plus the per-request ciphertext handles (from `--handle`).
             // Without `--handle`, or with `--no-verify`, we fetch without verifying.
-            let ext_verify = if result_parameters.no_verify {
-                tracing::warn!(
+            let verification = if result_parameters.no_verify {
+                tracing::error!(
                     "--no-verify set: fetching public decryption result WITHOUT verification"
                 );
                 None
             } else if result_parameters.external_handles.is_empty() {
-                tracing::warn!(
+                tracing::error!(
                     "no --handle provided: fetching public decryption result WITHOUT \
                      verification (ciphertext handles are required to verify the external \
                      signature)"
                 );
                 None
             } else {
-                let handles = result_parameters
+                let external_handles = result_parameters
                     .external_handles
                     .iter()
                     .map(|h| parse_hex(h))
                     .collect::<anyhow::Result<Vec<_>>>()?;
                 let extra_data = match &result_parameters.extra_data {
                     Some(s) => parse_hex(s)?,
-                    None => cc_conf.default_extra_data()?.unwrap_or_default(),
+                    // Same fallback as the keygen/CRS pure-fetch path: the default
+                    // `extra_data` follows RFC-005 (version 0x02: default context_id ‖
+                    // epoch_id). Revisit if a newer RFC changes the extra_data encoding
+                    // the gateway/relayer binds into the EIP-712 signature.
+                    None => cc_conf
+                        .default_extra_data()?
+                        .unwrap_or_else(default_extra_data),
                 };
-                Some((cc_conf.default_domain()?, handles, extra_data))
+                Some(PubDecVerificationMaterial::External {
+                    domain: cc_conf.default_domain()?,
+                    external_handles,
+                    extra_data,
+                })
             };
 
             let resp_response_vec = get_public_decrypt_responses(
                 &core_endpoints_req,
+                verification,
                 None,
-                None,
-                ext_verify,
                 req_id,
                 max_iter,
                 num_expected_responses,

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -138,17 +138,19 @@ impl Eip712DomainConfig {
         let verifying_contract =
             alloy_primitives::Address::from_str(self.verifying_contract.trim_start_matches("0x"))
                 .map_err(|e| {
-                    anyhow::anyhow!(
-                        "invalid verifying_contract '{}' in default_domain: {e}",
-                        self.verifying_contract
-                    )
-                })?;
+                anyhow::anyhow!(
+                    "invalid verifying_contract '{}' in default_domain: {e}",
+                    self.verifying_contract
+                )
+            })?;
         let salt = match &self.salt {
             Some(s) => {
                 let bytes = parse_hex(s)?;
-                Some(alloy_primitives::B256::try_from(bytes.as_slice()).map_err(|_| {
-                    anyhow::anyhow!("default_domain salt must be exactly 32 bytes")
-                })?)
+                Some(
+                    alloy_primitives::B256::try_from(bytes.as_slice()).map_err(|_| {
+                        anyhow::anyhow!("default_domain salt must be exactly 32 bytes")
+                    })?,
+                )
             }
             None => None,
         };
@@ -1128,14 +1130,14 @@ fn keygen_crs_verify_ctx(
     extra_data_cli: &Option<String>,
 ) -> anyhow::Result<Option<(alloy_sol_types::Eip712Domain, Vec<u8>)>> {
     if no_verify {
-        tracing::warn!(
-            "--no-verify set: fetching result WITHOUT external-signature verification"
-        );
+        tracing::warn!("--no-verify set: fetching result WITHOUT external-signature verification");
         return Ok(None);
     }
     let extra_data = match extra_data_cli {
         Some(s) => parse_hex(s)?,
-        None => cc_conf.default_extra_data()?.unwrap_or_else(default_extra_data),
+        None => cc_conf
+            .default_extra_data()?
+            .unwrap_or_else(default_extra_data),
     };
     Ok(Some((cc_conf.default_domain()?, extra_data)))
 }

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -35,7 +35,7 @@ use kms_grpc::rpc_types::PubDataType;
 use kms_grpc::{ContextId, KeyId, RequestId};
 use kms_lib::backup::custodian::{InternalCustodianRecoveryOutput, InternalCustodianSetupMessage};
 use kms_lib::client::client_wasm::Client;
-use kms_lib::consts::{DEFAULT_PARAM, SIGNING_KEY_ID, TEST_PARAM};
+use kms_lib::consts::{DEFAULT_PARAM, SIGNING_KEY_ID, TEST_PARAM, default_extra_data};
 use kms_lib::util::file_handling::{
     read_element, safe_read_element_versioned, safe_write_element_versioned, write_element,
 };
@@ -105,6 +105,80 @@ pub struct CoreClientConfig {
     #[validate(range(min = 1))]
     pub num_reconstruct: usize,
     pub fhe_params: Option<FheParameter>,
+    /// Default `extra_data` (hex-encoded) bound in the EIP-712 signature, used as
+    /// the default when verifying fetched results. It can be overridden per
+    /// invocation with `--extra-data`. When neither is set, each pure-fetch
+    /// command falls back to its operation-specific natural default (empty for
+    /// public decryption, [`kms_lib::consts::default_extra_data`] for keygen/CRS).
+    // NOTE: declared before `default_domain` so TOML serialization keeps this
+    // scalar value before the `default_domain` table.
+    pub default_extra_data: Option<String>,
+    /// Default EIP-712 domain used both when *building* requests (full-flow
+    /// commands) and when *verifying* fetched results (pure-fetch `*Result`
+    /// commands). When omitted from the TOML it falls back to [`dummy_domain`],
+    /// so existing config files keep their previous behaviour.
+    pub default_domain: Option<Eip712DomainConfig>,
+}
+
+/// EIP-712 domain as specified in the core-client config file (TOML).
+#[derive(Deserialize, Serialize, Clone, Debug, Hash, PartialEq, Eq)]
+pub struct Eip712DomainConfig {
+    pub name: String,
+    pub version: String,
+    pub chain_id: u64,
+    /// Hex-encoded verifying contract address (with or without `0x`).
+    pub verifying_contract: String,
+    /// Optional hex-encoded 32-byte domain salt.
+    pub salt: Option<String>,
+}
+
+impl Eip712DomainConfig {
+    /// Build an [`alloy_sol_types::Eip712Domain`] from the configured fields.
+    pub fn to_domain(&self) -> anyhow::Result<alloy_sol_types::Eip712Domain> {
+        let verifying_contract =
+            alloy_primitives::Address::from_str(self.verifying_contract.trim_start_matches("0x"))
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "invalid verifying_contract '{}' in default_domain: {e}",
+                        self.verifying_contract
+                    )
+                })?;
+        let salt = match &self.salt {
+            Some(s) => {
+                let bytes = parse_hex(s)?;
+                Some(alloy_primitives::B256::try_from(bytes.as_slice()).map_err(|_| {
+                    anyhow::anyhow!("default_domain salt must be exactly 32 bytes")
+                })?)
+            }
+            None => None,
+        };
+        Ok(alloy_sol_types::Eip712Domain {
+            name: Some(std::borrow::Cow::Owned(self.name.clone())),
+            version: Some(std::borrow::Cow::Owned(self.version.clone())),
+            chain_id: Some(alloy_primitives::U256::from(self.chain_id)),
+            verifying_contract: Some(verifying_contract),
+            salt,
+        })
+    }
+}
+
+impl CoreClientConfig {
+    /// The default EIP-712 domain to use for building requests and verifying
+    /// results, falling back to [`dummy_domain`] when not set in the config.
+    pub fn default_domain(&self) -> anyhow::Result<alloy_sol_types::Eip712Domain> {
+        match &self.default_domain {
+            Some(d) => d.to_domain(),
+            None => Ok(dummy_domain()),
+        }
+    }
+
+    /// The configured default `extra_data` (decoded from hex), if any.
+    pub fn default_extra_data(&self) -> anyhow::Result<Option<Vec<u8>>> {
+        match &self.default_extra_data {
+            Some(s) => Ok(Some(parse_hex(s)?)),
+            None => Ok(None),
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Clone, Validate, Default, Debug, Hash, PartialEq, Eq)]
@@ -293,6 +367,8 @@ impl<'de> Deserialize<'de> for CoreClientConfig {
             pub num_majority: usize,
             pub num_reconstruct: usize,
             pub fhe_params: Option<FheParameter>,
+            pub default_domain: Option<Eip712DomainConfig>,
+            pub default_extra_data: Option<String>,
         }
 
         let temp = CoreClientConfigBuffer::deserialize(deserializer)?;
@@ -307,6 +383,8 @@ impl<'de> Deserialize<'de> for CoreClientConfig {
             num_majority: temp.num_majority,
             num_reconstruct: temp.num_reconstruct,
             fhe_params: temp.fhe_params,
+            default_domain: temp.default_domain,
+            default_extra_data: temp.default_extra_data,
         };
 
         conf.validate().map_err(serde::de::Error::custom)?;
@@ -761,6 +839,49 @@ pub struct KeyGenResultParameters {
     /// Fetch legacy uncompressed public key material instead of the default compressed keyset.
     #[clap(long, short = 'u', default_value_t = false)]
     pub uncompressed: bool,
+    /// Optional `extra_data` (hex-encoded) bound in the EIP-712 signature, overriding
+    /// the config's `default_extra_data` for this verification.
+    /// Can optionally have a "0x" prefix.
+    #[clap(long)]
+    pub extra_data: Option<String>,
+    /// Skip verification of the external signature and just download the material.
+    #[clap(long, default_value_t = false)]
+    pub no_verify: bool,
+}
+
+#[derive(Debug, Parser, Clone)]
+pub struct CrsGenResultParameters {
+    #[clap(long, short = 'i')]
+    pub request_id: RequestId,
+    /// Optional `extra_data` (hex-encoded) bound in the EIP-712 signature, overriding
+    /// the config's `default_extra_data` for this verification.
+    /// Can optionally have a "0x" prefix.
+    #[clap(long)]
+    pub extra_data: Option<String>,
+    /// Skip verification of the external signature and just download the material.
+    #[clap(long, default_value_t = false)]
+    pub no_verify: bool,
+}
+
+#[derive(Debug, Parser, Clone)]
+pub struct PublicDecryptResultParameters {
+    #[clap(long, short = 'i')]
+    pub request_id: RequestId,
+    /// External ciphertext handle(s) (hex-encoded) from the original request, used to
+    /// verify the external signature. Repeat the flag once per ciphertext in the batch.
+    /// When omitted, the result is fetched but NOT verified (a warning is logged), since
+    /// handles are request-specific and cannot be defaulted from the config.
+    /// Can optionally have a "0x" prefix.
+    #[clap(long = "handle")]
+    pub external_handles: Vec<String>,
+    /// Optional `extra_data` (hex-encoded) bound in the EIP-712 signature, overriding
+    /// the config's `default_extra_data` for this verification.
+    /// Can optionally have a "0x" prefix.
+    #[clap(long)]
+    pub extra_data: Option<String>,
+    /// Skip verification of the external signature and just return the fetched responses.
+    #[clap(long, default_value_t = false)]
+    pub no_verify: bool,
 }
 
 #[derive(Debug, Parser, Clone)]
@@ -925,14 +1046,14 @@ pub enum CCCommand {
     Encrypt(CipherParameters),
     #[clap(subcommand)]
     PublicDecrypt(CipherArguments),
-    PublicDecryptResult(ResultParameters),
+    PublicDecryptResult(PublicDecryptResultParameters),
     #[clap(subcommand)]
     UserDecrypt(CipherArguments),
     CrsGen(CrsParameters),
-    CrsGenResult(ResultParameters),
+    CrsGenResult(CrsGenResultParameters),
     AbortCrsGen(AbortParameters),
     InsecureCrsGen(CrsParameters),
-    InsecureCrsGenResult(ResultParameters),
+    InsecureCrsGenResult(CrsGenResultParameters),
     NewCustodianContext(NewCustodianContextParameters),
     GetOperatorPublicKey(NoParameters),
     CustodianRecoveryInit(RecoveryInitParameters),
@@ -994,6 +1115,29 @@ fn dummy_domain() -> alloy_sol_types::Eip712Domain {
 // dummy ciphertext handle for testing
 fn dummy_handle() -> Vec<u8> {
     vec![23_u8; 32]
+}
+
+/// Build the `(domain, extra_data)` verification context for a keygen/CRS pure-fetch
+/// command. Returns `None` (skip verification, with a warning) when `no_verify` is set.
+/// Otherwise the domain comes from the config (falling back to [`dummy_domain`]) and the
+/// `extra_data` is taken from `--extra-data`, else the config default, else the natural
+/// keygen/CRS default ([`default_extra_data`]).
+fn keygen_crs_verify_ctx(
+    cc_conf: &CoreClientConfig,
+    no_verify: bool,
+    extra_data_cli: &Option<String>,
+) -> anyhow::Result<Option<(alloy_sol_types::Eip712Domain, Vec<u8>)>> {
+    if no_verify {
+        tracing::warn!(
+            "--no-verify set: fetching result WITHOUT external-signature verification"
+        );
+        return Ok(None);
+    }
+    let extra_data = match extra_data_cli {
+        Some(s) => parse_hex(s)?,
+        None => cc_conf.default_extra_data()?.unwrap_or_else(default_extra_data),
+    };
+    Ok(Some((cc_conf.default_domain()?, extra_data)))
 }
 
 pub struct EncryptionResult {
@@ -1756,6 +1900,7 @@ pub async fn execute_cmd(
                 cipher_args.get_inter_request_delay_ms(),
                 cipher_args.get_parallel_requests(),
                 cipher_args.get_extra_data(),
+                cc_conf.default_domain()?,
             )
             .await?
         }
@@ -1834,6 +1979,7 @@ pub async fn execute_cmd(
                 cipher_args.get_inter_request_delay_ms(),
                 cipher_args.get_parallel_requests(),
                 cipher_args.get_extra_data(),
+                cc_conf.default_domain()?,
             )
             .await?
         }
@@ -2108,16 +2254,18 @@ pub async fn execute_cmd(
             )
             .await?;
 
-            //NOTE: We assume the request comes from the core client too
-            //which (for now) uses the dummy_domain
+            let verify = keygen_crs_verify_ctx(
+                &cc_conf,
+                result_parameters.no_verify,
+                &result_parameters.extra_data,
+            )?;
             fetch_and_check_keygen(
                 num_expected_responses,
                 &cc_conf,
                 &kms_addrs,
                 destination_prefix,
                 req_id,
-                dummy_domain(),
-                vec![],
+                verify,
                 resp_response_vec,
                 cmd_config.download_all,
                 result_parameters.uncompressed,
@@ -2141,16 +2289,18 @@ pub async fn execute_cmd(
             )
             .await?;
 
-            //NOTE: We assume the request comes from the core client too
-            //which (for now) uses the dummy_domain
+            let verify = keygen_crs_verify_ctx(
+                &cc_conf,
+                result_parameters.no_verify,
+                &result_parameters.extra_data,
+            )?;
             fetch_and_check_keygen(
                 num_expected_responses,
                 &cc_conf,
                 &kms_addrs,
                 destination_prefix,
                 req_id,
-                dummy_domain(),
-                vec![],
+                verify,
                 resp_response_vec,
                 cmd_config.download_all,
                 result_parameters.uncompressed,
@@ -2165,10 +2315,40 @@ pub async fn execute_cmd(
                 cc_conf.num_majority
             };
             let req_id: RequestId = result_parameters.request_id;
+
+            // External-signature verification requires the request's EIP-712 domain
+            // (from config) plus the per-request ciphertext handles (from `--handle`).
+            // Without `--handle`, or with `--no-verify`, we fetch without verifying.
+            let ext_verify = if result_parameters.no_verify {
+                tracing::warn!(
+                    "--no-verify set: fetching public decryption result WITHOUT verification"
+                );
+                None
+            } else if result_parameters.external_handles.is_empty() {
+                tracing::warn!(
+                    "no --handle provided: fetching public decryption result WITHOUT \
+                     verification (ciphertext handles are required to verify the external \
+                     signature)"
+                );
+                None
+            } else {
+                let handles = result_parameters
+                    .external_handles
+                    .iter()
+                    .map(|h| parse_hex(h))
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+                let extra_data = match &result_parameters.extra_data {
+                    Some(s) => parse_hex(s)?,
+                    None => cc_conf.default_extra_data()?.unwrap_or_default(),
+                };
+                Some((cc_conf.default_domain()?, handles, extra_data))
+            };
+
             let resp_response_vec = get_public_decrypt_responses(
                 &core_endpoints_req,
                 None,
                 None,
+                ext_verify,
                 req_id,
                 max_iter,
                 num_expected_responses,
@@ -2196,16 +2376,18 @@ pub async fn execute_cmd(
             )
             .await?;
 
-            //NOTE: We assume the request comes from the core client too
-            //which (for now) uses the dummy_domain
+            let verify = keygen_crs_verify_ctx(
+                &cc_conf,
+                result_parameters.no_verify,
+                &result_parameters.extra_data,
+            )?;
             fetch_and_check_crsgen(
                 num_expected_responses,
                 &cc_conf,
                 &kms_addrs,
                 destination_prefix,
                 req_id,
-                dummy_domain(),
-                vec![],
+                verify,
                 resp_response_vec,
                 cmd_config.download_all,
             )
@@ -2228,16 +2410,18 @@ pub async fn execute_cmd(
             )
             .await?;
 
-            //NOTE: We assume the request comes from the core client too
-            //which (for now) uses the dummy_domain
+            let verify = keygen_crs_verify_ctx(
+                &cc_conf,
+                result_parameters.no_verify,
+                &result_parameters.extra_data,
+            )?;
             fetch_and_check_crsgen(
                 num_expected_responses,
                 &cc_conf,
                 &kms_addrs,
                 destination_prefix,
                 req_id,
-                dummy_domain(),
-                vec![],
+                verify,
                 resp_response_vec,
                 cmd_config.download_all,
             )
@@ -2843,6 +3027,8 @@ mod tests {
             num_majority: 1,
             num_reconstruct: 1,
             fhe_params: Some(FheParameter::Test),
+            default_domain: None,
+            default_extra_data: None,
         };
 
         let party_confs =

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -37,7 +37,10 @@ use kms_grpc::rpc_types::PubDataType;
 use kms_grpc::{ContextId, KeyId, RequestId};
 use kms_lib::backup::custodian::{InternalCustodianRecoveryOutput, InternalCustodianSetupMessage};
 use kms_lib::client::client_wasm::Client;
-use kms_lib::consts::{DEFAULT_PARAM, SIGNING_KEY_ID, TEST_PARAM, default_extra_data};
+use kms_lib::consts::{
+    DEFAULT_EPOCH_ID, DEFAULT_MPC_CONTEXT, DEFAULT_PARAM, SIGNING_KEY_ID, TEST_PARAM,
+};
+use kms_lib::engine::utils::make_extra_data;
 use kms_lib::util::file_handling::{
     read_element, safe_read_element_versioned, safe_write_element_versioned, write_element,
 };
@@ -107,14 +110,6 @@ pub struct CoreClientConfig {
     #[validate(range(min = 1))]
     pub num_reconstruct: usize,
     pub fhe_params: Option<FheParameter>,
-    /// Default `extra_data` (hex-encoded) bound in the EIP-712 signature, used as
-    /// the default when verifying fetched results. It can be overridden per
-    /// invocation with `--extra-data`. When neither is set, every pure-fetch
-    /// command falls back to [`kms_lib::consts::default_extra_data`] (RFC-005
-    /// version 0x02: default context_id ‖ epoch_id).
-    // NOTE: declared before `default_domain` so TOML serialization keeps this
-    // scalar value before the `default_domain` table.
-    pub default_extra_data: Option<String>,
     /// Default EIP-712 domain used both when *building* requests (full-flow
     /// commands) and when *verifying* fetched results (pure-fetch `*Result`
     /// commands). When omitted from the TOML it falls back to [`dummy_domain`],
@@ -173,14 +168,6 @@ impl CoreClientConfig {
         match &self.default_domain {
             Some(d) => d.to_domain(),
             None => Ok(dummy_domain()),
-        }
-    }
-
-    /// The configured default `extra_data` (decoded from hex), if any.
-    pub fn default_extra_data(&self) -> anyhow::Result<Option<Vec<u8>>> {
-        match &self.default_extra_data {
-            Some(s) => Ok(Some(parse_hex(s)?)),
-            None => Ok(None),
         }
     }
 }
@@ -372,7 +359,6 @@ impl<'de> Deserialize<'de> for CoreClientConfig {
             pub num_reconstruct: usize,
             pub fhe_params: Option<FheParameter>,
             pub default_domain: Option<Eip712DomainConfig>,
-            pub default_extra_data: Option<String>,
         }
 
         let temp = CoreClientConfigBuffer::deserialize(deserializer)?;
@@ -388,7 +374,6 @@ impl<'de> Deserialize<'de> for CoreClientConfig {
             num_reconstruct: temp.num_reconstruct,
             fhe_params: temp.fhe_params,
             default_domain: temp.default_domain,
-            default_extra_data: temp.default_extra_data,
         };
 
         conf.validate().map_err(serde::de::Error::custom)?;
@@ -605,20 +590,6 @@ impl CipherArguments {
             }
         }
     }
-
-    pub fn get_extra_data(&self) -> Vec<u8> {
-        let hex_str = match self {
-            CipherArguments::FromFile(cipher_file) => &cipher_file.extra_data,
-            CipherArguments::FromArgs(cipher_parameters) => &cipher_parameters.extra_data,
-        };
-        parse_extra_data(hex_str)
-    }
-}
-
-// Helper function to parse the extra data from the CLI arguments, with the same logic for both CipherParameters and CipherFile.
-// Defaults to an empty byte vector if the extra data is not provided or if the hex parsing fails.
-fn parse_extra_data(hex_str: &Option<String>) -> Vec<u8> {
-    parse_hex(hex_str.as_deref().unwrap_or("")).unwrap_or_default()
 }
 
 #[derive(Debug, Args, Clone, Serialize, Deserialize)]
@@ -673,11 +644,6 @@ pub struct CipherParameters {
     #[serde(skip_serializing, skip_deserializing)]
     #[clap(long, short = 'p', default_value_t = 0)]
     pub parallel_requests: usize,
-    /// Optional extra data (hex-encoded) to include in the request.
-    /// Can optionally have a "0x" prefix.
-    #[serde(skip_serializing, skip_deserializing)]
-    #[clap(long)]
-    pub extra_data: Option<String>,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -698,10 +664,6 @@ pub struct CipherFile {
     /// Number of requests to be sent in parallel (at most num_requests) before waiting for inter_request_delay_ms.
     #[clap(long, short = 'p', default_value_t = 0)]
     pub parallel_requests: usize,
-    /// Optional extra data (hex-encoded) to include in the request.
-    /// Can optionally have a "0x" prefix.
-    #[clap(long)]
-    pub extra_data: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -843,11 +805,16 @@ pub struct KeyGenResultParameters {
     /// Fetch legacy uncompressed public key material instead of the default compressed keyset.
     #[clap(long, short = 'u', default_value_t = false)]
     pub uncompressed: bool,
-    /// Optional `extra_data` (hex-encoded) bound in the EIP-712 signature, overriding
-    /// the config's `default_extra_data` for this verification.
-    /// Can optionally have a "0x" prefix.
+    /// Context ID the original request was made with, used to derive the `extra_data` the
+    /// external signature is bound to. Defaults to the built-in default context when omitted;
+    /// must match the context of the original request or verification fails.
     #[clap(long)]
-    pub extra_data: Option<String>,
+    pub context_id: Option<ContextId>,
+    /// Epoch ID the original request was made with, used to derive the `extra_data` the
+    /// external signature is bound to. Defaults to the built-in default epoch when omitted;
+    /// must match the epoch of the original request or verification fails.
+    #[clap(long)]
+    pub epoch_id: Option<EpochId>,
     /// Skip verification of the external signature and just download the material.
     #[clap(long, default_value_t = false)]
     pub no_verify: bool,
@@ -857,11 +824,16 @@ pub struct KeyGenResultParameters {
 pub struct CrsGenResultParameters {
     #[clap(long, short = 'i')]
     pub request_id: RequestId,
-    /// Optional `extra_data` (hex-encoded) bound in the EIP-712 signature, overriding
-    /// the config's `default_extra_data` for this verification.
-    /// Can optionally have a "0x" prefix.
+    /// Context ID the original request was made with, used to derive the `extra_data` the
+    /// external signature is bound to. Defaults to the built-in default context when omitted;
+    /// must match the context of the original request or verification fails.
     #[clap(long)]
-    pub extra_data: Option<String>,
+    pub context_id: Option<ContextId>,
+    /// Epoch ID the original request was made with, used to derive the `extra_data` the
+    /// external signature is bound to. Defaults to the built-in default epoch when omitted;
+    /// must match the epoch of the original request or verification fails.
+    #[clap(long)]
+    pub epoch_id: Option<EpochId>,
     /// Skip verification of the external signature and just download the material.
     #[clap(long, default_value_t = false)]
     pub no_verify: bool,
@@ -873,16 +845,21 @@ pub struct PublicDecryptResultParameters {
     pub request_id: RequestId,
     /// External ciphertext handle(s) (hex-encoded) from the original request, used to
     /// verify the external signature. Repeat the flag once per ciphertext in the batch.
-    /// When omitted, the result is fetched but NOT verified (a warning is logged), since
+    /// When omitted, the result is fetched but NOT verified (an error is logged), since
     /// handles are request-specific and cannot be defaulted from the config.
     /// Can optionally have a "0x" prefix.
     #[clap(long = "handle")]
     pub external_handles: Vec<String>,
-    /// Optional `extra_data` (hex-encoded) bound in the EIP-712 signature, overriding
-    /// the config's `default_extra_data` for this verification.
-    /// Can optionally have a "0x" prefix.
+    /// Context ID the original request was made with, used to derive the `extra_data` the
+    /// external signature is bound to. Defaults to the built-in default context when omitted;
+    /// must match the context of the original request or verification fails.
     #[clap(long)]
-    pub extra_data: Option<String>,
+    pub context_id: Option<ContextId>,
+    /// Epoch ID the original request was made with, used to derive the `extra_data` the
+    /// external signature is bound to. Defaults to the built-in default epoch when omitted;
+    /// must match the epoch of the original request or verification fails.
+    #[clap(long)]
+    pub epoch_id: Option<EpochId>,
     /// Skip verification of the external signature and just return the fetched responses.
     #[clap(long, default_value_t = false)]
     pub no_verify: bool,
@@ -1121,6 +1098,22 @@ fn dummy_handle() -> Vec<u8> {
     vec![23_u8; 32]
 }
 
+/// Derive the `extra_data` payload from an optional context/epoch, falling back to
+/// [`DEFAULT_MPC_CONTEXT`] / [`DEFAULT_EPOCH_ID`] when not supplied. This is the single
+/// source of truth for how the core-client builds `extra_data` (RFC-005 v2), used both
+/// when *constructing* requests (full-flow commands) and when *verifying* fetched
+/// `*Result`s (pure-fetch commands), so the two always agree for the same context/epoch.
+pub(crate) fn extra_data_from_context_epoch(
+    context_id: Option<ContextId>,
+    epoch_id: Option<EpochId>,
+) -> anyhow::Result<Vec<u8>> {
+    make_extra_data(
+        2,
+        Some(&context_id.unwrap_or(*DEFAULT_MPC_CONTEXT)),
+        Some(&epoch_id.unwrap_or(*DEFAULT_EPOCH_ID)),
+    )
+}
+
 /// External-signature verification material for a keygen/CRS result fetch: the
 /// EIP-712 `domain` and the `extra_data` the signature is bound to. Wrapped in an
 /// `Option` at the call sites, where `None` means "skip verification".
@@ -1132,26 +1125,21 @@ pub(crate) struct SigVerificationMaterial {
 /// Build the [`SigVerificationMaterial`] for a keygen/CRS pure-fetch command. Returns
 /// `None` (skip verification, with an error log) when `no_verify` is set. Otherwise the
 /// domain comes from the config (falling back to [`dummy_domain`]) and the `extra_data`
-/// is taken from `--extra-data`, else the config default, else the natural keygen/CRS
-/// default ([`default_extra_data`]).
+/// is derived from the supplied context/epoch via [`extra_data_from_context_epoch`]
+/// (RFC-005 v2), matching what the request builders emit for the same context/epoch.
 fn keygen_crs_verify_ctx(
     cc_conf: &CoreClientConfig,
     no_verify: bool,
-    extra_data_cli: &Option<String>,
+    context_id: Option<ContextId>,
+    epoch_id: Option<EpochId>,
 ) -> anyhow::Result<Option<SigVerificationMaterial>> {
     if no_verify {
         tracing::error!("--no-verify set: fetching result WITHOUT external-signature verification");
         return Ok(None);
     }
-    let extra_data = match extra_data_cli {
-        Some(s) => parse_hex(s)?,
-        None => cc_conf
-            .default_extra_data()?
-            .unwrap_or_else(default_extra_data),
-    };
     Ok(Some(SigVerificationMaterial {
         domain: cc_conf.default_domain()?,
-        extra_data,
+        extra_data: extra_data_from_context_epoch(context_id, epoch_id)?,
     }))
 }
 
@@ -1914,7 +1902,6 @@ pub async fn execute_cmd(
                 num_expected_responses,
                 cipher_args.get_inter_request_delay_ms(),
                 cipher_args.get_parallel_requests(),
-                cipher_args.get_extra_data(),
                 cc_conf.default_domain()?,
             )
             .await?
@@ -1993,7 +1980,6 @@ pub async fn execute_cmd(
                 num_expected_responses,
                 cipher_args.get_inter_request_delay_ms(),
                 cipher_args.get_parallel_requests(),
-                cipher_args.get_extra_data(),
                 cc_conf.default_domain()?,
             )
             .await?
@@ -2272,7 +2258,8 @@ pub async fn execute_cmd(
             let verify = keygen_crs_verify_ctx(
                 &cc_conf,
                 result_parameters.no_verify,
-                &result_parameters.extra_data,
+                result_parameters.context_id,
+                result_parameters.epoch_id,
             )?;
             fetch_and_check_keygen(
                 num_expected_responses,
@@ -2307,7 +2294,8 @@ pub async fn execute_cmd(
             let verify = keygen_crs_verify_ctx(
                 &cc_conf,
                 result_parameters.no_verify,
-                &result_parameters.extra_data,
+                result_parameters.context_id,
+                result_parameters.epoch_id,
             )?;
             fetch_and_check_keygen(
                 num_expected_responses,
@@ -2352,20 +2340,16 @@ pub async fn execute_cmd(
                     .iter()
                     .map(|h| parse_hex(h))
                     .collect::<anyhow::Result<Vec<_>>>()?;
-                let extra_data = match &result_parameters.extra_data {
-                    Some(s) => parse_hex(s)?,
-                    // Same fallback as the keygen/CRS pure-fetch path: the default
-                    // `extra_data` follows RFC-005 (version 0x02: default context_id ‖
-                    // epoch_id). Revisit if a newer RFC changes the extra_data encoding
-                    // the gateway/relayer binds into the EIP-712 signature.
-                    None => cc_conf
-                        .default_extra_data()?
-                        .unwrap_or_else(default_extra_data),
-                };
+                // `extra_data` is derived from the supplied context/epoch via
+                // `make_extra_data` (RFC-005 v2), matching what the request builder
+                // emits for the same context/epoch (defaults when not supplied).
                 Some(PubDecVerificationMaterial::External {
                     domain: cc_conf.default_domain()?,
                     external_handles,
-                    extra_data,
+                    extra_data: extra_data_from_context_epoch(
+                        result_parameters.context_id,
+                        result_parameters.epoch_id,
+                    )?,
                 })
             };
 
@@ -2403,7 +2387,8 @@ pub async fn execute_cmd(
             let verify = keygen_crs_verify_ctx(
                 &cc_conf,
                 result_parameters.no_verify,
-                &result_parameters.extra_data,
+                result_parameters.context_id,
+                result_parameters.epoch_id,
             )?;
             fetch_and_check_crsgen(
                 num_expected_responses,
@@ -2437,7 +2422,8 @@ pub async fn execute_cmd(
             let verify = keygen_crs_verify_ctx(
                 &cc_conf,
                 result_parameters.no_verify,
-                &result_parameters.extra_data,
+                result_parameters.context_id,
+                result_parameters.epoch_id,
             )?;
             fetch_and_check_crsgen(
                 num_expected_responses,
@@ -2864,6 +2850,75 @@ mod tests {
     }
 
     #[test]
+    fn default_domain_omitted_falls_back_to_dummy() {
+        let toml_str = build_test_toml("centralized", None, 1, 1, &[1]);
+        let conf: CoreClientConfig = toml::from_str(&toml_str).unwrap();
+        assert!(conf.default_domain.is_none());
+        // The fallback must equal the built-in dummy domain so config files without a
+        // [default_domain] section keep verifying against the same domain as before.
+        assert_eq!(conf.default_domain().unwrap(), dummy_domain());
+    }
+
+    #[test]
+    fn shipped_default_domain_values_match_dummy() {
+        // All shipped client TOMLs embed these literals and document them as matching the
+        // built-in default. This guards that the two stay in lockstep: if `dummy_domain()`
+        // changes, either this test or the shipped [default_domain] sections must change.
+        let mut toml_str = build_test_toml("centralized", None, 1, 1, &[1]);
+        toml_str.push_str(
+            "\n[default_domain]\n\
+             name = \"Authorization token\"\n\
+             version = \"1\"\n\
+             chain_id = 8006\n\
+             verifying_contract = \"0x66f9664f97F2b50F62D13eA064982f936dE76657\"\n",
+        );
+        let conf: CoreClientConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(conf.default_domain().unwrap(), dummy_domain());
+    }
+
+    #[test]
+    fn default_domain_salt_must_be_32_bytes() {
+        let cfg = Eip712DomainConfig {
+            name: "n".to_string(),
+            version: "1".to_string(),
+            chain_id: 1,
+            verifying_contract: "0x66f9664f97F2b50F62D13eA064982f936dE76657".to_string(),
+            salt: Some("0x1234".to_string()), // 2 bytes, not 32
+        };
+        let err = cfg.to_domain().unwrap_err().to_string();
+        assert!(err.contains("32 bytes"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn default_domain_rejects_invalid_verifying_contract() {
+        let cfg = Eip712DomainConfig {
+            name: "n".to_string(),
+            version: "1".to_string(),
+            chain_id: 1,
+            verifying_contract: "not-an-address".to_string(),
+            salt: None,
+        };
+        let err = cfg.to_domain().unwrap_err().to_string();
+        assert!(
+            err.contains("invalid verifying_contract"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn extra_data_from_context_epoch_matches_default_builders() {
+        // The pure-fetch *Result verification path and the full-flow request builders must
+        // derive `extra_data` identically for the same context/epoch — here, the defaults.
+        let from_helper = extra_data_from_context_epoch(None, None).unwrap();
+        let from_builder =
+            make_extra_data(2, Some(&DEFAULT_MPC_CONTEXT), Some(&DEFAULT_EPOCH_ID)).unwrap();
+        assert_eq!(from_helper, from_builder);
+        // v2 layout: 1 version byte + 32-byte context + 32-byte epoch.
+        assert_eq!(from_helper.len(), 1 + 32 + 32);
+        assert_eq!(from_helper[0], 2);
+    }
+
+    #[test]
     fn test_parse_previous_key_info() {
         let id1 = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
         let id2 = "1102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
@@ -3052,7 +3107,6 @@ mod tests {
             num_reconstruct: 1,
             fhe_params: Some(FheParameter::Test),
             default_domain: None,
-            default_extra_data: None,
         };
 
         let party_confs =

--- a/core-client/src/mpc_epoch.rs
+++ b/core-client/src/mpc_epoch.rs
@@ -1,6 +1,6 @@
 use crate::{
     CmdConfig, CoreClientConfig, CoreConf, DigestKeySet, NewEpochParameters,
-    PreviousEpochParameters, SLEEP_TIME_BETWEEN_REQUESTS_MS, dummy_domain,
+    PreviousEpochParameters, SLEEP_TIME_BETWEEN_REQUESTS_MS,
     keygen::check_uncompressed_keyset_ext_signature, s3_operations::fetch_public_elements,
 };
 use kms_grpc::{
@@ -122,8 +122,12 @@ pub(crate) async fn do_new_epoch(
         .as_ref()
         .map(|previous_epoch| previous_epoch.convert_to_grpc(fhe_params))
         .transpose()?;
+    // The EIP-712 domain comes from the config (falling back to `dummy_domain`), so the
+    // request built here and the reshared-keyset signature check below verify against the
+    // same domain — consistent with the keygen/CRS commands.
+    let default_domain = cc_conf.default_domain()?;
     let domain = if new_epoch_params.previous_epoch_params.is_some() {
-        Some(dummy_domain())
+        Some(default_domain.clone())
     } else {
         None
     };
@@ -358,7 +362,7 @@ pub(crate) async fn do_new_epoch(
                         &preproc_id,
                         &key_id,
                         &signature,
-                        &dummy_domain(),
+                        &default_domain,
                         request.extra_data.clone(),
                         kms_addrs,
                     )?;
@@ -373,7 +377,7 @@ pub(crate) async fn do_new_epoch(
                         &preproc_id,
                         &key_id,
                         &signature,
-                        &dummy_domain(),
+                        &default_domain,
                         request.extra_data.clone(),
                         kms_addrs,
                     )?;

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -243,7 +243,6 @@ fn generate_centralized_cli_config(
         num_reconstruct: 1,
         fhe_params: Some(fhe_params),
         default_domain: None,
-        default_extra_data: None,
     };
     write_core_client_toml(&config_path, &cfg)?;
     Ok(config_path)
@@ -518,7 +517,6 @@ fn generate_threshold_cli_config(
         num_reconstruct: majority,
         fhe_params: Some(fhe_params),
         default_domain: None,
-        default_extra_data: None,
     };
     write_core_client_toml(&config_path, &cfg)?;
     Ok(config_path)
@@ -906,7 +904,6 @@ async fn setup_party_resharing_servers(
         num_reconstruct: 3,
         fhe_params: Some(fhe_params),
         default_domain: None,
-        default_extra_data: None,
     };
     write_core_client_toml(&config_path_1234, &cfg_1234)?;
 
@@ -946,7 +943,6 @@ async fn setup_party_resharing_servers(
         num_reconstruct: 3,
         fhe_params: Some(fhe_params),
         default_domain: None,
-        default_extra_data: None,
     };
     write_core_client_toml(&config_path_5634, &cfg_5634)?;
 
@@ -1006,7 +1002,6 @@ fn cipher_params(
         parallel_requests: 1,
         ciphertext_output_path,
         inter_request_delay_ms: 0,
-        extra_data: None,
     }
 }
 
@@ -1181,7 +1176,6 @@ async fn integration_test_commands(
             num_requests: 3,
             parallel_requests: 1,
             inter_request_delay_ms: 0,
-            extra_data: None,
         })),
         CCCommand::UserDecrypt(CipherArguments::FromFile(CipherFile {
             input_path: ctxt_path.clone(),
@@ -1189,7 +1183,6 @@ async fn integration_test_commands(
             num_requests: 3,
             parallel_requests: 1,
             inter_request_delay_ms: 0,
-            extra_data: None,
         })),
     ];
 
@@ -1252,7 +1245,6 @@ async fn integration_test_commands(
             num_requests: 3,
             parallel_requests: 1,
             inter_request_delay_ms: 0,
-            extra_data: None,
         })),
         CCCommand::UserDecrypt(CipherArguments::FromFile(CipherFile {
             input_path: ctxt_with_sns_path.clone(),
@@ -1260,7 +1252,6 @@ async fn integration_test_commands(
             num_requests: 3,
             parallel_requests: 1,
             inter_request_delay_ms: 0,
-            extra_data: None,
         })),
     ];
 
@@ -1294,7 +1285,8 @@ async fn integration_test_commands(
                 CCCommand::KeyGenResult(KeyGenResultParameters {
                     request_id: req_id.unwrap(),
                     uncompressed: key_gen_parameters.shared_args.uncompressed,
-                    extra_data: None,
+                    context_id: None,
+                    epoch_id: None,
                     no_verify: false,
                 })
             }
@@ -1302,7 +1294,8 @@ async fn integration_test_commands(
                 CCCommand::InsecureKeyGenResult(KeyGenResultParameters {
                     request_id: req_id.unwrap(),
                     uncompressed: key_gen_parameters.shared_args.uncompressed,
-                    extra_data: None,
+                    context_id: None,
+                    epoch_id: None,
                     no_verify: false,
                 })
             }
@@ -1310,19 +1303,22 @@ async fn integration_test_commands(
                 CCCommand::PublicDecryptResult(PublicDecryptResultParameters {
                     request_id: req_id.unwrap(),
                     external_handles: vec![],
-                    extra_data: None,
+                    context_id: None,
+                    epoch_id: None,
                     no_verify: false,
                 })
             }
             CCCommand::CrsGen(_) => CCCommand::CrsGenResult(CrsGenResultParameters {
                 request_id: req_id.unwrap(),
-                extra_data: None,
+                context_id: None,
+                epoch_id: None,
                 no_verify: false,
             }),
             CCCommand::InsecureCrsGen(_) => {
                 CCCommand::InsecureCrsGenResult(CrsGenResultParameters {
                     request_id: req_id.unwrap(),
-                    extra_data: None,
+                    context_id: None,
+                    epoch_id: None,
                     no_verify: false,
                 })
             }
@@ -1420,7 +1416,8 @@ async fn integration_test_commands_default_keys(
                 CCCommand::PublicDecryptResult(PublicDecryptResultParameters {
                     request_id: req_id.unwrap(),
                     external_handles: vec![],
-                    extra_data: None,
+                    context_id: None,
+                    epoch_id: None,
                     no_verify: false,
                 })
             }
@@ -1997,7 +1994,6 @@ struct StrictCheckedInCoreClientToml {
     num_reconstruct: usize,
     decryption_mode: Option<String>,
     fhe_params: Option<String>,
-    default_extra_data: Option<String>,
     cores: Vec<StrictCheckedInCoreToml>,
     default_domain: Option<StrictCheckedInDomainToml>,
 }
@@ -3195,7 +3191,6 @@ async fn test_threshold_reshare() -> Result<()> {
             ciphertext_output_path: None,
             parallel_requests: 1,
             inter_request_delay_ms: 0,
-            extra_data: None,
         })),
         200,
     );

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1299,10 +1299,17 @@ async fn integration_test_commands(
                     no_verify: false,
                 })
             }
-            CCCommand::PublicDecrypt(_) => {
+            CCCommand::PublicDecrypt(ref cipher_args) => {
+                // Reconstruct the same distinct per-ciphertext handles the request builder
+                // used (`integration_test_handles`), so the external-signature verification
+                // path runs instead of the unverified fetch.
+                let external_handles = integration_test_handles(cipher_args.get_batch_size())
+                    .iter()
+                    .map(hex::encode)
+                    .collect();
                 CCCommand::PublicDecryptResult(PublicDecryptResultParameters {
                     request_id: req_id.unwrap(),
-                    external_handles: vec![],
+                    external_handles,
                     context_id: None,
                     epoch_id: None,
                     no_verify: false,
@@ -1412,10 +1419,17 @@ async fn integration_test_commands_default_keys(
         let req_id = results[0].0;
 
         let get_res_command = match command {
-            CCCommand::PublicDecrypt(_) => {
+            CCCommand::PublicDecrypt(ref cipher_args) => {
+                // Reconstruct the same distinct per-ciphertext handles the request builder
+                // used (`integration_test_handles`), so the external-signature verification
+                // path runs instead of the unverified fetch.
+                let external_handles = integration_test_handles(cipher_args.get_batch_size())
+                    .iter()
+                    .map(hex::encode)
+                    .collect();
                 CCCommand::PublicDecryptResult(PublicDecryptResultParameters {
                     request_id: req_id.unwrap(),
-                    external_handles: vec![],
+                    external_handles,
                     context_id: None,
                     epoch_id: None,
                     no_verify: false,

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -242,6 +242,8 @@ fn generate_centralized_cli_config(
         num_majority: 1,
         num_reconstruct: 1,
         fhe_params: Some(fhe_params),
+        default_domain: None,
+        default_extra_data: None,
     };
     write_core_client_toml(&config_path, &cfg)?;
     Ok(config_path)
@@ -515,6 +517,8 @@ fn generate_threshold_cli_config(
         num_majority: majority,
         num_reconstruct: majority,
         fhe_params: Some(fhe_params),
+        default_domain: None,
+        default_extra_data: None,
     };
     write_core_client_toml(&config_path, &cfg)?;
     Ok(config_path)
@@ -901,6 +905,8 @@ async fn setup_party_resharing_servers(
         num_majority: 2,
         num_reconstruct: 3,
         fhe_params: Some(fhe_params),
+        default_domain: None,
+        default_extra_data: None,
     };
     write_core_client_toml(&config_path_1234, &cfg_1234)?;
 
@@ -939,6 +945,8 @@ async fn setup_party_resharing_servers(
         num_majority: 2,
         num_reconstruct: 3,
         fhe_params: Some(fhe_params),
+        default_domain: None,
+        default_extra_data: None,
     };
     write_core_client_toml(&config_path_5634, &cfg_5634)?;
 
@@ -1286,23 +1294,38 @@ async fn integration_test_commands(
                 CCCommand::KeyGenResult(KeyGenResultParameters {
                     request_id: req_id.unwrap(),
                     uncompressed: key_gen_parameters.shared_args.uncompressed,
+                    extra_data: None,
+                    no_verify: false,
                 })
             }
             CCCommand::InsecureKeyGen(ref key_gen_parameters) => {
                 CCCommand::InsecureKeyGenResult(KeyGenResultParameters {
                     request_id: req_id.unwrap(),
                     uncompressed: key_gen_parameters.shared_args.uncompressed,
+                    extra_data: None,
+                    no_verify: false,
                 })
             }
-            CCCommand::PublicDecrypt(_) => CCCommand::PublicDecryptResult(ResultParameters {
+            CCCommand::PublicDecrypt(_) => {
+                CCCommand::PublicDecryptResult(PublicDecryptResultParameters {
+                    request_id: req_id.unwrap(),
+                    external_handles: vec![],
+                    extra_data: None,
+                    no_verify: false,
+                })
+            }
+            CCCommand::CrsGen(_) => CCCommand::CrsGenResult(CrsGenResultParameters {
                 request_id: req_id.unwrap(),
+                extra_data: None,
+                no_verify: false,
             }),
-            CCCommand::CrsGen(_) => CCCommand::CrsGenResult(ResultParameters {
-                request_id: req_id.unwrap(),
-            }),
-            CCCommand::InsecureCrsGen(_) => CCCommand::InsecureCrsGenResult(ResultParameters {
-                request_id: req_id.unwrap(),
-            }),
+            CCCommand::InsecureCrsGen(_) => {
+                CCCommand::InsecureCrsGenResult(CrsGenResultParameters {
+                    request_id: req_id.unwrap(),
+                    extra_data: None,
+                    no_verify: false,
+                })
+            }
             _ => CCCommand::DoNothing(NoParameters {}),
         };
 
@@ -1393,9 +1416,14 @@ async fn integration_test_commands_default_keys(
         let req_id = results[0].0;
 
         let get_res_command = match command {
-            CCCommand::PublicDecrypt(_) => CCCommand::PublicDecryptResult(ResultParameters {
-                request_id: req_id.unwrap(),
-            }),
+            CCCommand::PublicDecrypt(_) => {
+                CCCommand::PublicDecryptResult(PublicDecryptResultParameters {
+                    request_id: req_id.unwrap(),
+                    external_handles: vec![],
+                    extra_data: None,
+                    no_verify: false,
+                })
+            }
             _ => CCCommand::DoNothing(NoParameters {}),
         };
 
@@ -1961,6 +1989,7 @@ async fn custodian_backup_recovery(
 /// Mirror of shipped client TOML layout: unknown top-level or `[[cores]]` keys fail the test.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[allow(dead_code)] // Presence validated by deny_unknown_fields; only some fields asserted in tests
 struct StrictCheckedInCoreClientToml {
     kms_type: String,
     num_parties: usize,
@@ -1968,7 +1997,20 @@ struct StrictCheckedInCoreClientToml {
     num_reconstruct: usize,
     decryption_mode: Option<String>,
     fhe_params: Option<String>,
+    default_extra_data: Option<String>,
     cores: Vec<StrictCheckedInCoreToml>,
+    default_domain: Option<StrictCheckedInDomainToml>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(dead_code)] // Presence validated by deny_unknown_fields
+struct StrictCheckedInDomainToml {
+    name: String,
+    version: String,
+    chain_id: u64,
+    verifying_contract: String,
+    salt: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/core-client/tests/kind-testing/kubernetes_test_threshold.rs
+++ b/core-client/tests/kind-testing/kubernetes_test_threshold.rs
@@ -204,7 +204,6 @@ impl K8sTestContext {
             parallel_requests: 1,
             ciphertext_output_path: Some(cipher_path.clone()),
             inter_request_delay_ms: 0,
-            extra_data: None,
         }))
         .await;
 
@@ -242,7 +241,6 @@ impl K8sTestContext {
                     num_requests: 1,
                     inter_request_delay_ms: 0,
                     parallel_requests: 1,
-                    extra_data: None,
                 },
             )))
             .await;

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -366,8 +366,14 @@ Note that this operation does *NOT* run a secure distributed keygen protocol, an
 
 It is also possible to fetch the result of an insecure key generation through its `REQUEST_ID` using the following command:
 ```{bash}
-$ cargo run -- -f <path-to-toml-config-file> insecure-key-gen-result --request-id <REQUEST_ID> [--uncompressed]
+$ cargo run -- -f <path-to-toml-config-file> insecure-key-gen-result --request-id <REQUEST_ID> [--uncompressed] [--context-id <CONTEXT_ID>] [--epoch-id <EPOCH_ID>] [--no-verify]
 ```
+
+Optional arguments:
+ - `-u`/`--uncompressed`: Fetch legacy uncompressed public key material instead of the default compressed keyset.
+ - `--context-id <CONTEXT_ID>`: Context ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default context when omitted; must match the context of the original request or verification fails.
+ - `--epoch-id <EPOCH_ID>`: Epoch ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default epoch when omitted; must match the epoch of the original request or verification fails.
+ - `--no-verify`: Skip verification of the external signature and just download the material.
 
 Upon success, both the command to request to generate a key _and_ the command to fetch the result, will save the key material produced by the core in the `object_folder` given in the configuration file.
 
@@ -459,8 +465,14 @@ After this migration completes, the old key ID can be used without `--uncompress
 
 It is also possible to fetch the result of a key generation through its `REQUEST_ID` using the following command:
 ```{bash}
-$ cargo run -- -f <path-to-toml-config-file> key-gen-result --request-id <REQUEST_ID> [--compressed]
+$ cargo run -- -f <path-to-toml-config-file> key-gen-result --request-id <REQUEST_ID> [--uncompressed] [--context-id <CONTEXT_ID>] [--epoch-id <EPOCH_ID>] [--no-verify]
 ```
+
+Optional arguments:
+ - `-u`/`--uncompressed`: Fetch legacy uncompressed public key material instead of the default compressed keyset.
+ - `--context-id <CONTEXT_ID>`: Context ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default context when omitted; must match the context of the original request or verification fails.
+ - `--epoch-id <EPOCH_ID>`: Epoch ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default epoch when omitted; must match the epoch of the original request or verification fails.
+ - `--no-verify`: Skip verification of the external signature and just download the material.
 
 Upon success, both the command to request to generate a key _and_ the command to fetch the result, will save the key material produced by the core in the `object_folder` given in the configuration file.
 
@@ -480,8 +492,13 @@ Note that this operation does *NOT* run a secure distributed CRS generation prot
 
 It is also possible to fetch the result of an insecure CRS generation through its `REQUEST_ID` using the following command:
 ```{bash}
-$ cargo run -- -f <path-to-toml-config-file> insecure-crs-gen-result --request-id <REQUEST_ID>
+$ cargo run -- -f <path-to-toml-config-file> insecure-crs-gen-result --request-id <REQUEST_ID> [--context-id <CONTEXT_ID>] [--epoch-id <EPOCH_ID>] [--no-verify]
 ```
+
+Optional arguments:
+ - `--context-id <CONTEXT_ID>`: Context ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default context when omitted; must match the context of the original request or verification fails.
+ - `--epoch-id <EPOCH_ID>`: Epoch ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default epoch when omitted; must match the epoch of the original request or verification fails.
+ - `--no-verify`: Skip verification of the external signature and just download the material.
 
 Upon success, both the command to request to generate a CRS _and_ the command to fetch the result, will save the CRS produced by the core in the `object_folder` given in the configuration file.
 
@@ -497,8 +514,13 @@ Note that this operation runs the secure distributed CRS generation protocol, wh
 
 It is also possible to fetch the result of a CRS generation through its `REQUEST_ID` using the following command:
 ```{bash}
-$ cargo run -- -f <path-to-toml-config-file> crs-gen-result --request-id <REQUEST_ID>
+$ cargo run -- -f <path-to-toml-config-file> crs-gen-result --request-id <REQUEST_ID> [--context-id <CONTEXT_ID>] [--epoch-id <EPOCH_ID>] [--no-verify]
 ```
+
+Optional arguments:
+ - `--context-id <CONTEXT_ID>`: Context ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default context when omitted; must match the context of the original request or verification fails.
+ - `--epoch-id <EPOCH_ID>`: Epoch ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default epoch when omitted; must match the epoch of the original request or verification fails.
+ - `--no-verify`: Skip verification of the external signature and just download the material.
 
 Upon success, both the command to request to generate a CRS _and_ the command to fetch the result, will save the CRS produced by the core in the `object_folder` given in the configuration file.
 
@@ -558,8 +580,14 @@ Note that the key must have been previously generated using the (secure or insec
 
 It is also possible to fetch the result of a public decryption through its `REQUEST_ID` using the following command:
 ```{bash}
-$ cargo run -- -f <path-to-toml-config-file> public-decrypt-result --request-id <REQUEST_ID>
+$ cargo run -- -f <path-to-toml-config-file> public-decrypt-result --request-id <REQUEST_ID> [--handle <HANDLE>]... [--context-id <CONTEXT_ID>] [--epoch-id <EPOCH_ID>] [--no-verify]
 ```
+
+Optional arguments:
+ - `--handle <HANDLE>`: External ciphertext handle (hex-encoded, optionally with a "0x" prefix) from the original request, used to verify the external signature. Repeat the flag once per ciphertext in the batch. When omitted, the result is fetched but NOT verified (an error is logged), since handles are request-specific and cannot be defaulted from the config.
+ - `--context-id <CONTEXT_ID>`: Context ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default context when omitted; must match the context of the original request or verification fails.
+ - `--epoch-id <EPOCH_ID>`: Epoch ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default epoch when omitted; must match the epoch of the original request or verification fails.
+ - `--no-verify`: Skip verification of the external signature and just return the fetched responses.
 
 Upon success, both the commands to decrypt _and_ the command to fetch the result, will result in a print of `Vec<PublicDecryptionResponse> - <REQUEST_ID>` where the `Vec` size depends on the number of received responses (specified via `num_majority` in the configuration file) for each request (specified via `--num-requests`).
 

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -584,10 +584,10 @@ $ cargo run -- -f <path-to-toml-config-file> public-decrypt-result --request-id 
 ```
 
 Optional arguments:
- - `--handle <HANDLE>`: External ciphertext handle (hex-encoded, optionally with a "0x" prefix) from the original request, used to verify the external signature. Repeat the flag once per ciphertext in the batch. When omitted, the result is fetched but NOT verified (an error is logged), since handles are request-specific and cannot be defaulted from the config.
+ - `--handle <HANDLE>`: External ciphertext handle (hex-encoded, optionally with a "0x" prefix) from the original request, used to verify the external signature. Repeat the flag once per ciphertext in the batch. Required unless `--no-verify` is set, since handles are request-specific and cannot be defaulted from the config; the command fails when they are omitted.
  - `--context-id <CONTEXT_ID>`: Context ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default context when omitted; must match the context of the original request or verification fails.
  - `--epoch-id <EPOCH_ID>`: Epoch ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default epoch when omitted; must match the epoch of the original request or verification fails.
- - `--no-verify`: Skip verification of the external signature and just return the fetched responses.
+ - `--no-verify`: Skip all verification of the fetched responses (both the internal KMS-node signatures and the external signature) and just return them.
 
 Upon success, both the commands to decrypt _and_ the command to fetch the result, will result in a print of `Vec<PublicDecryptionResponse> - <REQUEST_ID>` where the `Vec` size depends on the number of received responses (specified via `num_majority` in the configuration file) for each request (specified via `--num-requests`).
 


### PR DESCRIPTION

## Description of changes
Improve verification on core-client. This is done by adding domain to core-client config and context and epoch ID to the CLI (to build extra data), and then using this information to verify the EIP-712 signatures when fetching for results. Previously, it was not possible to use the latest extra data format from RFC-005, with this PR it is possible. This is useful for E2E testing of RFC-005 (if we want to bypass the connector).

How to test it locally:
1. Start docker compose
2. Generate CRS (or key) `cargo run -p kms-core-client --features testing -- -f core-client/config/client_local_threshold.toml -l insecure-crs-gen -m 2048` 
3. Fetch the CRS `cargo run -p kms-core-client --features testing -- -f core-client/config/client_local_threshold.toml -l insecure-crs-gen-result -i $CRS_ID`, this should succeed
4. Modify something inside `core-client/config/client_local_threshold.toml`, like a part of the domain, then run the same command as above, then verification should fail
5. Adding the `--no-verify` to the command above should make it pass again, if we want to skip verification

This change should not cause any breaking changes on the CI or fhevm E2E tests. 

## Issue ticket number and link
Closes zama-ai/kms-internal#2951


## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
6. Low popularity?
7. Unusual version jump?
8. Lacking documentation?
9. Missing CI?
10. No security / disclosure policy?
11. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
