### PR TITLE
chore: Replace CLI arguments in `kms-gen-keys` with a config file

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -109,7 +109,7 @@ All under [core/service/src/bin/](core/service/src/bin/):
 - [kms-gen-keys.rs](core/service/src/bin/kms-gen-keys.rs) — generate the server
   signing keys (and, in threshold mode, per-party self-signed CA certificates
   for mTLS). Can read a keygen or server TOML with `--config-file`; supports
-  `--mock-enclave` for local dev, which must be compiled with the `insecure`
+  `mock_enclave` in config for local dev when compiled with the `insecure`
   feature.
 - [kms-custodian.rs](core/service/src/bin/kms-custodian.rs) — custodian-side
   tool for producing and recovering backup shares.

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -108,7 +108,7 @@ All under [core/service/src/bin/](core/service/src/bin/):
   initialization.
 - [kms-gen-keys.rs](core/service/src/bin/kms-gen-keys.rs) — generate the server
   signing keys (and, in threshold mode, per-party self-signed CA certificates
-  for mTLS). Can read a keygen or server TOML with `--config-file`; supports
+  for mTLS). Reads a keygen TOML with `--config-file`; supports
   `mock_enclave` in config for local dev when compiled with the `insecure`
   feature.
 - [kms-custodian.rs](core/service/src/bin/kms-custodian.rs) — custodian-side

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -108,8 +108,9 @@ All under [core/service/src/bin/](core/service/src/bin/):
   initialization.
 - [kms-gen-keys.rs](core/service/src/bin/kms-gen-keys.rs) — generate the server
   signing keys (and, in threshold mode, per-party self-signed CA certificates
-  for mTLS). Supports `--mock-enclave` for local dev, must be compiled with the
-  `insecure` feature.
+  for mTLS). Can read a keygen or server TOML with `--config-file`; supports
+  `--mock-enclave` for local dev, which must be compiled with the `insecure`
+  feature.
 - [kms-custodian.rs](core/service/src/bin/kms-custodian.rs) — custodian-side
   tool for producing and recovering backup shares.
 - [kms-gen-tls-certs.rs](core/service/src/bin/kms-gen-tls-certs.rs) — TLS

--- a/charts/kms-core/Chart.yaml
+++ b/charts/kms-core/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-core
 description: A helm chart to distribute and deploy the Zama KMS core service.
-version: 1.7.2
+version: 1.7.3
 appVersion: 0.14.0   # Minimum kms version to run this chart
 apiVersion: v2
 keywords:

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -66,7 +66,6 @@ data:
     {{- end }}
   kms-gen-keys.toml: |
     [keygen]
-    enabled = true
     {{- if .Values.kmsCore.thresholdMode.enabled }}
     [threshold]
     my_id = "${KMS_CORE__THRESHOLD__MY_ID}"

--- a/charts/kms-core/templates/kms-core-statefulset.yaml
+++ b/charts/kms-core/templates/kms-core-statefulset.yaml
@@ -56,9 +56,15 @@ spec:
               envsubst < /var/lib/kms-core/config/kms-server.toml > kms-server.toml
               envsubst < /var/lib/kms-core/config/aws.toml >> kms-server.toml
               envsubst < /var/lib/kms-core/config/vaults.toml >> kms-server.toml
+              envsubst < /var/lib/kms-core/config/kms-gen-keys.toml > kms-gen-keys.toml
+              envsubst < /var/lib/kms-core/config/aws.toml >> kms-gen-keys.toml
+              envsubst < /var/lib/kms-core/config/vaults.toml >> kms-gen-keys.toml
               echo "### BEGIN - kms-server.toml ###"
               cat kms-server.toml
               echo "### END - kms-server.toml ###"
+              echo "### BEGIN - kms-gen-keys.toml ###"
+              cat kms-gen-keys.toml
+              echo "### END - kms-gen-keys.toml ###"
           env:
             {{- if .Values.kmsCore.thresholdMode.enabled }}
             {{- if .Values.kmsPeers.id }}
@@ -230,44 +236,7 @@ spec:
             - |
               env
               echo "generating keys"
-              kms-gen-keys \
-            {{- if .Values.minio.enabled }}
-              --aws-s3-endpoint {{ .Values.minio.endpoint }} \
-            {{- end }}
-              --aws-region {{ .Values.kmsCore.aws.region }} \
-            {{- if .Values.kmsCore.publicVault.s3.enabled }}
-              --public-storage s3 \
-              --public-s3-bucket "${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.publicVault.s3.bucket }}}" \
-              {{- if .Values.kmsCore.publicVault.s3.prefix }}
-              --public-s3-prefix "${KMS_CORE__PUBLIC_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.publicVault.s3.prefix }}}" \
-              {{- end }}
-            {{- else }}
-              --public-storage file \
-              --public-file-path "/keys" \
-            {{- end }}
-            {{- if .Values.kmsCore.privateVault.s3.enabled }}
-              --private-storage s3 \
-              --private-s3-bucket "${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__BUCKET:={{ .Values.kmsCore.privateVault.s3.bucket }}}" \
-              {{- if .Values.kmsCore.privateVault.s3.prefix }}
-              --private-s3-prefix "${KMS_CORE__PRIVATE_VAULT__STORAGE__S3__PREFIX:={{ .Values.kmsCore.privateVault.s3.prefix }}}" \
-              {{- end }}
-            {{- else }}
-              --private-storage file \
-              --private-file-path "/keys" \
-            {{- end }}
-            {{- if .Values.kmsCore.privateVault.awskms.enabled }}
-              --root-key-id "${KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID:={{ .Values.kmsCore.privateVault.awskms.rootKeyId }}}" \
-              --root-key-spec "${KMS_CORE__PRIVATE_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC:={{ .Values.kmsCore.privateVault.awskms.rootKeySpec }}}" \
-            {{- end }}
-              {{ include "kmsCoreMode" . }} \
-            {{- if .Values.kmsCore.thresholdMode.enabled }}
-              --signing-key-party-id ${KMS_CORE__THRESHOLD__MY_ID} \
-            {{- if .Values.kmsCore.addressOverride }}
-              --tls-subject {{ .Values.kmsCore.addressOverride | quote }}
-            {{- else }}
-              --tls-subject "{{ include "kmsCoreName" . }}-${KMS_CORE__THRESHOLD__MY_ID}"
-            {{- end }}
-            {{- end }}
+              kms-gen-keys --config-file kms-gen-keys.toml
           env:
             {{- if .Values.kmsCore.thresholdMode.enabled }}
             {{- if .Values.kmsPeers.id }}
@@ -372,8 +341,11 @@ spec:
               value: {{ .Values.kmsCore.privateVault.awskms.rootKeyId | quote }}
             {{- end }}
             {{- end }}
-          {{- if not .Values.kmsCore.privateVault.s3.enabled }}
+          workingDir: {{ .Values.kmsCore.workdir }}
           volumeMounts:
+            - mountPath: {{ .Values.kmsCore.workdir }}
+              name: workdir
+          {{- if not .Values.kmsCore.privateVault.s3.enabled }}
             - mountPath: /keys
               name: keys
           {{- end }}

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -147,7 +147,7 @@ walkdir = { workspace = true }
 
 [features]
 default = ["non-wasm"]
