### PR TITLE
fix: use non-overlapping counters in batched PRSS-Mask

### DIFF
--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -628,12 +628,14 @@ where
         let prss_setup = self.prss_setup.clone();
         let mask_ctr = self.counters.mask_ctr;
 
-        // Each element is computed from an independent counter, so the batch is
-        // assembled in parallel. Element `idx` uses `ctr = mask_ctr + idx` (and
-        // `ctr + 1`).
+        // Each element consumes two distinct phi counters, matching `amount` sequential
+        // mask_next() calls. Element `idx` uses `ctr = mask_ctr + 2*idx` (and `ctr + 1`). The
+        // counter pairs must NOT overlap between elements: `mask_ctr + idx` would make adjacent
+        // elements share a phi value, diverging from the scalar path and reducing the
+        // independence of the noise-flooding masks.
         let res = spawn_compute_bound(move || {
         (0..amount).into_par_iter().with_min_len(*crate::constants::PRSS_GEN_PAR_MIN_CHUNK).map(|idx| {
-        let ctr = mask_ctr + idx as u128;
+        let ctr = mask_ctr + 2 * idx as u128;
         let mut res = Z::ZERO;
         for (i, set) in prss_setup.sets.iter().enumerate() {
             if set.parties.contains(&party_role) {
@@ -1419,6 +1421,62 @@ mod tests {
         // other counters must not have increased
         assert_eq!(state.counters.prss_ctr, 0);
         assert_eq!(state.counters.przs_ctr, 0);
+    }
+
+    #[tokio::test]
+    #[rstest]
+    #[case(0)]
+    #[case(1)]
+    #[case(2)]
+    #[case(23)]
+    // larger amounts exercise the parallel batch path
+    #[case(1025)]
+    #[case(2049)]
+    async fn test_prss_mask_next_vec_matches_scalar_calls(#[case] amount: usize) {
+        let num_parties = 4;
+        let threshold = 1;
+
+        let sid = SessionId::from(23425);
+
+        let role_one = Role::indexed_from_one(1);
+        let prss: PRSSSetup<ResiduePolyF4Z128> =
+            PRSSSetup::testing_party_epoch_init(num_parties, threshold, role_one)
+                .await
+                .unwrap();
+
+        let mut scalar_state = prss.new_prss_session_state(sid);
+        let mut batch_state = scalar_state.clone();
+
+        // `amount` sequential scalar mask_next() calls ...
+        let mut scalar_values = Vec::with_capacity(amount);
+        for _ in 0..amount {
+            scalar_values.push(
+                scalar_state
+                    .mask_next(role_one, B_SWITCH_SQUASH)
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        // ... must produce the same values (and counter state) as one batched call.
+        let batched_values = batch_state
+            .mask_next_vec(role_one, B_SWITCH_SQUASH, amount)
+            .await
+            .unwrap();
+
+        assert_eq!(batched_values, scalar_values);
+        assert_eq!(
+            batch_state.counters.mask_ctr,
+            scalar_state.counters.mask_ctr
+        );
+        assert_eq!(
+            batch_state.counters.prss_ctr,
+            scalar_state.counters.prss_ctr
+        );
+        assert_eq!(
+            batch_state.counters.przs_ctr,
+            scalar_state.counters.przs_ctr
+        );
     }
 
     #[tokio::test]

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -1429,9 +1429,10 @@ mod tests {
     #[case(1)]
     #[case(2)]
     #[case(23)]
-    // larger amounts exercise the parallel batch path
     #[case(1025)]
     #[case(2049)]
+    // check that the batched mask_next_vec() call produces the same values as sequential scalar mask_next() calls
+    // passing this test also shows that a bug was fixed, in which randomness was re-used across calls in the batched version
     async fn test_prss_mask_next_vec_matches_scalar_calls(#[case] amount: usize) {
         let num_parties = 4;
         let threshold = 1;


### PR DESCRIPTION
## Description of changes

The batched mask_next_vec advanced the phi counter by 1 per element (ctr = mask_ctr + idx, with mask = phi(ctr) + phi(ctr+1)) while the state counter advanced by 2*amount. Adjacent elements therefore shared a phi value, so a batch of N masks did not match N sequential mask_next() calls and the noise-flooding masks within a batch were not independent.

Use disjoint counter pairs (ctr = mask_ctr + 2*idx) so the batched path reproduces repeated scalar calls exactly; the 2*amount advance is now consistent with consuming two distinct counters per element.

Add a regression test asserting mask_next_vec(N) equals N mask_next() calls in both values and counter state.

## Issue ticket number and link
https://github.com/zama-ai/kms-internal/issues/3059

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

