### PR TITLE
chore: do not pass on server/sns key when not needed

### DIFF
--- a/core/service/src/engine/threshold/service/public_decryptor.rs
+++ b/core/service/src/engine/threshold/service/public_decryptor.rs
@@ -28,7 +28,7 @@ use tfhe::FheTypes;
 use thread_handles::spawn_compute_bound;
 use threshold_execution::{
     endpoints::decryption::{
-        DecryptionMode, LowLevelCiphertext, OfflineNoiseFloodSession,
+        DecryptionMode, LowLevelCiphertextAndKeys, OfflineNoiseFloodSession,
         SecureOnlineNoiseFloodDecryption, SmallOfflineNoiseFloodSession,
         decrypt_using_noiseflooding, secure_decrypt_using_bitdec,
     },
@@ -80,9 +80,7 @@ pub trait NoiseFloodDecryptor: Send + Sync {
 
     async fn decrypt<T>(
         noiseflood_session: &mut Self::Prep,
-        server_key: Arc<tfhe::integer::ServerKey>,
-        ck: Arc<tfhe::integer::noise_squashing::NoiseSquashingKey>,
-        ct: LowLevelCiphertext,
+        ct: LowLevelCiphertextAndKeys,
         secret_key_share: Arc<PrivateKeySet<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>>,
     ) -> anyhow::Result<(HashMap<String, T>, Duration)>
     where
@@ -102,9 +100,7 @@ impl NoiseFloodDecryptor for SecureNoiseFloodDecryptor {
 
     async fn decrypt<T>(
         noiseflood_session: &mut Self::Prep,
-        server_key: Arc<tfhe::integer::ServerKey>,
-        ck: Arc<tfhe::integer::noise_squashing::NoiseSquashingKey>,
-        ct: LowLevelCiphertext,
+        ct: LowLevelCiphertextAndKeys,
         secret_key_share: Arc<PrivateKeySet<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>>,
     ) -> anyhow::Result<(HashMap<String, T>, Duration)>
     where
@@ -117,7 +113,7 @@ impl NoiseFloodDecryptor for SecureNoiseFloodDecryptor {
             Self::Prep,
             SecureOnlineNoiseFloodDecryption,
             T,
-        >(noiseflood_session, server_key, ck, ct, secret_key_share)
+        >(noiseflood_session, ct, secret_key_share)
         .await
     }
 }
@@ -182,7 +178,13 @@ impl<
         );
 
         let keys = fhe_keys;
-        let decomp_key = keys.decompression_key();
+        // Only the SmallCompressed format needs the decompression key to deserialize.
+        // Fetching it would lazily decompress the (multi-GiB) keyset, so avoid it for
+        // the Big*/SmallExpanded formats that don't use it.
+        let decomp_key = match ct_format {
+            CiphertextFormat::SmallCompressed => keys.decompression_key(),
+            _ => None,
+        };
         let low_level_ct = spawn_compute_bound(move || {
             deserialize_to_low_level(fhe_type, ct_format, &ct, decomp_key.as_deref())
         })
@@ -200,14 +202,15 @@ impl<
                     })?;
                 let mut noiseflood_session = SmallOfflineNoiseFloodSession::new(session);
 
