### PR TITLE
chore: retire data_as_raw_vec everywhere

### DIFF
--- a/core/threshold-execution/src/endpoints/decryption_non_wasm.rs
+++ b/core/threshold-execution/src/endpoints/decryption_non_wasm.rs
@@ -1248,7 +1248,7 @@ where
 {
     let sns_secret_key = match ddec_key_type {
         SnsDecryptionKeyType::SnsKey => match &sk_share.glwe_secret_key_share_sns_as_lwe {
-            Some(key) => key.data_as_raw_iter(),
+            Some(key) => key.data_iter(),
             None => {
                 return Err(anyhow_error_and_log(
                     "Missing the switch and squash secret key".to_string(),
@@ -1257,7 +1257,7 @@ where
         },
         SnsDecryptionKeyType::SnsCompressionKey => {
             match &sk_share.glwe_sns_compression_key_as_lwe {
-                Some(key) => key.data_as_raw_iter(),
+                Some(key) => key.data_iter(),
                 None => {
                     return Err(anyhow_error_and_log(
                         "Missing the switch and squash compression secret key".to_string(),
@@ -1322,7 +1322,7 @@ where
                 .convert_to_z64()
         }
     };
-    let key_share64_iter = key_share64.data_as_raw_iter();
+    let key_share64_iter = key_share64.data_iter();
     let a_time_s = key_share64_iter.zip_eq(mask.as_ref()).fold(
         ResiduePoly::<Z64, EXTENSION_DEGREE>::ZERO,
         |acc, (sk, m)| {
@@ -1396,7 +1396,7 @@ mod tests {
                     .glwe_secret_key_share_sns_as_lwe
                     .as_ref()
                     .unwrap()
-                    .data_as_raw_iter()
+                    .data_iter()
                     .next()
                     .unwrap(),
             ));

--- a/core/threshold-execution/src/endpoints/decryption_non_wasm.rs
+++ b/core/threshold-execution/src/endpoints/decryption_non_wasm.rs
@@ -1392,12 +1392,12 @@ mod tests {
         (0..parties).for_each(|i| {
             first_bit_shares.push(Share::new(
                 Role::indexed_from_zero(i),
-                *shares[i]
+                shares[i]
                     .glwe_secret_key_share_sns_as_lwe
                     .as_ref()
                     .unwrap()
-                    .data_as_raw_vec()
-                    .first()
+                    .data_as_raw_iter()
+                    .next()
                     .unwrap(),
             ));
         });

--- a/core/threshold-execution/src/endpoints/reshare_sk.rs
+++ b/core/threshold-execution/src/endpoints/reshare_sk.rs
@@ -1053,8 +1053,7 @@ mod tests {
         for osh in old_shares.into_iter().flatten() {
             osh.glwe_secret_key_share_sns_as_lwe
                 .unwrap()
-                .data_as_raw_vec()
-                .iter()
+                .data_as_raw_iter()
                 .for_each(|x| assert!(x.is_zero()));
         }
         Ok(())
@@ -1234,16 +1233,14 @@ mod tests {
                 .glwe_secret_key_share_sns_as_lwe
                 .clone()
                 .unwrap()
-                .data_as_raw_vec()
-                .iter()
+                .data_as_raw_iter()
                 .all(|x| x.is_zero())
             {
                 println!("Role {:?} did not zeroize its old share! : {:?}", role, osh);
             }
             osh.glwe_secret_key_share_sns_as_lwe
                 .unwrap()
-                .data_as_raw_vec()
-                .iter()
+                .data_as_raw_iter()
                 .for_each(|x| assert!(x.is_zero()));
         }
         Ok(())
@@ -1469,7 +1466,8 @@ mod tests {
                 x.glwe_secret_key_share_sns_as_lwe
                     .clone()
                     .unwrap()
-                    .data_as_raw_vec()
+                    .data_as_raw_iter()
+                    .collect_vec()
             })
             .collect_vec();
         let glwe_sns_sk128 = reconstruct_shares_to_scalar(shares128, threshold, max_errors)
@@ -1487,7 +1485,8 @@ mod tests {
                         x.lwe_compute_secret_key_share
                             .clone()
                             .unsafe_cast_to_z64()
-                            .data_as_raw_vec()
+                            .data_as_raw_iter()
+                            .collect_vec()
                     })
                     .collect_vec();
                 reconstruct_shares_to_scalar(shares64, threshold, max_errors)
@@ -1502,7 +1501,8 @@ mod tests {
                         x.lwe_compute_secret_key_share
                             .clone()
                             .unsafe_cast_to_z128()
-                            .data_as_raw_vec()
+                            .data_as_raw_iter()
+                            .collect_vec()
                     })
                     .collect_vec();
                 reconstruct_shares_to_scalar(shares128, threshold, max_errors)
@@ -1522,7 +1522,8 @@ mod tests {
                         x.glwe_secret_key_share
                             .clone()
                             .unsafe_cast_to_z64()
-                            .data_as_raw_vec()
+                            .data_as_raw_iter()
+                            .collect_vec()
                     })
                     .collect_vec();
                 reconstruct_shares_to_scalar(shares64, threshold, max_errors)
@@ -1537,7 +1538,8 @@ mod tests {
                         x.glwe_secret_key_share
                             .clone()
                             .unsafe_cast_to_z128()
-                            .data_as_raw_vec()
+                            .data_as_raw_iter()
+                            .collect_vec()
                     })
                     .collect_vec();
                 reconstruct_shares_to_scalar(shares128, threshold, max_errors)

--- a/core/threshold-execution/src/endpoints/reshare_sk.rs
+++ b/core/threshold-execution/src/endpoints/reshare_sk.rs
@@ -1053,7 +1053,7 @@ mod tests {
         for osh in old_shares.into_iter().flatten() {
             osh.glwe_secret_key_share_sns_as_lwe
                 .unwrap()
-                .data_as_raw_iter()
+                .data_iter()
                 .for_each(|x| assert!(x.is_zero()));
         }
         Ok(())
@@ -1233,14 +1233,14 @@ mod tests {
                 .glwe_secret_key_share_sns_as_lwe
                 .clone()
                 .unwrap()
-                .data_as_raw_iter()
+                .data_iter()
                 .all(|x| x.is_zero())
             {
                 println!("Role {:?} did not zeroize its old share! : {:?}", role, osh);
             }
             osh.glwe_secret_key_share_sns_as_lwe
                 .unwrap()
-                .data_as_raw_iter()
+                .data_iter()
                 .for_each(|x| assert!(x.is_zero()));
         }
         Ok(())
@@ -1466,7 +1466,7 @@ mod tests {
                 x.glwe_secret_key_share_sns_as_lwe
                     .clone()
                     .unwrap()
-                    .data_as_raw_iter()
+                    .data_iter()
                     .collect_vec()
             })
             .collect_vec();
@@ -1485,7 +1485,7 @@ mod tests {
                         x.lwe_compute_secret_key_share
                             .clone()
                             .unsafe_cast_to_z64()
-                            .data_as_raw_iter()
+                            .data_iter()
                             .collect_vec()
                     })
                     .collect_vec();
@@ -1501,7 +1501,7 @@ mod tests {
                         x.lwe_compute_secret_key_share
                             .clone()
                             .unsafe_cast_to_z128()
-                            .data_as_raw_iter()
+                            .data_iter()
                             .collect_vec()
                     })
                     .collect_vec();
@@ -1522,7 +1522,7 @@ mod tests {
                         x.glwe_secret_key_share
                             .clone()
                             .unsafe_cast_to_z64()
-                            .data_as_raw_iter()
+                            .data_iter()
                             .collect_vec()
                     })
                     .collect_vec();
@@ -1538,7 +1538,7 @@ mod tests {
                         x.glwe_secret_key_share
                             .clone()
                             .unsafe_cast_to_z128()
-                            .data_as_raw_iter()
+                            .data_iter()
                             .collect_vec()
                     })
                     .collect_vec();

--- a/core/threshold-execution/src/tfhe_internals/compression_decompression_key.rs
+++ b/core/threshold-execution/src/tfhe_internals/compression_decompression_key.rs
@@ -57,10 +57,6 @@ where
         })
     }
 
