### PR TITLE
chore: speedup PRSS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,8 +34,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -45,8 +56,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.8.4",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -59,8 +70,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.8.4",
+ "cipher 0.4.4",
  "ctr",
  "polyval",
  "subtle",
@@ -73,7 +84,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49cccd49cb7034d6ee7db9ac3549bb3fb38ff17179d93b726efb974cc9ddafa9"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "byteorder",
  "rand 0.8.6",
 ]
@@ -1132,7 +1143,7 @@ name = "attestation-doc-validation"
 version = "0.10.0"
 source = "git+https://github.com/mkmks/attestation-doc-validation.git?branch=timestamps#764b6814e6536eb8fa5c9cfa60c27b0e84176214"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "aes-gcm",
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api 0.4.0",
@@ -2165,7 +2176,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2251,7 +2262,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -2499,6 +2520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,7 +2707,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -4201,6 +4228,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array 0.4.12",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4365,7 +4401,7 @@ dependencies = [
 name = "kms"
 version = "0.14.0-0"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "aes-gcm",
  "aes-gcm-siv",
  "aes-prng",
@@ -7600,7 +7636,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "995c7a17e55a75f380fb1706a988a142a01ad942a0b175fc6f79ac5ec8403570"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "getrandom 0.2.17",
  "libc",
  "rayon",
