### PR TITLE
chore: replace `escargot` crate with handrolled build commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3113,17 +3113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "escargot"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c3aea32bc97b500c9ca6a72b768a26e558264303d101d3409cf6d57a9ed0cf"
-dependencies = [
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4412,7 +4401,6 @@ dependencies = [
  "bc2wrap",
  "bytes",
  "clap",
- "escargot",
  "futures",
  "hex",
  "k256",
@@ -4424,6 +4412,7 @@ dependencies = [
  "rcgen",
  "reqwest",
  "serde",
+ "serde_json",
  "strum",
  "strum_macros",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,6 @@ crypto-bigint = { version = "=0.6.1", features = ["serde", "rand_core", "extra-s
 dashmap = "=6.1.0"  # Concurrent hashmap - HIGH RISK: Individual maintainer (xacrimon), despite 156M+ downloads
 derive_more = { version = "=2.0.1", features = ["display"] }  # Derive macros for common traits - HIGH RISK: Individual maintainer (JelteF), despite 180M+ downloads
 enum_dispatch = "=0.3.13"  # Enum dispatch optimization - HIGH RISK: Individual maintainer (Anton Lazarev), despite 29M+ downloads
-escargot = "=0.5.15" # Interact with cargo without spawning external processes. MEDIUM RISK: single maintainer, 8M downloads, test-only dependency.
 futures = "=0.3.31"  # Async futures - LOW RISK: rust-lang team
 futures-util = "=0.3.31"  # Futures utilities - LOW RISK: rust-lang team
 g2p = "=1.2.2"  # Galois field arithmetic (GF(2^p)) - LOW RISK: Essential for threshold cryptography, finite field operations

--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -77,7 +77,7 @@ validator.workspace = true
 # Use .workspace = true to reference workspace dependencies
 # Maintain alphabetical order
 assert_cmd.workspace = true
-escargot.workspace = true
+serde_json.workspace = true
 test-utils.workspace = true
 test-utils-cc = { path = "./test-utils-cc" }
 futures.workspace = true

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1787,11 +1787,13 @@ fn build_kms_custodian() -> Result<PathBuf> {
             "--message-format=json",
         ])
         .output()?;
-    assert!(
-        output.status.success(),
-        "failed to build kms-custodian: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    if !output.status.success() {
+        anyhow::bail!(
+            "failed to build kms-custodian (status {}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 
     // Cargo emits one JSON object per line; the artifact for our bin carries the absolute path to the freshly built
     // executable.

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1795,18 +1795,42 @@ fn build_kms_custodian() -> Result<PathBuf> {
         );
     }
 
-    // Cargo emits one JSON object per line; the artifact for our bin carries the absolute path to the freshly built
-    // executable.
-    let custodian_bin = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+    parse_custodian_bin(&String::from_utf8_lossy(&output.stdout))
+        .context("cargo build did not report a kms-custodian executable")
+}
+
+// Find the `kms-custodian` executable path in cargo's `--message-format=json` output.
+fn parse_custodian_bin(stdout: &str) -> Option<PathBuf> {
+    serde_json::Deserializer::from_str(stdout)
+        .into_iter::<serde_json::Value>()
+        .filter_map(|msg| msg.ok())
         .find_map(|msg| {
             (msg["reason"] == "compiler-artifact" && msg["target"]["name"] == "kms-custodian")
                 .then(|| msg["executable"].as_str().map(PathBuf::from))
                 .flatten()
         })
-        .context("cargo build did not report a kms-custodian executable")?;
-    Ok(custodian_bin)
+}
+
+#[cfg(test)]
+const CARGO_JSON_FIXTURE: &str = r#"{"reason":"compiler-artifact","package_id":"registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.22","manifest_path":"/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/unicode-ident-1.0.22/Cargo.toml","target":{"kind":["lib"],"crate_types":["lib"],"name":"unicode_ident","src_path":"/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/unicode-ident-1.0.22/src/lib.rs","edition":"2018","doc":true,"doctest":true,"test":true},"profile":{"opt_level":"1","debuginfo":"line-tables-only","debug_assertions":true,"overflow_checks":true,"test":false},"features":[],"filenames":["/repo/target/debug/deps/libunicode_ident-6a5967fbdebe44b4.rlib","/repo/target/debug/deps/libunicode_ident-6a5967fbdebe44b4.rmeta"],"executable":null,"fresh":true}
+{"reason":"compiler-artifact","package_id":"path+file:///repo/core/service#kms@0.14.0-0","manifest_path":"/repo/core/service/Cargo.toml","target":{"kind":["bin"],"crate_types":["bin"],"name":"kms-custodian","src_path":"/repo/core/service/src/bin/kms-custodian.rs","edition":"2024","doc":true,"doctest":false,"test":true},"profile":{"opt_level":"3","debuginfo":"line-tables-only","debug_assertions":true,"overflow_checks":true,"test":false},"features":["default","non-wasm"],"filenames":["/repo/target/debug/kms-custodian"],"executable":"/repo/target/debug/kms-custodian","fresh":false}
+{"reason":"build-finished","success":true}"#;
+
+#[test]
+fn parse_custodian_bin_picks_executable_from_artifact_line() {
+    assert_eq!(
+        parse_custodian_bin(CARGO_JSON_FIXTURE),
+        Some(PathBuf::from("/repo/target/debug/kms-custodian")),
+    );
+}
+
+#[test]
+fn parse_custodian_bin_returns_none_when_absent() {
+    // Same stream with the bin artifact removed: nothing for us to find.
+    let stdout = r#"{"reason":"compiler-artifact","package_id":"registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.22","target":{"kind":["lib"],"crate_types":["lib"],"name":"unicode_ident"},"executable":null,"fresh":true}
+{"reason":"build-finished","success":true}"#;
+
+    assert_eq!(parse_custodian_bin(stdout), None);
 }
 
 async fn generate_custodian_keys_to_file(

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -2,7 +2,7 @@
 //!
 //! Verifies kms-core-client CLI tool functionality using isolated native KMS servers.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use futures::future::join_all;
 use kms_core_client::*;
 use kms_grpc::KeyId;
@@ -35,7 +35,7 @@ use kms_grpc::{ContextId, RequestId};
 use kms_lib::backup::SEED_PHRASE_DESC;
 use kms_lib::engine::base::derive_request_id;
 use std::fs::create_dir_all;
-use std::process::Output;
+use std::process::{Command, Output};
 use tfhe::safe_serialization::safe_serialize;
 
 // Additional imports for reshare test (only needed with threshold_tests feature)
@@ -1766,18 +1766,54 @@ async fn new_custodian_context(
         .to_string()
 }
 
-/// Native implementation: Generate custodian keys using kms-custodian binary directly
+// Build the `kms-custodian` binary and return its path.
+//
+// The binary lives in the `kms` package, so nextest won't auto-build it for these cross-package tests. We invoke
+// `cargo build` directly.
+//
+// Rather than guess the output path from `current_exe` (which breaks under a custom `CARGO_TARGET_DIR`, split target
+// dirs, or nextest archive runs), we ask cargo where it put the binary via `--message-format=json` and read the
+// `executable` field of the `compiler-artifact` message for the bin target.
+fn build_kms_custodian() -> Result<PathBuf> {
+    let output = Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "--profile",
+            "test",
+            "--package",
+            "kms",
+            "--bin",
+            "kms-custodian",
+            "--message-format=json",
+        ])
+        .output()?;
+    assert!(
+        output.status.success(),
+        "failed to build kms-custodian: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Cargo emits one JSON object per line; the artifact for our bin carries the absolute path to the freshly built
+    // executable.
+    let custodian_bin = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find_map(|msg| {
+            (msg["reason"] == "compiler-artifact" && msg["target"]["name"] == "kms-custodian")
+                .then(|| msg["executable"].as_str().map(PathBuf::from))
+                .flatten()
+        })
+        .context("cargo build did not report a kms-custodian executable")?;
+    Ok(custodian_bin)
+}
+
 async fn generate_custodian_keys_to_file(
     temp_dir: &Path,
     custodian_count: usize,
 ) -> Result<(Vec<String>, Vec<PathBuf>)> {
     let mut seeds = Vec::new();
     let mut setup_msgs_paths = Vec::new();
-    let kms_custodian_cmd = escargot::CargoBuild::new()
-        .package("kms")
-        .bin("kms-custodian")
-        .args(["--profile", "test"])
-        .run()?;
+    let custodian_bin = build_kms_custodian()?;
 
     for cus_idx in 1..=custodian_count {
         let cur_setup_path = temp_dir
@@ -1788,9 +1824,7 @@ async fn generate_custodian_keys_to_file(
         // Ensure the dir exists
         create_dir_all(cur_setup_path.parent().unwrap()).unwrap();
 
-        // Build&run the kms-custodian binary directly. First time is slow.
-        let cmd_output = kms_custodian_cmd
-            .command()
+        let cmd_output = Command::new(&custodian_bin)
             .args([
                 "generate",
                 "--randomness",
@@ -1869,11 +1903,7 @@ async fn custodian_reencrypt(
     recovery_paths: &[PathBuf],
 ) -> Result<Vec<PathBuf>> {
     let mut response_paths = Vec::new();
-    let kms_custodian_cmd = escargot::CargoBuild::new()
-        .package("kms")
-        .bin("kms-custodian")
-        .args(["--profile", "test"])
-        .run()?;
+    let custodian_bin = build_kms_custodian()?;
 
     for operator_index in 1..=amount_operators {
         let pub_prefix = if amount_operators == 1 {
@@ -1901,9 +1931,7 @@ async fn custodian_reencrypt(
                 .join(PubDataType::VerfKey.to_string())
                 .join(SIGNING_KEY_ID.to_string());
 
-            // Build&run the kms-custodian binary. First time is slow.
-            let cmd_output = kms_custodian_cmd
-                .command()
+            let cmd_output = Command::new(&custodian_bin)
                 .args([
                     "decrypt",
                     "--seed-phrase",


### PR DESCRIPTION
[A recent PR](https://github.com/zama-ai/kms/pull/622) replaced the `KMS custodian binary` build step in CI with an on-demand build, saving wasteful work. 
That PR introduced a new dev dependency (`escargot`). This PR removes it, replacing it with a hand-rolled build setup. Saves a dependency.

Thanks to @jot2re for the suggestion.