-testing = ["dep:tempfile"]
+testing = ["dep:tempfile", "threshold-execution/testing"]
 non-wasm = [
     "kms-grpc/non-wasm",
     "threshold-execution/non-wasm",

--- a/core/service/config/compose_centralized_keygen.toml
+++ b/core/service/config/compose_centralized_keygen.toml
@@ -1,0 +1,13 @@
+# Key-generation config for docker-compose-core-centralized.yml.
+
+[keygen]
+
+[aws]
+region = "us-east-1"
+s3_endpoint = "http://dev-s3-mock:9000"
+
+[public_vault.storage.s3]
+bucket = "kms"
+
+[private_vault.storage.file]
+path = "./keys"

--- a/core/service/src/bin/kms-gen-keys.rs
+++ b/core/service/src/bin/kms-gen-keys.rs
@@ -103,7 +103,7 @@ struct KmsGenKeysConfig {
 #[derive(Serialize, Deserialize, Validate, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 struct KeygenConfig {
-    #[cfg(feature = "insecure")]
+    #[cfg(any(test, feature = "testing", feature = "insecure"))]
     /// Generate deterministic test keys instead of fresh random keys. Defaults to false.
     #[serde(default)]
     deterministic: bool,
@@ -136,7 +136,7 @@ struct KeygenThresholdConfig {
 struct CentralCmdArgs<'a, PubS: Storage, PrivS: Storage> {
     pub_storage: &'a mut PubS,
     priv_storage: &'a mut PrivS,
-    #[cfg(feature = "insecure")]
+    #[cfg(any(test, feature = "testing", feature = "insecure"))]
     deterministic: bool,
     overwrite: bool,
     show_existing: bool,
@@ -145,7 +145,7 @@ struct CentralCmdArgs<'a, PubS: Storage, PrivS: Storage> {
 struct ThresholdCmdArgs<'a, PubS: Storage, PrivS: Storage> {
     pub_storage: &'a mut PubS,
     priv_storage: &'a mut PrivS,
-    #[cfg(feature = "insecure")]
+    #[cfg(any(test, feature = "testing", feature = "insecure"))]
     deterministic: bool,
     overwrite: bool,
     show_existing: bool,
@@ -367,7 +367,7 @@ async fn main() -> anyhow::Result<()> {
             let mut cmdargs = CentralCmdArgs {
                 pub_storage: &mut pub_storage,
                 priv_storage: &mut priv_vault,
-                #[cfg(feature = "insecure")]
+                #[cfg(any(test, feature = "testing", feature = "insecure"))]
                 deterministic: config.keygen.deterministic,
                 overwrite: config.keygen.overwrite,
                 show_existing: config.keygen.show_existing,
@@ -382,7 +382,7 @@ async fn main() -> anyhow::Result<()> {
             let mut cmdargs = ThresholdCmdArgs {
                 pub_storage: &mut pub_storage,
                 priv_storage: &mut priv_vault,
-                #[cfg(feature = "insecure")]
+                #[cfg(any(test, feature = "testing", feature = "insecure"))]
                 deterministic: config.keygen.deterministic,
                 overwrite: config.keygen.overwrite,
                 show_existing: config.keygen.show_existing,
@@ -412,7 +412,7 @@ async fn handle_central_cmd<PubS: Storage, PrivS: Storage>(
         args.pub_storage,
         args.priv_storage,
         &SIGNING_KEY_ID,
-        #[cfg(feature = "insecure")]
+        #[cfg(any(test, feature = "testing", feature = "insecure"))]
         args.deterministic,
     )
     .await
@@ -436,7 +436,7 @@ async fn handle_threshold_cmd<PubS: Storage, PrivS: Storage>(
         args.pub_storage,
         args.priv_storage,
         &SIGNING_KEY_ID,
-        #[cfg(feature = "insecure")]
+        #[cfg(any(test, feature = "testing", feature = "insecure"))]
         args.deterministic,
         args.signing_key_party_id,
         args.tls_subject.clone(),
@@ -523,7 +523,7 @@ mod tests {
     fn base_config() -> KmsGenKeysConfig {
         KmsGenKeysConfig {
             keygen: KeygenConfig {
-                #[cfg(feature = "insecure")]
+                #[cfg(any(test, feature = "testing", feature = "insecure"))]
                 deterministic: false,
                 overwrite: false,
                 show_existing: false,
@@ -580,7 +580,7 @@ mod tests {
         assert!(config.private_vault.is_none());
         assert!(!config.keygen.overwrite);
         assert!(!config.keygen.show_existing);
-        #[cfg(feature = "insecure")]
+        #[cfg(any(test, feature = "testing", feature = "insecure"))]
         assert!(!config.keygen.deterministic);
         #[cfg(feature = "insecure")]
         assert!(!config.mock_enclave);
@@ -590,13 +590,13 @@ mod tests {
     fn keygen_flags_are_read_from_config() {
         let mut config = base_config();
         config.keygen = KeygenConfig {
-            #[cfg(feature = "insecure")]
+            #[cfg(any(test, feature = "testing", feature = "insecure"))]
             deterministic: true,
             overwrite: true,
             show_existing: true,
         };
 
-        #[cfg(feature = "insecure")]
+        #[cfg(any(test, feature = "testing", feature = "insecure"))]
         assert!(config.keygen.deterministic);
         assert!(config.keygen.overwrite);
         assert!(config.keygen.show_existing);
@@ -764,9 +764,9 @@ mock_enclave = true
     fn keygen_toml_deserializes_and_resolves() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("kms-gen-keys.toml");
-        #[cfg(feature = "insecure")]
+        #[cfg(any(test, feature = "testing", feature = "insecure"))]
         let deterministic_config = "deterministic = true";
-        #[cfg(not(feature = "insecure"))]
+        #[cfg(not(any(test, feature = "testing", feature = "insecure")))]
         let deterministic_config = "";
         std::fs::write(
             &config_path,
@@ -806,7 +806,7 @@ root_key_spec = "symm"
         let mode = resolve_mode_for_test(&config).unwrap();
 
         assert_eq!(resolved_tls_subject(mode), "kms-core-2");
-        #[cfg(feature = "insecure")]
+        #[cfg(any(test, feature = "testing", feature = "insecure"))]
         assert!(config.keygen.deterministic);
         assert!(config.keygen.overwrite);
         assert_eq!(

--- a/core/service/src/bin/kms-gen-keys.rs
+++ b/core/service/src/bin/kms-gen-keys.rs
@@ -59,6 +59,7 @@ struct KmsGenKeysRunConfig {
     public_storage: Option<StorageConfig>,
     private_storage: Option<StorageConfig>,
     private_keychain: Option<Keychain>,
+    #[cfg(feature = "insecure")]
     deterministic: bool,
     overwrite: bool,
     show_existing: bool,
@@ -90,6 +91,7 @@ struct KmsGenKeysOnlyConfig {
 #[derive(Serialize, Deserialize, Validate, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 struct KeygenConfig {
+    #[cfg(feature = "insecure")]
     deterministic: Option<bool>,
     overwrite: Option<bool>,
     show_existing: Option<bool>,
@@ -112,6 +114,7 @@ struct KeygenThresholdConfig {
 struct CentralCmdArgs<'a, PubS: Storage, PrivS: Storage> {
     pub_storage: &'a mut PubS,
     priv_storage: &'a mut PrivS,
+    #[cfg(feature = "insecure")]
     deterministic: bool,
     overwrite: bool,
     show_existing: bool,
@@ -120,6 +123,7 @@ struct CentralCmdArgs<'a, PubS: Storage, PrivS: Storage> {
 struct ThresholdCmdArgs<'a, PubS: Storage, PrivS: Storage> {
     pub_storage: &'a mut PubS,
     priv_storage: &'a mut PrivS,
+    #[cfg(feature = "insecure")]
     deterministic: bool,
     overwrite: bool,
     show_existing: bool,
@@ -156,6 +160,7 @@ fn resolve_keygen_config_file(config: KmsGenKeysOnlyConfig) -> anyhow::Result<Km
         public_storage,
         private_storage,
         private_keychain,
+        #[cfg(feature = "insecure")]
         deterministic: keygen.deterministic.unwrap_or(false),
         overwrite: keygen.overwrite.unwrap_or(false),
         show_existing: keygen.show_existing.unwrap_or(false),
@@ -346,6 +351,7 @@ async fn main() -> anyhow::Result<()> {
             let mut cmdargs = CentralCmdArgs {
                 pub_storage: &mut pub_storage,
                 priv_storage: &mut priv_vault,
+                #[cfg(feature = "insecure")]
                 deterministic: resolved.deterministic,
                 overwrite: resolved.overwrite,
                 show_existing: resolved.show_existing,
@@ -360,6 +366,7 @@ async fn main() -> anyhow::Result<()> {
             let mut cmdargs = ThresholdCmdArgs {
                 pub_storage: &mut pub_storage,
                 priv_storage: &mut priv_vault,
+                #[cfg(feature = "insecure")]
                 deterministic: resolved.deterministic,
                 overwrite: resolved.overwrite,
                 show_existing: resolved.show_existing,
@@ -389,6 +396,7 @@ async fn handle_central_cmd<PubS: Storage, PrivS: Storage>(
         args.pub_storage,
         args.priv_storage,
         &SIGNING_KEY_ID,
+        #[cfg(feature = "insecure")]
         args.deterministic,
     )
     .await
@@ -412,6 +420,7 @@ async fn handle_threshold_cmd<PubS: Storage, PrivS: Storage>(
         args.pub_storage,
         args.priv_storage,
         &SIGNING_KEY_ID,
+        #[cfg(feature = "insecure")]
         args.deterministic,
         args.signing_key_party_id,
         args.tls_subject.clone(),

--- a/core/service/src/bin/kms-gen-keys.rs
+++ b/core/service/src/bin/kms-gen-keys.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, bail, ensure};
+use anyhow::{Context, ensure};
 use clap::Parser;
 use core::fmt;
 use futures_util::future::OptionFuture;
@@ -6,9 +6,8 @@ use kms_grpc::RequestId;
 use kms_grpc::rpc_types::{PrivDataType, PubDataType};
 use kms_lib::{
     conf::{
-        AWSConfig, CoreConfig, EnclaveBootstrapConfig, Keychain, Storage as StorageConfig,
-        VaultConfig, init_conf,
-        threshold::{PeerConf, ThresholdPartyConf},
+        AWSConfig, EnclaveBootstrapConfig, Keychain, Storage as StorageConfig, VaultConfig,
+        init_conf, threshold::PeerConf,
     },
     consts::SIGNING_KEY_ID,
     cryptography::attestation::make_security_module,
@@ -26,7 +25,7 @@ use observability::conf::TelemetryConfig;
 use observability::telemetry::init_tracing;
 use serde::{Deserialize, Serialize};
 use std::{num::NonZeroUsize, sync::Arc};
-use validator::{Validate, ValidationErrors};
+use validator::Validate;
 
 #[derive(Parser)]
 #[clap(name = "Zama KMS Signing Key and Certificate Generator")]
@@ -67,26 +66,11 @@ struct KmsGenKeysRunConfig {
     mock_enclave: bool,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(untagged)]
-enum KmsGenKeysConfigFile {
-    Keygen(Box<KmsGenKeysOnlyConfig>),
-    Server(Box<CoreConfig>),
-}
-
-impl Validate for KmsGenKeysConfigFile {
-    fn validate(&self) -> Result<(), ValidationErrors> {
-        match self {
-            Self::Keygen(config) => config.validate(),
-            Self::Server(config) => config.validate(),
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Validate, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 struct KmsGenKeysOnlyConfig {
-    keygen: Option<KeygenConfig>,
+    #[validate(nested)]
+    keygen: KeygenConfig,
     #[validate(nested)]
     aws: Option<AWSConfig>,
     #[validate(nested)]
@@ -106,7 +90,6 @@ struct KmsGenKeysOnlyConfig {
 #[derive(Serialize, Deserialize, Validate, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 struct KeygenConfig {
-    enabled: Option<bool>,
     deterministic: Option<bool>,
     overwrite: Option<bool>,
     show_existing: Option<bool>,
@@ -146,37 +129,21 @@ struct ThresholdCmdArgs<'a, PubS: Storage, PrivS: Storage> {
 }
 
 fn resolve_args(args: &Args) -> anyhow::Result<KmsGenKeysRunConfig> {
-    let config = init_conf::<KmsGenKeysConfigFile>(&args.config_file).with_context(|| {
+    let config = init_conf::<KmsGenKeysOnlyConfig>(&args.config_file).with_context(|| {
         format!(
-            "failed to load kms-gen-keys config file {}",
+            "failed to load kms-gen-keys config file {}; expected a [keygen] section",
             args.config_file
         )
     })?;
     config
         .validate()
         .context("invalid kms-gen-keys config file")?;
-    resolve_config_file(config)
-}
-
-fn resolve_config_file(config: KmsGenKeysConfigFile) -> anyhow::Result<KmsGenKeysRunConfig> {
-    match config {
-        KmsGenKeysConfigFile::Keygen(config) => resolve_keygen_config_file(*config),
-        KmsGenKeysConfigFile::Server(config) => resolve_server_config_file(*config),
-    }
+    resolve_keygen_config_file(config)
 }
 
 fn resolve_keygen_config_file(config: KmsGenKeysOnlyConfig) -> anyhow::Result<KmsGenKeysRunConfig> {
-    if config
-        .keygen
-        .as_ref()
-        .and_then(|keygen| keygen.enabled)
-        .is_some_and(|enabled| !enabled)
-    {
-        bail!("[keygen].enabled is false");
-    }
-
     let mode = resolve_keygen_config_mode(config.threshold.as_ref())?;
-    let keygen = config.keygen.as_ref();
+    let keygen = &config.keygen;
     let public_storage = config.public_vault.map(|vault| vault.storage);
     let (private_storage, private_keychain) = config
         .private_vault
@@ -189,40 +156,11 @@ fn resolve_keygen_config_file(config: KmsGenKeysOnlyConfig) -> anyhow::Result<Km
         public_storage,
         private_storage,
         private_keychain,
-        deterministic: keygen
-            .and_then(|keygen| keygen.deterministic)
-            .unwrap_or(false),
-        overwrite: keygen.and_then(|keygen| keygen.overwrite).unwrap_or(false),
-        show_existing: keygen
-            .and_then(|keygen| keygen.show_existing)
-            .unwrap_or(false),
+        deterministic: keygen.deterministic.unwrap_or(false),
+        overwrite: keygen.overwrite.unwrap_or(false),
+        show_existing: keygen.show_existing.unwrap_or(false),
         #[cfg(feature = "insecure")]
-        mock_enclave: keygen
-            .and_then(|keygen| keygen.mock_enclave)
-            .or(config.mock_enclave)
-            .unwrap_or(false),
-    })
-}
-
-fn resolve_server_config_file(config: CoreConfig) -> anyhow::Result<KmsGenKeysRunConfig> {
-    let mode = resolve_server_config_mode(config.threshold.as_ref())?;
-    let public_storage = config.public_vault.map(|vault| vault.storage);
-    let (private_storage, private_keychain) = config
-        .private_vault
-        .map(|vault| (Some(vault.storage), vault.keychain))
-        .unwrap_or((None, None));
-
-    Ok(KmsGenKeysRunConfig {
-        mode,
-        aws: config.aws,
-        public_storage,
-        private_storage,
-        private_keychain,
-        deterministic: false,
-        overwrite: false,
-        show_existing: false,
-        #[cfg(feature = "insecure")]
-        mock_enclave: config.mock_enclave.unwrap_or(false),
+        mock_enclave: keygen.mock_enclave.or(config.mock_enclave).unwrap_or(false),
     })
 }
 
@@ -248,27 +186,6 @@ fn resolve_keygen_config_mode(
         signing_key_party_id,
         tls_subject,
         tls_wildcard: threshold.tls_wildcard.unwrap_or(false),
-    })
-}
-
-fn resolve_server_config_mode(
-    threshold: Option<&ThresholdPartyConf>,
-) -> anyhow::Result<KeygenMode> {
-    let Some(threshold) = threshold else {
-        return Ok(KeygenMode::Centralized);
-    };
-
-    let my_id = threshold
-        .my_id
-        .context("threshold.my_id is required when generating threshold signing keys")?;
-    let signing_key_party_id =
-        NonZeroUsize::new(my_id).context("threshold.my_id must be non-zero")?;
-    let tls_subject = resolve_threshold_tls_subject(None, threshold.peers.as_deref(), my_id)?;
-
-    Ok(KeygenMode::Threshold {
-        signing_key_party_id,
-        tls_subject,
-        tls_wildcard: false,
     })
 }
 
@@ -313,7 +230,7 @@ fn resolve_threshold_tls_subject(
 ///
 /// Examples:
 /// ```
-/// cargo run --bin kms-gen-keys -- --config-file config/default_1.toml
+/// cargo run --bin kms-gen-keys -- --config-file /path/to/kms-gen-keys.toml
 /// cargo run --bin kms-gen-keys -- --help
 /// ```
 #[tokio::main]
@@ -580,14 +497,13 @@ mod tests {
 
     fn base_config() -> KmsGenKeysOnlyConfig {
         KmsGenKeysOnlyConfig {
-            keygen: Some(KeygenConfig {
-                enabled: Some(true),
+            keygen: KeygenConfig {
                 deterministic: None,
                 overwrite: None,
                 show_existing: None,
                 #[cfg(feature = "insecure")]
                 mock_enclave: None,
-            }),
+            },
             aws: None,
             public_vault: None,
             private_vault: None,
@@ -620,9 +536,9 @@ mod tests {
     }
 
     fn resolve_config_for_test(
-        config: KmsGenKeysConfigFile,
+        config: KmsGenKeysOnlyConfig,
     ) -> anyhow::Result<KmsGenKeysRunConfig> {
-        resolve_config_file(config)
+        resolve_keygen_config_file(config)
     }
 
     fn resolved_tls_subject(resolved: KmsGenKeysRunConfig) -> String {
@@ -634,8 +550,7 @@ mod tests {
 
     #[test]
     fn config_file_resolves_centralized_defaults() {
-        let resolved =
-            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(base_config()))).unwrap();
+        let resolved = resolve_config_for_test(base_config()).unwrap();
 
         assert_eq!(resolved.mode, KeygenMode::Centralized);
         assert!(resolved.public_storage.is_none());
@@ -646,17 +561,15 @@ mod tests {
     #[test]
     fn keygen_flags_are_read_from_config() {
         let mut config = base_config();
-        config.keygen = Some(KeygenConfig {
-            enabled: Some(true),
+        config.keygen = KeygenConfig {
             deterministic: Some(true),
             overwrite: Some(true),
             show_existing: Some(true),
             #[cfg(feature = "insecure")]
             mock_enclave: None,
-        });
+        };
 
-        let resolved =
-            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+        let resolved = resolve_config_for_test(config).unwrap();
 
         assert!(resolved.deterministic);
         assert!(resolved.overwrite);
@@ -667,16 +580,14 @@ mod tests {
     #[test]
     fn mock_enclave_is_read_from_config() {
         let mut config = base_config();
-        config.keygen = Some(KeygenConfig {
-            enabled: Some(true),
+        config.keygen = KeygenConfig {
             deterministic: None,
             overwrite: None,
             show_existing: None,
             mock_enclave: Some(true),
-        });
+        };
 
-        let resolved =
-            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+        let resolved = resolve_config_for_test(config).unwrap();
 
         assert!(resolved.mock_enclave);
     }
@@ -689,8 +600,7 @@ mod tests {
         threshold.peers = Some(vec![peer(2, "peer-address", Some("peer-identity"))]);
         config.threshold = Some(threshold);
 
-        let resolved =
-            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+        let resolved = resolve_config_for_test(config).unwrap();
 
         assert_eq!(resolved_tls_subject(resolved), "explicit-party");
     }
@@ -705,8 +615,7 @@ mod tests {
         ]);
         config.threshold = Some(threshold);
 
-        let resolved =
-            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+        let resolved = resolve_config_for_test(config).unwrap();
 
         assert_eq!(resolved_tls_subject(resolved), "party-two");
     }
@@ -718,8 +627,7 @@ mod tests {
         threshold.peers = Some(vec![peer(1, "party-one-address", Some("   "))]);
         config.threshold = Some(threshold);
 
-        let resolved =
-            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+        let resolved = resolve_config_for_test(config).unwrap();
 
         assert_eq!(resolved_tls_subject(resolved), "party-one-address");
     }
@@ -731,9 +639,7 @@ mod tests {
         threshold.tls_subject = Some("party-one".to_string());
         config.threshold = Some(threshold);
 
-        let err = resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config)))
-            .unwrap_err()
-            .to_string();
+        let err = resolve_config_for_test(config).unwrap_err().to_string();
 
         assert!(err.contains("threshold.my_id"));
     }
@@ -745,9 +651,7 @@ mod tests {
         threshold.peers = Some(vec![peer(1, "party-one-address", None)]);
         config.threshold = Some(threshold);
 
-        let err = resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config)))
-            .unwrap_err()
-            .to_string();
+        let err = resolve_config_for_test(config).unwrap_err().to_string();
 
         assert!(err.contains("no entry for party 2"));
     }
@@ -781,8 +685,7 @@ mod tests {
             })),
         });
 
-        let resolved =
-            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+        let resolved = resolve_config_for_test(config).unwrap();
 
         assert_eq!(
             resolved.aws.as_ref().map(|aws| aws.region.as_str()),
@@ -812,16 +715,6 @@ mod tests {
     }
 
     #[test]
-    fn server_config_uses_core_config_threshold_shape() {
-        let config = init_conf::<KmsGenKeysConfigFile>("config/default_1").unwrap();
-        config.validate().unwrap();
-
-        let resolved = resolve_config_for_test(config).unwrap();
-
-        assert_eq!(resolved_tls_subject(resolved), "p1");
-    }
-
-    #[test]
     fn keygen_toml_deserializes_and_resolves() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("kms-gen-keys.toml");
@@ -829,7 +722,6 @@ mod tests {
             &config_path,
             r#"
 [keygen]
-enabled = true
 deterministic = true
 overwrite = true
 
@@ -857,7 +749,7 @@ root_key_spec = "symm"
         )
         .unwrap();
 
-        let config = init_conf::<KmsGenKeysConfigFile>(config_path.to_str().unwrap()).unwrap();
+        let config = init_conf::<KmsGenKeysOnlyConfig>(config_path.to_str().unwrap()).unwrap();
         config.validate().unwrap();
         let resolved = resolve_config_for_test(config).unwrap();
 

--- a/core/service/src/bin/kms-gen-keys.rs
+++ b/core/service/src/bin/kms-gen-keys.rs
@@ -1,17 +1,16 @@
 use anyhow::{Context, bail, ensure};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::Parser;
 use core::fmt;
 use futures_util::future::OptionFuture;
 use kms_grpc::RequestId;
 use kms_grpc::rpc_types::{PrivDataType, PubDataType};
 use kms_lib::{
     conf::{
-        AWSConfig, AwsKmsKeySpec, AwsKmsKeychain, CoreConfig, EnclaveBootstrapConfig,
-        FileStorage as FileStorageConfig, Keychain, S3Storage as S3StorageConfig,
-        Storage as StorageConfig, VaultConfig, init_conf,
+        AWSConfig, CoreConfig, EnclaveBootstrapConfig, Keychain, Storage as StorageConfig,
+        VaultConfig, init_conf,
         threshold::{PeerConf, ThresholdPartyConf},
     },
-    consts::{KEY_PATH_PREFIX, SIGNING_KEY_ID},
+    consts::SIGNING_KEY_ID,
     cryptography::attestation::make_security_module,
     util::key_setup::{
         ensure_central_server_signing_keys_exist, ensure_threshold_server_signing_key_exists,
@@ -26,9 +25,7 @@ use kms_lib::{
 use observability::conf::TelemetryConfig;
 use observability::telemetry::init_tracing;
 use serde::{Deserialize, Serialize};
-use std::{num::NonZeroUsize, path::PathBuf, sync::Arc};
-use strum::EnumIs;
-use url::Url;
+use std::{num::NonZeroUsize, sync::Arc};
 use validator::{Validate, ValidationErrors};
 
 #[derive(Parser)]
@@ -38,148 +35,12 @@ use validator::{Validate, ValidationErrors};
     In centralized mode it produces a single signing key plus its verification material. \
     In threshold mode it produces the signing key and self-signed CA certificate for one party; \
     run it once per party in a multi-party deployment. \
-    Multiple options are supported which can be explored with \
-    kms-gen-keys --help"
+    Pass --config-file to provide the key-generation settings."
 )]
 struct Args {
     /// Read key-generation settings from a TOML config file.
-    ///
-    /// This accepts the keygen-only enclave config and the full kms-server
-    /// config. When present, the mode subcommand and storage/AWS CLI flags are
-    /// ignored; `deterministic`, `overwrite`, and `show-existing` still apply.
-    #[clap(long, default_value = None)]
-    config_file: Option<String>,
-
-    #[clap(subcommand)]
-    mode: Option<Mode>,
-
-    /// AWS region to use for S3 storage
-    #[clap(long, default_value = "eu-west-3")]
-    aws_region: String,
-    /// Optional AWS IMDS API endpoint
-    #[clap(long, default_value = None)]
-    aws_imds_endpoint: Option<Url>,
-    /// Optional AWS STS API endpoint
-    #[clap(long, default_value = None)]
-    aws_sts_endpoint: Option<Url>,
-    /// Optional AWS S3 API endpoint
-    #[clap(long, default_value = None)]
-    aws_s3_endpoint: Option<Url>,
-    /// Optional AWS KMS API endpoint
-    #[clap(long, default_value = None)]
-    aws_kms_endpoint: Option<Url>,
-    /// Optional AWS KMS key id that encrypts the private storage
-    #[clap(long, default_value = None)]
-    root_key_id: Option<String>,
-    /// Optional AWS KMS key spec that encrypts the private storage
-    #[clap(long, default_value = None, value_enum)]
-    root_key_spec: Option<AwsKmsKeySpec>,
-    /// Use a software-emulated AWS Nitro security module instead of the real
-    /// NSM device. Only available with the `insecure` Cargo feature. See
-    /// `kms-server-bin.md` for more information.
-    #[cfg(feature = "insecure")]
-    #[clap(long, default_value_t = false)]
-    mock_enclave: bool,
-    #[clap(long, default_value_t = StorageCommand::File, value_enum)]
-    private_storage: StorageCommand,
-    #[clap(
-        long,
-        default_value = None,
-        conflicts_with_all = ["private_s3_bucket", "private_s3_prefix"],
-    )]
-    private_file_path: Option<PathBuf>,
-    #[clap(
-        long,
-        default_value = None,
-        conflicts_with_all = ["private_s3_bucket", "private_s3_prefix"],
-    )]
-    private_file_prefix: Option<String>,
-    #[clap(
-        long,
-        default_value = None,
-        required_if_eq("private_storage", "s3"),
-        conflicts_with_all = ["private_file_path", "private_file_prefix"],
-    )]
-    private_s3_bucket: Option<String>,
-    #[clap(
-        long,
-        default_value = None,
-        conflicts_with_all = ["private_file_path", "private_file_prefix"],
-    )]
-    private_s3_prefix: Option<String>,
-
-    #[clap(long, default_value_t = StorageCommand::File, value_enum)]
-    public_storage: StorageCommand,
-    #[clap(
-        long,
-        default_value = None,
-        conflicts_with_all = ["public_s3_bucket", "public_s3_prefix"],
-    )]
-    public_file_path: Option<PathBuf>,
-    #[clap(
-        long,
-        default_value = None,
-        conflicts_with_all = ["public_s3_bucket", "public_s3_prefix"],
-    )]
-    public_file_prefix: Option<String>,
-    #[clap(
-        long,
-        default_value = None,
-        required_if_eq("public_storage", "s3"),
-        conflicts_with_all = ["public_file_path", "public_file_prefix"],
-    )]
-    public_s3_bucket: Option<String>,
-    #[clap(
-        long,
-        default_value = None,
-        conflicts_with_all = ["public_file_path", "public_file_prefix"],
-    )]
-    public_s3_prefix: Option<String>,
-    /// Whether to generate keys deterministically,
-    /// only use this option for testing.
-    /// The determinism is not guaranteed to be the same between releases.
-    #[clap(long, default_value_t = false)]
-    deterministic: bool,
-    /// Whether to overwrite ALL the existing keys,
-    #[clap(long, default_value_t = false)]
-    overwrite: bool,
-    /// Only show existing keys, do not generate any
-    #[clap(long, default_value_t = false)]
-    show_existing: bool,
-}
-
-#[derive(Clone, Copy, Subcommand, Default, ValueEnum, EnumIs)]
-enum StorageCommand {
-    #[default]
-    File,
-    S3,
-}
-
-#[derive(Clone, Subcommand)]
-enum Mode {
-    /// Generate the centralized server signing key.
-    Centralized,
-
-    /// Generate the signing key and self-signed CA certificate for one
-    /// threshold party.
-    ///
-    /// One invocation generates the material for exactly one party; callers
-    /// that operate multiple parties (docker-compose loops, Helm per-pod jobs,
-    /// the enclave bootstrap script) invoke `kms-gen-keys threshold` once per
-    /// party.
-    Threshold {
-        /// Index of the party to generate keys for (1-based).
-        #[clap(long)]
-        signing_key_party_id: NonZeroUsize,
-
-        /// Subject used in the issued TLS certificate.
-        #[clap(long, default_value = "kms-party")]
-        tls_subject: String,
-
-        /// Whether to include a wildcard SAN entry for the CA certificates
-        #[clap(long, default_value_t = false)]
-        tls_wildcard: bool,
-    },
+    #[clap(long, short = 'f')]
+    config_file: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -246,6 +107,11 @@ struct KmsGenKeysOnlyConfig {
 #[serde(deny_unknown_fields)]
 struct KeygenConfig {
     enabled: Option<bool>,
+    deterministic: Option<bool>,
+    overwrite: Option<bool>,
+    show_existing: Option<bool>,
+    #[cfg(feature = "insecure")]
+    mock_enclave: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Validate, Clone, Debug)]
@@ -280,67 +146,26 @@ struct ThresholdCmdArgs<'a, PubS: Storage, PrivS: Storage> {
 }
 
 fn resolve_args(args: &Args) -> anyhow::Result<KmsGenKeysRunConfig> {
-    if let Some(config_file) = args.config_file.as_deref() {
-        ensure!(
-            args.mode.is_none(),
-            "--config-file cannot be combined with a mode subcommand"
-        );
-        let config = init_conf::<KmsGenKeysConfigFile>(config_file)
-            .with_context(|| format!("failed to load kms-gen-keys config file {config_file}"))?;
-        config
-            .validate()
-            .context("invalid kms-gen-keys config file")?;
-        return resolve_config_file(
-            config,
-            args.deterministic,
-            args.overwrite,
-            args.show_existing,
-            #[cfg(feature = "insecure")]
-            args.mock_enclave,
-        );
-    }
-
-    let mode = args
-        .mode
-        .clone()
-        .context("kms-gen-keys requires either --config-file or a mode subcommand")?;
-    resolve_cli_args(args, mode)
+    let config = init_conf::<KmsGenKeysConfigFile>(&args.config_file).with_context(|| {
+        format!(
+            "failed to load kms-gen-keys config file {}",
+            args.config_file
+        )
+    })?;
+    config
+        .validate()
+        .context("invalid kms-gen-keys config file")?;
+    resolve_config_file(config)
 }
 
-fn resolve_config_file(
-    config: KmsGenKeysConfigFile,
-    deterministic: bool,
-    overwrite: bool,
-    show_existing: bool,
-    #[cfg(feature = "insecure")] cli_mock_enclave: bool,
-) -> anyhow::Result<KmsGenKeysRunConfig> {
+fn resolve_config_file(config: KmsGenKeysConfigFile) -> anyhow::Result<KmsGenKeysRunConfig> {
     match config {
-        KmsGenKeysConfigFile::Keygen(config) => resolve_keygen_config_file(
-            *config,
-            deterministic,
-            overwrite,
-            show_existing,
-            #[cfg(feature = "insecure")]
-            cli_mock_enclave,
-        ),
-        KmsGenKeysConfigFile::Server(config) => resolve_server_config_file(
-            *config,
-            deterministic,
-            overwrite,
-            show_existing,
-            #[cfg(feature = "insecure")]
-            cli_mock_enclave,
-        ),
+        KmsGenKeysConfigFile::Keygen(config) => resolve_keygen_config_file(*config),
+        KmsGenKeysConfigFile::Server(config) => resolve_server_config_file(*config),
     }
 }
 
-fn resolve_keygen_config_file(
-    config: KmsGenKeysOnlyConfig,
-    deterministic: bool,
-    overwrite: bool,
-    show_existing: bool,
-    #[cfg(feature = "insecure")] cli_mock_enclave: bool,
-) -> anyhow::Result<KmsGenKeysRunConfig> {
+fn resolve_keygen_config_file(config: KmsGenKeysOnlyConfig) -> anyhow::Result<KmsGenKeysRunConfig> {
     if config
         .keygen
         .as_ref()
@@ -351,6 +176,7 @@ fn resolve_keygen_config_file(
     }
 
     let mode = resolve_keygen_config_mode(config.threshold.as_ref())?;
+    let keygen = config.keygen.as_ref();
     let public_storage = config.public_vault.map(|vault| vault.storage);
     let (private_storage, private_keychain) = config
         .private_vault
@@ -363,21 +189,22 @@ fn resolve_keygen_config_file(
         public_storage,
         private_storage,
         private_keychain,
-        deterministic,
-        overwrite,
-        show_existing,
+        deterministic: keygen
+            .and_then(|keygen| keygen.deterministic)
+            .unwrap_or(false),
+        overwrite: keygen.and_then(|keygen| keygen.overwrite).unwrap_or(false),
+        show_existing: keygen
+            .and_then(|keygen| keygen.show_existing)
+            .unwrap_or(false),
         #[cfg(feature = "insecure")]
-        mock_enclave: cli_mock_enclave || config.mock_enclave.unwrap_or(false),
+        mock_enclave: keygen
+            .and_then(|keygen| keygen.mock_enclave)
+            .or(config.mock_enclave)
+            .unwrap_or(false),
     })
 }
 
-fn resolve_server_config_file(
-    config: CoreConfig,
-    deterministic: bool,
-    overwrite: bool,
-    show_existing: bool,
-    #[cfg(feature = "insecure")] cli_mock_enclave: bool,
-) -> anyhow::Result<KmsGenKeysRunConfig> {
+fn resolve_server_config_file(config: CoreConfig) -> anyhow::Result<KmsGenKeysRunConfig> {
     let mode = resolve_server_config_mode(config.threshold.as_ref())?;
     let public_storage = config.public_vault.map(|vault| vault.storage);
     let (private_storage, private_keychain) = config
@@ -391,11 +218,11 @@ fn resolve_server_config_file(
         public_storage,
         private_storage,
         private_keychain,
-        deterministic,
-        overwrite,
-        show_existing,
+        deterministic: false,
+        overwrite: false,
+        show_existing: false,
         #[cfg(feature = "insecure")]
-        mock_enclave: cli_mock_enclave || config.mock_enclave.unwrap_or(false),
+        mock_enclave: config.mock_enclave.unwrap_or(false),
     })
 }
 
@@ -478,91 +305,6 @@ fn resolve_threshold_tls_subject(
     Ok(subject.to_string())
 }
 
-fn resolve_cli_args(args: &Args, mode: Mode) -> anyhow::Result<KmsGenKeysRunConfig> {
-    Ok(KmsGenKeysRunConfig {
-        mode: match mode {
-            Mode::Centralized => KeygenMode::Centralized,
-            Mode::Threshold {
-                signing_key_party_id,
-                tls_subject,
-                tls_wildcard,
-            } => KeygenMode::Threshold {
-                signing_key_party_id,
-                tls_subject,
-                tls_wildcard,
-            },
-        },
-        aws: Some(AWSConfig {
-            region: args.aws_region.clone(),
-            role_arn: None,
-            imds_endpoint: args.aws_imds_endpoint.clone(),
-            sts_endpoint: args.aws_sts_endpoint.clone(),
-            s3_endpoint: args.aws_s3_endpoint.clone(),
-            awskms_endpoint: args.aws_kms_endpoint.clone(),
-        }),
-        public_storage: resolve_cli_storage(
-            "public",
-            args.public_storage,
-            &args.public_file_path,
-            &args.public_file_prefix,
-            &args.public_s3_bucket,
-            &args.public_s3_prefix,
-        )?,
-        private_storage: resolve_cli_storage(
-            "private",
-            args.private_storage,
-            &args.private_file_path,
-            &args.private_file_prefix,
-            &args.private_s3_bucket,
-            &args.private_s3_prefix,
-        )?,
-        private_keychain: resolve_cli_keychain(args)?,
-        deterministic: args.deterministic,
-        overwrite: args.overwrite,
-        show_existing: args.show_existing,
-        #[cfg(feature = "insecure")]
-        mock_enclave: args.mock_enclave,
-    })
-}
-
-fn resolve_cli_storage(
-    name: &str,
-    storage: StorageCommand,
-    file_path: &Option<PathBuf>,
-    file_prefix: &Option<String>,
-    s3_bucket: &Option<String>,
-    s3_prefix: &Option<String>,
-) -> anyhow::Result<Option<StorageConfig>> {
-    match storage {
-        StorageCommand::File => Ok((file_path.is_some() || file_prefix.is_some()).then(|| {
-            StorageConfig::File(FileStorageConfig {
-                path: file_path
-                    .clone()
-                    .unwrap_or_else(|| PathBuf::from(KEY_PATH_PREFIX)),
-                prefix: file_prefix.clone(),
-            })
-        })),
-        StorageCommand::S3 => Ok(Some(StorageConfig::S3(S3StorageConfig {
-            bucket: s3_bucket.clone().with_context(|| {
-                format!("--{name}-s3-bucket is required with --{name}-storage s3")
-            })?,
-            prefix: s3_prefix.clone(),
-        }))),
-    }
-}
-
-fn resolve_cli_keychain(args: &Args) -> anyhow::Result<Option<Keychain>> {
-    match (&args.root_key_id, &args.root_key_spec) {
-        (Some(root_key_id), Some(root_key_spec)) => Ok(Some(Keychain::AwsKms(AwsKmsKeychain {
-            root_key_id: root_key_id.clone(),
-            root_key_spec: root_key_spec.clone(),
-        }))),
-        (None, None) => Ok(None),
-        (Some(_), None) => bail!("--root-key-spec is required when --root-key-id is set"),
-        (None, Some(_)) => bail!("--root-key-id is required when --root-key-spec is set"),
-    }
-}
-
 /// Generate the server signing keys and TLS material for a KMS deployment.
 ///
 /// Two modes are supported:
@@ -571,7 +313,7 @@ fn resolve_cli_keychain(args: &Args) -> anyhow::Result<Option<Keychain>> {
 ///
 /// Examples:
 /// ```
-/// cargo run --bin kms-gen-keys -- centralized
+/// cargo run --bin kms-gen-keys -- --config-file config/default_1.toml
 /// cargo run --bin kms-gen-keys -- --help
 /// ```
 #[tokio::main]
@@ -829,11 +571,22 @@ async fn show_key<S: Storage>(storage: &S, data_type: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kms_lib::conf::{
+        AwsKmsKeySpec, AwsKmsKeychain, FileStorage as FileStorageConfig,
+        S3Storage as S3StorageConfig,
+    };
+    use std::path::PathBuf;
+    use url::Url;
 
     fn base_config() -> KmsGenKeysOnlyConfig {
         KmsGenKeysOnlyConfig {
             keygen: Some(KeygenConfig {
                 enabled: Some(true),
+                deterministic: None,
+                overwrite: None,
+                show_existing: None,
+                #[cfg(feature = "insecure")]
+                mock_enclave: None,
             }),
             aws: None,
             public_vault: None,
@@ -869,14 +622,7 @@ mod tests {
     fn resolve_config_for_test(
         config: KmsGenKeysConfigFile,
     ) -> anyhow::Result<KmsGenKeysRunConfig> {
-        resolve_config_file(
-            config,
-            false,
-            false,
-            false,
-            #[cfg(feature = "insecure")]
-            false,
-        )
+        resolve_config_file(config)
     }
 
     fn resolved_tls_subject(resolved: KmsGenKeysRunConfig) -> String {
@@ -895,6 +641,44 @@ mod tests {
         assert!(resolved.public_storage.is_none());
         assert!(resolved.private_storage.is_none());
         assert!(resolved.private_keychain.is_none());
+    }
+
+    #[test]
+    fn keygen_flags_are_read_from_config() {
+        let mut config = base_config();
+        config.keygen = Some(KeygenConfig {
+            enabled: Some(true),
+            deterministic: Some(true),
+            overwrite: Some(true),
+            show_existing: Some(true),
+            #[cfg(feature = "insecure")]
+            mock_enclave: None,
+        });
+
+        let resolved =
+            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+
+        assert!(resolved.deterministic);
+        assert!(resolved.overwrite);
+        assert!(resolved.show_existing);
+    }
+
+    #[cfg(feature = "insecure")]
+    #[test]
+    fn mock_enclave_is_read_from_config() {
+        let mut config = base_config();
+        config.keygen = Some(KeygenConfig {
+            enabled: Some(true),
+            deterministic: None,
+            overwrite: None,
+            show_existing: None,
+            mock_enclave: Some(true),
+        });
+
+        let resolved =
+            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+
+        assert!(resolved.mock_enclave);
     }
 
     #[test]
@@ -1046,6 +830,8 @@ mod tests {
             r#"
 [keygen]
 enabled = true
+deterministic = true
+overwrite = true
 
 [threshold]
 my_id = 2
@@ -1076,6 +862,8 @@ root_key_spec = "symm"
         let resolved = resolve_config_for_test(config).unwrap();
 
         assert_eq!(resolved_tls_subject(resolved.clone()), "kms-core-2");
+        assert!(resolved.deterministic);
+        assert!(resolved.overwrite);
         assert_eq!(
             resolved.public_storage,
             Some(StorageConfig::S3(S3StorageConfig {

--- a/core/service/src/bin/kms-gen-keys.rs
+++ b/core/service/src/bin/kms-gen-keys.rs
@@ -1,11 +1,17 @@
+use anyhow::{Context, bail, ensure};
 use clap::{Parser, Subcommand, ValueEnum};
 use core::fmt;
 use futures_util::future::OptionFuture;
 use kms_grpc::RequestId;
 use kms_grpc::rpc_types::{PrivDataType, PubDataType};
 use kms_lib::{
-    conf::{AwsKmsKeySpec, AwsKmsKeychain, Keychain},
-    consts::SIGNING_KEY_ID,
+    conf::{
+        AWSConfig, AwsKmsKeySpec, AwsKmsKeychain, CoreConfig, EnclaveBootstrapConfig,
+        FileStorage as FileStorageConfig, Keychain, S3Storage as S3StorageConfig,
+        Storage as StorageConfig, VaultConfig, init_conf,
+        threshold::{PeerConf, ThresholdPartyConf},
+    },
+    consts::{KEY_PATH_PREFIX, SIGNING_KEY_ID},
     cryptography::attestation::make_security_module,
     util::key_setup::{
         ensure_central_server_signing_keys_exist, ensure_threshold_server_signing_key_exists,
@@ -14,18 +20,16 @@ use kms_lib::{
         Vault,
         aws::build_aws_sdk_config,
         keychain::{awskms::build_aws_kms_client, make_keychain_proxy},
-        storage::{
-            Storage, StorageProxy, StorageType, delete_at_request_id,
-            file::FileStorage,
-            s3::{S3Storage, build_s3_client},
-        },
+        storage::{Storage, StorageType, delete_at_request_id, make_storage, s3::build_s3_client},
     },
 };
 use observability::conf::TelemetryConfig;
 use observability::telemetry::init_tracing;
+use serde::{Deserialize, Serialize};
 use std::{num::NonZeroUsize, path::PathBuf, sync::Arc};
 use strum::EnumIs;
 use url::Url;
+use validator::{Validate, ValidationErrors};
 
 #[derive(Parser)]
 #[clap(name = "Zama KMS Signing Key and Certificate Generator")]
@@ -38,8 +42,16 @@ use url::Url;
     kms-gen-keys --help"
 )]
 struct Args {
+    /// Read key-generation settings from a TOML config file.
+    ///
+    /// This accepts the keygen-only enclave config and the full kms-server
+    /// config. When present, the mode subcommand and storage/AWS CLI flags are
+    /// ignored; `deterministic`, `overwrite`, and `show-existing` still apply.
+    #[clap(long, default_value = None)]
+    config_file: Option<String>,
+
     #[clap(subcommand)]
-    mode: Mode,
+    mode: Option<Mode>,
 
     /// AWS region to use for S3 storage
     #[clap(long, default_value = "eu-west-3")]
@@ -136,7 +148,7 @@ struct Args {
     show_existing: bool,
 }
 
-#[derive(Clone, Subcommand, Default, ValueEnum, EnumIs)]
+#[derive(Clone, Copy, Subcommand, Default, ValueEnum, EnumIs)]
 enum StorageCommand {
     #[default]
     File,
@@ -170,6 +182,84 @@ enum Mode {
     },
 }
 
+#[derive(Clone, Debug, PartialEq)]
+enum KeygenMode {
+    Centralized,
+    Threshold {
+        signing_key_party_id: NonZeroUsize,
+        tls_subject: String,
+        tls_wildcard: bool,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct KmsGenKeysRunConfig {
+    mode: KeygenMode,
+    aws: Option<AWSConfig>,
+    public_storage: Option<StorageConfig>,
+    private_storage: Option<StorageConfig>,
+    private_keychain: Option<Keychain>,
+    deterministic: bool,
+    overwrite: bool,
+    show_existing: bool,
+    #[cfg(feature = "insecure")]
+    mock_enclave: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+enum KmsGenKeysConfigFile {
+    Keygen(Box<KmsGenKeysOnlyConfig>),
+    Server(Box<CoreConfig>),
+}
+
+impl Validate for KmsGenKeysConfigFile {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        match self {
+            Self::Keygen(config) => config.validate(),
+            Self::Server(config) => config.validate(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Validate, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+struct KmsGenKeysOnlyConfig {
+    keygen: Option<KeygenConfig>,
+    #[validate(nested)]
+    aws: Option<AWSConfig>,
+    #[validate(nested)]
+    public_vault: Option<VaultConfig>,
+    #[validate(nested)]
+    private_vault: Option<VaultConfig>,
+    #[validate(nested)]
+    backup_vault: Option<VaultConfig>,
+    #[validate(nested)]
+    threshold: Option<KeygenThresholdConfig>,
+    #[validate(nested)]
+    enclave_bootstrap: Option<EnclaveBootstrapConfig>,
+    #[cfg(feature = "insecure")]
+    mock_enclave: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Validate, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+struct KeygenConfig {
+    enabled: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Validate, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+struct KeygenThresholdConfig {
+    #[validate(range(min = 1))]
+    my_id: Option<usize>,
+    #[validate(length(min = 1))]
+    tls_subject: Option<String>,
+    tls_wildcard: Option<bool>,
+    #[validate(nested)]
+    peers: Option<Vec<PeerConf>>,
+}
+
 struct CentralCmdArgs<'a, PubS: Storage, PrivS: Storage> {
     pub_storage: &'a mut PubS,
     priv_storage: &'a mut PrivS,
@@ -189,6 +279,290 @@ struct ThresholdCmdArgs<'a, PubS: Storage, PrivS: Storage> {
     tls_wildcard: bool,
 }
 
+fn resolve_args(args: &Args) -> anyhow::Result<KmsGenKeysRunConfig> {
+    if let Some(config_file) = args.config_file.as_deref() {
+        ensure!(
+            args.mode.is_none(),
+            "--config-file cannot be combined with a mode subcommand"
+        );
+        let config = init_conf::<KmsGenKeysConfigFile>(config_file)
+            .with_context(|| format!("failed to load kms-gen-keys config file {config_file}"))?;
+        config
+            .validate()
+            .context("invalid kms-gen-keys config file")?;
+        return resolve_config_file(
+            config,
+            args.deterministic,
+            args.overwrite,
+            args.show_existing,
+            #[cfg(feature = "insecure")]
+            args.mock_enclave,
+        );
+    }
+
+    let mode = args
+        .mode
+        .clone()
+        .context("kms-gen-keys requires either --config-file or a mode subcommand")?;
+    resolve_cli_args(args, mode)
+}
+
+fn resolve_config_file(
+    config: KmsGenKeysConfigFile,
+    deterministic: bool,
+    overwrite: bool,
+    show_existing: bool,
+    #[cfg(feature = "insecure")] cli_mock_enclave: bool,
+) -> anyhow::Result<KmsGenKeysRunConfig> {
+    match config {
+        KmsGenKeysConfigFile::Keygen(config) => resolve_keygen_config_file(
+            *config,
+            deterministic,
+            overwrite,
+            show_existing,
+            #[cfg(feature = "insecure")]
+            cli_mock_enclave,
+        ),
+        KmsGenKeysConfigFile::Server(config) => resolve_server_config_file(
+            *config,
+            deterministic,
+            overwrite,
+            show_existing,
+            #[cfg(feature = "insecure")]
+            cli_mock_enclave,
+        ),
+    }
+}
+
+fn resolve_keygen_config_file(
+    config: KmsGenKeysOnlyConfig,
+    deterministic: bool,
+    overwrite: bool,
+    show_existing: bool,
+    #[cfg(feature = "insecure")] cli_mock_enclave: bool,
+) -> anyhow::Result<KmsGenKeysRunConfig> {
+    if config
+        .keygen
+        .as_ref()
+        .and_then(|keygen| keygen.enabled)
+        .is_some_and(|enabled| !enabled)
+    {
+        bail!("[keygen].enabled is false");
+    }
+
+    let mode = resolve_keygen_config_mode(config.threshold.as_ref())?;
+    let public_storage = config.public_vault.map(|vault| vault.storage);
+    let (private_storage, private_keychain) = config
+        .private_vault
+        .map(|vault| (Some(vault.storage), vault.keychain))
+        .unwrap_or((None, None));
+
+    Ok(KmsGenKeysRunConfig {
+        mode,
+        aws: config.aws,
+        public_storage,
+        private_storage,
+        private_keychain,
+        deterministic,
+        overwrite,
+        show_existing,
+        #[cfg(feature = "insecure")]
+        mock_enclave: cli_mock_enclave || config.mock_enclave.unwrap_or(false),
+    })
+}
+
+fn resolve_server_config_file(
+    config: CoreConfig,
+    deterministic: bool,
+    overwrite: bool,
+    show_existing: bool,
+    #[cfg(feature = "insecure")] cli_mock_enclave: bool,
+) -> anyhow::Result<KmsGenKeysRunConfig> {
+    let mode = resolve_server_config_mode(config.threshold.as_ref())?;
+    let public_storage = config.public_vault.map(|vault| vault.storage);
+    let (private_storage, private_keychain) = config
+        .private_vault
+        .map(|vault| (Some(vault.storage), vault.keychain))
+        .unwrap_or((None, None));
+
+    Ok(KmsGenKeysRunConfig {
+        mode,
+        aws: config.aws,
+        public_storage,
+        private_storage,
+        private_keychain,
+        deterministic,
+        overwrite,
+        show_existing,
+        #[cfg(feature = "insecure")]
+        mock_enclave: cli_mock_enclave || config.mock_enclave.unwrap_or(false),
+    })
+}
+
+fn resolve_keygen_config_mode(
+    threshold: Option<&KeygenThresholdConfig>,
+) -> anyhow::Result<KeygenMode> {
+    let Some(threshold) = threshold else {
+        return Ok(KeygenMode::Centralized);
+    };
+
+    let my_id = threshold
+        .my_id
+        .context("threshold.my_id is required when generating threshold signing keys")?;
+    let signing_key_party_id =
+        NonZeroUsize::new(my_id).context("threshold.my_id must be non-zero")?;
+    let tls_subject = resolve_threshold_tls_subject(
+        threshold.tls_subject.as_deref(),
+        threshold.peers.as_deref(),
+        my_id,
+    )?;
+
+    Ok(KeygenMode::Threshold {
+        signing_key_party_id,
+        tls_subject,
+        tls_wildcard: threshold.tls_wildcard.unwrap_or(false),
+    })
+}
+
+fn resolve_server_config_mode(
+    threshold: Option<&ThresholdPartyConf>,
+) -> anyhow::Result<KeygenMode> {
+    let Some(threshold) = threshold else {
+        return Ok(KeygenMode::Centralized);
+    };
+
+    let my_id = threshold
+        .my_id
+        .context("threshold.my_id is required when generating threshold signing keys")?;
+    let signing_key_party_id =
+        NonZeroUsize::new(my_id).context("threshold.my_id must be non-zero")?;
+    let tls_subject = resolve_threshold_tls_subject(None, threshold.peers.as_deref(), my_id)?;
+
+    Ok(KeygenMode::Threshold {
+        signing_key_party_id,
+        tls_subject,
+        tls_wildcard: false,
+    })
+}
+
+fn resolve_threshold_tls_subject(
+    explicit_subject: Option<&str>,
+    peers: Option<&[PeerConf]>,
+    my_id: usize,
+) -> anyhow::Result<String> {
+    if let Some(subject) = explicit_subject
+        .map(str::trim)
+        .filter(|subject| !subject.is_empty())
+    {
+        return Ok(subject.to_string());
+    }
+
+    let peers = peers.context(
+        "threshold.tls_subject is not set and threshold.peers is missing; cannot derive TLS subject",
+    )?;
+    let peer = peers.iter().find(|peer| peer.party_id == my_id).ok_or_else(|| {
+        anyhow::anyhow!(
+            "threshold.tls_subject is not set and threshold.peers has no entry for party {my_id}"
+        )
+    })?;
+    let subject = peer
+        .mpc_identity
+        .as_deref()
+        .map(str::trim)
+        .filter(|identity| !identity.is_empty())
+        .unwrap_or_else(|| peer.address.trim());
+    ensure!(
+        !subject.is_empty(),
+        "cannot derive TLS subject for party {my_id} from an empty peer identity/address"
+    );
+    Ok(subject.to_string())
+}
+
+fn resolve_cli_args(args: &Args, mode: Mode) -> anyhow::Result<KmsGenKeysRunConfig> {
+    Ok(KmsGenKeysRunConfig {
+        mode: match mode {
+            Mode::Centralized => KeygenMode::Centralized,
+            Mode::Threshold {
+                signing_key_party_id,
+                tls_subject,
+                tls_wildcard,
+            } => KeygenMode::Threshold {
+                signing_key_party_id,
+                tls_subject,
+                tls_wildcard,
+            },
+        },
+        aws: Some(AWSConfig {
+            region: args.aws_region.clone(),
+            role_arn: None,
+            imds_endpoint: args.aws_imds_endpoint.clone(),
+            sts_endpoint: args.aws_sts_endpoint.clone(),
+            s3_endpoint: args.aws_s3_endpoint.clone(),
+            awskms_endpoint: args.aws_kms_endpoint.clone(),
+        }),
+        public_storage: resolve_cli_storage(
+            "public",
+            args.public_storage,
+            &args.public_file_path,
+            &args.public_file_prefix,
+            &args.public_s3_bucket,
+            &args.public_s3_prefix,
+        )?,
+        private_storage: resolve_cli_storage(
+            "private",
+            args.private_storage,
+            &args.private_file_path,
+            &args.private_file_prefix,
+            &args.private_s3_bucket,
+            &args.private_s3_prefix,
+        )?,
+        private_keychain: resolve_cli_keychain(args)?,
+        deterministic: args.deterministic,
+        overwrite: args.overwrite,
+        show_existing: args.show_existing,
+        #[cfg(feature = "insecure")]
+        mock_enclave: args.mock_enclave,
+    })
+}
+
+fn resolve_cli_storage(
+    name: &str,
+    storage: StorageCommand,
+    file_path: &Option<PathBuf>,
+    file_prefix: &Option<String>,
+    s3_bucket: &Option<String>,
+    s3_prefix: &Option<String>,
+) -> anyhow::Result<Option<StorageConfig>> {
+    match storage {
+        StorageCommand::File => Ok((file_path.is_some() || file_prefix.is_some()).then(|| {
+            StorageConfig::File(FileStorageConfig {
+                path: file_path
+                    .clone()
+                    .unwrap_or_else(|| PathBuf::from(KEY_PATH_PREFIX)),
+                prefix: file_prefix.clone(),
+            })
+        })),
+        StorageCommand::S3 => Ok(Some(StorageConfig::S3(S3StorageConfig {
+            bucket: s3_bucket.clone().with_context(|| {
+                format!("--{name}-s3-bucket is required with --{name}-storage s3")
+            })?,
+            prefix: s3_prefix.clone(),
+        }))),
+    }
+}
+
+fn resolve_cli_keychain(args: &Args) -> anyhow::Result<Option<Keychain>> {
+    match (&args.root_key_id, &args.root_key_spec) {
+        (Some(root_key_id), Some(root_key_spec)) => Ok(Some(Keychain::AwsKms(AwsKmsKeychain {
+            root_key_id: root_key_id.clone(),
+            root_key_spec: root_key_spec.clone(),
+        }))),
+        (None, None) => Ok(None),
+        (Some(_), None) => bail!("--root-key-spec is required when --root-key-id is set"),
+        (None, Some(_)) => bail!("--root-key-id is required when --root-key-spec is set"),
+    }
+}
+
 /// Generate the server signing keys and TLS material for a KMS deployment.
 ///
 /// Two modes are supported:
@@ -201,7 +575,7 @@ struct ThresholdCmdArgs<'a, PubS: Storage, PrivS: Storage> {
 /// cargo run --bin kms-gen-keys -- --help
 /// ```
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     // Initialize telemetry with stdout tracing only and disabled metrics
@@ -210,23 +584,67 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build();
     init_tracing(&telemetry).await?;
 
-    let aws_sdk_config = build_aws_sdk_config(
-        args.aws_region,
-        args.aws_imds_endpoint,
-        args.aws_sts_endpoint,
-    )
-    .await;
+    let resolved = resolve_args(&args)?;
+
     // AWS S3 client
-    let need_s3_client = args.public_storage.is_s_3() || args.private_storage.is_s_3();
-    let s3_client = if need_s3_client {
-        Some(build_s3_client(&aws_sdk_config, args.aws_s3_endpoint).await?)
+    let need_s3_client = resolved
+        .public_storage
+        .as_ref()
+        .is_some_and(StorageConfig::is_s_3)
+        || resolved
+            .private_storage
+            .as_ref()
+            .is_some_and(StorageConfig::is_s_3);
+    // AWS KMS client
+    let need_awskms_client = resolved
+        .private_keychain
+        .as_ref()
+        .is_some_and(Keychain::is_aws_kms);
+    let aws_sdk_config = if need_s3_client || need_awskms_client || resolved.aws.is_some() {
+        let aws = resolved
+            .aws
+            .as_ref()
+            .context("[aws] config is required when using S3 storage or an AWS KMS keychain")?;
+        Some(
+            build_aws_sdk_config(
+                aws.region.clone(),
+                aws.imds_endpoint.clone(),
+                aws.sts_endpoint.clone(),
+            )
+            .await,
+        )
     } else {
         None
     };
-    // AWS KMS client
-    let need_awskms_client = args.root_key_id.is_some();
+    let s3_client = if need_s3_client {
+        Some(
+            build_s3_client(
+                aws_sdk_config
+                    .as_ref()
+                    .expect("AWS config is built when S3 storage is configured"),
+                resolved
+                    .aws
+                    .as_ref()
+                    .and_then(|aws| aws.s3_endpoint.clone()),
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
     let awskms_client = if need_awskms_client {
-        Some(build_aws_kms_client(&aws_sdk_config, args.aws_kms_endpoint).await)
+        Some(
+            build_aws_kms_client(
+                aws_sdk_config
+                    .as_ref()
+                    .expect("AWS config is built when AWS KMS keychain is configured"),
+                resolved
+                    .aws
+                    .as_ref()
+                    .and_then(|aws| aws.awskms_endpoint.clone()),
+            )
+            .await,
+        )
     } else {
         None
     };
@@ -234,7 +652,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let security_module = if need_awskms_client {
         Some(Arc::new(make_security_module(
             #[cfg(feature = "insecure")]
-            args.mock_enclave,
+            resolved.mock_enclave,
         )?))
     } else {
         None
@@ -242,86 +660,40 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create storages (one pub + one priv per invocation; multi-party
     // deployments invoke this binary once per party)
-    let mut pub_storage = match args.public_storage {
-        StorageCommand::File => StorageProxy::from(FileStorage::new(
-            args.public_file_path.as_deref(),
-            StorageType::PUB,
-            args.public_file_prefix.as_deref(),
-        )?),
-        StorageCommand::S3 => StorageProxy::from(S3Storage::new(
-            // `need_s3_client` covers public_storage == s3, so the client is built above
-            s3_client
-                .clone()
-                .expect("S3 client is built when public_storage == s3"),
-            // clap's `required_if_eq` on `public_s3_bucket` guarantees this
-            // is `Some` whenever public_storage == s3.
-            args.public_s3_bucket
-                .clone()
-                .expect("clap-required: public_s3_bucket"),
-            StorageType::PUB,
-            args.public_s3_prefix.as_deref(),
-        )?),
-    };
-    let private_keychain = OptionFuture::from(
-        args.root_key_id
-            .as_ref()
-            .zip(args.root_key_spec.as_ref())
-            .map(|(root_key_id, root_key_spec)| {
-                Keychain::AwsKms(AwsKmsKeychain {
-                    root_key_id: root_key_id.clone(),
-                    root_key_spec: root_key_spec.clone(),
-                })
-            })
-            .as_ref()
-            .map(|k| {
-                make_keychain_proxy(
-                    k,
-                    awskms_client.clone(),
-                    security_module.as_ref().map(Arc::clone),
-                    Some(&pub_storage),
-                    false,
-                )
-            }),
-    )
+    let mut pub_storage = make_storage(
+        resolved.public_storage.clone(),
+        StorageType::PUB,
+        s3_client.clone(),
+    )?;
+    let private_keychain = OptionFuture::from(resolved.private_keychain.as_ref().map(|k| {
+        make_keychain_proxy(
+            k,
+            awskms_client.clone(),
+            security_module.as_ref().map(Arc::clone),
+            Some(&pub_storage),
+            false,
+        )
+    }))
     .await
     .transpose()?;
     let mut priv_vault = Vault {
-        storage: match args.private_storage {
-            StorageCommand::File => StorageProxy::from(FileStorage::new(
-                args.private_file_path.as_deref(),
-                StorageType::PRIV,
-                args.private_file_prefix.as_deref(),
-            )?),
-            StorageCommand::S3 => StorageProxy::from(S3Storage::new(
-                // `need_s3_client` covers private_storage == s3, so the client is built above
-                s3_client
-                    .clone()
-                    .expect("S3 client is built when private_storage == s3"),
-                // clap's `required_if_eq` on `private_s3_bucket` guarantees
-                // this is `Some` whenever private_storage == s3.
-                args.private_s3_bucket
-                    .clone()
-                    .expect("clap-required: private_s3_bucket"),
-                StorageType::PRIV,
-                args.private_s3_prefix.as_deref(),
-            )?),
-        },
+        storage: make_storage(resolved.private_storage, StorageType::PRIV, s3_client)?,
         keychain: private_keychain,
     };
 
     // generate keys
-    match args.mode {
-        Mode::Centralized => {
+    match resolved.mode {
+        KeygenMode::Centralized => {
             let mut cmdargs = CentralCmdArgs {
                 pub_storage: &mut pub_storage,
                 priv_storage: &mut priv_vault,
-                deterministic: args.deterministic,
-                overwrite: args.overwrite,
-                show_existing: args.show_existing,
+                deterministic: resolved.deterministic,
+                overwrite: resolved.overwrite,
+                show_existing: resolved.show_existing,
             };
             handle_central_cmd(&mut cmdargs).await;
         }
-        Mode::Threshold {
+        KeygenMode::Threshold {
             signing_key_party_id,
             tls_subject,
             tls_wildcard,
@@ -329,9 +701,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut cmdargs = ThresholdCmdArgs {
                 pub_storage: &mut pub_storage,
                 priv_storage: &mut priv_vault,
-                deterministic: args.deterministic,
-                overwrite: args.overwrite,
-                show_existing: args.show_existing,
+                deterministic: resolved.deterministic,
+                overwrite: resolved.overwrite,
+                show_existing: resolved.show_existing,
                 signing_key_party_id,
                 tls_subject,
                 tls_wildcard,
@@ -451,5 +823,272 @@ async fn show_key<S: Storage>(storage: &S, data_type: &str) {
         // TODO read the key material and print extra info
         let exists = storage.data_exists(&id, data_type).await.unwrap();
         println!("{data_type}, {id}, exists={exists}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_config() -> KmsGenKeysOnlyConfig {
+        KmsGenKeysOnlyConfig {
+            keygen: Some(KeygenConfig {
+                enabled: Some(true),
+            }),
+            aws: None,
+            public_vault: None,
+            private_vault: None,
+            backup_vault: None,
+            threshold: None,
+            enclave_bootstrap: None,
+            #[cfg(feature = "insecure")]
+            mock_enclave: None,
+        }
+    }
+
+    fn threshold_config(my_id: Option<usize>) -> KeygenThresholdConfig {
+        KeygenThresholdConfig {
+            my_id,
+            tls_subject: None,
+            tls_wildcard: None,
+            peers: None,
+        }
+    }
+
+    fn peer(party_id: usize, address: &str, mpc_identity: Option<&str>) -> PeerConf {
+        PeerConf {
+            party_id,
+            address: address.to_string(),
+            mpc_identity: mpc_identity.map(ToString::to_string),
+            port: 50001,
+            tls_cert: None,
+            verification_address: None,
+        }
+    }
+
+    fn resolve_config_for_test(
+        config: KmsGenKeysConfigFile,
+    ) -> anyhow::Result<KmsGenKeysRunConfig> {
+        resolve_config_file(
+            config,
+            false,
+            false,
+            false,
+            #[cfg(feature = "insecure")]
+            false,
+        )
+    }
+
+    fn resolved_tls_subject(resolved: KmsGenKeysRunConfig) -> String {
+        match resolved.mode {
+            KeygenMode::Threshold { tls_subject, .. } => tls_subject,
+            KeygenMode::Centralized => panic!("expected threshold mode"),
+        }
+    }
+
+    #[test]
+    fn config_file_resolves_centralized_defaults() {
+        let resolved =
+            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(base_config()))).unwrap();
+
+        assert_eq!(resolved.mode, KeygenMode::Centralized);
+        assert!(resolved.public_storage.is_none());
+        assert!(resolved.private_storage.is_none());
+        assert!(resolved.private_keychain.is_none());
+    }
+
+    #[test]
+    fn threshold_tls_subject_prefers_explicit_config() {
+        let mut config = base_config();
+        let mut threshold = threshold_config(Some(2));
+        threshold.tls_subject = Some(" explicit-party ".to_string());
+        threshold.peers = Some(vec![peer(2, "peer-address", Some("peer-identity"))]);
+        config.threshold = Some(threshold);
+
+        let resolved =
+            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+
+        assert_eq!(resolved_tls_subject(resolved), "explicit-party");
+    }
+
+    #[test]
+    fn threshold_tls_subject_uses_matching_peer_identity() {
+        let mut config = base_config();
+        let mut threshold = threshold_config(Some(2));
+        threshold.peers = Some(vec![
+            peer(1, "party-one-address", Some("party-one")),
+            peer(2, "party-two-address", Some("party-two")),
+        ]);
+        config.threshold = Some(threshold);
+
+        let resolved =
+            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+
+        assert_eq!(resolved_tls_subject(resolved), "party-two");
+    }
+
+    #[test]
+    fn threshold_tls_subject_falls_back_to_peer_address() {
+        let mut config = base_config();
+        let mut threshold = threshold_config(Some(1));
+        threshold.peers = Some(vec![peer(1, "party-one-address", Some("   "))]);
+        config.threshold = Some(threshold);
+
+        let resolved =
+            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+
+        assert_eq!(resolved_tls_subject(resolved), "party-one-address");
+    }
+
+    #[test]
+    fn threshold_config_requires_my_id() {
+        let mut config = base_config();
+        let mut threshold = threshold_config(None);
+        threshold.tls_subject = Some("party-one".to_string());
+        config.threshold = Some(threshold);
+
+        let err = resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config)))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("threshold.my_id"));
+    }
+
+    #[test]
+    fn threshold_config_requires_matching_peer_when_subject_is_not_explicit() {
+        let mut config = base_config();
+        let mut threshold = threshold_config(Some(2));
+        threshold.peers = Some(vec![peer(1, "party-one-address", None)]);
+        config.threshold = Some(threshold);
+
+        let err = resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config)))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("no entry for party 2"));
+    }
+
+    #[test]
+    fn config_file_preserves_aws_storage_and_keychain() {
+        let mut config = base_config();
+        config.aws = Some(AWSConfig {
+            region: "us-east-1".to_string(),
+            role_arn: Some("arn:aws:iam::123456789012:role/kms".to_string()),
+            imds_endpoint: Some(Url::parse("http://127.0.0.1:5000").unwrap()),
+            sts_endpoint: Some(Url::parse("http://127.0.0.1:4566").unwrap()),
+            s3_endpoint: Some(Url::parse("http://127.0.0.1:4566").unwrap()),
+            awskms_endpoint: Some(Url::parse("http://127.0.0.1:4566").unwrap()),
+        });
+        config.public_vault = Some(VaultConfig {
+            storage: StorageConfig::S3(S3StorageConfig {
+                bucket: "public-bucket".to_string(),
+                prefix: Some("PUB-p1".to_string()),
+            }),
+            keychain: None,
+        });
+        config.private_vault = Some(VaultConfig {
+            storage: StorageConfig::File(FileStorageConfig {
+                path: PathBuf::from("/keys"),
+                prefix: Some("PRIV-p1".to_string()),
+            }),
+            keychain: Some(Keychain::AwsKms(AwsKmsKeychain {
+                root_key_id: "root-key".to_string(),
+                root_key_spec: AwsKmsKeySpec::Symm,
+            })),
+        });
+
+        let resolved =
+            resolve_config_for_test(KmsGenKeysConfigFile::Keygen(Box::new(config))).unwrap();
+
+        assert_eq!(
+            resolved.aws.as_ref().map(|aws| aws.region.as_str()),
+            Some("us-east-1")
+        );
+        assert_eq!(
+            resolved.public_storage,
+            Some(StorageConfig::S3(S3StorageConfig {
+                bucket: "public-bucket".to_string(),
+                prefix: Some("PUB-p1".to_string()),
+            }))
+        );
+        assert_eq!(
+            resolved.private_storage,
+            Some(StorageConfig::File(FileStorageConfig {
+                path: PathBuf::from("/keys"),
+                prefix: Some("PRIV-p1".to_string()),
+            }))
+        );
+        assert_eq!(
+            resolved.private_keychain,
+            Some(Keychain::AwsKms(AwsKmsKeychain {
+                root_key_id: "root-key".to_string(),
+                root_key_spec: AwsKmsKeySpec::Symm,
+            }))
+        );
+    }
+
+    #[test]
+    fn server_config_uses_core_config_threshold_shape() {
+        let config = init_conf::<KmsGenKeysConfigFile>("config/default_1").unwrap();
+        config.validate().unwrap();
+
+        let resolved = resolve_config_for_test(config).unwrap();
+
+        assert_eq!(resolved_tls_subject(resolved), "p1");
+    }
+
+    #[test]
+    fn keygen_toml_deserializes_and_resolves() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("kms-gen-keys.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[keygen]
+enabled = true
+
+[threshold]
+my_id = 2
+tls_subject = "kms-core-2"
+
+[aws]
+region = "eu-west-3"
+s3_endpoint = "http://127.0.0.1:4566"
+awskms_endpoint = "http://127.0.0.1:4566"
+
+[public_vault.storage.s3]
+bucket = "public-bucket"
+prefix = "PUB-p2"
+
+[private_vault.storage.s3]
+bucket = "private-bucket"
+prefix = "PRIV-p2"
+
+[private_vault.keychain.aws_kms]
+root_key_id = "root-key"
+root_key_spec = "symm"
+"#,
+        )
+        .unwrap();
+
+        let config = init_conf::<KmsGenKeysConfigFile>(config_path.to_str().unwrap()).unwrap();
+        config.validate().unwrap();
+        let resolved = resolve_config_for_test(config).unwrap();
+
+        assert_eq!(resolved_tls_subject(resolved.clone()), "kms-core-2");
+        assert_eq!(
+            resolved.public_storage,
+            Some(StorageConfig::S3(S3StorageConfig {
+                bucket: "public-bucket".to_string(),
+                prefix: Some("PUB-p2".to_string()),
+            }))
+        );
+        assert_eq!(
+            resolved.private_storage,
+            Some(StorageConfig::S3(S3StorageConfig {
+                bucket: "private-bucket".to_string(),
+                prefix: Some("PRIV-p2".to_string()),
+            }))
+        );
     }
 }

--- a/core/service/src/bin/kms-gen-keys.rs
+++ b/core/service/src/bin/kms-gen-keys.rs
@@ -34,7 +34,23 @@ use validator::Validate;
     In centralized mode it produces a single signing key plus its verification material. \
     In threshold mode it produces the signing key and self-signed CA certificate for one party; \
     run it once per party in a multi-party deployment. \
-    Pass --config-file to provide the key-generation settings."
+    Pass --config-file to provide the key-generation settings.",
+    after_long_help = r#"Config file example:
+
+[keygen]
+overwrite = false
+show_existing = false
+
+[public_vault.storage.file]
+path = "./keys"
+
+[private_vault.storage.file]
+path = "./keys"
+
+# Add this section to generate threshold signing material for one party.
+[threshold]
+my_id = 1
+tls_subject = "kms-core-1""#
 )]
 struct Args {
     /// Read key-generation settings from a TOML config file.
@@ -52,49 +68,67 @@ enum KeygenMode {
     },
 }
 
+/// Full TOML configuration accepted by the kms-gen-keys binary.
 #[derive(Serialize, Deserialize, Validate, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 struct KmsGenKeysConfig {
+    /// Required key-generation controls such as overwrite and listing behavior.
     #[validate(nested)]
     keygen: KeygenConfig,
+    /// AWS settings used when any configured storage or keychain depends on AWS services.
     #[validate(nested)]
     aws: Option<AWSConfig>,
+    /// Public vault where verification keys, verification addresses, and CA certificates are stored.
     #[validate(nested)]
     public_vault: Option<VaultConfig>,
+    /// Private vault where server signing keys are stored.
     #[validate(nested)]
     private_vault: Option<VaultConfig>,
+    /// Backup vault settings accepted for consistency with server configs but unused by key generation.
     #[validate(nested)]
     backup_vault: Option<VaultConfig>,
+    /// Threshold-party settings; when absent, centralized signing material is generated.
     #[validate(nested)]
     threshold: Option<KeygenThresholdConfig>,
+    /// Enclave bootstrap settings accepted for consistency with server configs but unused by key generation.
     #[validate(nested)]
     enclave_bootstrap: Option<EnclaveBootstrapConfig>,
     #[cfg(feature = "insecure")]
+    /// Use the software-emulated enclave security module for local testing. Defaults to false.
     #[serde(default)]
     mock_enclave: bool,
 }
 
+/// Options under the required `[keygen]` section.
 #[derive(Serialize, Deserialize, Validate, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 struct KeygenConfig {
     #[cfg(feature = "insecure")]
+    /// Generate deterministic test keys instead of fresh random keys. Defaults to false.
     #[serde(default)]
     deterministic: bool,
+    /// Delete existing signing material at the fixed signing-key request ID before generation. Defaults to false.
     #[serde(default)]
     overwrite: bool,
+    /// Print existing signing-material handles instead of generating or deleting keys. Defaults to false.
     #[serde(default)]
     show_existing: bool,
 }
 
+/// Optional `[threshold]` section used when generating one threshold party's signing material.
 #[derive(Serialize, Deserialize, Validate, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 struct KeygenThresholdConfig {
+    /// One-indexed party id whose threshold signing material should be generated.
     #[validate(range(min = 1))]
     my_id: Option<usize>,
+    /// TLS certificate subject for the generated self-signed CA certificate.
     #[validate(length(min = 1))]
     tls_subject: Option<String>,
+    /// Generate a wildcard TLS certificate subject for the party. Defaults to false.
     #[serde(default)]
     tls_wildcard: bool,
+    /// Peer list used to derive the TLS subject when `tls_subject` is not set.
     #[validate(nested)]
     peers: Option<Vec<PeerConf>>,
 }
@@ -202,6 +236,24 @@ fn resolve_threshold_tls_subject(
 /// cargo run --bin kms-gen-keys -- --config-file /path/to/kms-gen-keys.toml
 /// cargo run --bin kms-gen-keys -- --help
 /// ```
+///
+/// Minimal config file:
+/// ```toml
+/// [keygen]
+/// overwrite = false
+/// show_existing = false
+///
+/// [public_vault.storage.file]
+/// path = "./keys"
+///
+/// [private_vault.storage.file]
+/// path = "./keys"
+///
+/// # Add this section to generate threshold signing material for one party.
+/// [threshold]
+/// my_id = 1
+/// tls_subject = "kms-core-1"
+/// ```
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
@@ -219,6 +271,12 @@ async fn main() -> anyhow::Result<()> {
         .as_ref()
         .map(|vault| vault.storage.clone());
     let private_vault = config.private_vault.as_ref();
+    if private_vault.is_none() {
+        tracing::warn!(
+            "No [private_vault] section configured; kms-gen-keys will store private signing keys \
+            in unencrypted filesystem storage using the default private storage path"
+        );
+    }
     let private_storage = private_vault.map(|vault| vault.storage.clone());
     let private_keychain_config = private_vault.and_then(|vault| vault.keychain.clone());
 

--- a/core/service/src/bin/kms-gen-keys.rs
+++ b/core/service/src/bin/kms-gen-keys.rs
@@ -52,24 +52,9 @@ enum KeygenMode {
     },
 }
 
-#[derive(Clone, Debug)]
-struct KmsGenKeysRunConfig {
-    mode: KeygenMode,
-    aws: Option<AWSConfig>,
-    public_storage: Option<StorageConfig>,
-    private_storage: Option<StorageConfig>,
-    private_keychain: Option<Keychain>,
-    #[cfg(feature = "insecure")]
-    deterministic: bool,
-    overwrite: bool,
-    show_existing: bool,
-    #[cfg(feature = "insecure")]
-    mock_enclave: bool,
-}
-
 #[derive(Serialize, Deserialize, Validate, Clone, Debug)]
 #[serde(deny_unknown_fields)]
-struct KmsGenKeysOnlyConfig {
+struct KmsGenKeysConfig {
     #[validate(nested)]
     keygen: KeygenConfig,
     #[validate(nested)]
@@ -85,18 +70,20 @@ struct KmsGenKeysOnlyConfig {
     #[validate(nested)]
     enclave_bootstrap: Option<EnclaveBootstrapConfig>,
     #[cfg(feature = "insecure")]
-    mock_enclave: Option<bool>,
+    #[serde(default)]
+    mock_enclave: bool,
 }
 
 #[derive(Serialize, Deserialize, Validate, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 struct KeygenConfig {
     #[cfg(feature = "insecure")]
-    deterministic: Option<bool>,
-    overwrite: Option<bool>,
-    show_existing: Option<bool>,
-    #[cfg(feature = "insecure")]
-    mock_enclave: Option<bool>,
+    #[serde(default)]
+    deterministic: bool,
+    #[serde(default)]
+    overwrite: bool,
+    #[serde(default)]
+    show_existing: bool,
 }
 
 #[derive(Serialize, Deserialize, Validate, Clone, Debug)]
@@ -106,7 +93,8 @@ struct KeygenThresholdConfig {
     my_id: Option<usize>,
     #[validate(length(min = 1))]
     tls_subject: Option<String>,
-    tls_wildcard: Option<bool>,
+    #[serde(default)]
+    tls_wildcard: bool,
     #[validate(nested)]
     peers: Option<Vec<PeerConf>>,
 }
@@ -132,8 +120,8 @@ struct ThresholdCmdArgs<'a, PubS: Storage, PrivS: Storage> {
     tls_wildcard: bool,
 }
 
-fn resolve_args(args: &Args) -> anyhow::Result<KmsGenKeysRunConfig> {
-    let config = init_conf::<KmsGenKeysOnlyConfig>(&args.config_file).with_context(|| {
+fn resolve_args(args: &Args) -> anyhow::Result<KmsGenKeysConfig> {
+    let config = init_conf::<KmsGenKeysConfig>(&args.config_file).with_context(|| {
         format!(
             "failed to load kms-gen-keys config file {}; expected a [keygen] section",
             args.config_file
@@ -142,31 +130,7 @@ fn resolve_args(args: &Args) -> anyhow::Result<KmsGenKeysRunConfig> {
     config
         .validate()
         .context("invalid kms-gen-keys config file")?;
-    resolve_keygen_config_file(config)
-}
-
-fn resolve_keygen_config_file(config: KmsGenKeysOnlyConfig) -> anyhow::Result<KmsGenKeysRunConfig> {
-    let mode = resolve_keygen_config_mode(config.threshold.as_ref())?;
-    let keygen = &config.keygen;
-    let public_storage = config.public_vault.map(|vault| vault.storage);
-    let (private_storage, private_keychain) = config
-        .private_vault
-        .map(|vault| (Some(vault.storage), vault.keychain))
-        .unwrap_or((None, None));
-
-    Ok(KmsGenKeysRunConfig {
-        mode,
-        aws: config.aws,
-        public_storage,
-        private_storage,
-        private_keychain,
-        #[cfg(feature = "insecure")]
-        deterministic: keygen.deterministic.unwrap_or(false),
-        overwrite: keygen.overwrite.unwrap_or(false),
-        show_existing: keygen.show_existing.unwrap_or(false),
-        #[cfg(feature = "insecure")]
-        mock_enclave: keygen.mock_enclave.or(config.mock_enclave).unwrap_or(false),
-    })
+    Ok(config)
 }
 
 fn resolve_keygen_config_mode(
@@ -190,7 +154,7 @@ fn resolve_keygen_config_mode(
     Ok(KeygenMode::Threshold {
         signing_key_party_id,
         tls_subject,
-        tls_wildcard: threshold.tls_wildcard.unwrap_or(false),
+        tls_wildcard: threshold.tls_wildcard,
     })
 }
 
@@ -248,24 +212,25 @@ async fn main() -> anyhow::Result<()> {
         .build();
     init_tracing(&telemetry).await?;
 
-    let resolved = resolve_args(&args)?;
+    let config = resolve_args(&args)?;
+    let mode = resolve_keygen_config_mode(config.threshold.as_ref())?;
+    let public_storage = config
+        .public_vault
+        .as_ref()
+        .map(|vault| vault.storage.clone());
+    let private_vault = config.private_vault.as_ref();
+    let private_storage = private_vault.map(|vault| vault.storage.clone());
+    let private_keychain_config = private_vault.and_then(|vault| vault.keychain.clone());
 
     // AWS S3 client
-    let need_s3_client = resolved
-        .public_storage
-        .as_ref()
-        .is_some_and(StorageConfig::is_s_3)
-        || resolved
-            .private_storage
-            .as_ref()
-            .is_some_and(StorageConfig::is_s_3);
+    let need_s3_client = public_storage.as_ref().is_some_and(StorageConfig::is_s_3)
+        || private_storage.as_ref().is_some_and(StorageConfig::is_s_3);
     // AWS KMS client
-    let need_awskms_client = resolved
-        .private_keychain
+    let need_awskms_client = private_keychain_config
         .as_ref()
         .is_some_and(Keychain::is_aws_kms);
-    let aws_sdk_config = if need_s3_client || need_awskms_client || resolved.aws.is_some() {
-        let aws = resolved
+    let aws_sdk_config = if need_s3_client || need_awskms_client || config.aws.is_some() {
+        let aws = config
             .aws
             .as_ref()
             .context("[aws] config is required when using S3 storage or an AWS KMS keychain")?;
@@ -286,10 +251,7 @@ async fn main() -> anyhow::Result<()> {
                 aws_sdk_config
                     .as_ref()
                     .expect("AWS config is built when S3 storage is configured"),
-                resolved
-                    .aws
-                    .as_ref()
-                    .and_then(|aws| aws.s3_endpoint.clone()),
+                config.aws.as_ref().and_then(|aws| aws.s3_endpoint.clone()),
             )
             .await?,
         )
@@ -302,7 +264,7 @@ async fn main() -> anyhow::Result<()> {
                 aws_sdk_config
                     .as_ref()
                     .expect("AWS config is built when AWS KMS keychain is configured"),
-                resolved
+                config
                     .aws
                     .as_ref()
                     .and_then(|aws| aws.awskms_endpoint.clone()),
@@ -316,7 +278,7 @@ async fn main() -> anyhow::Result<()> {
     let security_module = if need_awskms_client {
         Some(Arc::new(make_security_module(
             #[cfg(feature = "insecure")]
-            resolved.mock_enclave,
+            config.mock_enclave,
         )?))
     } else {
         None
@@ -324,12 +286,8 @@ async fn main() -> anyhow::Result<()> {
 
     // create storages (one pub + one priv per invocation; multi-party
     // deployments invoke this binary once per party)
-    let mut pub_storage = make_storage(
-        resolved.public_storage.clone(),
-        StorageType::PUB,
-        s3_client.clone(),
-    )?;
-    let private_keychain = OptionFuture::from(resolved.private_keychain.as_ref().map(|k| {
+    let mut pub_storage = make_storage(public_storage, StorageType::PUB, s3_client.clone())?;
+    let private_keychain = OptionFuture::from(private_keychain_config.as_ref().map(|k| {
         make_keychain_proxy(
             k,
             awskms_client.clone(),
@@ -341,20 +299,20 @@ async fn main() -> anyhow::Result<()> {
     .await
     .transpose()?;
     let mut priv_vault = Vault {
-        storage: make_storage(resolved.private_storage, StorageType::PRIV, s3_client)?,
+        storage: make_storage(private_storage, StorageType::PRIV, s3_client)?,
         keychain: private_keychain,
     };
 
     // generate keys
-    match resolved.mode {
+    match mode {
         KeygenMode::Centralized => {
             let mut cmdargs = CentralCmdArgs {
                 pub_storage: &mut pub_storage,
                 priv_storage: &mut priv_vault,
                 #[cfg(feature = "insecure")]
-                deterministic: resolved.deterministic,
-                overwrite: resolved.overwrite,
-                show_existing: resolved.show_existing,
+                deterministic: config.keygen.deterministic,
+                overwrite: config.keygen.overwrite,
+                show_existing: config.keygen.show_existing,
             };
             handle_central_cmd(&mut cmdargs).await;
         }
@@ -367,9 +325,9 @@ async fn main() -> anyhow::Result<()> {
                 pub_storage: &mut pub_storage,
                 priv_storage: &mut priv_vault,
                 #[cfg(feature = "insecure")]
-                deterministic: resolved.deterministic,
-                overwrite: resolved.overwrite,
-                show_existing: resolved.show_existing,
+                deterministic: config.keygen.deterministic,
+                overwrite: config.keygen.overwrite,
+                show_existing: config.keygen.show_existing,
                 signing_key_party_id,
                 tls_subject,
                 tls_wildcard,
@@ -504,14 +462,13 @@ mod tests {
     use std::path::PathBuf;
     use url::Url;
 
-    fn base_config() -> KmsGenKeysOnlyConfig {
-        KmsGenKeysOnlyConfig {
+    fn base_config() -> KmsGenKeysConfig {
+        KmsGenKeysConfig {
             keygen: KeygenConfig {
-                deterministic: None,
-                overwrite: None,
-                show_existing: None,
                 #[cfg(feature = "insecure")]
-                mock_enclave: None,
+                deterministic: false,
+                overwrite: false,
+                show_existing: false,
             },
             aws: None,
             public_vault: None,
@@ -520,7 +477,7 @@ mod tests {
             threshold: None,
             enclave_bootstrap: None,
             #[cfg(feature = "insecure")]
-            mock_enclave: None,
+            mock_enclave: false,
         }
     }
 
@@ -528,7 +485,7 @@ mod tests {
         KeygenThresholdConfig {
             my_id,
             tls_subject: None,
-            tls_wildcard: None,
+            tls_wildcard: false,
             peers: None,
         }
     }
@@ -544,14 +501,12 @@ mod tests {
         }
     }
 
-    fn resolve_config_for_test(
-        config: KmsGenKeysOnlyConfig,
-    ) -> anyhow::Result<KmsGenKeysRunConfig> {
-        resolve_keygen_config_file(config)
+    fn resolve_mode_for_test(config: &KmsGenKeysConfig) -> anyhow::Result<KeygenMode> {
+        resolve_keygen_config_mode(config.threshold.as_ref())
     }
 
-    fn resolved_tls_subject(resolved: KmsGenKeysRunConfig) -> String {
-        match resolved.mode {
+    fn resolved_tls_subject(mode: KeygenMode) -> String {
+        match mode {
             KeygenMode::Threshold { tls_subject, .. } => tls_subject,
             KeygenMode::Centralized => panic!("expected threshold mode"),
         }
@@ -559,46 +514,63 @@ mod tests {
 
     #[test]
     fn config_file_resolves_centralized_defaults() {
-        let resolved = resolve_config_for_test(base_config()).unwrap();
+        let config = base_config();
+        let mode = resolve_mode_for_test(&config).unwrap();
 
-        assert_eq!(resolved.mode, KeygenMode::Centralized);
-        assert!(resolved.public_storage.is_none());
-        assert!(resolved.private_storage.is_none());
-        assert!(resolved.private_keychain.is_none());
+        assert_eq!(mode, KeygenMode::Centralized);
+        assert!(config.public_vault.is_none());
+        assert!(config.private_vault.is_none());
+        assert!(!config.keygen.overwrite);
+        assert!(!config.keygen.show_existing);
+        #[cfg(feature = "insecure")]
+        assert!(!config.keygen.deterministic);
+        #[cfg(feature = "insecure")]
+        assert!(!config.mock_enclave);
     }
 
     #[test]
     fn keygen_flags_are_read_from_config() {
         let mut config = base_config();
         config.keygen = KeygenConfig {
-            deterministic: Some(true),
-            overwrite: Some(true),
-            show_existing: Some(true),
             #[cfg(feature = "insecure")]
-            mock_enclave: None,
+            deterministic: true,
+            overwrite: true,
+            show_existing: true,
         };
 
-        let resolved = resolve_config_for_test(config).unwrap();
-
-        assert!(resolved.deterministic);
-        assert!(resolved.overwrite);
-        assert!(resolved.show_existing);
+        #[cfg(feature = "insecure")]
+        assert!(config.keygen.deterministic);
+        assert!(config.keygen.overwrite);
+        assert!(config.keygen.show_existing);
     }
 
     #[cfg(feature = "insecure")]
     #[test]
     fn mock_enclave_is_read_from_config() {
         let mut config = base_config();
-        config.keygen = KeygenConfig {
-            deterministic: None,
-            overwrite: None,
-            show_existing: None,
-            mock_enclave: Some(true),
-        };
+        config.mock_enclave = true;
 
-        let resolved = resolve_config_for_test(config).unwrap();
+        assert!(config.mock_enclave);
+    }
 
-        assert!(resolved.mock_enclave);
+    #[cfg(feature = "insecure")]
+    #[test]
+    fn keygen_toml_deserializes_top_level_mock_enclave() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("kms-gen-keys.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+mock_enclave = true
+
+[keygen]
+"#,
+        )
+        .unwrap();
+
+        let config = init_conf::<KmsGenKeysConfig>(config_path.to_str().unwrap()).unwrap();
+
+        assert!(config.mock_enclave);
     }
 
     #[test]
@@ -609,9 +581,9 @@ mod tests {
         threshold.peers = Some(vec![peer(2, "peer-address", Some("peer-identity"))]);
         config.threshold = Some(threshold);
 
-        let resolved = resolve_config_for_test(config).unwrap();
+        let mode = resolve_mode_for_test(&config).unwrap();
 
-        assert_eq!(resolved_tls_subject(resolved), "explicit-party");
+        assert_eq!(resolved_tls_subject(mode), "explicit-party");
     }
 
     #[test]
@@ -624,9 +596,9 @@ mod tests {
         ]);
         config.threshold = Some(threshold);
 
-        let resolved = resolve_config_for_test(config).unwrap();
+        let mode = resolve_mode_for_test(&config).unwrap();
 
-        assert_eq!(resolved_tls_subject(resolved), "party-two");
+        assert_eq!(resolved_tls_subject(mode), "party-two");
     }
 
     #[test]
@@ -636,9 +608,9 @@ mod tests {
         threshold.peers = Some(vec![peer(1, "party-one-address", Some("   "))]);
         config.threshold = Some(threshold);
 
-        let resolved = resolve_config_for_test(config).unwrap();
+        let mode = resolve_mode_for_test(&config).unwrap();
 
-        assert_eq!(resolved_tls_subject(resolved), "party-one-address");
+        assert_eq!(resolved_tls_subject(mode), "party-one-address");
     }
 
     #[test]
@@ -648,7 +620,7 @@ mod tests {
         threshold.tls_subject = Some("party-one".to_string());
         config.threshold = Some(threshold);
 
-        let err = resolve_config_for_test(config).unwrap_err().to_string();
+        let err = resolve_mode_for_test(&config).unwrap_err().to_string();
 
         assert!(err.contains("threshold.my_id"));
     }
@@ -660,7 +632,7 @@ mod tests {
         threshold.peers = Some(vec![peer(1, "party-one-address", None)]);
         config.threshold = Some(threshold);
 
-        let err = resolve_config_for_test(config).unwrap_err().to_string();
+        let err = resolve_mode_for_test(&config).unwrap_err().to_string();
 
         assert!(err.contains("no entry for party 2"));
     }
@@ -694,28 +666,35 @@ mod tests {
             })),
         });
 
-        let resolved = resolve_config_for_test(config).unwrap();
-
         assert_eq!(
-            resolved.aws.as_ref().map(|aws| aws.region.as_str()),
+            config.aws.as_ref().map(|aws| aws.region.as_str()),
             Some("us-east-1")
         );
         assert_eq!(
-            resolved.public_storage,
+            config
+                .public_vault
+                .as_ref()
+                .map(|vault| vault.storage.clone()),
             Some(StorageConfig::S3(S3StorageConfig {
                 bucket: "public-bucket".to_string(),
                 prefix: Some("PUB-p1".to_string()),
             }))
         );
         assert_eq!(
-            resolved.private_storage,
+            config
+                .private_vault
+                .as_ref()
+                .map(|vault| vault.storage.clone()),
             Some(StorageConfig::File(FileStorageConfig {
                 path: PathBuf::from("/keys"),
                 prefix: Some("PRIV-p1".to_string()),
             }))
         );
         assert_eq!(
-            resolved.private_keychain,
+            config
+                .private_vault
+                .as_ref()
+                .and_then(|vault| vault.keychain.clone()),
             Some(Keychain::AwsKms(AwsKmsKeychain {
                 root_key_id: "root-key".to_string(),
                 root_key_spec: AwsKmsKeySpec::Symm,
@@ -727,11 +706,16 @@ mod tests {
     fn keygen_toml_deserializes_and_resolves() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("kms-gen-keys.toml");
+        #[cfg(feature = "insecure")]
+        let deterministic_config = "deterministic = true";
+        #[cfg(not(feature = "insecure"))]
+        let deterministic_config = "";
         std::fs::write(
             &config_path,
-            r#"
+            format!(
+                r#"
 [keygen]
-deterministic = true
+{deterministic_config}
 overwrite = true
 
 [threshold]
@@ -755,25 +739,33 @@ prefix = "PRIV-p2"
 root_key_id = "root-key"
 root_key_spec = "symm"
 "#,
+            ),
         )
         .unwrap();
 
-        let config = init_conf::<KmsGenKeysOnlyConfig>(config_path.to_str().unwrap()).unwrap();
+        let config = init_conf::<KmsGenKeysConfig>(config_path.to_str().unwrap()).unwrap();
         config.validate().unwrap();
-        let resolved = resolve_config_for_test(config).unwrap();
+        let mode = resolve_mode_for_test(&config).unwrap();
 
-        assert_eq!(resolved_tls_subject(resolved.clone()), "kms-core-2");
-        assert!(resolved.deterministic);
-        assert!(resolved.overwrite);
+        assert_eq!(resolved_tls_subject(mode), "kms-core-2");
+        #[cfg(feature = "insecure")]
+        assert!(config.keygen.deterministic);
+        assert!(config.keygen.overwrite);
         assert_eq!(
-            resolved.public_storage,
+            config
+                .public_vault
+                .as_ref()
+                .map(|vault| vault.storage.clone()),
             Some(StorageConfig::S3(S3StorageConfig {
                 bucket: "public-bucket".to_string(),
                 prefix: Some("PUB-p2".to_string()),
             }))
         );
         assert_eq!(
-            resolved.private_storage,
+            config
+                .private_vault
+                .as_ref()
+                .map(|vault| vault.storage.clone()),
             Some(StorageConfig::S3(S3StorageConfig {
                 bucket: "private-bucket".to_string(),
                 prefix: Some("PRIV-p2".to_string()),

--- a/core/service/src/bin/kms-server.rs
+++ b/core/service/src/bin/kms-server.rs
@@ -2,7 +2,7 @@ use algebra::{
     galois_fields::lagrange::init_lagrange_stores, galois_rings::degree_4::ResiduePolyF4Z128,
     structure_traits::Ring,
 };
-use anyhow::ensure;
+use anyhow::{Context, ensure};
 use clap::Parser;
 use futures_util::future::OptionFuture;
 use kms_grpc::rpc_types::{KMSType, PubDataType};
@@ -328,7 +328,12 @@ fn main() -> anyhow::Result<()> {
     let args = KmsArgs::parse();
     // NOTE: this config is only needed to set up the tokio runtime
     // we read it again in [main_exec] to set up the rest of the server
-    let core_config = init_conf::<CoreConfig>(&args.config_file)?;
+    let core_config = init_conf::<CoreConfig>(&args.config_file).with_context(|| {
+        format!(
+            "failed to load kms-server config file {}; expected a [service] section",
+            args.config_file
+        )
+    })?;
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/core/service/src/cryptography/attestation/mod.rs
+++ b/core/service/src/cryptography/attestation/mod.rs
@@ -239,7 +239,7 @@ pub trait SecurityModule {
     }
 }
 
-#[expect(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 #[enum_dispatch(SecurityModule)]
 pub enum SecurityModuleProxy {
     Nitro(nitro::Nitro),

--- a/core/service/src/util/key_setup/mod.rs
+++ b/core/service/src/util/key_setup/mod.rs
@@ -165,7 +165,7 @@ pub async fn ensure_central_server_signing_keys_exist<PubS, PrivS>(
     pub_storage: &mut PubS,
     priv_storage: &mut PrivS,
     req_id: &RequestId,
-    #[cfg(feature = "insecure")] deterministic: bool,
+    #[cfg(any(test, feature = "testing", feature = "insecure"))] deterministic: bool,
 ) -> bool
 where
     PubS: Storage,
@@ -259,9 +259,9 @@ where
 
         return false;
     }
-    #[cfg(feature = "insecure")]
+    #[cfg(any(test, feature = "testing", feature = "insecure"))]
     let mut rng = get_rng(deterministic, Some(0));
-    #[cfg(not(feature = "insecure"))]
+    #[cfg(not(any(test, feature = "testing", feature = "insecure")))]
     let mut rng = get_rng(false, Some(0));
     let (pk, sk) = gen_sig_keys(&mut rng);
 
@@ -669,7 +669,7 @@ pub async fn ensure_threshold_server_signing_keys_exist<PubS, PrivS>(
     pub_storages: &mut [PubS],
     priv_storages: &mut [PrivS],
     request_id: &RequestId,
-    #[cfg(feature = "insecure")] deterministic: bool,
+    #[cfg(any(test, feature = "testing", feature = "insecure"))] deterministic: bool,
     config: ThresholdSigningKeyConfig,
     tls_wildcard: bool,
 ) -> anyhow::Result<()>
@@ -708,7 +708,7 @@ where
             &mut pub_storages[storage_index],
             &mut priv_storages[storage_index],
             request_id,
-            #[cfg(feature = "insecure")]
+            #[cfg(any(test, feature = "testing", feature = "insecure"))]
             deterministic,
             // 1-based party id; NonZeroUsize by construction (saturates on overflow).
             // computes storage_index + 1
@@ -733,7 +733,7 @@ pub async fn ensure_threshold_server_signing_key_exists<PubS, PrivS>(
     pub_storage: &mut PubS,
     priv_storage: &mut PrivS,
     request_id: &RequestId,
-    #[cfg(feature = "insecure")] deterministic: bool,
+    #[cfg(any(test, feature = "testing", feature = "insecure"))] deterministic: bool,
     party_id: std::num::NonZeroUsize,
     subject: String,
     tls_wildcard: bool,
@@ -742,9 +742,9 @@ where
     PubS: Storage,
     PrivS: Storage,
 {
-    #[cfg(feature = "insecure")]
+    #[cfg(any(test, feature = "testing", feature = "insecure"))]
     let mut rng = get_rng(deterministic, Some(party_id.get() as u64));
-    #[cfg(not(feature = "insecure"))]
+    #[cfg(not(any(test, feature = "testing", feature = "insecure")))]
     let mut rng = get_rng(false, Some(party_id.get() as u64));
 
     // Check if keys already exist with error handling

--- a/core/service/src/util/key_setup/mod.rs
+++ b/core/service/src/util/key_setup/mod.rs
@@ -165,8 +165,7 @@ pub async fn ensure_central_server_signing_keys_exist<PubS, PrivS>(
     pub_storage: &mut PubS,
     priv_storage: &mut PrivS,
     req_id: &RequestId,
-    #[cfg(feature = "insecure")]
-    deterministic: bool,
+    #[cfg(feature = "insecure")] deterministic: bool,
 ) -> bool
 where
     PubS: Storage,
@@ -670,8 +669,7 @@ pub async fn ensure_threshold_server_signing_keys_exist<PubS, PrivS>(
     pub_storages: &mut [PubS],
     priv_storages: &mut [PrivS],
     request_id: &RequestId,
-    #[cfg(feature = "insecure")]
-    deterministic: bool,
+    #[cfg(feature = "insecure")] deterministic: bool,
     config: ThresholdSigningKeyConfig,
     tls_wildcard: bool,
 ) -> anyhow::Result<()>
@@ -735,8 +733,7 @@ pub async fn ensure_threshold_server_signing_key_exists<PubS, PrivS>(
     pub_storage: &mut PubS,
     priv_storage: &mut PrivS,
     request_id: &RequestId,
-    #[cfg(feature = "insecure")]
-    deterministic: bool,
+    #[cfg(feature = "insecure")] deterministic: bool,
     party_id: std::num::NonZeroUsize,
     subject: String,
     tls_wildcard: bool,
@@ -749,7 +746,7 @@ where
     let mut rng = get_rng(deterministic, Some(party_id.get() as u64));
     #[cfg(not(feature = "insecure"))]
     let mut rng = get_rng(false, Some(party_id.get() as u64));
-    
+
     // Check if keys already exist with error handling
     let signing_keys_map: HashMap<RequestId, PrivateSigKey> =
         read_all_data_versioned(priv_storage, &PrivDataType::SigningKey.to_string())

--- a/core/service/src/util/key_setup/mod.rs
+++ b/core/service/src/util/key_setup/mod.rs
@@ -165,6 +165,7 @@ pub async fn ensure_central_server_signing_keys_exist<PubS, PrivS>(
     pub_storage: &mut PubS,
     priv_storage: &mut PrivS,
     req_id: &RequestId,
+    #[cfg(feature = "insecure")]
     deterministic: bool,
 ) -> bool
 where
@@ -259,8 +260,10 @@ where
 
         return false;
     }
-
+    #[cfg(feature = "insecure")]
     let mut rng = get_rng(deterministic, Some(0));
+    #[cfg(not(feature = "insecure"))]
+    let mut rng = get_rng(false, Some(0));
     let (pk, sk) = gen_sig_keys(&mut rng);
 
     // Store public verification key
@@ -667,6 +670,7 @@ pub async fn ensure_threshold_server_signing_keys_exist<PubS, PrivS>(
     pub_storages: &mut [PubS],
     priv_storages: &mut [PrivS],
     request_id: &RequestId,
+    #[cfg(feature = "insecure")]
     deterministic: bool,
     config: ThresholdSigningKeyConfig,
     tls_wildcard: bool,
@@ -706,6 +710,7 @@ where
             &mut pub_storages[storage_index],
             &mut priv_storages[storage_index],
             request_id,
+            #[cfg(feature = "insecure")]
             deterministic,
             // 1-based party id; NonZeroUsize by construction (saturates on overflow).
             // computes storage_index + 1
@@ -730,6 +735,7 @@ pub async fn ensure_threshold_server_signing_key_exists<PubS, PrivS>(
     pub_storage: &mut PubS,
     priv_storage: &mut PrivS,
     request_id: &RequestId,
+    #[cfg(feature = "insecure")]
     deterministic: bool,
     party_id: std::num::NonZeroUsize,
     subject: String,
@@ -739,8 +745,11 @@ where
     PubS: Storage,
     PrivS: Storage,
 {
+    #[cfg(feature = "insecure")]
     let mut rng = get_rng(deterministic, Some(party_id.get() as u64));
-
+    #[cfg(not(feature = "insecure"))]
+    let mut rng = get_rng(false, Some(party_id.get() as u64));
+    
     // Check if keys already exist with error handling
     let signing_keys_map: HashMap<RequestId, PrivateSigKey> =
         read_all_data_versioned(priv_storage, &PrivDataType::SigningKey.to_string())

--- a/core/service/tests/integration_test.rs
+++ b/core/service/tests/integration_test.rs
@@ -40,6 +40,8 @@ mod kms_init_binary_test {
 
 #[cfg(test)]
 mod kms_gen_keys_binary_test {
+    use std::path::{Path, PathBuf};
+
     use tempfile::tempdir;
 
     use super::*;
@@ -59,29 +61,42 @@ mod kms_gen_keys_binary_test {
         command
     }
 
+    fn write_file_storage_config(
+        config_dir: &tempfile::TempDir,
+        private_path: &Path,
+        public_path: &Path,
+        keygen_options: &str,
+        threshold_config: Option<&str>,
+    ) -> PathBuf {
+        let config_path = config_dir.path().join("kms-gen-keys.toml");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+[keygen]
+enabled = true
+{keygen_options}
+{threshold_config}
+[public_vault.storage.file]
+path = "{public_path}"
+
+[private_vault.storage.file]
+path = "{private_path}"
+"#,
+                public_path = public_path.display(),
+                private_path = private_path.display(),
+                threshold_config = threshold_config.unwrap_or_default(),
+            ),
+        )
+        .unwrap();
+        config_path
+    }
+
     #[test]
     #[integration_test]
     fn help() {
         Command::cargo_bin(KMS_GEN_KEYS)
             .unwrap()
-            .arg("--help")
-            .output()
-            .unwrap()
-            .assert()
-            .success();
-
-        Command::cargo_bin(KMS_GEN_KEYS)
-            .unwrap()
-            .arg("centralized")
-            .arg("--help")
-            .output()
-            .unwrap()
-            .assert()
-            .success();
-
-        Command::cargo_bin(KMS_GEN_KEYS)
-            .unwrap()
-            .arg("threshold")
             .arg("--help")
             .output()
             .unwrap()
@@ -96,15 +111,17 @@ mod kms_gen_keys_binary_test {
         // written by the first.
         let temp_dir_priv = tempdir().unwrap();
         let temp_dir_pub = tempdir().unwrap();
+        let config_dir = tempdir().unwrap();
+        let config_path = write_file_storage_config(
+            &config_dir,
+            temp_dir_priv.path(),
+            temp_dir_pub.path(),
+            "overwrite = true",
+            None,
+        );
         let output = kms_gen_keys_command()
-            .arg("--private-storage=file")
-            .arg("--private-file-path")
-            .arg(temp_dir_priv.path())
-            .arg("--public-storage=file")
-            .arg("--public-file-path")
-            .arg(temp_dir_pub.path())
-            .arg("--overwrite")
-            .arg("centralized")
+            .arg("--config-file")
+            .arg(&config_path)
             .output()
             .unwrap();
         let log = String::from_utf8_lossy(&output.stdout);
@@ -115,14 +132,16 @@ mod kms_gen_keys_binary_test {
             "Successfully stored public centralized server signing key under the handle"
         ));
 
+        let config_path = write_file_storage_config(
+            &config_dir,
+            temp_dir_priv.path(),
+            temp_dir_pub.path(),
+            "",
+            None,
+        );
         let new_output = kms_gen_keys_command()
-            .arg("--private-storage=file")
-            .arg("--private-file-path")
-            .arg(temp_dir_priv.path())
-            .arg("--public-storage=file")
-            .arg("--public-file-path")
-            .arg(temp_dir_pub.path())
-            .arg("centralized")
+            .arg("--config-file")
+            .arg(config_path)
             .output()
             .unwrap();
         assert!(new_output.status.success());
@@ -135,14 +154,17 @@ mod kms_gen_keys_binary_test {
     fn central_signing_address_format() {
         let temp_dir_priv = tempdir().unwrap();
         let temp_dir_pub = tempdir().unwrap();
+        let config_dir = tempdir().unwrap();
+        let config_path = write_file_storage_config(
+            &config_dir,
+            temp_dir_priv.path(),
+            temp_dir_pub.path(),
+            "",
+            None,
+        );
         let output = kms_gen_keys_command()
-            .arg("--private-storage=file")
-            .arg("--private-file-path")
-            .arg(temp_dir_priv.path())
-            .arg("--public-storage=file")
-            .arg("--public-file-path")
-            .arg(temp_dir_pub.path())
-            .arg("centralized")
+            .arg("--config-file")
+            .arg(config_path)
             .output()
             .unwrap();
 
@@ -173,26 +195,31 @@ mod kms_gen_keys_binary_test {
         let temp_dir_priv = tempdir().unwrap();
         let temp_dir_pub = tempdir().unwrap();
 
-        // party id 0 is invalid (parties are 1-indexed); the value parser
-        // rejects id 0 at parse time.
+        // party id 0 is invalid (parties are 1-indexed).
+        let config_dir = tempdir().unwrap();
+        let config_path = write_file_storage_config(
+            &config_dir,
+            temp_dir_priv.path(),
+            temp_dir_pub.path(),
+            "",
+            Some(
+                r#"
+[threshold]
+my_id = 0
+tls_subject = "kms-party"
+
+"#,
+            ),
+        );
         let output = Command::cargo_bin(KMS_GEN_KEYS)
             .unwrap()
-            .arg("--private-storage=file")
-            .arg("--private-file-path")
-            .arg(temp_dir_priv.path())
-            .arg("--public-storage=file")
-            .arg("--public-file-path")
-            .arg(temp_dir_pub.path())
-            .arg("threshold")
-            .arg("--signing-key-party-id=0")
+            .arg("--config-file")
+            .arg(config_path)
             .output()
             .unwrap();
 
         assert!(!output.status.success());
-        assert!(
-            String::from_utf8_lossy(&output.stderr)
-                .contains("invalid value '0' for '--signing-key-party-id")
-        );
+        assert!(String::from_utf8_lossy(&output.stderr).contains("invalid kms-gen-keys config"));
     }
 
     #[test]
@@ -201,21 +228,29 @@ mod kms_gen_keys_binary_test {
         let temp_dir_priv = tempdir().unwrap();
         let temp_dir_pub = tempdir().unwrap();
 
-        // --signing-key-party-id is a required flag now.
+        let config_dir = tempdir().unwrap();
+        let config_path = write_file_storage_config(
+            &config_dir,
+            temp_dir_priv.path(),
+            temp_dir_pub.path(),
+            "",
+            Some(
+                r#"
+[threshold]
+tls_subject = "kms-party"
+
+"#,
+            ),
+        );
         let output = Command::cargo_bin(KMS_GEN_KEYS)
             .unwrap()
-            .arg("--private-storage=file")
-            .arg("--private-file-path")
-            .arg(temp_dir_priv.path())
-            .arg("--public-storage=file")
-            .arg("--public-file-path")
-            .arg(temp_dir_pub.path())
-            .arg("threshold")
+            .arg("--config-file")
+            .arg(config_path)
             .output()
             .unwrap();
 
         assert!(!output.status.success());
-        assert!(String::from_utf8_lossy(&output.stderr).contains("--signing-key-party-id"));
+        assert!(String::from_utf8_lossy(&output.stderr).contains("threshold.my_id"));
     }
 
     #[test]
@@ -224,16 +259,25 @@ mod kms_gen_keys_binary_test {
     fn threshold_signing_key() {
         let temp_dir_priv = tempdir().unwrap();
         let temp_dir_pub = tempdir().unwrap();
+        let config_dir = tempdir().unwrap();
+        let config_path = write_file_storage_config(
+            &config_dir,
+            temp_dir_priv.path(),
+            temp_dir_pub.path(),
+            "",
+            Some(
+                r#"
+[threshold]
+my_id = 5
+tls_subject = "kms-party"
+
+"#,
+            ),
+        );
 
         let output = kms_gen_keys_command()
-            .arg("--private-storage=file")
-            .arg("--private-file-path")
-            .arg(temp_dir_priv.path())
-            .arg("--public-storage=file")
-            .arg("--public-file-path")
-            .arg(temp_dir_pub.path())
-            .arg("threshold")
-            .arg("--signing-key-party-id=5")
+            .arg("--config-file")
+            .arg(config_path)
             .output()
             .unwrap();
 
@@ -262,22 +306,35 @@ mod kms_gen_keys_binary_test {
         );
         let temp_dir_priv = tempdir().unwrap();
 
-        // Test the following command:
-        // cargo run --bin kms-gen-keys -- --aws-region eu-north-1 --public-storage=s3 --public-s3-bucket ci-kms-key-test --public-s3-prefix=<unique> --private-storage=file --private-file-path=<tempdir> --overwrite --deterministic centralized
+        let config_dir = tempdir().unwrap();
+        let config_path = config_dir.path().join("kms-gen-keys.toml");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+[keygen]
+enabled = true
+deterministic = true
+overwrite = true
+
+[aws]
+region = "{AWS_REGION}"
+s3_endpoint = "{AWS_S3_ENDPOINT}"
+
+[public_vault.storage.s3]
+bucket = "{BUCKET_NAME}"
+prefix = "{s3_prefix}"
+
+[private_vault.storage.file]
+path = "{private_path}"
+"#,
+                private_path = temp_dir_priv.path().display(),
+            ),
+        )
+        .unwrap();
         let output = kms_gen_keys_command()
-            .arg(format!("--aws-region={AWS_REGION}"))
-            .arg(format!("--aws-s3-endpoint={AWS_S3_ENDPOINT}"))
-            .arg("--public-storage=s3")
-            .arg("--public-s3-bucket")
-            .arg(BUCKET_NAME)
-            .arg("--public-s3-prefix")
-            .arg(&s3_prefix)
-            .arg("--private-storage=file")
-            .arg("--private-file-path")
-            .arg(temp_dir_priv.path())
-            .arg("--overwrite")
-            .arg("--deterministic")
-            .arg("centralized")
+            .arg("--config-file")
+            .arg(config_path)
             .output()
             .unwrap();
         let log = String::from_utf8_lossy(&output.stdout);

--- a/core/service/tests/integration_test.rs
+++ b/core/service/tests/integration_test.rs
@@ -74,7 +74,6 @@ mod kms_gen_keys_binary_test {
             format!(
                 r#"
 [keygen]
-enabled = true
 {keygen_options}
 {threshold_config}
 [public_vault.storage.file]
@@ -102,6 +101,20 @@ path = "{private_path}"
             .unwrap()
             .assert()
             .success();
+    }
+
+    #[test]
+    #[integration_test]
+    fn server_config_is_rejected() {
+        let output = Command::cargo_bin(KMS_GEN_KEYS)
+            .unwrap()
+            .arg("--config-file")
+            .arg("config/default_1.toml")
+            .output()
+            .unwrap();
+
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("expected a [keygen] section"));
     }
 
     #[test]
@@ -313,7 +326,6 @@ tls_subject = "kms-party"
             format!(
                 r#"
 [keygen]
-enabled = true
 deterministic = true
 overwrite = true
 
@@ -367,6 +379,36 @@ mod kms_server_binary_test {
             .unwrap()
             .assert()
             .success();
+    }
+
+    #[test]
+    #[integration_test]
+    fn keygen_config_is_rejected() {
+        let config_dir = tempfile::tempdir().unwrap();
+        let config_path = config_dir.path().join("kms-gen-keys.toml");
+        fs::write(
+            &config_path,
+            r#"
+[keygen]
+
+[public_vault.storage.file]
+path = "/tmp"
+
+[private_vault.storage.file]
+path = "/tmp"
+"#,
+        )
+        .unwrap();
+
+        let output = Command::cargo_bin(KMS_SERVER)
+            .unwrap()
+            .arg("--config-file")
+            .arg(config_path)
+            .output()
+            .unwrap();
+
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("expected a [service] section"));
     }
 }
 

--- a/docker-compose-core-centralized.yml
+++ b/docker-compose-core-centralized.yml
@@ -37,7 +37,7 @@ services:
       export AWS_ACCESS_KEY_ID=$$(cat /minio_secrets/access_key) &&
       export AWS_SECRET_ACCESS_KEY=$$(cat /minio_secrets/secret_key) &&
       echo 'Generating signing keys' &&
-      kms-gen-keys --config-file config/compose_centralized.toml &&
+      kms-gen-keys --config-file config/compose_centralized_keygen.toml &&
       echo 'Starting kms service' &&
       if [[ "${KMS_DOCKER_BACKUP_SECRET_SHARING}" = "true" ]]; then
         KMS_CORE__BACKUP_VAULT__KEYCHAIN__SECRET_SHARING__ENABLED=true kms-server --config-file config/compose_centralized.toml

--- a/docker-compose-core-centralized.yml
+++ b/docker-compose-core-centralized.yml
@@ -37,7 +37,7 @@ services:
       export AWS_ACCESS_KEY_ID=$$(cat /minio_secrets/access_key) &&
       export AWS_SECRET_ACCESS_KEY=$$(cat /minio_secrets/secret_key) &&
       echo 'Generating signing keys' &&
-      kms-gen-keys --public-storage s3 --public-s3-bucket kms --aws-s3-endpoint http://dev-s3-mock:9000 --aws-region us-east-1 --private-storage file --private-file-path ./keys centralized &&
+      kms-gen-keys --config-file config/compose_centralized.toml &&
       echo 'Starting kms service' &&
       if [[ "${KMS_DOCKER_BACKUP_SECRET_SHARING}" = "true" ]]; then
         KMS_CORE__BACKUP_VAULT__KEYCHAIN__SECRET_SHARING__ENABLED=true kms-server --config-file config/compose_centralized.toml

--- a/docker-compose-core-threshold-6.yml
+++ b/docker-compose-core-threshold-6.yml
@@ -34,7 +34,6 @@ services:
         mock_enclave = true
 
         [keygen]
-        enabled = true
 
         [threshold]
         my_id = $${i}

--- a/docker-compose-core-threshold-6.yml
+++ b/docker-compose-core-threshold-6.yml
@@ -29,16 +29,33 @@ services:
         AWS_SECRET_ACCESS_KEY=$$(cat /minio_secrets/secret_key) &&
         export AWS_SECRET_ACCESS_KEY &&
         echo 'Starting signing key and CA certificates generation for all cores' &&
-        for i in 1 2 3 4 5 6; do \
-          kms-gen-keys --mock-enclave --aws-region us-east-1 \
-            --public-storage s3 --public-s3-bucket kms --public-s3-prefix PUB-p$$i \
-            --aws-s3-endpoint http://dev-s3-mock:9000 \
-            --private-storage s3 --private-s3-bucket kms --private-s3-prefix PRIV-p$$i \
-            threshold \
-            --signing-key-party-id $$i --tls-subject dev-kms-core-$$i.com \
-            --tls-wildcard && \
-            wget -O ./certs/cert_dev-kms-core-$$i.com.pem ftp://$$AWS_ACCESS_KEY_ID:$$AWS_SECRET_ACCESS_KEY@dev-s3-mock:8021/kms/PUB-p$$i/CACert/60b7070add74be3827160aa635fb255eeeeb88586c4debf7ab1134ddceb4beee && \
-            cat ./certs/cert_dev-kms-core-$$i.com.pem; \
+        for i in 1 2 3 4 5 6; do
+          cat > /tmp/kms-gen-keys-$${i}.toml <<EOF
+        mock_enclave = true
+
+        [keygen]
+        enabled = true
+
+        [threshold]
+        my_id = $${i}
+        tls_subject = "dev-kms-core-$${i}.com"
+        tls_wildcard = true
+
+        [aws]
+        region = "us-east-1"
+        s3_endpoint = "http://dev-s3-mock:9000"
+
+        [public_vault.storage.s3]
+        bucket = "kms"
+        prefix = "PUB-p$${i}"
+
+        [private_vault.storage.s3]
+        bucket = "kms"
+        prefix = "PRIV-p$${i}"
+        EOF
+          kms-gen-keys --config-file /tmp/kms-gen-keys-$${i}.toml &&
+            wget -O ./certs/cert_dev-kms-core-$${i}.com.pem ftp://$$AWS_ACCESS_KEY_ID:$$AWS_SECRET_ACCESS_KEY@dev-s3-mock:8021/kms/PUB-p$${i}/CACert/60b7070add74be3827160aa635fb255eeeeb88586c4debf7ab1134ddceb4beee &&
+            cat ./certs/cert_dev-kms-core-$${i}.com.pem
         done &&
         exit 0
     volumes:

--- a/docker-compose-core-threshold.yml
+++ b/docker-compose-core-threshold.yml
@@ -32,7 +32,6 @@ services:
         mock_enclave = true
 
         [keygen]
-        enabled = true
 
         [threshold]
         my_id = $${i}

--- a/docker-compose-core-threshold.yml
+++ b/docker-compose-core-threshold.yml
@@ -27,16 +27,33 @@ services:
         AWS_SECRET_ACCESS_KEY=$$(cat /minio_secrets/secret_key) &&
         export AWS_SECRET_ACCESS_KEY &&
         echo 'Starting signing key and CA certificates generation for all cores' &&
-        for i in 1 2 3 4; do \
-          kms-gen-keys --mock-enclave --aws-region us-east-1 \
-            --public-storage s3 --public-s3-bucket kms --public-s3-prefix PUB-p$$i \
-            --aws-s3-endpoint http://dev-s3-mock:9000 \
-            --private-storage s3 --private-s3-bucket kms --private-s3-prefix PRIV-p$$i \
-            threshold \
-            --signing-key-party-id $$i --tls-subject dev-kms-core-$$i.com \
-            --tls-wildcard && \
-            wget -O ./certs/cert_dev-kms-core-$$i.com.pem ftp://$$AWS_ACCESS_KEY_ID:$$AWS_SECRET_ACCESS_KEY@dev-s3-mock:8021/kms/PUB-p$$i/CACert/60b7070add74be3827160aa635fb255eeeeb88586c4debf7ab1134ddceb4beee && \
-            cat ./certs/cert_dev-kms-core-$$i.com.pem; \
+        for i in 1 2 3 4; do
+          cat > /tmp/kms-gen-keys-$${i}.toml <<EOF
+        mock_enclave = true
+
+        [keygen]
+        enabled = true
+
+        [threshold]
+        my_id = $${i}
+        tls_subject = "dev-kms-core-$${i}.com"
+        tls_wildcard = true
+
+        [aws]
+        region = "us-east-1"
+        s3_endpoint = "http://dev-s3-mock:9000"
+
+        [public_vault.storage.s3]
+        bucket = "kms"
+        prefix = "PUB-p$${i}"
+
+        [private_vault.storage.s3]
+        bucket = "kms"
+        prefix = "PRIV-p$${i}"
+        EOF
+          kms-gen-keys --config-file /tmp/kms-gen-keys-$${i}.toml &&
+            wget -O ./certs/cert_dev-kms-core-$${i}.com.pem ftp://$$AWS_ACCESS_KEY_ID:$$AWS_SECRET_ACCESS_KEY@dev-s3-mock:8021/kms/PUB-p$${i}/CACert/60b7070add74be3827160aa635fb255eeeeb88586c4debf7ab1134ddceb4beee &&
+            cat ./certs/cert_dev-kms-core-$${i}.com.pem
         done &&
         exit 0
     volumes:

--- a/docker/core/service/init_enclave.sh
+++ b/docker/core/service/init_enclave.sh
@@ -43,18 +43,18 @@ has_value() {
 export PATH="/app/kms/core/service/bin:$PATH"
 cd /app/kms/core/service |& logger  || fail "cannot set working directory"
 
-# receive kms-server configuration from the parent
-log "requesting kms-server config"
+# receive keygen or server configuration from the parent
+log "requesting KMS config"
 socat -u VSOCK-CONNECT:$PARENT_CID:$CONFIG_PORT \
       CREATE:$KMS_SERVER_CONFIG_FILE \
-    |& logger || fail "cannot receive kms-server config"
-[ -f "$KMS_SERVER_CONFIG_FILE" ] || fail "did not receive kms-server config"
+    |& logger || fail "cannot receive KMS config"
+[ -f "$KMS_SERVER_CONFIG_FILE" ] || fail "did not receive KMS config"
 
 # log configuration hash for sanity
 [ -f "$KMS_SERVER_CONFIG_FILE" ] && \
     {
 	KMS_SERVER_CONFIG_HASH="$(sha256sum $KMS_SERVER_CONFIG_FILE | cut -d " " -f 1)"
-	log "received kms-server config with sha256 $KMS_SERVER_CONFIG_HASH"
+	log "received KMS config with sha256 $KMS_SERVER_CONFIG_HASH"
     }
 
 # extract bootstrap settings from the received config
@@ -110,27 +110,25 @@ has_value "aws.sts_endpoint" && {
 # because kms-gen-keys also generates party CA certificates and those need to be
 # included in the peer list and voted on before all parties can start.
 
-# If the [keygen] section is present in the received configuration file,
-# kms-gen-keys will run. It is not a section understood by the kms-server
-# configuration parser, so kms-server will not start if this section is present.
-has_value "keygen" && \
-    {
-	# Ensure that signing keys exist. FHE keys and CRS are generated at
-	# runtime by kms-server (in centralized mode) or by the threshold
-	# protocol (in threshold mode), so this script only handles signing
-	# keys. kms-gen-keys parses the config file itself so values from the
-	# parent-provided config are never reinterpreted as shell syntax.
-	log "generating signing keys"
-	kms-gen-keys --config-file "$KMS_SERVER_CONFIG_FILE" \
-	    |& logger || fail "cannot generate keys"
-    }
-has_value "keygen" || \
-    log "[keygen] configuration section not present, skipping key generation"
+# Ensure that signing keys exist when this invocation received a keygen config.
+# FHE keys and CRS are generated at runtime by kms-server (in centralized mode)
+# or by the threshold protocol (in threshold mode), so this script only handles
+# signing keys. kms-gen-keys parses the config file itself so values from the
+# parent-provided config are never reinterpreted as shell syntax.
+log "attempting signing key generation"
+if kms-gen-keys --config-file "$KMS_SERVER_CONFIG_FILE" |& logger; then
+    KEYGEN_STATUS=0
+else
+    KEYGEN_STATUS=$?
+fi
 
-has_value "service" && \
-    {
-	log "starting kms-server"
-	kms-server --config-file=$KMS_SERVER_CONFIG_FILE |& logger
-    }
-has_value "service" || \
-    log "[service] configuration section not present, not launching kms-server"
+log "attempting to start kms-server"
+if kms-server --config-file="$KMS_SERVER_CONFIG_FILE" |& logger; then
+    SERVER_STATUS=0
+else
+    SERVER_STATUS=$?
+fi
+
+if [ "$KEYGEN_STATUS" -ne 0 ] && [ "$SERVER_STATUS" -ne 0 ]; then
+    fail "neither kms-gen-keys nor kms-server completed successfully"
+fi

--- a/docker/core/service/init_enclave.sh
+++ b/docker/core/service/init_enclave.sh
@@ -111,66 +111,18 @@ has_value "aws.sts_endpoint" && {
 # included in the peer list and voted on before all parties can start.
 
 # If the [keygen] section is present in the received configuration file,
-# kms-gen-keys will run. It doesn't have any fields. It's not a section
-# understood by the configuration parser in kms-server, so kms-server will not
-# start if this section is present.
+# kms-gen-keys will run. It is not a section understood by the kms-server
+# configuration parser, so kms-server will not start if this section is present.
 has_value "keygen" && \
     {
-	AWS_IMDS_ENDPOINT_ARG=""
-	has_value "aws.imds_endpoint" && \
-	    AWS_IMDS_ENDPOINT_ARG="--aws-imds-endpoint $(get_value "aws.imds_endpoint")"
-
-	AWS_STS_ENDPOINT_ARG=""
-	has_value "aws.sts_endpoint" && \
-	    AWS_STS_ENDPOINT_ARG="--aws-sts-endpoint $(get_value "aws.sts_endpoint")"
-
-	AWS_S3_ENDPOINT_ARG=""
-	has_value "aws.s3_endpoint" && \
-	    AWS_S3_ENDPOINT_ARG="--aws-s3-endpoint $(get_value "aws.s3_endpoint")"
-
-	AWS_KMS_ENDPOINT_ARG=""
-	has_value "aws.awskms_endpoint" && \
-	    AWS_KMS_ENDPOINT_ARG="--aws-kms-endpoint $(get_value "aws.awskms_endpoint")"
-	
-	AWS_ARGS="--aws-region $(get_value "aws.region") $AWS_IMDS_ENDPOINT_ARG $AWS_STS_ENDPOINT_ARG $AWS_S3_ENDPOINT_ARG $AWS_KMS_ENDPOINT_ARG"
-
-	PUBLIC_S3_PREFIX_ARG=""
-	has_value "public_vault.storage.s3.prefix" && \
-	    PUBLIC_S3_PREFIX_ARG="--public-s3-prefix $(get_value "public_vault.storage.s3.prefix")"
-	PRIVATE_S3_PREFIX_ARG=""
-	has_value "private_vault.storage.s3.prefix" && \
-	    PRIVATE_S3_PREFIX_ARG="--private-s3-prefix $(get_value "private_vault.storage.s3.prefix")"
-
-	VAULT_ARGS="--public-storage s3 \
-		    --public-s3-bucket $(get_value "public_vault.storage.s3.bucket") $PUBLIC_S3_PREFIX_ARG \
-                    --private-storage s3 \
-                    --private-s3-bucket $(get_value "private_vault.storage.s3.bucket") $PRIVATE_S3_PREFIX_ARG \
-                    --root-key-id $(get_value "private_vault.keychain.aws_kms.root_key_id") \
-                    --root-key-spec $(get_value "private_vault.keychain.aws_kms.root_key_spec")"
-
-	KMS_GEN_KEYS_CMD="kms-gen-keys $AWS_ARGS $VAULT_ARGS"
-
 	# Ensure that signing keys exist. FHE keys and CRS are generated at
 	# runtime by kms-server (in centralized mode) or by the threshold
 	# protocol (in threshold mode), so this script only handles signing
-	# keys. Note that in threshold mode, the [threshold] section used for
-	# kms-gen-keys is not the same as one used for kms-server. It has two
-	# fields only: my_id and tls_subject. The latter is not accepted by
-	# kms-server.
-	if has_value "threshold"; then
-	    log "generating signing keys for threshold KMS"
-	    PARTY_ID_ARG=""
-	    has_value "threshold.my_id" && \
-		PARTY_ID_ARG="--signing-key-party-id $(get_value "threshold.my_id")"
-	    eval "$KMS_GEN_KEYS_CMD \
-                   threshold $PARTY_ID_ARG \
-                   --tls-subject $(get_value "threshold.tls_subject")" \
-		|& logger || fail "cannot generate keys"
-	else
-	    log "generating signing keys for centralized KMS"
-	    eval "$KMS_GEN_KEYS_CMD centralized" \
-		|& logger || fail "cannot generate keys"
-	fi
+	# keys. kms-gen-keys parses the config file itself so values from the
+	# parent-provided config are never reinterpreted as shell syntax.
+	log "generating signing keys"
+	kms-gen-keys --config-file "$KMS_SERVER_CONFIG_FILE" \
+	    |& logger || fail "cannot generate keys"
     }
 has_value "keygen" || \
     log "[keygen] configuration section not present, skipping key generation"

--- a/docs/guides/kms-server-bin.md
+++ b/docs/guides/kms-server-bin.md
@@ -4,21 +4,27 @@
 
 `kms-gen-keys` generates the server signing keys (and, in threshold mode, the per-party self-signed CA certificates used for mTLS).
 
-To generate the signing material before the KMS server is started, run one of:
-
-```bash
-# for centralized:
-cargo run --bin kms-gen-keys -- centralized
-
-# for threshold (run this once per party, with party IDs 1..N):
-cargo run --bin kms-gen-keys -- threshold --signing-key-party-id <SIGNING_KEY_PARTY_ID>
-```
-
-`kms-gen-keys` can also read the storage, AWS, and mode settings from a TOML
-configuration file:
+To generate the signing material before the KMS server is started, pass a TOML config file:
 
 ```bash
 cargo run --bin kms-gen-keys -- --config-file config/default_1.toml
+```
+
+The config can be either a full `kms-server` config or a keygen-only config:
+
+```toml
+[keygen]
+enabled = true
+
+[threshold]
+my_id = 1
+tls_subject = "kms-core-1"
+
+[public_vault.storage.file]
+path = "./keys"
+
+[private_vault.storage.file]
+path = "./keys"
 ```
 
 For threshold configs, `threshold.my_id` selects the party. The TLS certificate
@@ -92,11 +98,11 @@ mock_enclave = true
 
 See `core/service/config/compose_*.toml` for working examples used by the docker-compose threshold setup.
 
-On the key-generation side, pass the matching CLI flag or set the same field in
-the config used with `--config-file`:
+On the key-generation side, set the same field in the config used with
+`--config-file`:
 
-```bash
-cargo run --bin kms-gen-keys --features insecure -- --mock-enclave ...
+```toml
+mock_enclave = true
 ```
 
 Both sides must agree: a server with `mock_enclave = true` will only accept attestations from peers and KMS keys that were also produced under the mock module, and vice versa.

--- a/docs/guides/kms-server-bin.md
+++ b/docs/guides/kms-server-bin.md
@@ -14,6 +14,18 @@ cargo run --bin kms-gen-keys -- centralized
 cargo run --bin kms-gen-keys -- threshold --signing-key-party-id <SIGNING_KEY_PARTY_ID>
 ```
 
+`kms-gen-keys` can also read the storage, AWS, and mode settings from a TOML
+configuration file:
+
+```bash
+cargo run --bin kms-gen-keys -- --config-file config/default_1.toml
+```
+
+For threshold configs, `threshold.my_id` selects the party. The TLS certificate
+subject is read from `threshold.tls_subject` when present; otherwise it is
+derived from the matching `[[threshold.peers]]` entry, preferring `mpc_identity`
+and falling back to `address`.
+
 For local test/dev runs that need pre-baked FHE keys + CRS, use `generate-test-material` instead (see the `generate-test-material-*` targets in the top-level `Makefile`).
 
 ## Threshold KMS TLS Certificates
@@ -80,7 +92,8 @@ mock_enclave = true
 
 See `core/service/config/compose_*.toml` for working examples used by the docker-compose threshold setup.
 
-On the key-generation side, pass the matching CLI flag:
+On the key-generation side, pass the matching CLI flag or set the same field in
+the config used with `--config-file`:
 
 ```bash
 cargo run --bin kms-gen-keys --features insecure -- --mock-enclave ...

--- a/docs/guides/kms-server-bin.md
+++ b/docs/guides/kms-server-bin.md
@@ -7,14 +7,13 @@
 To generate the signing material before the KMS server is started, pass a TOML config file:
 
 ```bash
-cargo run --bin kms-gen-keys -- --config-file config/default_1.toml
+cargo run --bin kms-gen-keys -- --config-file /path/to/kms-gen-keys.toml
 ```
 
-The config can be either a full `kms-server` config or a keygen-only config:
+The config must include a `[keygen]` section and the storage settings used to write the generated material:
 
 ```toml
 [keygen]
-enabled = true
 
 [threshold]
 my_id = 1


### PR DESCRIPTION
## Description of changes
Traditionally, we run `kms-gen-keys` with lots of CLI arguments which adds unnecessary complexity in deployment scripts and charts. This PR puts replaces all `kms-gen-keys` arguments with a configuration.file

## PR Checklist
<!-- Review each item and tick all that apply. Explain any exceptions in the description. -->
I attest that all checked items are satisfied. Any deviation is clearly justified above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new pub item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked as `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config changes OR `devops` label + infra notified + infra-team reviewer assigned.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields added OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