@@ -7819,7 +7855,7 @@ dependencies = [
 name = "threshold-execution"
 version = "0.14.0-0"
 dependencies = [
- "aes",
+ "aes 0.9.1",
  "aes-prng",
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,8 @@ threshold-types = { path = "./core/threshold-types" } # Types share across the K
 thread-handles = { path = "./core/thread-handles" }
 
 # External dependencies (alphabetically sorted)
-aes = "=0.8.4"  # AES encryption - LOW RISK: RustCrypto org, very popular (135M+ downloads), actively maintained
+aes = "=0.9.1"  # AES block cipher for direct hot-path use - LOW RISK: RustCrypto org, very popular, actively maintained
+aes08 = { package = "aes", version = "=0.8.4" }  # AES 0.8 compatibility for cipher 0.4 CBC users - LOW RISK: same trusted RustCrypto crate, retained only where required
 aes-gcm = { version = "=0.10.3", features = ["std"] }  # AES-GCM authenticated encryption - LOW RISK: RustCrypto org, 62M+ downloads
 aes-gcm-siv = "=0.11.1"  # AES-GCM-SIV authenticated encryption - LOW RISK: RustCrypto org, nonce misuse resistant, 9M+ downloads
 aes-prng = "=0.2.1"  # AES-based PRNG for deterministic randomness - LOW RISK: Maintained by @mortendahl (Zama) and Dragos (ex Zama)

--- a/core/experiments/benches/bench_prss.rs
+++ b/core/experiments/benches/bench_prss.rs
@@ -1,10 +1,10 @@
-use std::hint::black_box;
-use std::sync::Arc;
-
 use aes_prng::AesRng;
 use algebra::galois_rings::degree_8::ResiduePolyF8Z128;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
+use std::hint::black_box;
+use std::sync::Arc;
+use threshold_execution::constants::B_SWITCH_SQUASH;
 use threshold_execution::{
     large_execution::vss::DummyVss,
     runtime::{
@@ -25,22 +25,19 @@ use threshold_types::role::Role;
 use threshold_types::session_id::SessionId;
 
 fn bench_prss(c: &mut Criterion) {
-    let sizes = vec![1_usize, 100, 10_000];
-    let mask_sizes = vec![1_usize, 100, 10_000, 100_000];
+    let sizes = vec![1_usize, 10, 100, 10_000];
     let mut group = c.benchmark_group("prss");
 
+    // params for PRSS.init
     let num_parties = 7;
     let threshold = 2;
 
-    let sid = SessionId::from(42);
+    let bench_role = Role::indexed_from_one(1); // we can pick an arbitrary role for the bench, needed to derive the PRSS state
+    let sid = SessionId::from(42); // pick an arbitrary session id for the bench, needed to derive the PRSS state
 
-    //Going with sync although PRSS init_with_abort can work in both
-    let mut sess = get_base_session_for_parties(
-        num_parties,
-        threshold,
-        Role::indexed_from_one(1),
-        NetworkMode::Sync,
-    );
+    //Going with a sync network even though PRSS init_with_abort can work in both
+    let mut sess =
+        get_base_session_for_parties(num_parties, threshold, bench_role, NetworkMode::Sync);
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     let _guard = rt.enter();
@@ -54,12 +51,12 @@ fn bench_prss(c: &mut Criterion) {
 
     let mut state = prss.new_prss_session_state(sid);
 
-    for size in &mask_sizes {
+    for size in &sizes {
         group.bench_function(BenchmarkId::new("prss_mask_next", size), |b| {
             b.iter(|| {
                 rt.block_on(async {
                     let shares = state
-                        .mask_next_vec(Role::indexed_from_one(1), 1_u128 << 70, *size)
+                        .mask_next_vec(bench_role, B_SWITCH_SQUASH, *size)
                         .await
                         .unwrap();
                     black_box(shares);
@@ -72,10 +69,7 @@ fn bench_prss(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("prss_next", size), |b| {
             b.iter(|| {
                 rt.block_on(async {
-                    let shares = state
-                        .prss_next_vec(Role::indexed_from_one(1), *size)
-                        .await
-                        .unwrap();
+                    let shares = state.prss_next_vec(bench_role, *size).await.unwrap();
                     black_box(shares);
                 });
             });
@@ -87,7 +81,7 @@ fn bench_prss(c: &mut Criterion) {
             b.iter(|| {
                 rt.block_on(async {
                     let shares = state
-                        .przs_next_vec(Role::indexed_from_one(1), threshold, *size)
+                        .przs_next_vec(bench_role, threshold, *size)
                         .await
                         .unwrap();
                     black_box(shares);

--- a/core/experiments/benches/bench_prss.rs
+++ b/core/experiments/benches/bench_prss.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use aes_prng::AesRng;
 use algebra::galois_rings::degree_8::ResiduePolyF8Z128;
+use algebra::structure_traits::{Sample, Zero};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
 use threshold_execution::{
@@ -92,6 +93,33 @@ fn bench_prss(c: &mut Criterion) {
                         .unwrap();
                     black_box(shares);
                 });
+            });
+        });
+    }
+
+    // Decomposition probe: isolate the Karatsuba multiply that prss_next does per set
+    // (`f_a * psi`), WITHOUT the psi AES generation or allocation. For n=7,t=2 each party is in
+    // C(6,2) = 15 sets, and prss_next does one full ResiduePolyF8Z128 multiply per set per element.
+    // Comparing this to prss_next/<size> shows how much of prss_next is the (AES-independent)
+    // multiply vs the AES+allocation in psi.
+    let num_sets = 15usize;
+    let mut mul_rng = AesRng::seed_from_u64(7);
+    let f_as: Vec<ResiduePolyF8Z128> = (0..num_sets)
+        .map(|_| ResiduePolyF8Z128::sample(&mut mul_rng))
+        .collect();
+    let psis: Vec<ResiduePolyF8Z128> = (0..num_sets)
+        .map(|_| ResiduePolyF8Z128::sample(&mut mul_rng))
+        .collect();
+    for size in &sizes {
+        group.bench_function(BenchmarkId::new("prss_mul_only", size), |b| {
+            b.iter(|| {
+                let mut acc = ResiduePolyF8Z128::ZERO;
+                for _ in 0..*size {
+                    for s in 0..num_sets {
+                        acc += black_box(f_as[s]) * black_box(psis[s]);
+                    }
+                }
+                black_box(acc);
             });
         });
     }

--- a/core/experiments/benches/bench_prss.rs
+++ b/core/experiments/benches/bench_prss.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use aes_prng::AesRng;
 use algebra::galois_rings::degree_8::ResiduePolyF8Z128;
-use algebra::structure_traits::{Sample, Zero};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
 use threshold_execution::{
@@ -93,33 +92,6 @@ fn bench_prss(c: &mut Criterion) {
                         .unwrap();
                     black_box(shares);
                 });
-            });
-        });
-    }
-
-    // Decomposition probe: isolate the Karatsuba multiply that prss_next does per set
-    // (`f_a * psi`), WITHOUT the psi AES generation or allocation. For n=7,t=2 each party is in
-    // C(6,2) = 15 sets, and prss_next does one full ResiduePolyF8Z128 multiply per set per element.
-    // Comparing this to prss_next/<size> shows how much of prss_next is the (AES-independent)
-    // multiply vs the AES+allocation in psi.
-    let num_sets = 15usize;
-    let mut mul_rng = AesRng::seed_from_u64(7);
-    let f_as: Vec<ResiduePolyF8Z128> = (0..num_sets)
-        .map(|_| ResiduePolyF8Z128::sample(&mut mul_rng))
-        .collect();
-    let psis: Vec<ResiduePolyF8Z128> = (0..num_sets)
-        .map(|_| ResiduePolyF8Z128::sample(&mut mul_rng))
-        .collect();
-    for size in &sizes {
-        group.bench_function(BenchmarkId::new("prss_mul_only", size), |b| {
-            b.iter(|| {
-                let mut acc = ResiduePolyF8Z128::ZERO;
-                for _ in 0..*size {
-                    for s in 0..num_sets {
-                        acc += black_box(f_as[s]) * black_box(psis[s]);
-                    }
-                }
-                black_box(acc);
             });
         });
     }

--- a/core/experiments/benches/bench_prss.rs
+++ b/core/experiments/benches/bench_prss.rs
@@ -4,7 +4,8 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
 use std::hint::black_box;
 use std::sync::Arc;
-use threshold_execution::constants::B_SWITCH_SQUASH;
+
+const B_SWITCH_SQUASH: u128 = 1u128 << 70;
 use threshold_execution::{
     large_execution::vss::DummyVss,
     runtime::{

--- a/core/experiments/benches/bench_prss.rs
+++ b/core/experiments/benches/bench_prss.rs
@@ -25,7 +25,8 @@ use threshold_types::role::Role;
 use threshold_types::session_id::SessionId;
 
 fn bench_prss(c: &mut Criterion) {
-    let sizes = vec![1_usize, 100, 10000, 100000];
+    let sizes = vec![1_usize, 100, 10_000];
+    let mask_sizes = vec![1_usize, 100, 10_000, 100_000];
     let mut group = c.benchmark_group("prss");
 
     let num_parties = 7;
@@ -53,12 +54,40 @@ fn bench_prss(c: &mut Criterion) {
 
     let mut state = prss.new_prss_session_state(sid);
 
-    for size in &sizes {
+    for size in &mask_sizes {
         group.bench_function(BenchmarkId::new("prss_mask_next", size), |b| {
             b.iter(|| {
                 rt.block_on(async {
                     let shares = state
                         .mask_next_vec(Role::indexed_from_one(1), 1_u128 << 70, *size)
+                        .await
+                        .unwrap();
+                    black_box(shares);
+                });
+            });
+        });
+    }
+
+    for size in &sizes {
+        group.bench_function(BenchmarkId::new("prss_next", size), |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let shares = state
+                        .prss_next_vec(Role::indexed_from_one(1), *size)
+                        .await
+                        .unwrap();
+                    black_box(shares);
+                });
+            });
+        });
+    }
+
+    for size in &sizes {
+        group.bench_function(BenchmarkId::new("przs_next", size), |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let shares = state
+                        .przs_next_vec(Role::indexed_from_one(1), threshold, *size)
                         .await
                         .unwrap();
                     black_box(shares);

--- a/core/experiments/benches/bench_prss.rs
+++ b/core/experiments/benches/bench_prss.rs
@@ -1,3 +1,4 @@
+use std::hint::black_box;
 use std::sync::Arc;
 
 use aes_prng::AesRng;
@@ -24,7 +25,7 @@ use threshold_types::role::Role;
 use threshold_types::session_id::SessionId;
 
 fn bench_prss(c: &mut Criterion) {
-    let sizes = vec![1_usize, 100, 10000];
+    let sizes = vec![1_usize, 100, 10000, 100000];
     let mut group = c.benchmark_group("prss");
 
     let num_parties = 7;
@@ -55,9 +56,13 @@ fn bench_prss(c: &mut Criterion) {
     for size in &sizes {
         group.bench_function(BenchmarkId::new("prss_mask_next", size), |b| {
             b.iter(|| {
-                for _ in 0..*size {
-                    let _e_shares = state.mask_next(Role::indexed_from_one(1), 1_u128 << 70);
-                }
+                rt.block_on(async {
+                    let shares = state
+                        .mask_next_vec(Role::indexed_from_one(1), 1_u128 << 70, *size)
+                        .await
+                        .unwrap();
+                    black_box(shares);
+                });
             });
         });
     }

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -40,7 +40,7 @@ path = "src/bin/kms-custodian.rs"
 aes-gcm-siv.workspace = true
 aes-gcm.workspace = true
 aes-prng.workspace = true
-aes.workspace = true
+aes08.workspace = true
 algebra = { workspace= true }
 alloy-dyn-abi.workspace = true
 alloy-primitives = { workspace = true, features = ["k256"] }

--- a/core/service/src/vault/keychain/awskms.rs
+++ b/core/service/src/vault/keychain/awskms.rs
@@ -6,7 +6,7 @@ use crate::{
     anyhow_error_and_log, consts::SAFE_SER_SIZE_LIMIT, cryptography::attestation::SecurityModule,
     some_or_err,
 };
-use aes::{
+use aes08::{
     Aes256,
     cipher::{BlockDecryptMut, IvSizeUser, KeyIvInit, KeySizeUser, block_padding::Pkcs7},
 };

--- a/core/threshold-algebra/src/galois_rings/common.rs
+++ b/core/threshold-algebra/src/galois_rings/common.rs
@@ -783,6 +783,17 @@ impl<const EXTENSION_DEGREE: usize> PRSSConversions for ResiduePoly<Z128, EXTENS
     fn from_i128(value: i128) -> Self {
         Self::from_scalar(Wrapping(value as u128))
     }
+
+    fn mul_by_i128(self, scalar: i128) -> Self {
+        // `from_i128(scalar)` places the base residue in coef[0] and zeros elsewhere, so the full
+        // multiply `self * from_i128(scalar)` collapses to scaling every coefficient by that base
+        // residue — no Karatsuba and no reduction. For Z128 the residue is `Wrapping(scalar as u128)`,
+        // matching `from_i128` exactly.
+        let base = Wrapping(scalar as u128);
+        Self {
+            coefs: self.coefs.map(|c| c * base),
+        }
+    }
 }
 
 impl<const EXTENSION_DEGREE: usize> PRSSConversions for ResiduePoly<Z64, EXTENSION_DEGREE> {

--- a/core/threshold-algebra/src/galois_rings/common.rs
+++ b/core/threshold-algebra/src/galois_rings/common.rs
@@ -789,7 +789,7 @@ impl<const EXTENSION_DEGREE: usize> PRSSConversions for ResiduePoly<Z128, EXTENS
         // multiply `self * from_i128(scalar)` collapses to scaling every coefficient by that base
         // residue — no Karatsuba and no reduction. For Z128 the residue is `Wrapping(scalar as u128)`,
         // matching `from_i128` exactly.
-        let base = Wrapping(scalar as u128);
+        let zscalar = Wrapping(scalar as u128); // signed scalar interpreted modulo 2^128 (Z128's modulus)
         Self {
             coefs: self.coefs.map(|c| c * base),
         }

--- a/core/threshold-algebra/src/galois_rings/common.rs
+++ b/core/threshold-algebra/src/galois_rings/common.rs
@@ -785,10 +785,8 @@ impl<const EXTENSION_DEGREE: usize> PRSSConversions for ResiduePoly<Z128, EXTENS
     }
 
     fn mul_by_i128(self, scalar: i128) -> Self {
-        // `from_i128(scalar)` places the base residue in coef[0] and zeros elsewhere, so the full
-        // multiply `self * from_i128(scalar)` collapses to scaling every coefficient by that base
-        // residue — no Karatsuba and no reduction. For Z128 the residue is `Wrapping(scalar as u128)`,
-        // matching `from_i128` exactly.
+        // from_i128(scalar) is a scalar poly (only coef[0] is nonzero),
+        // so the full multiply reduces to simply scaling each coefficient.
         let zscalar = Wrapping(scalar as u128); // signed scalar interpreted modulo 2^128 (Z128's modulus)
         Self {
             coefs: self.coefs.map(|c| c * base),

--- a/core/threshold-algebra/src/galois_rings/common.rs
+++ b/core/threshold-algebra/src/galois_rings/common.rs
@@ -789,7 +789,7 @@ impl<const EXTENSION_DEGREE: usize> PRSSConversions for ResiduePoly<Z128, EXTENS
         // so the full multiply reduces to simply scaling each coefficient.
         let zscalar = Wrapping(scalar as u128); // signed scalar interpreted modulo 2^128 (Z128's modulus)
         Self {
-            coefs: self.coefs.map(|c| c * base),
+            coefs: self.coefs.map(|c| c * zscalar),
         }
     }
 }

--- a/core/threshold-algebra/src/galois_rings/degree_4.rs
+++ b/core/threshold-algebra/src/galois_rings/degree_4.rs
@@ -913,6 +913,21 @@ mod tests {
     }
 
     #[test]
+    fn test_mul_by_i128_matches_full_mul_z128() {
+        // The fast coefficient-scale override must equal the generic `self * from_i128(scalar)`
+        // for every scalar, including negative ones.
+        let mut rng = AesRng::seed_from_u64(42);
+        for scalar in [-1_000_000_i128, -7, -1, 0, 1, 7, 1_000_000] {
+            let rpoly = ResiduePolyF4Z128::sample(&mut rng);
+            assert_eq!(
+                rpoly.mul_by_i128(scalar),
+                rpoly * ResiduePolyF4Z128::from_i128(scalar),
+                "mul_by_i128 mismatch for scalar {scalar}"
+            );
+        }
+    }
+
+    #[test]
     fn test_to_from_bytes_z128() {
         let rpoly = ResiduePolyF4Z128::sample(&mut AesRng::seed_from_u64(0));
         let byte_vec: [u8; ResiduePolyF4Z128::BIT_LENGTH >> 3] =

--- a/core/threshold-algebra/src/lib.rs
+++ b/core/threshold-algebra/src/lib.rs
@@ -15,4 +15,17 @@ pub mod syndrome;
 pub trait PRSSConversions {
     fn from_u128_chunks(coefs: Vec<u128>) -> Self;
     fn from_i128(value: i128) -> Self;
+
+    /// Multiply `self` by the ring element `from_i128(scalar)`.
+    ///
+    /// The default does a full ring multiply; `ResiduePoly` overrides it with a cheaper
+    /// coefficient-wise scale. It always goes through `from_i128`, so it stays correct for rings
+    /// whose modulus does not divide 2^128 (e.g. a prime modulus), unlike scaling by
+    /// `from_u128(scalar as u128)` which mis-reduces negative scalars on such rings.
+    fn mul_by_i128(self, scalar: i128) -> Self
+    where
+        Self: Sized + core::ops::Mul<Self, Output = Self>,
+    {
+        self * Self::from_i128(scalar)
+    }
 }

--- a/core/threshold-bgv/src/algebra/levels.rs
+++ b/core/threshold-bgv/src/algebra/levels.rs
@@ -1506,6 +1506,28 @@ mod tests {
     }
 
     #[test]
+    fn test_mul_by_i128_signed_prime_modulus() {
+        // Regression: LevelOne has a prime modulus (does not divide 2^128). Scaling by a negative
+        // scalar must go through from_i128; using mul_by_u128(scalar as u128) mis-reduces negative
+        // values (it adds 2^128) and previously corrupted noise-flooding masks in threshold
+        // decryption (the mask wrapped mod q and flipped the recovered plaintext).
+        use algebra::PRSSConversions;
+        use algebra::structure_traits::Ring;
+
+        let a = LevelOne::from_u128(7);
+        for scalar in [-1_000_000_i128, -7, -1, 1, 7, 1_000_000] {
+            assert_eq!(
+                a.mul_by_i128(scalar),
+                a * LevelOne::from_i128(scalar),
+                "mul_by_i128 must match the full multiply for scalar {scalar}"
+            );
+        }
+        // The buggy unsigned cast must differ for a negative scalar on a prime modulus.
+        let neg = -7_i128;
+        assert_ne!(a.mul_by_i128(neg), a.mul_by_u128(neg as u128));
+    }
+
+    #[test]
     fn test_l1_lagrange() {
         let poly = Poly::from_coefs(vec![
             LevelOne::from_u128(11),

--- a/core/threshold-execution/src/constants.rs
+++ b/core/threshold-execution/src/constants.rs
@@ -4,7 +4,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "non-wasm")] {
         /// log_2 of parameter B_{SwitchSquash}, always using the upper bound
         pub(crate) const LOG_B_SWITCH_SQUASH: u32 = 70;
-        pub(crate) const B_SWITCH_SQUASH: u128 = 1 << LOG_B_SWITCH_SQUASH;
+        pub const B_SWITCH_SQUASH: u128 = 1 << LOG_B_SWITCH_SQUASH;
 
         /// maximum number of PRSS party sets (n choose t) before the precomputation aborts
         pub(crate) const PRSS_SIZE_MAX: usize = 2047;

--- a/core/threshold-execution/src/constants.rs
+++ b/core/threshold-execution/src/constants.rs
@@ -4,7 +4,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "non-wasm")] {
         /// log_2 of parameter B_{SwitchSquash}, always using the upper bound
         pub(crate) const LOG_B_SWITCH_SQUASH: u32 = 70;
-        pub const B_SWITCH_SQUASH: u128 = 1 << LOG_B_SWITCH_SQUASH;
+        pub (crate) const B_SWITCH_SQUASH: u128 = 1 << LOG_B_SWITCH_SQUASH;
 
         /// maximum number of PRSS party sets (n choose t) before the precomputation aborts
         pub(crate) const PRSS_SIZE_MAX: usize = 2047;

--- a/core/threshold-execution/src/small_execution/prf.rs
+++ b/core/threshold-execution/src/small_execution/prf.rs
@@ -157,6 +157,11 @@ pub(crate) fn phi_range(
     Ok(res)
 }
 
+/// Number of AES blocks encrypted per `encrypt_blocks` call in psi/chi. Sized to the AES-NI /
+/// ARMv8 parallel width so a single batch covers the common degree-8 case, while a stack buffer
+/// (rather than a per-call heap allocation) holds the blocks.
+const AES_BATCH: usize = 8;
+
 /// Function Psi that generates bounded randomness for PRSS.next()
 pub(crate) fn psi<Z: Ring + PRSSConversions>(pa: &PsiAes, ctr: u128) -> anyhow::Result<Z> {
     // check ctr is smaller 2^112, so nothing gets overwritten by setting the indices below
@@ -168,28 +173,31 @@ pub(crate) fn psi<Z: Ring + PRSSConversions>(pa: &PsiAes, ctr: u128) -> anyhow::
 
     //Compute v = ceil(log(q)/128) if q power of 2, v = (dist + log(q)/128) else
     let num_u128_base_ring = Z::NUM_BITS_STAT_SEC_BASE_RING.div_ceil(128);
-
-    // Build one block per coefficient chunk and encrypt them in a single pipelined call. Block
-    // (i, block_ctr) carries the dimension index i and the block counter in its MSBs; the outputs
-    // are laid out as coefs[i * num_u128_base_ring + block_ctr] (i outer, block_ctr inner).
+    let n_blocks = Z::EXTENSION_DEGREE * num_u128_base_ring;
     let base = ctr.to_le_bytes();
-    let mut blocks = Vec::with_capacity(Z::EXTENSION_DEGREE * num_u128_base_ring);
-    for i in 0..Z::EXTENSION_DEGREE {
-        for block_ctr in 0..num_u128_base_ring {
+
+    // Block (i, block_ctr) carries the dimension index i and the block counter in its MSBs; the
+    // outputs are laid out as coefs[i * num_u128_base_ring + block_ctr] (i outer, block_ctr inner).
+    // Encrypt in fixed stack-buffer batches so the AES backend still pipelines, without a per-call
+    // heap allocation for the block buffer.
+    let mut coefs = vec![0_u128; n_blocks];
+    #[allow(deprecated)]
+    let mut buf = [GenericArray::from([0u8; 16]); AES_BATCH];
+    let mut start = 0;
+    while start < n_blocks {
+        let chunk = (n_blocks - start).min(AES_BATCH);
+        for (slot, block) in buf[..chunk].iter_mut().enumerate() {
+            let idx = start + slot;
             let mut ctr_bytes = base;
-            ctr_bytes[15] = block_ctr as u8; // v - the block counter
-            ctr_bytes[14] = i as u8; // i - the dimension index
-            #[allow(deprecated)]
-            let block = GenericArray::from(ctr_bytes);
-            blocks.push(block);
+            ctr_bytes[15] = (idx % num_u128_base_ring) as u8; // v - the block counter
+            ctr_bytes[14] = (idx / num_u128_base_ring) as u8; // i - the dimension index
+            block.copy_from_slice(&ctr_bytes);
         }
-    }
-
-    pa.aes.encrypt_blocks(&mut blocks);
-
-    let mut coefs = Vec::with_capacity(blocks.len());
-    for block in blocks {
-        coefs.push(u128::from_le_bytes(block.into()));
+        pa.aes.encrypt_blocks(&mut buf[..chunk]);
+        for (slot, block) in buf[..chunk].iter().enumerate() {
+            coefs[start + slot] = u128::from_le_bytes((*block).into());
+        }
+        start += chunk;
     }
 
     Ok(Z::from_u128_chunks(coefs))
@@ -207,29 +215,32 @@ pub(crate) fn chi<Z: Ring + PRSSConversions>(pa: &ChiAes, ctr: u128, j: u8) -> a
 
     //Compute v = ceil(log(q)/128) if q power of 2, v = (dist + log(q)/128) else
     let num_u128_base_ring = Z::NUM_BITS_STAT_SEC_BASE_RING.div_ceil(128);
-
-    // Build one block per coefficient chunk and encrypt them in a single pipelined call. Block
-    // (i, block_ctr) carries the dimension index i, threshold index j and block counter; the
-    // outputs are laid out as coefs[i * num_u128_base_ring + block_ctr] (i outer, block_ctr inner).
+    let n_blocks = Z::EXTENSION_DEGREE * num_u128_base_ring;
     let base = ctr.to_le_bytes();
-    let mut blocks = Vec::with_capacity(Z::EXTENSION_DEGREE * num_u128_base_ring);
-    for i in 0..Z::EXTENSION_DEGREE {
-        for block_ctr in 0..num_u128_base_ring {
+
+    // Block (i, block_ctr) carries the dimension index i, threshold index j and block counter; the
+    // outputs are laid out as coefs[i * num_u128_base_ring + block_ctr] (i outer, block_ctr inner).
+    // Encrypt in fixed stack-buffer batches so the AES backend still pipelines, without a per-call
+    // heap allocation for the block buffer.
+    let mut coefs = vec![0_u128; n_blocks];
+    #[allow(deprecated)]
+    let mut buf = [GenericArray::from([0u8; 16]); AES_BATCH];
+    let mut start = 0;
+    while start < n_blocks {
+        let chunk = (n_blocks - start).min(AES_BATCH);
+        for (slot, block) in buf[..chunk].iter_mut().enumerate() {
+            let idx = start + slot;
             let mut ctr_bytes = base;
-            ctr_bytes[15] = block_ctr as u8; // v - the block counter
-            ctr_bytes[14] = i as u8; // i - the dimension index
+            ctr_bytes[15] = (idx % num_u128_base_ring) as u8; // v - the block counter
+            ctr_bytes[14] = (idx / num_u128_base_ring) as u8; // i - the dimension index
             ctr_bytes[13] = j; // j - the threshold index
-            #[allow(deprecated)]
-            let block = GenericArray::from(ctr_bytes);
-            blocks.push(block);
+            block.copy_from_slice(&ctr_bytes);
         }
-    }
-
-    pa.aes.encrypt_blocks(&mut blocks);
-
-    let mut coefs = Vec::with_capacity(blocks.len());
-    for block in blocks {
-        coefs.push(u128::from_le_bytes(block.into()));
+        pa.aes.encrypt_blocks(&mut buf[..chunk]);
+        for (slot, block) in buf[..chunk].iter().enumerate() {
+            coefs[start + slot] = u128::from_le_bytes((*block).into());
+        }
+        start += chunk;
     }
 
     Ok(Z::from_u128_chunks(coefs))

--- a/core/threshold-execution/src/small_execution/prf.rs
+++ b/core/threshold-execution/src/small_execution/prf.rs
@@ -95,10 +95,24 @@ impl PsiAes {
 
 //NOTE: I BELIEVE WE NEVER NEED PRSS-MASK TO GENERATE MASK BIGGER THAN 2^126 EVEN FOR BGV
 //AFAICT, ONLY USED IN BGV DDEC WITH BD1<Q1 AND Q1 IS 94BIT LONG
-/// Function Phi that generates bounded randomness for PRSS-Mask.Next()
-/// This currently assumes that the value Bd_1 in the NIST doc is smaller than 2^126
-pub(crate) fn phi(pa: &PhiAes, ctr: u128, bd1: u128) -> anyhow::Result<i128> {
-    // we currently assume that Bd1 is at most 126 bits large, so we only need a single block of AES and can fit the result in an i128.
+/// Function Phi that generates bounded randomness for PRSS-Mask.Next(), evaluated over the
+/// contiguous counter range `[start, start + count)`.
+///
+/// This currently assumes that the value Bd_1 in the NIST doc is smaller than 2^126. A single
+/// `encrypt_blocks` call is issued so the AES-NI backend can pipeline the blocks, and the
+/// (loop-invariant) bounds are checked only once for the whole range.
+pub(crate) fn phi_range(
+    pa: &PhiAes,
+    start: u128,
+    count: usize,
+    bd1: u128,
+) -> anyhow::Result<Vec<i128>> {
+    if count == 0 {
+        return Ok(Vec::new());
+    }
+
+    // we currently assume that Bd1 is at most 126 bits large, so we only need a single block of
+    // AES per value and can fit the result in an i128.
     // check that bd1 is small enough to not cause overflow of the result
     if bd1 > (1 << 126) {
         return Err(anyhow_error_and_log(
@@ -106,29 +120,41 @@ pub(crate) fn phi(pa: &PhiAes, ctr: u128, bd1: u128) -> anyhow::Result<i128> {
         ));
     }
 
-    // check ctr is smaller 2^120, so nothing gets overwritten by setting the index below
-    if ctr >= 1 << 120 {
+    // the highest counter touched; since the range is contiguous and increasing, checking it
+    // bounds the whole range so nothing gets overwritten by setting the block-counter byte below
+    let max_ctr = start + (count as u128 - 1);
+    if max_ctr >= 1 << 120 {
         return Err(anyhow_error_and_log(format!(
-            "ctr in phi must be smaller than 2^120 but was {ctr}."
+            "ctr in phi must be smaller than 2^120 but was {max_ctr}."
         )));
     }
 
-    // number of AES blocks, currently limited to 1. See NOTE above.
+    // number of AES blocks per value, currently limited to 1. See NOTE above.
     let v = (((bd1 + 1) as f32).log2() / 128_f32).ceil() as u32;
     debug_assert_eq!(v, 1);
 
-    // TODO iterate over blocks form 0..v here if we ever need Bd1 > 2^126
-    let mut ctr_bytes = ctr.to_le_bytes();
-    ctr_bytes[15] = 0; // v - the block counter, currently fixed to zero
-    #[allow(deprecated)]
-    let mut to_enc = GenericArray::from(ctr_bytes);
-    pa.aes.encrypt_block(&mut to_enc);
-    let out = u128::from_le_bytes(to_enc.into());
+    // TODO iterate over blocks from 0..v here if we ever need Bd1 > 2^126
+    let mut blocks = Vec::with_capacity(count);
+    for k in 0..count {
+        let mut ctr_bytes = (start + k as u128).to_le_bytes();
+        ctr_bytes[15] = 0; // v - the block counter, currently fixed to zero
+        #[allow(deprecated)]
+        let block = GenericArray::from(ctr_bytes);
+        blocks.push(block);
+    }
 
-    // compute output as -BD1 + (AES (mod 2*BD1)), a uniform random value in [-BD1 .. BD1)
-    let ret: i128 = -(bd1 as i128) + (out % (2 * bd1)) as i128;
+    // single pipelined AES call over the whole range
+    pa.aes.encrypt_blocks(&mut blocks);
 
-    Ok(ret)
+    let modulus = 2 * bd1;
+    let neg_bd1 = -(bd1 as i128);
+    let mut res = Vec::with_capacity(count);
+    for block in blocks {
+        let out = u128::from_le_bytes(block.into());
+        // compute output as -BD1 + (AES (mod 2*BD1)), a uniform random value in [-BD1 .. BD1)
+        res.push(neg_bd1 + (out % modulus) as i128);
+    }
+    Ok(res)
 }
 
 /// Function Psi that generates bounded randomness for PRSS.next()
@@ -214,6 +240,11 @@ mod tests {
     use super::*;
     use crate::constants::{B_SWITCH_SQUASH, LOG_B_SWITCH_SQUASH, STATSEC};
     use algebra::galois_rings::degree_4::{ResiduePolyF4Z64, ResiduePolyF4Z128};
+
+    /// Single-value convenience wrapper over [`phi_range`] used by the phi tests.
+    fn phi(pa: &PhiAes, ctr: u128, bd1: u128) -> anyhow::Result<i128> {
+        Ok(phi_range(pa, ctr, 1, bd1)?[0])
+    }
 
     #[test]
     fn test_phi() {

--- a/core/threshold-execution/src/small_execution/prf.rs
+++ b/core/threshold-execution/src/small_execution/prf.rs
@@ -1,7 +1,7 @@
 use crate::constants::{CHI_XOR_CONSTANT, PHI_XOR_CONSTANT};
 use aes::{
-    Aes128,
-    cipher::{Array, BlockCipherEncrypt, KeyInit},
+    Aes128, Block as AesBlock,
+    cipher::{BlockCipherEncrypt, KeyInit},
 };
 pub use algebra::PRSSConversions;
 use algebra::structure_traits::Ring;
@@ -137,7 +137,7 @@ pub(crate) fn phi_range(
     for k in 0..count {
         let mut ctr_bytes = (start + k as u128).to_le_bytes();
         ctr_bytes[15] = 0; // v - the block counter, currently fixed to zero
-        let block = Array::from(ctr_bytes);
+        let block = AesBlock::from(ctr_bytes);
         blocks.push(block);
     }
 
@@ -160,71 +160,71 @@ pub(crate) fn phi_range(
 /// (rather than a per-call heap allocation) holds the blocks.
 const AES_BATCH: usize = 8;
 
-/// Shared core of [`psi`] and [`chi`]: derives the residue-polynomial value for `ctr` by
-/// encrypting one AES block per base-ring coefficient.
-///
-/// Each block carries the dimension index `i` in byte 14 and the block counter in byte 15; chi
-/// additionally carries its threshold index in byte 13 (pass `Some(j)`, psi passes `None`). Outputs
-/// are laid out as `coefs[i * num_u128_base_ring + block_ctr]` (i outer, block_ctr inner). Blocks
-/// are encrypted in fixed stack-buffer batches so the AES backend pipelines them without a per-call
-/// heap allocation.
-fn prf_residue_poly<Z: Ring + PRSSConversions>(
-    aes: &Aes128,
-    ctr: u128,
-    j: Option<u8>,
-) -> anyhow::Result<Z> {
-    // Bytes 14 (dimension) and 15 (block counter) are always written into the MSBs below; chi also
-    // writes byte 13 (threshold index j). ctr must stay below 2^(8 * free low bytes) so it cannot
-    // overwrite them: 2^112 for psi (bytes 14-15 reserved), 2^104 for chi (bytes 13-15 reserved).
-    let (name, ctr_bits): (&str, u32) = if j.is_some() {
-        ("chi", 104)
-    } else {
-        ("psi", 112)
-    };
-    if ctr >= 1u128 << ctr_bits {
-        return Err(anyhow_error_and_log(format!(
-            "ctr in {name} must be smaller than 2^{ctr_bits} but was {ctr}."
-        )));
-    }
-
-    //Compute v = ceil(log(q)/128) if q power of 2, v = (dist + log(q)/128) else
+#[inline(always)]
+fn encrypt_indexed_prf_blocks<Z, F>(aes: &Aes128, ctr: u128, mut encode_block_indices: F) -> Z
+where
+    Z: Ring + PRSSConversions,
+    F: FnMut(&mut AesBlock, usize, usize),
+{
+    // Compute v = ceil(log(q)/128) if q is a power of 2, v = dist + log(q)/128 otherwise.
     let num_u128_base_ring = Z::NUM_BITS_STAT_SEC_BASE_RING.div_ceil(128);
     let n_blocks = Z::EXTENSION_DEGREE * num_u128_base_ring;
     let base = ctr.to_le_bytes();
 
-    let mut coefs = vec![0_u128; n_blocks];
-    let mut buf = [Array::from([0u8; 16]); AES_BATCH];
+    let mut chunks = Vec::with_capacity(n_blocks);
+    let mut buf = [AesBlock::from([0u8; 16]); AES_BATCH];
     let mut start = 0;
     while start < n_blocks {
         let chunk = (n_blocks - start).min(AES_BATCH);
         for (slot, block) in buf[..chunk].iter_mut().enumerate() {
             let idx = start + slot;
             block.copy_from_slice(&base);
-            block[15] = (idx % num_u128_base_ring) as u8; // v - the block counter
-            block[14] = (idx / num_u128_base_ring) as u8; // i - the dimension index
-            if let Some(j) = j {
-                block[13] = j; // j - the threshold index (chi only)
-            }
+            let v = idx % num_u128_base_ring;
+            let i = idx / num_u128_base_ring;
+            encode_block_indices(block, i, v);
         }
         aes.encrypt_blocks(&mut buf[..chunk]);
-        for (slot, block) in buf[..chunk].iter().enumerate() {
-            coefs[start + slot] = u128::from_le_bytes((*block).into());
+        for block in &buf[..chunk] {
+            chunks.push(u128::from_le_bytes((*block).into()));
         }
         start += chunk;
     }
 
-    Ok(Z::from_u128_chunks(coefs))
+    Z::from_u128_chunks(chunks)
 }
 
 /// Function Psi that generates bounded randomness for PRSS.next()
 pub(crate) fn psi<Z: Ring + PRSSConversions>(pa: &PsiAes, ctr: u128) -> anyhow::Result<Z> {
-    prf_residue_poly(&pa.aes, ctr, None)
+    // Bytes 14 and 15 are reserved for the dimension index and block counter. Keep ctr below
+    // 2^112 so those bytes are zero before we write the indices below.
+    if ctr >= 1 << 112 {
+        return Err(anyhow_error_and_log(format!(
+            "ctr in psi must be smaller than 2^112 but was {ctr}."
+        )));
+    }
+
+    Ok(encrypt_indexed_prf_blocks(&pa.aes, ctr, |block, i, v| {
+        block[15] = v as u8;
+        block[14] = i as u8;
+    }))
 }
 
 /// Function Chi that generates bounded randomness for PRZS.next()
 /// This currently assumes that q = 2^128
 pub(crate) fn chi<Z: Ring + PRSSConversions>(pa: &ChiAes, ctr: u128, j: u8) -> anyhow::Result<Z> {
-    prf_residue_poly(&pa.aes, ctr, Some(j))
+    // Bytes 13, 14, and 15 are reserved for the threshold index, dimension index, and block
+    // counter. Keep ctr below 2^104 so those bytes are zero before we write the indices below.
+    if ctr >= 1 << 104 {
+        return Err(anyhow_error_and_log(format!(
+            "ctr in chi must be smaller than 2^104 but was {ctr}."
+        )));
+    }
+
+    Ok(encrypt_indexed_prf_blocks(&pa.aes, ctr, |block, i, v| {
+        block[15] = v as u8;
+        block[14] = i as u8;
+        block[13] = j;
+    }))
 }
 
 #[cfg(test)]
@@ -336,7 +336,7 @@ mod tests {
 
     #[test]
     fn test_chi_z64() {
-        test_chi::<ResiduePolyF4Z128>();
+        test_chi::<ResiduePolyF4Z64>();
     }
 
     /// check that all three PRFs cause different encryptions, even when initialized from the same key
@@ -351,12 +351,9 @@ mod tests {
         assert_ne!(chi::<Z>(&chiaes, 0, 0).unwrap(), psi(&psiaes, 0).unwrap());
 
         // initialize identical 128-bit block
-        #[allow(deprecated)]
-        let mut chi_block = Array::from([42u8; 16]);
-        #[allow(deprecated)]
-        let mut psi_block = Array::from([42u8; 16]);
-        #[allow(deprecated)]
-        let mut phi_block = Array::from([42u8; 16]);
+        let mut chi_block = AesBlock::from([42u8; 16]);
+        let mut psi_block = AesBlock::from([42u8; 16]);
+        let mut phi_block = AesBlock::from([42u8; 16]);
 
         // encrypt with different PRFs
         chiaes.aes.encrypt_block(&mut chi_block);

--- a/core/threshold-execution/src/small_execution/prf.rs
+++ b/core/threshold-execution/src/small_execution/prf.rs
@@ -98,9 +98,9 @@ impl PsiAes {
 /// Function Phi that generates bounded randomness for PRSS-Mask.Next(), evaluated over the
 /// contiguous counter range `[start, start + count)`.
 ///
-/// This currently assumes that the value Bd_1 in the NIST doc is smaller than 2^126. A single
-/// `encrypt_blocks` call is issued so the AES-NI backend can pipeline the blocks, and the
-/// (loop-invariant) bounds are checked only once for the whole range.
+/// This currently assumes and checks that the value Bd_1 in the NIST doc is smaller than 2^126.
+/// A single `encrypt_blocks` call is issued so the AES-NI backend can pipeline the blocks,
+/// and the (loop-invariant) bounds are checked only once for the whole range.
 pub(crate) fn phi_range(
     pa: &PhiAes,
     start: u128,
@@ -111,9 +111,7 @@ pub(crate) fn phi_range(
         return Ok(Vec::new());
     }
 
-    // we currently assume that Bd1 is at most 126 bits large, so we only need a single block of
-    // AES per value and can fit the result in an i128.
-    // check that bd1 is small enough to not cause overflow of the result
+    // check that bd1 is within expected bounds, to avoid overflow when computing -Bd1 + (AES mod 2*Bd1)
     if bd1 > (1 << 126) {
         return Err(anyhow_error_and_log(
             "Bd1 must be at most 2^126 to not overflow, but is larger".to_string(),

--- a/core/threshold-execution/src/small_execution/prf.rs
+++ b/core/threshold-execution/src/small_execution/prf.rs
@@ -159,7 +159,7 @@ pub(crate) fn phi_range(
 
 /// Function Psi that generates bounded randomness for PRSS.next()
 pub(crate) fn psi<Z: Ring + PRSSConversions>(pa: &PsiAes, ctr: u128) -> anyhow::Result<Z> {
-    // check ctr is smaller 2^112, so nothing gets overwritten by setting the indices in inner_psi
+    // check ctr is smaller 2^112, so nothing gets overwritten by setting the indices below
     if ctr >= 1 << 112 {
         return Err(anyhow_error_and_log(format!(
             "ctr in psi must be smaller than 2^112 but was {ctr}."
@@ -168,37 +168,37 @@ pub(crate) fn psi<Z: Ring + PRSSConversions>(pa: &PsiAes, ctr: u128) -> anyhow::
 
     //Compute v = ceil(log(q)/128) if q power of 2, v = (dist + log(q)/128) else
     let num_u128_base_ring = Z::NUM_BITS_STAT_SEC_BASE_RING.div_ceil(128);
-    let mut coefs = vec![0_u128; Z::EXTENSION_DEGREE * num_u128_base_ring];
 
-    //Loop over psi^(i)
+    // Build one block per coefficient chunk and encrypt them in a single pipelined call. Block
+    // (i, block_ctr) carries the dimension index i and the block counter in its MSBs; the outputs
+    // are laid out as coefs[i * num_u128_base_ring + block_ctr] (i outer, block_ctr inner).
+    let base = ctr.to_le_bytes();
+    let mut blocks = Vec::with_capacity(Z::EXTENSION_DEGREE * num_u128_base_ring);
     for i in 0..Z::EXTENSION_DEGREE {
-        //loop over block counter for each base ring element
         for block_ctr in 0..num_u128_base_ring {
-            coefs[i * num_u128_base_ring + block_ctr] =
-                inner_psi(pa, ctr, i as u8, block_ctr as u8);
+            let mut ctr_bytes = base;
+            ctr_bytes[15] = block_ctr as u8; // v - the block counter
+            ctr_bytes[14] = i as u8; // i - the dimension index
+            #[allow(deprecated)]
+            let block = GenericArray::from(ctr_bytes);
+            blocks.push(block);
         }
+    }
+
+    pa.aes.encrypt_blocks(&mut blocks);
+
+    let mut coefs = Vec::with_capacity(blocks.len());
+    for block in blocks {
+        coefs.push(u128::from_le_bytes(block.into()));
     }
 
     Ok(Z::from_u128_chunks(coefs))
 }
 
-/// Inner function Psi^(i) that generates bounded randomness for PRSS.next()
-fn inner_psi(pa: &PsiAes, ctr: u128, i: u8, block_ctr: u8) -> u128 {
-    let mut ctr_bytes = ctr.to_le_bytes();
-
-    // pad/truncate ctr value and put v and i in the MSBs
-    ctr_bytes[15] = block_ctr; // v - the block counter
-    ctr_bytes[14] = i; // i - the dimension index
-    #[allow(deprecated)]
-    let mut to_enc = GenericArray::from(ctr_bytes);
-    pa.aes.encrypt_block(&mut to_enc);
-    u128::from_le_bytes(to_enc.into())
-}
-
 /// Function Chi that generates bounded randomness for PRZS.next()
 /// This currently assumes that q = 2^128
 pub(crate) fn chi<Z: Ring + PRSSConversions>(pa: &ChiAes, ctr: u128, j: u8) -> anyhow::Result<Z> {
-    // check ctr is smaller 2^104, so nothing gets overwritten by setting the indices in inner_chi
+    // check ctr is smaller 2^104, so nothing gets overwritten by setting the indices below
     if ctr >= 1 << 104 {
         return Err(anyhow_error_and_log(format!(
             "ctr in chi must be smaller than 2^104 but was {ctr}."
@@ -207,32 +207,32 @@ pub(crate) fn chi<Z: Ring + PRSSConversions>(pa: &ChiAes, ctr: u128, j: u8) -> a
 
     //Compute v = ceil(log(q)/128) if q power of 2, v = (dist + log(q)/128) else
     let num_u128_base_ring = Z::NUM_BITS_STAT_SEC_BASE_RING.div_ceil(128);
-    let mut coefs = vec![0_u128; Z::EXTENSION_DEGREE * num_u128_base_ring];
 
-    //Loop over chi^(i)
+    // Build one block per coefficient chunk and encrypt them in a single pipelined call. Block
+    // (i, block_ctr) carries the dimension index i, threshold index j and block counter; the
+    // outputs are laid out as coefs[i * num_u128_base_ring + block_ctr] (i outer, block_ctr inner).
+    let base = ctr.to_le_bytes();
+    let mut blocks = Vec::with_capacity(Z::EXTENSION_DEGREE * num_u128_base_ring);
     for i in 0..Z::EXTENSION_DEGREE {
-        //loop over block counter for each base ring element
         for block_ctr in 0..num_u128_base_ring {
-            coefs[i * num_u128_base_ring + block_ctr] =
-                inner_chi(pa, ctr, i as u8, j, block_ctr as u8);
+            let mut ctr_bytes = base;
+            ctr_bytes[15] = block_ctr as u8; // v - the block counter
+            ctr_bytes[14] = i as u8; // i - the dimension index
+            ctr_bytes[13] = j; // j - the threshold index
+            #[allow(deprecated)]
+            let block = GenericArray::from(ctr_bytes);
+            blocks.push(block);
         }
     }
 
+    pa.aes.encrypt_blocks(&mut blocks);
+
+    let mut coefs = Vec::with_capacity(blocks.len());
+    for block in blocks {
+        coefs.push(u128::from_le_bytes(block.into()));
+    }
+
     Ok(Z::from_u128_chunks(coefs))
-}
-
-/// Inner function Chi^(i) that generates bounded randomness for PRZS.next()
-fn inner_chi(pa: &ChiAes, ctr: u128, i: u8, j: u8, block_ctr: u8) -> u128 {
-    let mut ctr_bytes = ctr.to_le_bytes();
-
-    // pad/truncate ctr value and put v and i in the MSBs, and j in the LSBs
-    ctr_bytes[15] = block_ctr; // v - the block counter
-    ctr_bytes[14] = i; // i - the dimension index
-    ctr_bytes[13] = j; // j - the threshold index
-    #[allow(deprecated)]
-    let mut to_enc = GenericArray::from(ctr_bytes);
-    pa.aes.encrypt_block(&mut to_enc);
-    u128::from_le_bytes(to_enc.into())
 }
 
 #[cfg(test)]

--- a/core/threshold-execution/src/small_execution/prf.rs
+++ b/core/threshold-execution/src/small_execution/prf.rs
@@ -161,12 +161,30 @@ pub(crate) fn phi_range(
 /// (rather than a per-call heap allocation) holds the blocks.
 const AES_BATCH: usize = 8;
 
-/// Function Psi that generates bounded randomness for PRSS.next()
-pub(crate) fn psi<Z: Ring + PRSSConversions>(pa: &PsiAes, ctr: u128) -> anyhow::Result<Z> {
-    // check ctr is smaller 2^112, so nothing gets overwritten by setting the indices below
-    if ctr >= 1 << 112 {
+/// Shared core of [`psi`] and [`chi`]: derives the residue-polynomial value for `ctr` by
+/// encrypting one AES block per base-ring coefficient.
+///
+/// Each block carries the dimension index `i` in byte 14 and the block counter in byte 15; chi
+/// additionally carries its threshold index in byte 13 (pass `Some(j)`, psi passes `None`). Outputs
+/// are laid out as `coefs[i * num_u128_base_ring + block_ctr]` (i outer, block_ctr inner). Blocks
+/// are encrypted in fixed stack-buffer batches so the AES backend pipelines them without a per-call
+/// heap allocation.
+fn prf_residue_poly<Z: Ring + PRSSConversions>(
+    aes: &Aes128,
+    ctr: u128,
+    j: Option<u8>,
+) -> anyhow::Result<Z> {
+    // Bytes 14 (dimension) and 15 (block counter) are always written into the MSBs below; chi also
+    // writes byte 13 (threshold index j). ctr must stay below 2^(8 * free low bytes) so it cannot
+    // overwrite them: 2^112 for psi (bytes 14-15 reserved), 2^104 for chi (bytes 13-15 reserved).
+    let (name, ctr_bits): (&str, u32) = if j.is_some() {
+        ("chi", 104)
+    } else {
+        ("psi", 112)
+    };
+    if ctr >= 1u128 << ctr_bits {
         return Err(anyhow_error_and_log(format!(
-            "ctr in psi must be smaller than 2^112 but was {ctr}."
+            "ctr in {name} must be smaller than 2^{ctr_bits} but was {ctr}."
         )));
     }
 
@@ -175,12 +193,6 @@ pub(crate) fn psi<Z: Ring + PRSSConversions>(pa: &PsiAes, ctr: u128) -> anyhow::
     let n_blocks = Z::EXTENSION_DEGREE * num_u128_base_ring;
     let base = ctr.to_le_bytes();
 
-    // Compute the EXTENSION_DEGREE base-ring coefficients psi^(i) for this counter.
-    // Compute one AES block each, encrypted in stack-buffer batches.
-    // Block (i, block_ctr) carries the dimension index i and the block counter in its MSBs; the
-    // outputs are laid out as coefs[i * num_u128_base_ring + block_ctr] (i outer, block_ctr inner).
-    // Encrypt in fixed stack-buffer batches so the AES backend still pipelines, without a per-call
-    // heap allocation for the block buffer.
     let mut coefs = vec![0_u128; n_blocks];
     #[allow(deprecated)]
     let mut buf = [GenericArray::from([0u8; 16]); AES_BATCH];
@@ -189,12 +201,14 @@ pub(crate) fn psi<Z: Ring + PRSSConversions>(pa: &PsiAes, ctr: u128) -> anyhow::
         let chunk = (n_blocks - start).min(AES_BATCH);
         for (slot, block) in buf[..chunk].iter_mut().enumerate() {
             let idx = start + slot;
-            let mut ctr_bytes = base;
-            ctr_bytes[15] = (idx % num_u128_base_ring) as u8; // v - the block counter
-            ctr_bytes[14] = (idx / num_u128_base_ring) as u8; // i - the dimension index
-            block.copy_from_slice(&ctr_bytes);
+            block.copy_from_slice(&base);
+            block[15] = (idx % num_u128_base_ring) as u8; // v - the block counter
+            block[14] = (idx / num_u128_base_ring) as u8; // i - the dimension index
+            if let Some(j) = j {
+                block[13] = j; // j - the threshold index (chi only)
+            }
         }
-        pa.aes.encrypt_blocks(&mut buf[..chunk]);
+        aes.encrypt_blocks(&mut buf[..chunk]);
         for (slot, block) in buf[..chunk].iter().enumerate() {
             coefs[start + slot] = u128::from_le_bytes((*block).into());
         }
@@ -204,49 +218,15 @@ pub(crate) fn psi<Z: Ring + PRSSConversions>(pa: &PsiAes, ctr: u128) -> anyhow::
     Ok(Z::from_u128_chunks(coefs))
 }
 
+/// Function Psi that generates bounded randomness for PRSS.next()
+pub(crate) fn psi<Z: Ring + PRSSConversions>(pa: &PsiAes, ctr: u128) -> anyhow::Result<Z> {
+    prf_residue_poly(&pa.aes, ctr, None)
+}
+
 /// Function Chi that generates bounded randomness for PRZS.next()
 /// This currently assumes that q = 2^128
 pub(crate) fn chi<Z: Ring + PRSSConversions>(pa: &ChiAes, ctr: u128, j: u8) -> anyhow::Result<Z> {
-    // check ctr is smaller 2^104, so nothing gets overwritten by setting the indices below
-    if ctr >= 1 << 104 {
-        return Err(anyhow_error_and_log(format!(
-            "ctr in chi must be smaller than 2^104 but was {ctr}."
-        )));
-    }
-
-    //Compute v = ceil(log(q)/128) if q power of 2, v = (dist + log(q)/128) else
-    let num_u128_base_ring = Z::NUM_BITS_STAT_SEC_BASE_RING.div_ceil(128);
-    let n_blocks = Z::EXTENSION_DEGREE * num_u128_base_ring;
-    let base = ctr.to_le_bytes();
-
-    // Compute the EXTENSION_DEGREE base-ring coefficients chi^(i) for this counter.
-    // Compute one AES block each, encrypted in stack-buffer batches.
-    // Block (i, block_ctr) carries the dimension index i, threshold index j and block counter; the
-    // outputs are laid out as coefs[i * num_u128_base_ring + block_ctr] (i outer, block_ctr inner).
-    // Encrypt in fixed stack-buffer batches so the AES backend still pipelines, without a per-call
-    // heap allocation for the block buffer.
-    let mut coefs = vec![0_u128; n_blocks];
-    #[allow(deprecated)]
-    let mut buf = [GenericArray::from([0u8; 16]); AES_BATCH];
-    let mut start = 0;
-    while start < n_blocks {
-        let chunk = (n_blocks - start).min(AES_BATCH);
-        for (slot, block) in buf[..chunk].iter_mut().enumerate() {
-            let idx = start + slot;
-            let mut ctr_bytes = base;
-            ctr_bytes[15] = (idx % num_u128_base_ring) as u8; // v - the block counter
-            ctr_bytes[14] = (idx / num_u128_base_ring) as u8; // i - the dimension index
-            ctr_bytes[13] = j; // j - the threshold index
-            block.copy_from_slice(&ctr_bytes);
-        }
-        pa.aes.encrypt_blocks(&mut buf[..chunk]);
-        for (slot, block) in buf[..chunk].iter().enumerate() {
-            coefs[start + slot] = u128::from_le_bytes((*block).into());
-        }
-        start += chunk;
-    }
-
-    Ok(Z::from_u128_chunks(coefs))
+    prf_residue_poly(&pa.aes, ctr, Some(j))
 }
 
 #[cfg(test)]

--- a/core/threshold-execution/src/small_execution/prf.rs
+++ b/core/threshold-execution/src/small_execution/prf.rs
@@ -1,7 +1,7 @@
 use crate::constants::{CHI_XOR_CONSTANT, PHI_XOR_CONSTANT};
 use aes::Aes128;
-use aes::cipher::BlockCipherEncrypt;
 #[allow(deprecated)]
+use aes::cipher::generic_array::GenericArray;
 use aes::cipher::{BlockEncrypt, KeyInit};
 pub use algebra::PRSSConversions;
 use algebra::structure_traits::Ring;
@@ -175,6 +175,8 @@ pub(crate) fn psi<Z: Ring + PRSSConversions>(pa: &PsiAes, ctr: u128) -> anyhow::
     let n_blocks = Z::EXTENSION_DEGREE * num_u128_base_ring;
     let base = ctr.to_le_bytes();
 
+    // Compute the EXTENSION_DEGREE base-ring coefficients psi^(i) for this counter.
+    // Compute one AES block each, encrypted in stack-buffer batches.
     // Block (i, block_ctr) carries the dimension index i and the block counter in its MSBs; the
     // outputs are laid out as coefs[i * num_u128_base_ring + block_ctr] (i outer, block_ctr inner).
     // Encrypt in fixed stack-buffer batches so the AES backend still pipelines, without a per-call
@@ -217,6 +219,8 @@ pub(crate) fn chi<Z: Ring + PRSSConversions>(pa: &ChiAes, ctr: u128, j: u8) -> a
     let n_blocks = Z::EXTENSION_DEGREE * num_u128_base_ring;
     let base = ctr.to_le_bytes();
 
+    // Compute the EXTENSION_DEGREE base-ring coefficients chi^(i) for this counter.
+    // Compute one AES block each, encrypted in stack-buffer batches.
     // Block (i, block_ctr) carries the dimension index i, threshold index j and block counter; the
     // outputs are laid out as coefs[i * num_u128_base_ring + block_ctr] (i outer, block_ctr inner).
     // Encrypt in fixed stack-buffer batches so the AES backend still pipelines, without a per-call

--- a/core/threshold-execution/src/small_execution/prf.rs
+++ b/core/threshold-execution/src/small_execution/prf.rs
@@ -1,8 +1,8 @@
 use crate::constants::{CHI_XOR_CONSTANT, PHI_XOR_CONSTANT};
-use aes::Aes128;
-#[allow(deprecated)]
-use aes::cipher::generic_array::GenericArray;
-use aes::cipher::{BlockEncrypt, KeyInit};
+use aes::{
+    Aes128,
+    cipher::{Array, BlockCipherEncrypt, KeyInit},
+};
 pub use algebra::PRSSConversions;
 use algebra::structure_traits::Ring;
 use error_utils::anyhow_error_and_log;
@@ -137,8 +137,7 @@ pub(crate) fn phi_range(
     for k in 0..count {
         let mut ctr_bytes = (start + k as u128).to_le_bytes();
         ctr_bytes[15] = 0; // v - the block counter, currently fixed to zero
-        #[allow(deprecated)]
-        let block = GenericArray::from(ctr_bytes);
+        let block = Array::from(ctr_bytes);
         blocks.push(block);
     }
 
@@ -194,8 +193,7 @@ fn prf_residue_poly<Z: Ring + PRSSConversions>(
     let base = ctr.to_le_bytes();
 
     let mut coefs = vec![0_u128; n_blocks];
-    #[allow(deprecated)]
-    let mut buf = [GenericArray::from([0u8; 16]); AES_BATCH];
+    let mut buf = [Array::from([0u8; 16]); AES_BATCH];
     let mut start = 0;
     while start < n_blocks {
         let chunk = (n_blocks - start).min(AES_BATCH);
@@ -354,11 +352,11 @@ mod tests {
 
         // initialize identical 128-bit block
         #[allow(deprecated)]
-        let mut chi_block = GenericArray::from([42u8; 16]);
+        let mut chi_block = Array::from([42u8; 16]);
         #[allow(deprecated)]
-        let mut psi_block = GenericArray::from([42u8; 16]);
+        let mut psi_block = Array::from([42u8; 16]);
         #[allow(deprecated)]
-        let mut phi_block = GenericArray::from([42u8; 16]);
+        let mut phi_block = Array::from([42u8; 16]);
 
         // encrypt with different PRFs
         chiaes.aes.encrypt_block(&mut chi_block);

--- a/core/threshold-execution/src/small_execution/prf.rs
+++ b/core/threshold-execution/src/small_execution/prf.rs
@@ -1,7 +1,7 @@
 use crate::constants::{CHI_XOR_CONSTANT, PHI_XOR_CONSTANT};
 use aes::Aes128;
+use aes::cipher::BlockCipherEncrypt;
 #[allow(deprecated)]
-use aes::cipher::generic_array::GenericArray;
 use aes::cipher::{BlockEncrypt, KeyInit};
 pub use algebra::PRSSConversions;
 use algebra::structure_traits::Ring;
@@ -120,7 +120,8 @@ pub(crate) fn phi_range(
         ));
     }
 
-    // check ctr is smaller 2^120, so nothing gets overwritten by setting the index below.
+    // We assume the block counter is stored in ctr_bytes[15] (even though it's currently fixed to zero, given our parameters)
+    // Thus, we need to check that ctr is smaller 2^120, so nothing gets overwritten by setting the index below.
     // Also ensure it doesn't overflow when adding count-1 to it.
     let max_ctr = start.saturating_add(count as u128 - 1);
     if max_ctr >= 1 << 120 {
@@ -133,7 +134,7 @@ pub(crate) fn phi_range(
     let v = (((bd1 + 1) as f32).log2() / 128_f32).ceil() as u32;
     debug_assert_eq!(v, 1);
 
-    // TODO iterate over blocks from 0..v here if we ever need Bd1 > 2^126
+    // TODO iterate over blocks from 0..v here, if we ever need Bd1 > 2^126
     let mut blocks = Vec::with_capacity(count);
     for k in 0..count {
         let mut ctr_bytes = (start + k as u128).to_le_bytes();

--- a/core/threshold-execution/src/small_execution/prf.rs
+++ b/core/threshold-execution/src/small_execution/prf.rs
@@ -121,8 +121,10 @@ pub(crate) fn phi_range(
     }
 
     // the highest counter touched; since the range is contiguous and increasing, checking it
-    // bounds the whole range so nothing gets overwritten by setting the block-counter byte below
-    let max_ctr = start + (count as u128 - 1);
+    // bounds the whole range so nothing gets overwritten by setting the block-counter byte below.
+    // saturating_add so an out-of-range `start` can never wrap past the guard below (it would
+    // saturate to u128::MAX and trip it) instead of panicking in debug / wrapping in release.
+    let max_ctr = start.saturating_add(count as u128 - 1);
     if max_ctr >= 1 << 120 {
         return Err(anyhow_error_and_log(format!(
             "ctr in phi must be smaller than 2^120 but was {max_ctr}."

--- a/core/threshold-execution/src/small_execution/prf.rs
+++ b/core/threshold-execution/src/small_execution/prf.rs
@@ -120,10 +120,8 @@ pub(crate) fn phi_range(
         ));
     }
 
-    // the highest counter touched; since the range is contiguous and increasing, checking it
-    // bounds the whole range so nothing gets overwritten by setting the block-counter byte below.
-    // saturating_add so an out-of-range `start` can never wrap past the guard below (it would
-    // saturate to u128::MAX and trip it) instead of panicking in debug / wrapping in release.
+    // check ctr is smaller 2^120, so nothing gets overwritten by setting the index below.
+    // Also ensure it doesn't overflow when adding count-1 to it.
     let max_ctr = start.saturating_add(count as u128 - 1);
     if max_ctr >= 1 << 120 {
         return Err(anyhow_error_and_log(format!(
@@ -131,7 +129,7 @@ pub(crate) fn phi_range(
         )));
     }
 
-    // number of AES blocks per value, currently limited to 1. See NOTE above.
+    // Number of AES blocks per value, currently limited to 1. See NOTE above.
     let v = (((bd1 + 1) as f32).log2() / 128_f32).ceil() as u32;
     debug_assert_eq!(v, 1);
 

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -630,11 +630,8 @@ where
         let mask_ctr = self.counters.mask_ctr;
 
         // Element `idx` is the f_A-weighted sum over all sets of
-        // phi(mask_ctr+idx) + phi(mask_ctr+idx+1). Consecutive elements share a phi
-        // value (the phi1 of element idx is the phi0 of element idx+1), so a chunk of
-        // `len` elements needs only `len+1` AES-PRF evaluations per set instead of
-        // `2*len`. We parallelize over chunks and precompute each chunk's phi range
-        // once per set.
+        // phi(mask_ctr+2*idx) + phi(mask_ctr+2*idx+1). This matches repeated
+        // scalar calls while still batching each chunk's AES-PRF evaluations.
         let res = spawn_compute_bound(move || -> anyhow::Result<Vec<Z>> {
             let chunk = (*crate::constants::PRSS_GEN_PAR_MIN_CHUNK).max(1);
             let mut res = vec![Z::ZERO; amount];
@@ -655,13 +652,16 @@ where
                         let f_a = set.f_a_points[&party_role];
 
                         // One pipelined AES call for the chunk's counter range. Element `idx`
-                        // needs phi(mask_ctr+idx) + phi(mask_ctr+idx+1), so a chunk of `len`
-                        // elements shares counters and needs only `len+1` evaluations.
-                        let phi_vals =
-                            phi_range(&aes_prf.phi_aes, mask_ctr + lo as u128, out.len() + 1, bd1)?;
+                        // consumes two distinct phi counters, matching one scalar mask_next().
+                        let phi_vals = phi_range(
+                            &aes_prf.phi_aes,
+                            mask_ctr + 2 * lo as u128,
+                            2 * out.len(),
+                            bd1,
+                        )?;
 
                         for (j, out_elem) in out.iter_mut().enumerate() {
-                            let phi = phi_vals[j] + phi_vals[j + 1];
+                            let phi = phi_vals[2 * j] + phi_vals[2 * j + 1];
                             // phi is a scalar, so a coefficient-wise scale (mul_by_u128) replaces a
                             // full extension multiply; `phi as u128` matches from_i128's wrapping.
                             *out_elem += f_a.mul_by_u128(phi as u128);
@@ -675,8 +675,7 @@ where
         .await??;
 
         // Advance the counter by two per element, matching one mask_next() call per
-        // element (each consumes two phi counters). The batch reuses the shared phi
-        // values internally but still never reuses counters across calls.
+        // element (each consumes two phi counters).
         self.counters.mask_ctr += 2 * (amount as u128);
 
         Ok(res)
@@ -1446,9 +1445,10 @@ mod tests {
         let sid = SessionId::from(23425);
 
         let role_one = Role::indexed_from_one(1);
-        let prss = PRSSSetup::testing_party_epoch_init(num_parties, threshold, role_one)
-            .await
-            .unwrap();
+        let prss: PRSSSetup<ResiduePolyF4Z128> =
+            PRSSSetup::testing_party_epoch_init(num_parties, threshold, role_one)
+                .await
+                .unwrap();
 
         let mut state = prss.new_prss_session_state(sid);
 
@@ -1468,6 +1468,57 @@ mod tests {
         // other counters must not have increased
         assert_eq!(state.counters.prss_ctr, 0);
         assert_eq!(state.counters.przs_ctr, 0);
+    }
+
+    #[tokio::test]
+    #[rstest]
+    #[case(0)]
+    #[case(1)]
+    #[case(2)]
+    #[case(23)]
+    async fn test_prss_mask_next_vec_matches_scalar_calls(#[case] amount: usize) {
+        let num_parties = 4;
+        let threshold = 1;
+
+        let sid = SessionId::from(23425);
+
+        let role_one = Role::indexed_from_one(1);
+        let prss: PRSSSetup<ResiduePolyF4Z128> =
+            PRSSSetup::testing_party_epoch_init(num_parties, threshold, role_one)
+                .await
+                .unwrap();
+
+        let mut scalar_state = prss.new_prss_session_state(sid);
+        let mut batch_state = scalar_state.clone();
+
+        let mut scalar_values = Vec::with_capacity(amount);
+        for _ in 0..amount {
+            scalar_values.push(
+                scalar_state
+                    .mask_next(role_one, B_SWITCH_SQUASH)
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        let batched_values = batch_state
+            .mask_next_vec(role_one, B_SWITCH_SQUASH, amount)
+            .await
+            .unwrap();
+
+        assert_eq!(batched_values, scalar_values);
+        assert_eq!(
+            batch_state.counters.mask_ctr,
+            scalar_state.counters.mask_ctr
+        );
+        assert_eq!(
+            batch_state.counters.prss_ctr,
+            scalar_state.counters.prss_ctr
+        );
+        assert_eq!(
+            batch_state.counters.przs_ctr,
+            scalar_state.counters.przs_ctr
+        );
     }
 
     #[tokio::test]

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -26,6 +26,7 @@ use anyhow::Context;
 use error_utils::{anyhow_error_and_log, log_error_wrapper};
 use itertools::Itertools;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use rayon::slice::ParallelSliceMut;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -628,41 +629,57 @@ where
         let prss_setup = self.prss_setup.clone();
         let mask_ctr = self.counters.mask_ctr;
 
-        // Each element is computed from an independent counter, so the batch is
-        // assembled in parallel. Element `idx` uses `ctr = mask_ctr + idx` (and
-        // `ctr + 1`).
-        let res = spawn_compute_bound(move || {
-        (0..amount).into_par_iter().with_min_len(*crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
-        let ctr = mask_ctr + idx as u128;
-        let mut res = Z::ZERO;
-        for (i, set) in prss_setup.sets.iter().enumerate() {
-            if set.parties.contains(&party_role) {
-                if let Some(aes_prf) = prfs.get(i) {
-                    let phi0 = phi(&aes_prf.phi_aes, ctr , bd1)?;
-                    let phi1 = phi(&aes_prf.phi_aes, ctr + 1, bd1)?;
-                    let phi = phi0 + phi1;
+        // Element `idx` is the f_A-weighted sum over all sets of
+        // phi(mask_ctr+idx) + phi(mask_ctr+idx+1). Consecutive elements share a phi
+        // value (the phi1 of element idx is the phi0 of element idx+1), so a chunk of
+        // `len` elements needs only `len+1` AES-PRF evaluations per set instead of
+        // `2*len`. We parallelize over chunks and precompute each chunk's phi range
+        // once per set.
+        let res = spawn_compute_bound(move || -> anyhow::Result<Vec<Z>> {
+            let chunk = (*crate::constants::PRSS_GEN_PAR_MIN_CHUNK).max(1);
+            let mut res = vec![Z::ZERO; amount];
+            res.par_chunks_mut(chunk)
+                .enumerate()
+                .try_for_each(|(chunk_idx, out)| -> anyhow::Result<()> {
+                    let lo = chunk_idx * chunk;
+                    // reused across sets to avoid a per-set allocation
+                    let mut phi_vals: Vec<i128> = Vec::with_capacity(out.len() + 1);
+                    for (i, set) in prss_setup.sets.iter().enumerate() {
+                        if !set.parties.contains(&party_role) {
+                            return Err(anyhow_error_and_log(format!(
+                                "Called prss.mask_next() with party role {party_role} that is not in a precomputed set of parties!"
+                            )));
+                        }
+                        let aes_prf = prfs.get(i).ok_or_else(|| {
+                            anyhow_error_and_log("PRFs not properly initialized!".to_string())
+                        })?;
+                        // compute f_A(alpha_i): the embedded party ID indexes into f_a_points (from zero)
+                        let f_a = set.f_a_points[&party_role];
 
-                    // compute f_A(alpha_i), where alpha_i is simply the embedded party ID, so we can just index into the f_a_points (indexed from zero)
-                    let f_a = set.f_a_points[&party_role];
+                        // phi for counters [mask_ctr+lo .. mask_ctr+lo+len], evaluated once per set
+                        phi_vals.clear();
+                        for k in 0..=out.len() {
+                            let ctr = mask_ctr + (lo + k) as u128;
+                            phi_vals.push(phi(&aes_prf.phi_aes, ctr, bd1)?);
+                        }
 
-                    // phi is a scalar, so embedding it via from_i128 and doing a full
-                    // extension-field multiply (Karatsuba + reduction) is wasteful: mul_by_u128
-                    // scales each coefficient directly. `phi as u128` reproduces from_i128's
-                    // `Wrapping(phi as u128)`, so negative values wrap identically.
-                    res += f_a.mul_by_u128(phi as u128);
-                } else {
-                    return Err(anyhow_error_and_log(
-                        "PRFs not properly initialized!".to_string(),
-                    ));
-                }
-            } else {
-                return Err(anyhow_error_and_log(format!("Called prss.mask_next() with party role {party_role} that is not in a precomputed set of parties!")));
-            }
-        }
-            Ok(res)}).collect::<anyhow::Result<Vec<_>>>()
-    }).instrument(tracing::Span::current()).await??;
+                        for (j, out_elem) in out.iter_mut().enumerate() {
+                            let phi = phi_vals[j] + phi_vals[j + 1];
+                            // phi is a scalar, so a coefficient-wise scale (mul_by_u128) replaces a
+                            // full extension multiply; `phi as u128` matches from_i128's wrapping.
+                            *out_elem += f_a.mul_by_u128(phi as u128);
+                        }
+                    }
+                    Ok(())
+                })?;
+            Ok(res)
+        })
+        .instrument(tracing::Span::current())
+        .await??;
 
-        // increase counter by two for each element generated, since we have two phi calls above
+        // Advance the counter by two per element, matching one mask_next() call per
+        // element (each consumes two phi counters). The batch reuses the shared phi
+        // values internally but still never reuses counters across calls.
         self.counters.mask_ctr += 2 * (amount as u128);
 
         Ok(res)

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -695,30 +695,42 @@ where
 
         // Independent per-counter elements, assembled in parallel. Element `idx`
         // uses `ctr = prss_ctr + idx`.
-        let res = spawn_compute_bound(move ||{
-            (0..amount).into_par_iter().with_min_len(*crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
-        let ctr = prss_ctr + idx as u128;
-        let mut res = Z::ZERO;
-        for (i, set) in prss_setup.sets.iter().enumerate() {
-            if set.parties.contains(&party_role) {
-                if let Some(aes_prf) = prfs.get(i) {
-                    let psi = psi(&aes_prf.psi_aes, ctr)?;
-
-                    // compute f_A(alpha_i), where alpha_i is simply the embedded party ID, so we can just index into the precomputed f_a_points (indexed from zero)
-                    let f_a = set.f_a_points[&party_role];
-
-                    res += f_a * psi;
-                } else {
-                    return Err(anyhow_error_and_log(
-                        "PRFs not properly initialized!".to_string(),
-                    ));
-                }
-            } else {
-                return Err(anyhow_error_and_log(format!("Called prss.next() with party role {party_role} that is not in a precomputed set of parties!")));
+        let res = spawn_compute_bound(move || -> anyhow::Result<Vec<Z>> {
+            if amount == 0 {
+                return Ok(Vec::new());
             }
-        }
-        Ok(res)}).collect::<anyhow::Result<Vec<_>>>()
-    }).instrument(tracing::Span::current()).await??;
+
+            // Per-set invariants (membership, PRF key, f_A), computed once instead of per element.
+            let mut set_data: Vec<(&PrfAes, Z)> = Vec::with_capacity(prss_setup.sets.len());
+            for (i, set) in prss_setup.sets.iter().enumerate() {
+                if !set.parties.contains(&party_role) {
+                    return Err(anyhow_error_and_log(format!(
+                        "Called prss.next() with party role {party_role} that is not in a precomputed set of parties!"
+                    )));
+                }
+                let aes_prf = prfs.get(i).ok_or_else(|| {
+                    anyhow_error_and_log("PRFs not properly initialized!".to_string())
+                })?;
+                // f_A(alpha_i): the embedded party ID indexes into f_a_points (from zero)
+                set_data.push((aes_prf, set.f_a_points[&party_role]));
+            }
+
+            (0..amount)
+                .into_par_iter()
+                .with_min_len(*crate::constants::PRSS_GEN_PAR_MIN_CHUNK)
+                .map(|idx| {
+                    let ctr = prss_ctr + idx as u128;
+                    let mut res = Z::ZERO;
+                    for &(aes_prf, f_a) in &set_data {
+                        let psi = psi(&aes_prf.psi_aes, ctr)?;
+                        res += f_a * psi;
+                    }
+                    Ok(res)
+                })
+                .collect::<anyhow::Result<Vec<_>>>()
+        })
+        .instrument(tracing::Span::current())
+        .await??;
 
         self.counters.prss_ctr += amount as u128;
 
@@ -745,32 +757,52 @@ where
 
         // Independent per-counter elements, assembled in parallel. Element `idx`
         // uses `ctr = przs_ctr + idx`.
-        let res = spawn_compute_bound(move ||{
-            (0..amount).into_par_iter().with_min_len(*crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
-        let ctr = przs_ctr + idx as u128;
-        let mut res = Z::ZERO;
-        for (i, set) in prss_setup.sets.iter().enumerate() {
-            if set.parties.contains(&party_role) {
-                if let Some(aes_prf) = prfs.get(i) {
-                    for j in 1..=threshold {
-                        let chi = chi(&aes_prf.chi_aes, ctr, j)?;
-                        // compute f_A(alpha_i), where alpha_i is simply the embedded party ID, so we can just index into the f_a_points (indexed from zero)
-                        let f_a = set.f_a_points[&party_role];
-                        // power of alpha_i^j
-                        let alpha_j = prss_setup.alpha_powers[&party_role][j as usize];
-                        res += f_a * alpha_j * chi;
-                    }
-                } else {
-                    return Err(anyhow_error_and_log(
-                        "PRFs not properly initialized!".to_string(),
-                    ));
-                }
-            } else {
-                return Err(anyhow_error_and_log(format!("Called przs.next() with party role {party_role} that is not in a precomputed set of parties!")));
+        let res = spawn_compute_bound(move || -> anyhow::Result<Vec<Z>> {
+            if amount == 0 {
+                return Ok(Vec::new());
             }
-        }
-        Ok(res)}).collect::<anyhow::Result<Vec<_>>>()
-}).instrument(tracing::Span::current()).await??;
+
+            // Per-set invariants, computed once instead of per element: the products
+            // f_A(alpha_i) * alpha_i^j (for j in 1..=threshold) do not depend on the counter.
+            let mut set_data: Vec<(&PrfAes, Vec<Z>)> = Vec::with_capacity(prss_setup.sets.len());
+            for (i, set) in prss_setup.sets.iter().enumerate() {
+                if !set.parties.contains(&party_role) {
+                    return Err(anyhow_error_and_log(format!(
+                        "Called przs.next() with party role {party_role} that is not in a precomputed set of parties!"
+                    )));
+                }
+                let aes_prf = prfs.get(i).ok_or_else(|| {
+                    anyhow_error_and_log("PRFs not properly initialized!".to_string())
+                })?;
+                // f_A(alpha_i): the embedded party ID indexes into f_a_points (from zero)
+                let f_a = set.f_a_points[&party_role];
+                let mut fa_alpha = Vec::with_capacity(threshold as usize);
+                for j in 1..=threshold {
+                    // power of alpha_i^j
+                    let alpha_j = prss_setup.alpha_powers[&party_role][j as usize];
+                    fa_alpha.push(f_a * alpha_j);
+                }
+                set_data.push((aes_prf, fa_alpha));
+            }
+
+            (0..amount)
+                .into_par_iter()
+                .with_min_len(*crate::constants::PRSS_GEN_PAR_MIN_CHUNK)
+                .map(|idx| {
+                    let ctr = przs_ctr + idx as u128;
+                    let mut res = Z::ZERO;
+                    for (aes_prf, fa_alpha) in &set_data {
+                        for (j_idx, fa_alpha_j) in fa_alpha.iter().enumerate() {
+                            let chi = chi(&aes_prf.chi_aes, ctr, (j_idx + 1) as u8)?;
+                            res += *fa_alpha_j * chi;
+                        }
+                    }
+                    Ok(res)
+                })
+                .collect::<anyhow::Result<Vec<_>>>()
+        })
+        .instrument(tracing::Span::current())
+        .await??;
 
         self.counters.przs_ctr += amount as u128;
 

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -645,8 +645,11 @@ where
                     // compute f_A(alpha_i), where alpha_i is simply the embedded party ID, so we can just index into the f_a_points (indexed from zero)
                     let f_a = set.f_a_points[&party_role];
 
-                    //Leave it to the Ring's implementation to deal with negative values
-                    res += f_a * Z::from_i128(phi);
+                    // phi is a scalar, so embedding it via from_i128 and doing a full
+                    // extension-field multiply (Karatsuba + reduction) is wasteful: mul_by_u128
+                    // scales each coefficient directly. `phi as u128` reproduces from_i128's
+                    // `Wrapping(phi as u128)`, so negative values wrap identically.
+                    res += f_a.mul_by_u128(phi as u128);
                 } else {
                     return Err(anyhow_error_and_log(
                         "PRFs not properly initialized!".to_string(),

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -662,9 +662,13 @@ where
 
                         for (j, out_elem) in out.iter_mut().enumerate() {
                             let phi = phi_vals[2 * j] + phi_vals[2 * j + 1];
-                            // phi is a scalar, so a coefficient-wise scale (mul_by_u128) replaces a
-                            // full extension multiply; `phi as u128` matches from_i128's wrapping.
-                            *out_elem += f_a.mul_by_u128(phi as u128);
+                            // mul_by_i128 scales by the signed scalar via from_i128, so it is a
+                            // cheap coefficient scale for ResiduePoly yet still correct for base
+                            // rings whose modulus does not divide 2^128 (e.g. the BGV prime
+                            // modulus). Do NOT use mul_by_u128(phi as u128): that mis-reduces
+                            // negative phi on such rings (the wrong large mask would wrap mod q and
+                            // corrupt the decrypted plaintext).
+                            *out_elem += f_a.mul_by_i128(phi);
                         }
                     }
                     Ok(())

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -1476,6 +1476,10 @@ mod tests {
     #[case(1)]
     #[case(2)]
     #[case(23)]
+    // amounts above span multiple rayon chunks (default PRSS_GEN_PAR_MIN_CHUNK = 1024),
+    // exercising the per-chunk counter offset and the partial last chunk
+    #[case(1025)]
+    #[case(2049)]
     async fn test_prss_mask_next_vec_matches_scalar_calls(#[case] amount: usize) {
         let num_parties = 4;
         let threshold = 1;
@@ -1503,6 +1507,100 @@ mod tests {
 
         let batched_values = batch_state
             .mask_next_vec(role_one, B_SWITCH_SQUASH, amount)
+            .await
+            .unwrap();
+
+        assert_eq!(batched_values, scalar_values);
+        assert_eq!(
+            batch_state.counters.mask_ctr,
+            scalar_state.counters.mask_ctr
+        );
+        assert_eq!(
+            batch_state.counters.prss_ctr,
+            scalar_state.counters.prss_ctr
+        );
+        assert_eq!(
+            batch_state.counters.przs_ctr,
+            scalar_state.counters.przs_ctr
+        );
+    }
+
+    #[tokio::test]
+    #[rstest]
+    #[case(0)]
+    #[case(1)]
+    #[case(2)]
+    #[case(23)]
+    // amount above spans multiple rayon chunks (default PRSS_GEN_PAR_MIN_CHUNK = 1024)
+    #[case(1025)]
+    async fn test_prss_next_vec_matches_scalar_calls(#[case] amount: usize) {
+        let num_parties = 4;
+        let threshold = 1;
+
+        let sid = SessionId::from(23425);
+
+        let role_one = Role::indexed_from_one(1);
+        let prss: PRSSSetup<ResiduePolyF4Z128> =
+            PRSSSetup::testing_party_epoch_init(num_parties, threshold, role_one)
+                .await
+                .unwrap();
+
+        let mut scalar_state = prss.new_prss_session_state(sid);
+        let mut batch_state = scalar_state.clone();
+
+        let mut scalar_values = Vec::with_capacity(amount);
+        for _ in 0..amount {
+            scalar_values.push(scalar_state.prss_next(role_one).await.unwrap());
+        }
+
+        let batched_values = batch_state.prss_next_vec(role_one, amount).await.unwrap();
+
+        assert_eq!(batched_values, scalar_values);
+        assert_eq!(
+            batch_state.counters.mask_ctr,
+            scalar_state.counters.mask_ctr
+        );
+        assert_eq!(
+            batch_state.counters.prss_ctr,
+            scalar_state.counters.prss_ctr
+        );
+        assert_eq!(
+            batch_state.counters.przs_ctr,
+            scalar_state.counters.przs_ctr
+        );
+    }
+
+    #[tokio::test]
+    #[rstest]
+    #[case(0)]
+    #[case(1)]
+    #[case(2)]
+    #[case(23)]
+    // amount above spans multiple rayon chunks (default PRSS_GEN_PAR_MIN_CHUNK = 1024)
+    #[case(1025)]
+    async fn test_przs_next_vec_matches_scalar_calls(#[case] amount: usize) {
+        // n = 7, t = 2 exercises multiple alpha powers (j = 1..=t) per set
+        let num_parties = 7;
+        let threshold: u8 = 2;
+
+        let sid = SessionId::from(23425);
+
+        let role_one = Role::indexed_from_one(1);
+        let prss: PRSSSetup<ResiduePolyF4Z128> =
+            PRSSSetup::testing_party_epoch_init(num_parties, threshold as usize, role_one)
+                .await
+                .unwrap();
+
+        let mut scalar_state = prss.new_prss_session_state(sid);
+        let mut batch_state = scalar_state.clone();
+
+        let mut scalar_values = Vec::with_capacity(amount);
+        for _ in 0..amount {
+            scalar_values.push(scalar_state.przs_next(role_one, threshold).await.unwrap());
+        }
+
+        let batched_values = batch_state
+            .przs_next_vec(role_one, threshold, amount)
             .await
             .unwrap();
 

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -14,7 +14,7 @@ use crate::{
         runtime::sessions::{
             base_session::BaseSessionHandles, session_parameters::ParameterHandles,
         },
-        small_execution::prf::{PhiAes, chi, phi, psi},
+        small_execution::prf::{PhiAes, chi, phi_range, psi},
     },
 };
 use algebra::{
@@ -642,8 +642,6 @@ where
                 .enumerate()
                 .try_for_each(|(chunk_idx, out)| -> anyhow::Result<()> {
                     let lo = chunk_idx * chunk;
-                    // reused across sets to avoid a per-set allocation
-                    let mut phi_vals: Vec<i128> = Vec::with_capacity(out.len() + 1);
                     for (i, set) in prss_setup.sets.iter().enumerate() {
                         if !set.parties.contains(&party_role) {
                             return Err(anyhow_error_and_log(format!(
@@ -656,12 +654,11 @@ where
                         // compute f_A(alpha_i): the embedded party ID indexes into f_a_points (from zero)
                         let f_a = set.f_a_points[&party_role];
 
-                        // phi for counters [mask_ctr+lo .. mask_ctr+lo+len], evaluated once per set
-                        phi_vals.clear();
-                        for k in 0..=out.len() {
-                            let ctr = mask_ctr + (lo + k) as u128;
-                            phi_vals.push(phi(&aes_prf.phi_aes, ctr, bd1)?);
-                        }
+                        // One pipelined AES call for the chunk's counter range. Element `idx`
+                        // needs phi(mask_ctr+idx) + phi(mask_ctr+idx+1), so a chunk of `len`
+                        // elements shares counters and needs only `len+1` evaluations.
+                        let phi_vals =
+                            phi_range(&aes_prf.phi_aes, mask_ctr + lo as u128, out.len() + 1, bd1)?;
 
                         for (j, out_elem) in out.iter_mut().enumerate() {
                             let phi = phi_vals[j] + phi_vals[j + 1];

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -1537,61 +1537,6 @@ mod tests {
     #[case(1)]
     #[case(2)]
     #[case(23)]
-    // amounts above span multiple rayon chunks (default PRSS_GEN_PAR_MIN_CHUNK = 1024),
-    // exercising the per-chunk counter offset and the partial last chunk
-    #[case(1025)]
-    #[case(2049)]
-    async fn test_prss_mask_next_vec_matches_scalar_calls(#[case] amount: usize) {
-        let num_parties = 4;
-        let threshold = 1;
-
-        let sid = SessionId::from(23425);
-
-        let role_one = Role::indexed_from_one(1);
-        let prss: PRSSSetup<ResiduePolyF4Z128> =
-            PRSSSetup::testing_party_epoch_init(num_parties, threshold, role_one)
-                .await
-                .unwrap();
-
-        let mut scalar_state = prss.new_prss_session_state(sid);
-        let mut batch_state = scalar_state.clone();
-
-        let mut scalar_values = Vec::with_capacity(amount);
-        for _ in 0..amount {
-            scalar_values.push(
-                scalar_state
-                    .mask_next(role_one, B_SWITCH_SQUASH)
-                    .await
-                    .unwrap(),
-            );
-        }
-
-        let batched_values = batch_state
-            .mask_next_vec(role_one, B_SWITCH_SQUASH, amount)
-            .await
-            .unwrap();
-
-        assert_eq!(batched_values, scalar_values);
-        assert_eq!(
-            batch_state.counters.mask_ctr,
-            scalar_state.counters.mask_ctr
-        );
-        assert_eq!(
-            batch_state.counters.prss_ctr,
-            scalar_state.counters.prss_ctr
-        );
-        assert_eq!(
-            batch_state.counters.przs_ctr,
-            scalar_state.counters.przs_ctr
-        );
-    }
-
-    #[tokio::test]
-    #[rstest]
-    #[case(0)]
-    #[case(1)]
-    #[case(2)]
-    #[case(23)]
     // amount above spans multiple rayon chunks (default PRSS_GEN_PAR_MIN_CHUNK = 1024)
     #[case(1025)]
     async fn test_prss_next_vec_matches_scalar_calls(#[case] amount: usize) {


### PR DESCRIPTION
## Description of changes
This PR improves performance of our PRSS primitives:

  1. Batched AES: replaced single-block `encrypt_block` with `encrypt_blocks` for phi (mask), psi
  (PRSS.next) and chi (PRZS.next), so the AES backend pipelines blocks. psi/chi encrypt into
  a stack buffer instead of a per-call heap Vec (allocation-free).
  2. Cheaper mask multiply: the mask's f_a · phi now uses a coefficient-wise scalar multiply
  (mul_by_i128) instead of a full degree-8 extension (Karatsuba) multiply, since phi is a
  scalar. Implemented ring-agnostically so it stays correct for non-2^128 moduli (e.g. BGV's
  prime ring).
  3. Hoisted per-set invariants: the set-membership check, the `f_a` lookup, and (for PRZS) the
  f_a · αʲ product are computed once per set instead of once per element.
  4. Parallel batch generation: the `*_next_vec` batches are produced in parallel via rayon,
  offloaded through `spawn_compute_bound`.

The fix of #662 is already included here.

### Benchmarks
Local criterion benchmarks on my Mac M1Pro, comparing `main` with this PR's branch `dd/chore/prss_speedup`. Left side without hardware AES; right side with hardware AES. Both show a pretty good speed up, except for a small overhead for batch size one (which we rarely have in practice, I think)

#### PRSS-Mask.next (`prss_mask_next`)

| batch size | main (sw) | PR (sw) | speedup | main (hw) | PR (hw) | speedup |
|-----------:|----------:|--------:|--------:|----------:|--------:|--------:|
| 1          | 24.21 µs  | 24.32 µs| 1.0×    | 17.48 µs  | 18.78 µs| 0.93×   |
| 100        | 821.8 µs  | 216.7 µs| 3.8×    | 103.8 µs  | 40.17 µs| 2.6×    |
| 10 000     | 11.17 ms  | 3.747 ms| 3.0×    | 1.654 ms  | 656.6 µs| 2.5×    |
| 100 000    | 105.0 ms  | 27.15 ms| 3.9×    | 13.83 ms  | 4.866 ms| 2.8×    |

#### PRSS.next (`prss_next`)

| batch size | main (sw) | PR (sw) | speedup | main (hw) | PR (hw) | speedup |
|-----------:|----------:|--------:|--------:|----------:|--------:|--------:|
| 1          | 41.08 µs  | 23.87 µs| 1.7×    | 16.64 µs  | 18.99 µs| 0.88×   |
| 100        | 3.029 ms  | 817.2 µs| 3.7×    | 108.9 µs  | 98.66 µs| 1.1×    |
| 10 000     | 40.96 ms  | 10.96 ms| 3.7×    | 1.992 ms  | 1.637 ms| 1.2×    |

#### PRZS.next (`przs_next`)

| batch size | main (sw) | PR (sw) | speedup | main (hw) | PR (hw) | speedup |
|-----------:|----------:|--------:|--------:|----------:|--------:|--------:|
| 1          | 70.35 µs  | 33.48 µs| 2.1×    | 20.44 µs  | 21.84 µs| 0.94×   |
| 100        | 6.169 ms  | 1.636 ms| 3.8×    | 323.8 µs  | 187.6 µs| 1.7×    |
| 10 000     | 83.48 ms  | 21.65 ms| 3.9×    | 4.853 ms  | 2.687 ms| 1.8×    |


## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
