### PR TITLE
fix: use non-overlapping counters in batched PRSS-Mask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "error-utils"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "anyhow",
  "tracing",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "experiments"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "aes-prng",
  "anyhow",
@@ -3387,7 +3387,7 @@ checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
 
 [[package]]
 name = "generate-test-material"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "kms"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "kms-core-client"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "aes-prng",
  "alloy-primitives",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "kms-grpc"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4393,7 +4393,7 @@ dependencies = [
 
 [[package]]
 name = "kms-health-check"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "anyhow",
  "axum",
@@ -7404,7 +7404,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -7415,11 +7415,11 @@ dependencies = [
 
 [[package]]
 name = "test-utils-cc"
-version = "0.13.20"
+version = "0.13.21"
 
 [[package]]
 name = "test-utils-service"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -7590,7 +7590,7 @@ dependencies = [
 
 [[package]]
 name = "thread-handles"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "anyhow",
  "error-utils",
@@ -7620,7 +7620,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-algebra"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "aes-prng",
  "anyhow",
@@ -7647,7 +7647,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-bgv"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "aes-prng",
  "anyhow",
@@ -7675,7 +7675,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-execution"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "aes",
  "aes-prng",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-hashing"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -7734,7 +7734,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-networking"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7771,7 +7771,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-types"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ authors = ["Zama"]
 publish = true
 edition = "2024"
 license = "BSD-3-Clause-Clear"
-version = "0.13.20"
+version = "0.13.21"
 repository = "https://github.com/zama-ai/kms"
 description = "Key Management System for the Zama Protocol."
 

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -633,7 +633,12 @@ where
         let mask_ctr = self.counters.mask_ctr;
 
         let res = spawn_compute_bound(move || {
-        (mask_ctr..mask_ctr + (amount as u128)).map(|ctr| {
+        // Element `idx` consumes a disjoint counter pair (mask_ctr + 2*idx, +1), matching one
+        // scalar mask_next() call. The pairs must NOT overlap: iterating the counter by 1 would
+        // make adjacent elements share a phi value, diverging from repeated scalar calls and
+        // reducing the independence of the noise-flooding masks.
+        (0..amount as u128).map(|idx| {
+        let ctr = mask_ctr + 2 * idx;
         let mut res = Z::ZERO;
         for (i, set) in prss_setup.sets.iter().enumerate() {
             if set.parties.contains(&party_role) {
@@ -1420,6 +1425,63 @@ mod tests {
         // other counters must not have increased
         assert_eq!(state.counters.prss_ctr, 0);
         assert_eq!(state.counters.przs_ctr, 0);
+    }
+
+    #[tokio::test]
+    #[rstest]
+    #[case(0)]
+    #[case(1)]
+    #[case(2)]
+    #[case(23)]
+    #[case(1025)]
+    #[case(2049)]
+    // check that the batched mask_next_vec() call produces the same values as sequential scalar mask_next() calls
+    // passing this test also shows that a bug was fixed, in which randomness was re-used across calls in the batched version
+    async fn test_prss_mask_next_vec_matches_scalar_calls(#[case] amount: usize) {
+        let num_parties = 4;
+        let threshold = 1;
+
+        let sid = SessionId::from(23425);
+
+        let role_one = Role::indexed_from_one(1);
+        let prss: PRSSSetup<ResiduePolyF4Z128> =
+            PRSSSetup::testing_party_epoch_init(num_parties, threshold, role_one)
+                .await
+                .unwrap();
+
+        let mut scalar_state = prss.new_prss_session_state(sid);
+        let mut batch_state = scalar_state.clone();
+
+        // `amount` sequential scalar mask_next() calls ...
+        let mut scalar_values = Vec::with_capacity(amount);
+        for _ in 0..amount {
+            scalar_values.push(
+                scalar_state
+                    .mask_next(role_one, B_SWITCH_SQUASH)
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        // ... must produce the same values (and counter state) as one batched call.
+        let batched_values = batch_state
+            .mask_next_vec(role_one, B_SWITCH_SQUASH, amount)
+            .await
+            .unwrap();
+
+        assert_eq!(batched_values, scalar_values);
+        assert_eq!(
+            batch_state.counters.mask_ctr,
+            scalar_state.counters.mask_ctr
+        );
+        assert_eq!(
+            batch_state.counters.prss_ctr,
+            scalar_state.counters.prss_ctr
+        );
+        assert_eq!(
+            batch_state.counters.przs_ctr,
+            scalar_state.counters.przs_ctr
+        );
     }
 
     #[tokio::test]

--- a/dylint.toml
+++ b/dylint.toml
@@ -1,6 +1,6 @@
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/trailofbits/dylint", pattern = "examples/general/non_local_effect_before_error_return" },
+    { git = "https://github.com/trailofbits/dylint", rev = "2c20d164e06c446de2cecadff0c55e16a877c006", pattern = "examples/general/non_local_effect_before_error_return" },
 ]
 
 [non_local_effect_before_error_return]


### PR DESCRIPTION
## Description of changes
Same fix as in #662 but for the v0.13.20 release branch.

## Issue ticket number and link
https://github.com/zama-ai/kms-internal/issues/3059

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.