### PR TITLE
Micro optimizations in `mult_list`

### DIFF
--- a/core/thread-handles/src/lib.rs
+++ b/core/thread-handles/src/lib.rs
@@ -86,6 +86,8 @@ pub async fn init_rayon_thread_pool(num_threads: usize) -> anyhow::Result<usize>
 /// Spawn a compute task on rayon and returns its result.
 ///
 /// This can be used to offload the tokio executor from CPU bound tasks.
+///
+/// The setup overhead introduced by this call is ~25µs.
 pub async fn spawn_compute_bound<R: Send + 'static, F: FnOnce() -> R + Send + 'static>(
     compute_fn: F,
 ) -> anyhow::Result<R> {

--- a/core/threshold-execution/src/online/triple.rs
+++ b/core/threshold-execution/src/online/triple.rs
@@ -65,40 +65,34 @@ pub async fn mult_list<Z: Ring + ErrorCorrect, Ses: BaseSessionHandles>(
     triples: Vec<Triple<Z>>,
     session: &Ses,
 ) -> anyhow::Result<Vec<Share<Z>>> {
-    let amount = x_vec.len();
-    if amount != y_vec.len() || amount != triples.len() {
+    let batch_size = x_vec.len();
+    if batch_size != y_vec.len() || batch_size != triples.len() {
         return Err(anyhow_error_and_log(format!(
             "Trying to multiply two lists of values using a list of triple, but they are not of equal length: a_vec: {:?}, b_vec: {:?}, triples: {:?}",
-            amount,
+            batch_size,
             y_vec.len(),
             triples.len()
         )));
     }
-    let x_vec_cloned = x_vec.clone();
-    let y_vec_cloned = y_vec.clone();
-    let (triples_a, (triples_b, triples_c)): (Vec<_>, (Vec<_>, Vec<_>)) = triples
-        .into_iter()
-        .map(|triple| (triple.a, (triple.b, triple.c)))
-        .unzip();
 
-    let (y_vec, triples_a,to_open) = spawn_compute_bound(move || {
-        let res: Vec<Z> = x_vec_cloned.iter().zip_eq(
-            y_vec_cloned
-                .iter()
-                .zip(triples_a.iter().zip_eq(triples_b.into_iter())),
-        ).fold(Vec::with_capacity(2*amount), |mut acc, (cur_x, (cur_y, (cur_a, cur_b)))| {
-            if cur_x.owner() != cur_y.owner()
-                || cur_a.owner() != cur_x.owner()
-                || cur_b.owner() != cur_x.owner()
-            {
-                tracing::warn!("Trying to multiply with shares of different owners. This will always result in an incorrect share");
-            }
-            acc.push((cur_x + cur_a).value()); // epsilon
-            acc.push((cur_b + cur_y).value()); // rho
-            acc
-    });
-    (y_vec_cloned,triples_a,res)
-    }).await?;
+    // Assumption: within a session owners match by construction: x_vec, y_vec and every triple share are owned by the
+    // local party and preprocessing uses the local role and `Share` +/-/* preserve the owner.
+
+    let (y_vec, triples, to_open) = spawn_compute_bound(move || {
+        let to_open: Vec<Z> = x_vec
+            .iter()
+            .zip_eq(y_vec.iter().zip_eq(triples.iter()))
+            .fold(
+                Vec::with_capacity(2 * batch_size),
+                |mut acc, (cur_x, (cur_y, triple))| {
+                    acc.push((cur_x + &triple.a).value()); // epsilon
+                    acc.push((triple.b + cur_y).value()); // rho
+                    acc
+                },
+            );
+        (y_vec, triples, to_open)
+    })
+    .await?;
 
     //NOTE: We execute the "linear equation loop" with epsilonrho directly
     // Open and separate the list of both epsilon and rho values into two lists of values.
@@ -110,23 +104,23 @@ pub async fn mult_list<Z: Ring + ErrorCorrect, Ses: BaseSessionHandles>(
         None => return Err(anyhow_error_and_log("Could not open shares".to_string())),
     };
 
-    if 2 * amount != epsilonrho.len() {
+    if 2 * batch_size != epsilonrho.len() {
         return Err(anyhow_error_and_log(format!(
             "Inconsistent share lengths: epsilonrho: {:?}. Expected {:?}",
             epsilonrho.len(),
-            2 * amount
+            2 * batch_size
         )));
     }
     // Compute the linear equation of shares to get the result
     spawn_compute_bound(move || {
-        let epsilon_rho_vec = epsilonrho.chunks(2);
+        // `epsilonrho.len` is checked above to be guaranteed even, so `chunks_exact` drops nothing.
+        let epsilon_rho_vec = epsilonrho.chunks_exact(2);
         y_vec
             .iter()
-            .zip_eq(epsilon_rho_vec.zip_eq(triples_a.into_iter().zip_eq(triples_c.into_iter())))
-            .map(|(curr_y, (curr_epsilonrho, (curr_a, curr_c)))| {
-                //curr_epsilonrho is a pair of shares, so we need to extract them
-                //first is epsilon then rho
-                curr_y * curr_epsilonrho[0] - curr_a * curr_epsilonrho[1] + curr_c
+            .zip_eq(epsilon_rho_vec.zip_eq(triples.iter()))
+            .map(|(curr_y, (curr_epsilonrho, triple))| {
+                //curr_epsilonrho is a pair of opened values, epsilon then rho
+                curr_y * curr_epsilonrho[0] - triple.a * curr_epsilonrho[1] + triple.c
             })
             .collect()
     })


### PR DESCRIPTION
Very minor speedup of the `mult_list` method, shaving off 3 allocations, where we avoid scanning and splitting the `triples` to construct a particular tuple shape. For `ResiduePolyF4Z128`, `Share` is 80 bytes, so avoiding `triples_a/b/c` saves about `240 * batch_size` bytes of temporary buffers. 

I learned that our batch sizes vary a LOT. For bootstraping and ORPF keys it's 918*2048 = 1880064, decompression key it's 1024*2048 = 2097152 and for noise-squashing it's 918*4096 = 3760128. For `BitDec` the batches are tiny. Default DKG is 100 larger still.

So depending on what operation we're performing, this saving may or may not matter.

There is one optimization that does yield a little bit more: applying rayon to the two full scans + simple arithmetic performed before and after the call to `robust_open_list_to_all`. For DKG-preprocessing and keygen sized batches this yields a ~4x speedup, but given that reconstruction is several orders of magnitude slower I don't think it makes sense to complicate the code. 

Interestingly, for `BitDec` decryption where batches are much smaller, there's the opposite optimization to consider: removing the `spawn_compute_bound` is actually faster for batches below ~10k.