-    pub fn data_as_raw_vec(&self) -> Vec<ResiduePoly<Z, EXTENSION_DEGREE>> {
-        self.post_packing_ks_key.data_as_raw_vec()
-    }
-
     pub fn into_lwe_secret_key(self) -> LweSecretKeyShare<Z, EXTENSION_DEGREE> {
         self.post_packing_ks_key.into_lwe_secret_key()
     }

--- a/core/threshold-execution/src/tfhe_internals/glwe_key.rs
+++ b/core/threshold-execution/src/tfhe_internals/glwe_key.rs
@@ -105,8 +105,10 @@ where
         })
     }
 
-    pub fn data_as_raw_vec(&self) -> Vec<ResiduePoly<Z, EXTENSION_DEGREE>> {
-        self.data.iter().map(|share| share.value()).collect_vec()
+    pub fn data_as_raw_iter(
+        &self,
+    ) -> impl ExactSizeIterator<Item = ResiduePoly<Z, EXTENSION_DEGREE>> {
+        self.data.iter().map(|share| share.value())
     }
 
     pub fn from_lwe_secret_key(

--- a/core/threshold-execution/src/tfhe_internals/glwe_key.rs
+++ b/core/threshold-execution/src/tfhe_internals/glwe_key.rs
@@ -105,9 +105,7 @@ where
         })
     }
 