-                Dec::decrypt(
-                    &mut noiseflood_session,
-                    keys.integer_server_key(),
-                    keys.sns_key().ok_or(anyhow::anyhow!("Missing sns key"))?,
-                    low_level_ct,
-                    keys.private_keys.clone(),
-                )
-                .await
+                // Only `Small` ciphertexts need switch&squash; the closure (and hence the
+                // lazy key decompression it triggers) does not run for the Big* variants.
+                let ct = low_level_ct.with_sns_keys(|| {
+                    let server_key = keys.integer_server_key();
+                    let ck = keys.sns_key().ok_or(anyhow::anyhow!("Missing sns key"))?;
+                    Ok((server_key, ck))
+                })?;
+
+                Dec::decrypt(&mut noiseflood_session, ct, keys.private_keys.clone()).await
             }
             DecryptionMode::BitDecSmall => {
                 let mut session = session_maker
@@ -741,9 +744,7 @@ mod tests {
 
         async fn decrypt<T>(
             noiseflood_session: &mut Self::Prep,
-            _server_key: Arc<tfhe::integer::ServerKey>,
-            _ck: Arc<tfhe::integer::noise_squashing::NoiseSquashingKey>,
-            _ct: LowLevelCiphertext,
+            _ct: LowLevelCiphertextAndKeys,
             _secret_key_share: Arc<PrivateKeySet<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>>,
         ) -> anyhow::Result<(HashMap<String, T>, Duration)>
         where

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -20,8 +20,8 @@ use kms_grpc::{
     RequestId,
     identifiers::{ContextId, EpochId},
     kms::v1::{
-        self, Empty, TypedCiphertext, TypedSigncryptedCiphertext, UserDecryptionRequest,
-        UserDecryptionResponse, UserDecryptionResponsePayload,
+        self, CiphertextFormat, Empty, TypedCiphertext, TypedSigncryptedCiphertext,
+        UserDecryptionRequest, UserDecryptionResponse, UserDecryptionResponsePayload,
     },
 };
 use observability::{
@@ -35,7 +35,7 @@ use rand::{CryptoRng, RngCore};
 use thread_handles::spawn_compute_bound;
 use threshold_execution::{
     endpoints::decryption::{
-        DecryptionMode, LowLevelCiphertext, OfflineNoiseFloodSession,
+        DecryptionMode, LowLevelCiphertextAndKeys, OfflineNoiseFloodSession,
         SmallOfflineNoiseFloodSession, partial_decrypt_using_noiseflooding,
         secure_partial_decrypt_using_bitdec,
     },
@@ -87,9 +87,7 @@ pub trait NoiseFloodPartialDecryptor: Send + Sync {
     type Prep: OfflineNoiseFloodSession<{ ResiduePolyF4Z128::EXTENSION_DEGREE }> + Send;
     async fn partial_decrypt(
         noiseflood_session: &mut Self::Prep,
-        server_key: Arc<tfhe::integer::ServerKey>,
-        ck: Arc<tfhe::integer::noise_squashing::NoiseSquashingKey>,
-        ct: LowLevelCiphertext,
+        ct: LowLevelCiphertextAndKeys,
         secret_key_share: &PrivateKeySet<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
     ) -> anyhow::Result<(
         HashMap<String, Vec<ResiduePoly<Z128, { ResiduePolyF4Z128::EXTENSION_DEGREE }>>>,
@@ -111,9 +109,7 @@ impl NoiseFloodPartialDecryptor for SecureNoiseFloodPartialDecryptor {
 
     async fn partial_decrypt(
         noiseflood_session: &mut Self::Prep,
-        server_key: Arc<tfhe::integer::ServerKey>,
-        ck: Arc<tfhe::integer::noise_squashing::NoiseSquashingKey>,
-        ct: LowLevelCiphertext,
+        ct: LowLevelCiphertextAndKeys,
         secret_key_share: &PrivateKeySet<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
     ) -> anyhow::Result<(
         HashMap<String, Vec<ResiduePoly<Z128, { ResiduePolyF4Z128::EXTENSION_DEGREE }>>>,
@@ -123,14 +119,7 @@ impl NoiseFloodPartialDecryptor for SecureNoiseFloodPartialDecryptor {
     where
         ResiduePoly<Z128, { ResiduePolyF4Z128::EXTENSION_DEGREE }>: ErrorCorrect + Invert + Solve,
     {
-        partial_decrypt_using_noiseflooding(
-            noiseflood_session,
-            server_key,
-            ck,
-            ct,
-            secret_key_share,
-        )
-        .await
+        partial_decrypt_using_noiseflooding(noiseflood_session, ct, secret_key_share).await
     }
 }
 
@@ -229,7 +218,13 @@ impl<
                 hex::encode(&typed_ciphertext.external_handle)
             );
 
-            let decomp_key = keys.decompression_key();
+            // Only the SmallCompressed format needs the decompression key to deserialize.
+            // Fetching it would lazily decompress the (multi-GiB) keyset, so avoid it for
+            // the Big*/SmallExpanded formats that don't use it.
+            let decomp_key = match ct_format {
+                CiphertextFormat::SmallCompressed => keys.decompression_key(),
+                _ => None,
+            };
             let low_level_ct = spawn_compute_bound(move || {
                 deserialize_to_low_level(fhe_type, ct_format, &ct, decomp_key.as_deref())
             })
@@ -247,14 +242,16 @@ impl<
                         })?;
                     let mut noiseflood_session = Dec::Prep::new(session);
 
-                    let pdec = Dec::partial_decrypt(
-                        &mut noiseflood_session,
-                        keys.integer_server_key(),
-                        keys.sns_key().ok_or(anyhow::anyhow!("Missing sns key"))?,
-                        low_level_ct,
-                        &keys.private_keys,
-                    )
-                    .await;
+                    // Only `Small` ciphertexts need switch&squash; the closure (and hence the
+                    // lazy key decompression it triggers) does not run for the Big* variants.
+                    let ct = low_level_ct.with_sns_keys(|| {
+                        let server_key = keys.integer_server_key();
+                        let ck = keys.sns_key().ok_or(anyhow::anyhow!("Missing sns key"))?;
+                        Ok((server_key, ck))
+                    })?;
+
+                    let pdec =
+                        Dec::partial_decrypt(&mut noiseflood_session, ct, &keys.private_keys).await;
 
                     let res = match pdec {
                         Ok((partial_dec_map, packing_factor, time)) => {
@@ -687,9 +684,7 @@ mod tests {
 
         async fn partial_decrypt(
             noiseflood_session: &mut Self::Prep,
-            _server_key: Arc<tfhe::integer::ServerKey>,
-            _ck: Arc<tfhe::integer::noise_squashing::NoiseSquashingKey>,
-            _ct: LowLevelCiphertext,
+            _ct: LowLevelCiphertextAndKeys,
             _secret_key_share: &PrivateKeySet<{ ResiduePolyF4Z128::EXTENSION_DEGREE }>,
         ) -> anyhow::Result<(
             HashMap<String, Vec<ResiduePoly<Z128, { ResiduePolyF4Z128::EXTENSION_DEGREE }>>>,

--- a/core/threshold-execution/src/endpoints/decryption_non_wasm.rs
+++ b/core/threshold-execution/src/endpoints/decryption_non_wasm.rs
@@ -69,6 +69,55 @@ use super::decryption::LowLevelCiphertext;
 use super::reconstruct::{combine_decryptions, reconstruct_message};
 use crate::tfhe_internals::private_keysets::PrivateKeySet;
 
+/// A [`LowLevelCiphertext`] bundled with exactly the keys its variant needs to be
+/// converted into a squashed-noise ciphertext.
+///
+/// The `Big*` variants are already squashed and need no keys; the `Small` variant
+/// always carries the switch-and-squash keys (server key + noise squashing key).
+/// This makes it impossible to call the noise-flooding decryption with a keyless
+/// small ciphertext, and lets the production (`Big*`) path avoid touching — and
+/// thus avoid lazily decompressing — those keys entirely.
+pub enum LowLevelCiphertextAndKeys {
+    BigCompressed(SnsRadixOrBoolCiphertext),
+    BigStandard(SnsRadixOrBoolCiphertext),
+    Small {
+        ct: RadixOrBoolCiphertext,
+        server_key: Arc<ServerKey>,
+        ck: Arc<NoiseSquashingKey>,
+    },
+}
+
+impl LowLevelCiphertextAndKeys {
+    pub fn decryption_key_type(&self) -> SnsDecryptionKeyType {
+        match self {
+            Self::BigCompressed(_) => SnsDecryptionKeyType::SnsCompressionKey,
+            Self::BigStandard(_) | Self::Small { .. } => SnsDecryptionKeyType::SnsKey,
+        }
+    }
+}
+
+impl LowLevelCiphertext {
+    /// Attach the switch-and-squash keys needed to decrypt this ciphertext.
+    ///
+    /// `provide` is invoked **only** for the [`LowLevelCiphertext::Small`] variant —
+    /// the `Big*` variants are already squashed and need no keys, so callers never
+    /// fetch (and thus never trigger lazy decompression of) the keys on the
+    /// production path.
+    pub fn with_sns_keys<F>(self, provide: F) -> anyhow::Result<LowLevelCiphertextAndKeys>
+    where
+        F: FnOnce() -> anyhow::Result<(Arc<ServerKey>, Arc<NoiseSquashingKey>)>,
+    {
+        Ok(match self {
+            LowLevelCiphertext::BigCompressed(ct) => LowLevelCiphertextAndKeys::BigCompressed(ct),
+            LowLevelCiphertext::BigStandard(ct) => LowLevelCiphertextAndKeys::BigStandard(ct),
+            LowLevelCiphertext::Small(ct) => {
+                let (server_key, ck) = provide()?;
+                LowLevelCiphertextAndKeys::Small { ct, server_key, ck }
+            }
+        })
+    }
+}
+
 // NOTE: This whole trait system for noiseflood preproc is
 // a bit convoluted and could probably be refactored to be simpler.
 pub struct SmallOfflineNoiseFloodSession<
@@ -280,9 +329,9 @@ impl<const EXTENSION_DEGREE: usize> OnlineNoiseFloodDecryption<EXTENSION_DEGREE>
 ///
 /// # Arguments
 /// * `noiseflood_session` - The preparation object that contains the decryption `ProtocolType`. `ProtocolType` is the preparation of the noise flooding which holds the `Session` type
-/// * `server_key` - The server key, used together with `ck` for switch&squash
-/// * `ck` - The conversion key, used for switch&squash
-/// * `ct` - The ciphertext to be decrypted
+/// * `ct` - The ciphertext to be decrypted, bundled with the switch&squash keys
+///   (server key + noise squashing key) that its `Small` variant requires; the
+///   `Big*` variants carry no keys
 /// * `secret_key_share` - The secret key share of the party_keyshare
 ///
 /// # Returns
@@ -300,9 +349,7 @@ impl<const EXTENSION_DEGREE: usize> OnlineNoiseFloodDecryption<EXTENSION_DEGREE>
 #[instrument(skip_all, fields(sid, my_role))]
 pub async fn decrypt_using_noiseflooding<const EXTENSION_DEGREE: usize, P, O, T>(
     noiseflood_session: &mut P,
-    server_key: Arc<ServerKey>,
-    ck: Arc<NoiseSquashingKey>,
-    ct: LowLevelCiphertext,
+    ct: LowLevelCiphertextAndKeys,
     secret_key_share: Arc<PrivateKeySet<EXTENSION_DEGREE>>,
 ) -> anyhow::Result<(HashMap<String, T>, Duration)>
 where
@@ -315,9 +362,9 @@ where
     let execution_start_timer = Instant::now();
     let ddec_key_type = ct.decryption_key_type();
     let ct_large = match ct {
-        LowLevelCiphertext::BigCompressed(ct128) => ct128,
-        LowLevelCiphertext::BigStandard(ct128) => ct128,
-        LowLevelCiphertext::Small(ct64) => match ct64 {
+        LowLevelCiphertextAndKeys::BigCompressed(ct128) => ct128,
+        LowLevelCiphertextAndKeys::BigStandard(ct128) => ct128,
+        LowLevelCiphertextAndKeys::Small { ct, server_key, ck } => match ct {
             RadixOrBoolCiphertext::Radix(base_radix_ciphertext) => SnsRadixOrBoolCiphertext::Radix(
                 spawn_compute_bound(move || {
                     ck.squash_radix_ciphertext_noise(&server_key, &base_radix_ciphertext)
@@ -371,9 +418,9 @@ where
 ///
 /// # Arguments
 /// * `noiseflood_session` - The preparation object that contains the decryption `ProtocolType`. `ProtocolType` is the preparation of the noise flooding which holds the `Session` type
-/// * `server_key` - The server key, used together with `ck` for switch&squash
-/// * `ck` - The conversion key, used for switch&squash
-/// * `ct` - The ciphertext to be decrypted
+/// * `ct` - The ciphertext to be decrypted, bundled with the switch&squash keys
+///   (server key + noise squashing key) that its `Small` variant requires; the
+///   `Big*` variants carry no keys
 /// * `secret_key_share` - The secret key share of the party_keyshare
 ///
 /// # Returns
@@ -394,9 +441,7 @@ where
 #[instrument(skip_all, fields(sid, my_role))]
 pub async fn partial_decrypt_using_noiseflooding<const EXTENSION_DEGREE: usize, P>(
     noiseflood_session: &mut P,
-    server_key: Arc<ServerKey>,
-    ck: Arc<NoiseSquashingKey>,
-    ct: LowLevelCiphertext,
+    ct: LowLevelCiphertextAndKeys,
     secret_key_share: &PrivateKeySet<EXTENSION_DEGREE>,
 ) -> anyhow::Result<(
     HashMap<String, Vec<ResiduePoly<Z128, EXTENSION_DEGREE>>>,
@@ -419,9 +464,9 @@ where
     let execution_start_timer = Instant::now();
     let ddec_key_type = ct.decryption_key_type();
     let ct_large = match ct {
-        LowLevelCiphertext::BigCompressed(ct128) => ct128,
-        LowLevelCiphertext::BigStandard(ct128) => ct128,
-        LowLevelCiphertext::Small(ct64) => match ct64 {
+        LowLevelCiphertextAndKeys::BigCompressed(ct128) => ct128,
+        LowLevelCiphertextAndKeys::BigStandard(ct128) => ct128,
+        LowLevelCiphertextAndKeys::Small { ct, server_key, ck } => match ct {
             RadixOrBoolCiphertext::Radix(base_radix_ciphertext) => SnsRadixOrBoolCiphertext::Radix(
                 spawn_compute_bound(move || {
                     ck.squash_radix_ciphertext_noise(&server_key, &base_radix_ciphertext)


### PR DESCRIPTION
## Description of changes
Do not do expand and get the decompression key unless we need it, depending on the input ciphertext type during decryption. Seems with this change there's an improvement from 4s for public decryption to 512 ms.

## Issue ticket number and link
Closes zama-ai/kms-internal#3049

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
Answer in the `Cargo.toml` next to the dependency (or here if updating):
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details and explanations for the checklist and dependency updates can be found in [CONTRIBUTING.md](../CONTRIBUTING.md#6-pr-checklist)