-    pub fn data_as_raw_iter(
-        &self,
-    ) -> impl ExactSizeIterator<Item = ResiduePoly<Z, EXTENSION_DEGREE>> {
+    pub fn data_iter(&self) -> impl ExactSizeIterator<Item = ResiduePoly<Z, EXTENSION_DEGREE>> {
         self.data.iter().map(|share| share.value())
     }
 

--- a/core/threshold-execution/src/tfhe_internals/lwe_ciphertext.rs
+++ b/core/threshold-execution/src/tfhe_internals/lwe_ciphertext.rs
@@ -245,7 +245,7 @@ fn fill_lwe_mask_and_body_for_encryption<Z, Gen, const EXTENSION_DEGREE: usize>(
 
     //Compute the multisum betweem sk and mask
     let mask_key_dot_product =
-        slice_wrapping_dot_product(output_mask, lwe_secret_key_share.data_as_raw_iter());
+        slice_wrapping_dot_product(output_mask, lwe_secret_key_share.data_iter());
 
     //Finish computing the body
     *output_body = mask_key_dot_product + noise + encoded;

--- a/core/threshold-execution/src/tfhe_internals/lwe_ciphertext.rs
+++ b/core/threshold-execution/src/tfhe_internals/lwe_ciphertext.rs
@@ -245,7 +245,7 @@ fn fill_lwe_mask_and_body_for_encryption<Z, Gen, const EXTENSION_DEGREE: usize>(
 
     //Compute the multisum betweem sk and mask
     let mask_key_dot_product =
-        slice_wrapping_dot_product(output_mask, &lwe_secret_key_share.data_as_raw_vec());
+        slice_wrapping_dot_product(output_mask, lwe_secret_key_share.data_as_raw_iter());
 
     //Finish computing the body
     *output_body = mask_key_dot_product + noise + encoded;

--- a/core/threshold-execution/src/tfhe_internals/lwe_key.rs
+++ b/core/threshold-execution/src/tfhe_internals/lwe_key.rs
@@ -231,9 +231,7 @@ where
         LweDimension(self.data.len())
     }
 
-    pub fn data_as_raw_iter(
-        &self,
-    ) -> impl ExactSizeIterator<Item = ResiduePoly<Z, EXTENSION_DEGREE>> {
+    pub fn data_iter(&self) -> impl ExactSizeIterator<Item = ResiduePoly<Z, EXTENSION_DEGREE>> {
         self.data.iter().map(|share| share.value())
     }
 }
@@ -267,7 +265,7 @@ pub fn generate_lwe_compact_public_key<Z, Gen, const EXTENSION_DEGREE: usize>(
     let (mask, body) = output.get_mut_mask_and_body();
     generator.fill_slice_with_random_mask_custom_mod(mask, encryption_type);
 
-    slice_semi_reverse_negacyclic_convolution(body, mask, lwe_secret_key_share.data_as_raw_iter());
+    slice_semi_reverse_negacyclic_convolution(body, mask, lwe_secret_key_share.data_iter());
 
     generator.unsigned_torus_slice_wrapping_add_random_noise_custom_mod_assign(body);
 }

--- a/core/threshold-execution/src/tfhe_internals/lwe_key.rs
+++ b/core/threshold-execution/src/tfhe_internals/lwe_key.rs
@@ -231,11 +231,9 @@ where
         LweDimension(self.data.len())
     }
 
-    pub fn data_as_raw_vec(&self) -> Vec<ResiduePoly<Z, EXTENSION_DEGREE>> {
-        self.data.iter().map(|share| share.value()).collect_vec()
-    }
-
-    pub fn data_as_raw_iter(&self) -> impl Iterator<Item = ResiduePoly<Z, EXTENSION_DEGREE>> + '_ {
+    pub fn data_as_raw_iter(
+        &self,
+    ) -> impl ExactSizeIterator<Item = ResiduePoly<Z, EXTENSION_DEGREE>> {
         self.data.iter().map(|share| share.value())
     }
 }
@@ -269,7 +267,7 @@ pub fn generate_lwe_compact_public_key<Z, Gen, const EXTENSION_DEGREE: usize>(
     let (mask, body) = output.get_mut_mask_and_body();
     generator.fill_slice_with_random_mask_custom_mod(mask, encryption_type);
 
-    slice_semi_reverse_negacyclic_convolution(body, mask, &lwe_secret_key_share.data_as_raw_vec());
+    slice_semi_reverse_negacyclic_convolution(body, mask, lwe_secret_key_share.data_as_raw_iter());
 
     generator.unsigned_torus_slice_wrapping_add_random_noise_custom_mod_assign(body);
 }

--- a/core/threshold-execution/src/tfhe_internals/lwe_keyswitch_key_generation.rs
+++ b/core/threshold-execution/src/tfhe_internals/lwe_keyswitch_key_generation.rs
@@ -42,7 +42,7 @@ where
     let decomp_base_log = lwe_keyswitch_key.decomposition_base_log();
     let decomp_level_count = lwe_keyswitch_key.decomposition_level_count();
 
-    let input_key_it = input_lwe_sk.data_as_raw_iter();
+    let input_key_it = input_lwe_sk.data_iter();
     let key_switch_key_block_it = lwe_keyswitch_key.iter_mut_levels();
 
     assert_eq!(

--- a/core/threshold-execution/src/tfhe_internals/lwe_keyswitch_key_generation.rs
+++ b/core/threshold-execution/src/tfhe_internals/lwe_keyswitch_key_generation.rs
@@ -42,7 +42,7 @@ where
     let decomp_base_log = lwe_keyswitch_key.decomposition_base_log();
     let decomp_level_count = lwe_keyswitch_key.decomposition_level_count();
 
-    let input_key_it = input_lwe_sk.data_as_raw_vec().into_iter();
+    let input_key_it = input_lwe_sk.data_as_raw_iter();
     let key_switch_key_block_it = lwe_keyswitch_key.iter_mut_levels();
 
     assert_eq!(

--- a/core/threshold-execution/src/tfhe_internals/lwe_packing_keyswitch_key_generation.rs
+++ b/core/threshold-execution/src/tfhe_internals/lwe_packing_keyswitch_key_generation.rs
@@ -38,7 +38,7 @@ fn generate_lwe_packing_keyswitch_key<Z, Gen, const EXTENSION_DEGREE: usize>(
     let decomp_level_count = lwe_packing_keyswitch_key.decomposition_level_count();
     let polynomial_size = lwe_packing_keyswitch_key.output_polynomial_size();
 
-    let input_key_it = input_lwe_sk.data_as_raw_vec().into_iter();
+    let input_key_it = input_lwe_sk.data_as_raw_iter();
     let packing_key_switch_key_block_it = lwe_packing_keyswitch_key.iter_mut_levels();
 
     let mut decomposition_plaintexts_buffer =

--- a/core/threshold-execution/src/tfhe_internals/lwe_packing_keyswitch_key_generation.rs
+++ b/core/threshold-execution/src/tfhe_internals/lwe_packing_keyswitch_key_generation.rs
@@ -38,7 +38,7 @@ fn generate_lwe_packing_keyswitch_key<Z, Gen, const EXTENSION_DEGREE: usize>(
     let decomp_level_count = lwe_packing_keyswitch_key.decomposition_level_count();
     let polynomial_size = lwe_packing_keyswitch_key.output_polynomial_size();
 
-    let input_key_it = input_lwe_sk.data_as_raw_iter();
+    let input_key_it = input_lwe_sk.data_iter();
     let packing_key_switch_key_block_it = lwe_packing_keyswitch_key.iter_mut_levels();
 
     let mut decomposition_plaintexts_buffer =

--- a/core/threshold-execution/src/tfhe_internals/sns_compression_key.rs
+++ b/core/threshold-execution/src/tfhe_internals/sns_compression_key.rs
@@ -55,10 +55,6 @@ where
         }
     }
 
-    pub fn data_as_raw_vec(&self) -> Vec<ResiduePoly<Z, EXTENSION_DEGREE>> {
-        self.post_packing_ks_key.data_as_raw_vec()
-    }
-
     pub fn into_lwe_secret_key(self) -> LweSecretKeyShare<Z, EXTENSION_DEGREE> {
         self.post_packing_ks_key.into_lwe_secret_key()
     }

--- a/core/threshold-execution/src/tfhe_internals/utils.rs
+++ b/core/threshold-execution/src/tfhe_internals/utils.rs
@@ -132,7 +132,7 @@ pub fn polynomial_wrapping_add_multisum_assign<Z: BaseRing, const EXTENSION_DEGR
 {
     let pol_dimension = glwe_secret_key_share.polynomial_size.0;
     let mut pol_output_body = Poly::from_coefs(output_body.to_vec());
-    let pol_output_mask = slice_to_polynomials(output_mask.iter().cloned(), pol_dimension);
+    let pol_output_mask = slice_to_polynomials(output_mask.iter().copied(), pol_dimension);
     let pol_glwe_secret_key_share =
         slice_to_polynomials(glwe_secret_key_share.data_iter(), pol_dimension);
 

--- a/core/threshold-execution/src/tfhe_internals/utils.rs
+++ b/core/threshold-execution/src/tfhe_internals/utils.rs
@@ -26,7 +26,7 @@ use super::glwe_key::GlweSecretKeyShare;
 pub fn slice_semi_reverse_negacyclic_convolution<Z: BaseRing, const EXTENSION_DEGREE: usize>(
     output: &mut Vec<ResiduePoly<Z, EXTENSION_DEGREE>>,
     lhs: &[Z],
-    rhs: &[ResiduePoly<Z, EXTENSION_DEGREE>],
+    rhs: impl ExactSizeIterator<Item = ResiduePoly<Z, EXTENSION_DEGREE>>,
 ) {
     debug_assert!(
         lhs.len() == rhs.len(),
@@ -41,7 +41,7 @@ pub fn slice_semi_reverse_negacyclic_convolution<Z: BaseRing, const EXTENSION_DE
         lhs.len()
     );
     output.fill(ResiduePoly::ZERO);
-    let mut rev_rhs = rhs.to_vec();
+    let mut rev_rhs = rhs.collect_vec();
     rev_rhs.reverse();
     let lhs_pol = Poly::from_coefs(lhs.to_vec());
     let rhs_pol = Poly::from_coefs(rev_rhs);
@@ -50,11 +50,13 @@ pub fn slice_semi_reverse_negacyclic_convolution<Z: BaseRing, const EXTENSION_DE
     *output = res.coefs().to_vec();
 }
 
-pub fn slice_to_polynomials<Z: Ring>(slice: &[Z], pol_size: usize) -> Vec<Poly<Z>> {
+pub fn slice_to_polynomials<Z: Ring>(
+    slice: impl ExactSizeIterator<Item = Z>,
+    pol_size: usize,
+) -> Vec<Poly<Z>> {
     let mut res: Vec<Poly<Z>> = Vec::new();
-    for coefs in &slice.iter().chunks(pol_size) {
-        let coef = coefs.copied().collect_vec();
-        res.push(Poly::from_coefs(coef));
+    for coefs in &slice.chunks(pol_size) {
+        res.push(Poly::from_coefs(coefs.collect()));
     }
     res
 }
@@ -103,7 +105,7 @@ pub fn pol_mul_reduce<Z: BaseRing, const EXTENSION_DEGREE: usize>(
 
 pub fn slice_wrapping_dot_product<Z: BaseRing, const EXTENSION_DEGREE: usize>(
     lhs: &[Z],
-    rhs: &[ResiduePoly<Z, EXTENSION_DEGREE>],
+    rhs: impl ExactSizeIterator<Item = ResiduePoly<Z, EXTENSION_DEGREE>>,
 ) -> ResiduePoly<Z, EXTENSION_DEGREE> {
     assert_eq!(
         lhs.len(),
@@ -117,7 +119,7 @@ pub fn slice_wrapping_dot_product<Z: BaseRing, const EXTENSION_DEGREE: usize>(
     // zip_eq can panic but we just asserted that lhs and rhs have the same length
     // so that'd panic first but would be a bug in the code
     lhs.iter()
-        .zip_eq(rhs.iter())
+        .zip_eq(rhs)
         .fold(ResiduePoly::ZERO, |acc, (left, right)| acc + right * *left)
 }
 
@@ -130,9 +132,9 @@ pub fn polynomial_wrapping_add_multisum_assign<Z: BaseRing, const EXTENSION_DEGR
 {
     let pol_dimension = glwe_secret_key_share.polynomial_size.0;
     let mut pol_output_body = Poly::from_coefs(output_body.to_vec());
-    let pol_output_mask = slice_to_polynomials(output_mask, pol_dimension);
+    let pol_output_mask = slice_to_polynomials(output_mask.iter().cloned(), pol_dimension);
     let pol_glwe_secret_key_share =
-        slice_to_polynomials(&glwe_secret_key_share.data_as_raw_vec(), pol_dimension);
+        slice_to_polynomials(glwe_secret_key_share.data_iter(), pol_dimension);
 
     for (poly_1, poly_2) in pol_output_mask
         .iter()


### PR DESCRIPTION
Remove the `data_as_raw_vec` methods and replace with the iterator-returning `data_iter`.

This makes it easier to see where allocations happen (and avoid them ofc).

PR #669 makes a few more changes unlocked by this PR.
