### PR TITLE
chore: Refactor public decrypt perf-test

### DIFF
--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -100,6 +100,11 @@ jobs:
       packages: write # Required to publish Docker images
       attestations: write # Required to create build attestations
     uses: ./.github/workflows/docker-build.yml
+    with:
+      # Perf only deploys the enclave image for thresholdWithEnclave runs (the scheduled
+      # default). For a plain `threshold` run the enclave build + sign jobs are dead weight,
+      # so skip them. core-service/core-client (and the cached golden image) are always needed.
+      build-enclave: ${{ (inputs.deployment_type || 'thresholdWithEnclave') == 'thresholdWithEnclave' }}
     secrets:
       BLOCKCHAIN_ACTIONS_TOKEN: ${{ secrets.BLOCKCHAIN_ACTIONS_TOKEN }}
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}

--- a/ci/perf-testing/PERF_TEST_README.md
+++ b/ci/perf-testing/PERF_TEST_README.md
@@ -39,17 +39,17 @@ they produce are real regardless of this setting.
 
 ## Reading the results
 
-The public-decrypt test runs three scenarios, each sending `1 × euint64` for 60
+The public-decrypt test runs three scenarios, each sending `1 × euint64` for 30
 seconds:
 
 | Scenario | Rate | Budget (allowed slack) |
 | --- | ---: | --- |
-| stable | 500 req/s | no failures, no shedding, ≥98% of target rate |
-| near-limit | 1,000 req/s | ≤1% failures, ≤1% shed, ≥90% of target rate |
-| over-limit | 1,200 req/s | ≤10% failures, ≤25% shed, ≥70% of target rate |
+| stable | 1,100 req/s | no failures, no shedding, ≥98% of target rate |
+| near-limit | 1,300 req/s | ≤1% failures, ≤1% shed, ≥90% of target rate |
+| over-limit | 1,500 req/s | ≤10% failures, ≤25% shed, ≥70% of target rate |
 
 The user-decrypt test also runs three scenarios, each sending `1 × euint64` for
-60 seconds:
+30 seconds:
 
 | Scenario | Rate | Budget (allowed slack) |
 | --- | ---: | --- |
@@ -67,10 +67,10 @@ Each scenario lands on one of these outcomes:
 - **✅ pass** — stayed inside its budget with zero failed, shed, or saturated
   traffic.
 - **⚠️ warn** — either stayed inside budget but saw *some* failed/shed/saturated
-  traffic, **or** it's the `2,750` probe, which is expected to run hot and is
-  never allowed to fail the workflow.
-- **❌ fail** — a `2,400` or `2,700` scenario went outside its budget. This
-  fails the whole workflow.
+  traffic, **or** it's the `1,500` (pdec) or `2,750` (udec) probe, which is
+  expected to run hot and is never allowed to fail the workflow.
+- **❌ fail** — a `1,100`/`1,300` (pdec) or `2,400`/`2,700` (udec) scenario went
+  outside its budget. This fails the whole workflow.
 - **⏭️ skipped** — an earlier scenario failed, so this one didn't run (scenarios
   run in ascending order and stop climbing once one falls over).
 

--- a/ci/perf-testing/PERF_TEST_README.md
+++ b/ci/perf-testing/PERF_TEST_README.md
@@ -6,18 +6,18 @@ the Actions tab ("Run workflow").
 
 The workflow spins up a real KMS deployment in Kubernetes, runs a suite of perf
 tests against it (keygen, CRS generation, public decrypt, and user decrypt),
-and posts a summary to Slack. This document focuses on the **user-decrypt**
-test, which is the part most people come here to run.
+and posts a summary to Slack. This document focuses on user/public decryption rate tests,
+which are the part most people come here to run.
 
-## User-decrypt rate test
+## Decryption rate tests
 
-The user-decrypt test offers a fixed number of requests per second for a fixed
-duration, then reports whether the KMS kept up. The current CI suite uses this
-to measure how many user decryptions per second the deployment can handle.
+The public- and user-decrypt tests offer a fixed number of requests per second
+for a fixed duration, then report whether the KMS kept up. The current CI suite
+uses this to measure how many decryptions per second the deployment can handle.
 
 ## Quick start
 
-To iterate on the user-decrypt test, trigger the workflow with these values:
+To iterate on the decrypt tests, trigger the workflow with these values:
 
 | Field | Value |
 | --- | --- |
@@ -39,8 +39,17 @@ they produce are real regardless of this setting.
 
 ## Reading the results
 
-The user-decrypt test runs three scenarios, each sending `1 × euint64` for 60
+The public-decrypt test runs three scenarios, each sending `1 × euint64` for 60
 seconds:
+
+| Scenario | Rate | Budget (allowed slack) |
+| --- | ---: | --- |
+| stable | 500 req/s | no failures, no shedding, ≥98% of target rate |
+| near-limit | 1,000 req/s | ≤1% failures, ≤1% shed, ≥90% of target rate |
+| over-limit | 1,200 req/s | ≤10% failures, ≤25% shed, ≥70% of target rate |
+
+The user-decrypt test also runs three scenarios, each sending `1 × euint64` for
+60 seconds:
 
 | Scenario | Rate | Budget (allowed slack) |
 | --- | ---: | --- |
@@ -65,8 +74,8 @@ Each scenario lands on one of these outcomes:
 - **⏭️ skipped** — an earlier scenario failed, so this one didn't run (scenarios
   run in ascending order and stop climbing once one falls over).
 
-The `2,750` scenario is deliberately just above the clean `2,700` run: it probes
-where capacity starts to break down, so it warns instead of failing.
+The top public- and user-decrypt scenarios are deliberately exploratory probes:
+they run just above the current clean range, so they warn instead of failing.
 
 ### Metric glossary
 
@@ -91,7 +100,7 @@ overhead):
 | `request_payload_bytes` | Total request bytes submitted, counted once per core target. |
 | `request_payload_mib_per_sec` | Request bytes per second, in MiB/s. |
 | `request_payload_avg_bytes` | Average encoded size of one request. |
-| `response_payload_bytes` | Total response bytes accepted for reconstruction (excludes late/abandoned responses). |
+| `response_payload_bytes` | Total response bytes accepted for verification/reconstruction (excludes late/abandoned responses). |
 | `response_payload_mib_per_sec` | Response bytes per second, in MiB/s. |
 | `response_payload_avg_bytes` | Average encoded size of one accepted response. |
 
@@ -165,7 +174,7 @@ Network diagnostics are printed directly in the GitHub Actions log. The output
 is intentionally terse: node placement, KMS core pod placement, and after-run
 `eth0` rx/tx deltas for each running KMS core pod plus a total.
 
-Each user-decrypt scenario also captures its own `eth0` rx/tx counters *inside* the
+Each decrypt scenario also captures its own `eth0` rx/tx counters *inside* the
 Argo test pod, reported as `net_rx`/`net_tx` in Slack — the outer before/after
 diagnostics only include KMS core pods that are still running when the snapshot
 is taken.

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -1202,15 +1202,15 @@ spec:
           crs_block="$(printf '*CRS*\n%b' "${crs_lines:-No CRS tests\n}")"
           pdec_raw_text="$(printf '%b' "$pdec_raw_lines" | head -c 2200)"
           if [ -n "$pdec_raw_text" ]; then
-            pdec_block="$(printf '*Public decrypt {{workflow.parameters.data-type}}*\n%b\n*Raw data*\n```%s\n```' "${pdec_lines:-No public decrypt tests\n}" "$pdec_raw_text")"
+            pdec_block="$(printf '*Public decrypt {{workflow.parameters.data-type}}, {{inputs.parameters.duration}}s*\n%b\n```%s\n```' "${pdec_lines:-No public decrypt tests\n}" "$pdec_raw_text")"
           else
-            pdec_block="$(printf '*Public decrypt {{workflow.parameters.data-type}}*\n%b' "${pdec_lines:-No public decrypt tests\n}")"
+            pdec_block="$(printf '*Public decrypt {{workflow.parameters.data-type}}, {{inputs.parameters.duration}}s*\n%b' "${pdec_lines:-No public decrypt tests\n}")"
           fi
           udec_raw_text="$(printf '%b' "$udec_raw_lines" | head -c 2200)"
           if [ -n "$udec_raw_text" ]; then
-            udec_block="$(printf '*User decrypt {{workflow.parameters.data-type}}*\n%b\n*Raw data*\n```%s\n```' "${udec_lines:-No user decrypt tests\n}" "$udec_raw_text")"
+            udec_block="$(printf '*User decrypt {{workflow.parameters.data-type}}, {{inputs.parameters.duration}}s*\n%b\n```%s\n```' "${udec_lines:-No user decrypt tests\n}" "$udec_raw_text")"
           else
-            udec_block="$(printf '*User decrypt {{workflow.parameters.data-type}}*\n%b' "${udec_lines:-No user decrypt tests\n}")"
+            udec_block="$(printf '*User decrypt {{workflow.parameters.data-type}}, {{inputs.parameters.duration}}s*\n%b' "${udec_lines:-No user decrypt tests\n}")"
           fi
           status_line="Keygen: ${keygen_passed}/${keygen_total} | CRS: ${crs_passed}/${crs_total} | Public decrypt: ${pdec_passed}/${pdec_total} | User decrypt: ${udec_passed}/${udec_total}"
           # NOTE: core/core-client instance types and tokioWorkerThreads/rayonNumThreads below are
@@ -1220,7 +1220,7 @@ spec:
           # (core-img/client-img ARE live: <version>/<client-version> are sed-substituted at submit.)
           # Two physical lines: the '\n' renders as a line break in the Slack context element.
           config_line=$(printf '%s\n%s' \
-            "payload={{workflow.parameters.batch-size}} x {{workflow.parameters.data-type}}, preproc/keygen params={{workflow.parameters.fhe-params}}, decrypt params=Default, duration={{inputs.parameters.duration}}s, max-in-flight={{inputs.parameters.max-in-flight}}, TLS={{inputs.parameters.tls}}" \
+            "payload={{workflow.parameters.batch-size}} x {{workflow.parameters.data-type}}, preproc/keygen params={{workflow.parameters.fhe-params}}, decrypt params=Default, max-in-flight={{inputs.parameters.max-in-flight}}, TLS={{inputs.parameters.tls}}" \
             "core=c7a.16xlarge, core-client=m5n, tokioWorkerThreads=10, rayonNumThreads=40, core-img=<version>, client-img=<client-version>")
           if echo "{{inputs.parameters.job_url}}" | grep -q '^http'; then
             run_line="<{{inputs.parameters.job_url}}|{{inputs.parameters.job_label}}>"

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -38,7 +38,7 @@ spec:
     - name: fhe-params
       value: "Test"
     - name: duration
-      value: "45"
+      value: "30"
     - name: max-in-flight
       value: "10000"
     - name: data-type

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -124,7 +124,7 @@ spec:
               - name: fhe-params
                 value: "Default"
 
-          - name: pdec-rate-500
+          - name: pdec-rate-1500
             dependencies: ["crs-gen"]
             template: run-decrypt-rate
             arguments:
@@ -132,43 +132,43 @@ spec:
               - name: kind
                 value: "pdec"
               - name: rate
-                value: "500"
+                value: "1500"
               - name: key_id
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
                 value: "true"
 
-          - name: pdec-rate-1000
-            dependencies: ["pdec-rate-500"]
+          - name: pdec-rate-1800
+            dependencies: ["pdec-rate-1500"]
             template: run-decrypt-rate
             arguments:
               parameters:
               - name: kind
                 value: "pdec"
               - name: rate
-                value: "1000"
+                value: "1800"
               - name: key_id
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
-                value: "{{tasks.pdec-rate-500.outputs.parameters.capacity-ok}}"
+                value: "{{tasks.pdec-rate-1500.outputs.parameters.capacity-ok}}"
 
-          - name: pdec-rate-1200
-            dependencies: ["pdec-rate-1000"]
+          - name: pdec-rate-2000
+            dependencies: ["pdec-rate-1800"]
             template: run-decrypt-rate
             arguments:
               parameters:
               - name: kind
                 value: "pdec"
               - name: rate
-                value: "1200"
+                value: "2000"
               - name: key_id
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
-                value: "{{tasks.pdec-rate-1000.outputs.parameters.capacity-ok}}"
+                value: "{{tasks.pdec-rate-1800.outputs.parameters.capacity-ok}}"
 
           # Temporarily disabled while iterating on Slack report formatting.
           # - name: udec-rate-2400
-          #   dependencies: ["udec-key-gen", "pdec-rate-1200"]
+          #   dependencies: ["udec-key-gen", "pdec-rate-2000"]
           #   template: run-decrypt-rate
           #   arguments:
           #     parameters:
@@ -216,9 +216,9 @@ spec:
               - "udec-preproc-key-gen"
               - "udec-key-gen"
               - "crs-gen"
-              - "pdec-rate-500"
-              - "pdec-rate-1000"
-              - "pdec-rate-1200"
+              - "pdec-rate-1500"
+              - "pdec-rate-1800"
+              - "pdec-rate-2000"
               # Temporarily disabled while iterating on Slack report formatting.
               # - "udec-rate-2400"
               # - "udec-rate-2700"
@@ -236,12 +236,12 @@ spec:
                 value: "{{tasks.udec-key-gen.outputs.parameters.test-result}}"
               - name: test-result-crs-gen
                 value: "{{tasks.crs-gen.outputs.parameters.test-result}}"
-              - name: test-result-pdec-500
-                value: "{{tasks.pdec-rate-500.outputs.parameters.test-result}}"
-              - name: test-result-pdec-1000
-                value: "{{tasks.pdec-rate-1000.outputs.parameters.test-result}}"
-              - name: test-result-pdec-1200
-                value: "{{tasks.pdec-rate-1200.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1500
+                value: "{{tasks.pdec-rate-1500.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1800
+                value: "{{tasks.pdec-rate-1800.outputs.parameters.test-result}}"
+              - name: test-result-pdec-2000
+                value: "{{tasks.pdec-rate-2000.outputs.parameters.test-result}}"
               # Temporarily disabled while iterating on Slack report formatting.
               # - name: test-result-udec-2400
               #   value: "{{tasks.udec-rate-2400.outputs.parameters.test-result}}"
@@ -635,7 +635,7 @@ spec:
 
           allowed_failure_for_rate() {
             case "$1:$2" in
-              pdec:1200|udec:2750) return 0 ;;
+              pdec:2000|udec:2750) return 0 ;;
               *) return 1 ;;
             esac
           }
@@ -644,10 +644,10 @@ spec:
             case "$1:$2" in
               # maxfail/maxshed are percentages of offered requests, not counts.
               # pct is the minimum achieved_rate/target_rate percentage.
-              pdec:500) echo "maxfail=0,maxshed=0,pct=98" ;;
-              pdec:1000) echo "maxfail=1,maxshed=1,pct=90" ;;
-              # 1.2k is an exploratory public-decrypt probe and may warn.
-              pdec:1200) echo "maxfail=10,maxshed=25,pct=70" ;;
+              pdec:1500) echo "maxfail=0,maxshed=0,pct=98" ;;
+              pdec:1800) echo "maxfail=1,maxshed=1,pct=90" ;;
+              # 2k is an exploratory public-decrypt probe and may warn.
+              pdec:2000) echo "maxfail=10,maxshed=25,pct=70" ;;
               udec:2400) echo "maxfail=0,maxshed=0,pct=98" ;;
               udec:2700) echo "maxfail=1,maxshed=1,pct=95" ;;
               # 2.75k probes just above the clean 2.7k run; outside-set results warn.
@@ -845,9 +845,9 @@ spec:
         - name: test-result-udec-preproc-key-gen
         - name: test-result-udec-key-gen
         - name: test-result-crs-gen
-        - name: test-result-pdec-500
-        - name: test-result-pdec-1000
-        - name: test-result-pdec-1200
+        - name: test-result-pdec-1500
+        - name: test-result-pdec-1800
+        - name: test-result-pdec-2000
         # Temporarily disabled while iterating on Slack report formatting.
         # - name: test-result-udec-2400
         # - name: test-result-udec-2700
@@ -877,9 +877,9 @@ spec:
           echo '{{inputs.parameters.test-result-udec-preproc-key-gen}}' > /mnt/results/udec-preproc-key-gen.json
           echo '{{inputs.parameters.test-result-udec-key-gen}}' > /mnt/results/udec-key-gen.json
           echo '{{inputs.parameters.test-result-crs-gen}}' > /mnt/results/crs-gen.json
-          echo '{{inputs.parameters.test-result-pdec-500}}' > /mnt/results/pdec-rate-500.json
-          echo '{{inputs.parameters.test-result-pdec-1000}}' > /mnt/results/pdec-rate-1000.json
-          echo '{{inputs.parameters.test-result-pdec-1200}}' > /mnt/results/pdec-rate-1200.json
+          echo '{{inputs.parameters.test-result-pdec-1500}}' > /mnt/results/pdec-rate-1500.json
+          echo '{{inputs.parameters.test-result-pdec-1800}}' > /mnt/results/pdec-rate-1800.json
+          echo '{{inputs.parameters.test-result-pdec-2000}}' > /mnt/results/pdec-rate-2000.json
           # Temporarily disabled while iterating on Slack report formatting.
           # echo '{ {inputs.parameters.test-result-udec-2400}}' > /mnt/results/udec-rate-2400.json
           # echo '{ {inputs.parameters.test-result-udec-2700}}' > /mnt/results/udec-rate-2700.json
@@ -1168,7 +1168,7 @@ spec:
           done
 
           echo ""
-          summarize_decrypt_rates pdec "Public decrypt" public_decrypt 500 1000 1200
+          summarize_decrypt_rates pdec "Public decrypt" public_decrypt 1500 1800 2000
           # Temporarily disabled while iterating on Slack report formatting.
           # summarize_decrypt_rates udec "User decrypt" user_decrypt 2400 2700 2750
 

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -152,7 +152,7 @@ spec:
               - name: previous-ok
                 value: "{{tasks.pdec-rate-1500.outputs.parameters.capacity-ok}}"
 
-          - name: pdec-rate-1950
+          - name: pdec-rate-1900
             dependencies: ["pdec-rate-1800"]
             template: run-decrypt-rate
             arguments:
@@ -160,7 +160,7 @@ spec:
               - name: kind
                 value: "pdec"
               - name: rate
-                value: "1950"
+                value: "1900"
               - name: key_id
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
@@ -168,7 +168,7 @@ spec:
 
           # Temporarily disabled while iterating on Slack report formatting.
           # - name: udec-rate-2400
-          #   dependencies: ["udec-key-gen", "pdec-rate-1950"]
+          #   dependencies: ["udec-key-gen", "pdec-rate-1900"]
           #   template: run-decrypt-rate
           #   arguments:
           #     parameters:
@@ -218,7 +218,7 @@ spec:
               - "crs-gen"
               - "pdec-rate-1500"
               - "pdec-rate-1800"
-              - "pdec-rate-1950"
+              - "pdec-rate-1900"
               # Temporarily disabled while iterating on Slack report formatting.
               # - "udec-rate-2400"
               # - "udec-rate-2700"
@@ -240,8 +240,8 @@ spec:
                 value: "{{tasks.pdec-rate-1500.outputs.parameters.test-result}}"
               - name: test-result-pdec-1800
                 value: "{{tasks.pdec-rate-1800.outputs.parameters.test-result}}"
-              - name: test-result-pdec-1950
-                value: "{{tasks.pdec-rate-1950.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1900
+                value: "{{tasks.pdec-rate-1900.outputs.parameters.test-result}}"
               # Temporarily disabled while iterating on Slack report formatting.
               # - name: test-result-udec-2400
               #   value: "{{tasks.udec-rate-2400.outputs.parameters.test-result}}"
@@ -635,7 +635,7 @@ spec:
 
           allowed_failure_for_rate() {
             case "$1:$2" in
-              pdec:1950|udec:2750) return 0 ;;
+              pdec:1900|udec:2750) return 0 ;;
               *) return 1 ;;
             esac
           }
@@ -646,8 +646,8 @@ spec:
               # pct is the minimum achieved_rate/target_rate percentage.
               pdec:1500) echo "maxfail=0,maxshed=0,pct=98" ;;
               pdec:1800) echo "maxfail=1,maxshed=1,pct=90" ;;
-              # 1.95k is an exploratory public-decrypt probe and may warn.
-              pdec:1950) echo "maxfail=10,maxshed=25,pct=70" ;;
+              # 1.9k is an exploratory public-decrypt probe and may warn.
+              pdec:1900) echo "maxfail=10,maxshed=25,pct=70" ;;
               udec:2400) echo "maxfail=0,maxshed=0,pct=98" ;;
               udec:2700) echo "maxfail=1,maxshed=1,pct=95" ;;
               # 2.75k probes just above the clean 2.7k run; outside-set results warn.
@@ -847,7 +847,7 @@ spec:
         - name: test-result-crs-gen
         - name: test-result-pdec-1500
         - name: test-result-pdec-1800
-        - name: test-result-pdec-1950
+        - name: test-result-pdec-1900
         # Temporarily disabled while iterating on Slack report formatting.
         # - name: test-result-udec-2400
         # - name: test-result-udec-2700
@@ -879,7 +879,7 @@ spec:
           echo '{{inputs.parameters.test-result-crs-gen}}' > /mnt/results/crs-gen.json
           echo '{{inputs.parameters.test-result-pdec-1500}}' > /mnt/results/pdec-rate-1500.json
           echo '{{inputs.parameters.test-result-pdec-1800}}' > /mnt/results/pdec-rate-1800.json
-          echo '{{inputs.parameters.test-result-pdec-1950}}' > /mnt/results/pdec-rate-1950.json
+          echo '{{inputs.parameters.test-result-pdec-1900}}' > /mnt/results/pdec-rate-1900.json
           # Temporarily disabled while iterating on Slack report formatting.
           # echo '{ {inputs.parameters.test-result-udec-2400}}' > /mnt/results/udec-rate-2400.json
           # echo '{ {inputs.parameters.test-result-udec-2700}}' > /mnt/results/udec-rate-2700.json
@@ -1168,7 +1168,7 @@ spec:
           done
 
           echo ""
-          summarize_decrypt_rates pdec "Public decrypt" public_decrypt 1500 1800 1950
+          summarize_decrypt_rates pdec "Public decrypt" public_decrypt 1500 1800 1900
           # Temporarily disabled while iterating on Slack report formatting.
           # summarize_decrypt_rates udec "User decrypt" user_decrypt 2400 2700 2750
 

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -38,7 +38,7 @@ spec:
     - name: fhe-params
       value: "Test"
     - name: duration
-      value: "120"
+      value: "30"
     - name: max-in-flight
       value: "10000"
     - name: data-type

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -630,13 +630,47 @@ spec:
             ' /tmp/net-before.tsv /tmp/net-after.tsv
           }
 
+          allowed_failure_for_rate() {
+            case "$1:$2" in
+              pdec:1200|udec:2750) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          parameter_set_for_rate() {
+            case "$1:$2" in
+              # maxfail/maxshed are percentages of offered requests, not counts.
+              # pct is the minimum achieved_rate/target_rate percentage.
+              pdec:500) echo "maxfail=0,maxshed=0,pct=98" ;;
+              pdec:1000) echo "maxfail=1,maxshed=1,pct=90" ;;
+              # 1.2k is an exploratory public-decrypt probe and may warn.
+              pdec:1200) echo "maxfail=10,maxshed=25,pct=70" ;;
+              udec:2400) echo "maxfail=0,maxshed=0,pct=98" ;;
+              udec:2700) echo "maxfail=1,maxshed=1,pct=95" ;;
+              # 2.75k probes just above the clean 2.7k run; outside-set results warn.
+              udec:2750) echo "maxfail=10,maxshed=25,pct=70" ;;
+              *) echo "maxfail=0,maxshed=0,pct=100" ;;
+            esac
+          }
+
+          parameter_value() {
+            echo "$1" | tr ',' '\n' | sed -n "s/^$2=//p" | head -n 1
+          }
+
           if [ -z "$key_id" ]; then
-            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "failed",\n  "exit_code": 1,\n  "duration": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": {\n      "target_rate": %s,\n      "failed": 1\n    }\n  }\n}\n' \
+            parameter_set=$(parameter_set_for_rate "$kind" "{{inputs.parameters.rate}}")
+            allowed_failure=false
+            if allowed_failure_for_rate "$kind" "{{inputs.parameters.rate}}"; then
+              allowed_failure=true
+            fi
+            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "failed",\n  "exit_code": 1,\n  "duration": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": {\n      "target_rate": %s,\n      "failed": 1,\n      "parameter_set": "%s",\n      "within_parameter_set": false,\n      "allowed_failure": %s\n    }\n  }\n}\n' \
               "$test_name" \
               "$test_command" \
               "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
               "$metrics_key" \
               "{{inputs.parameters.rate}}" \
+              "$parameter_set" \
+              "$allowed_failure" \
               > /tmp/artifacts/${test_name}.json
             echo "false" > /tmp/artifacts/${test_name}.ok
             echo "Missing key_id from udec-key-gen; refusing to run $display_name"
@@ -644,12 +678,19 @@ spec:
           fi
 
           if [ "{{inputs.parameters.previous-ok}}" != "true" ]; then
-            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "skipped",\n  "exit_code": 0,\n  "duration": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": {\n      "target_rate": %s\n    }\n  }\n}\n' \
+            parameter_set=$(parameter_set_for_rate "$kind" "{{inputs.parameters.rate}}")
+            allowed_failure=false
+            if allowed_failure_for_rate "$kind" "{{inputs.parameters.rate}}"; then
+              allowed_failure=true
+            fi
+            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "skipped",\n  "exit_code": 0,\n  "duration": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": {\n      "target_rate": %s,\n      "parameter_set": "%s",\n      "within_parameter_set": false,\n      "allowed_failure": %s\n    }\n  }\n}\n' \
               "$test_name" \
               "$test_command" \
               "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
               "$metrics_key" \
               "{{inputs.parameters.rate}}" \
+              "$parameter_set" \
+              "$allowed_failure" \
               > /tmp/artifacts/${test_name}.json
             echo "false" > /tmp/artifacts/${test_name}.ok
             echo "Skipping $test_name because a lower $display_name rate did not produce valid metrics"
@@ -710,15 +751,57 @@ spec:
             echo "ERROR: no valid $metrics_marker JSON with failed/shed/saturated found"
           fi
           network_metrics="$(network_metrics_suffix "$duration")"
+          parameter_set=$(parameter_set_for_rate "$kind" "{{inputs.parameters.rate}}")
+          maxfail=$(parameter_value "$parameter_set" maxfail)
+          maxshed=$(parameter_value "$parameter_set" maxshed)
+          pct=$(parameter_value "$parameter_set" pct)
+          allowed_failure=false
+          if allowed_failure_for_rate "$kind" "{{inputs.parameters.rate}}"; then
+            allowed_failure=true
+          fi
+          if [[ "$decrypt_metrics" =~ \"offered\":([0-9]+) ]]; then
+            metrics_offered="${BASH_REMATCH[1]}"
+          else
+            metrics_offered=0
+          fi
+          if [[ "$decrypt_metrics" =~ \"achieved_rate\":([-0-9.eE]+) ]]; then
+            metrics_achieved_rate="${BASH_REMATCH[1]}"
+          else
+            metrics_achieved_rate=0
+          fi
+          within_parameter_set=$(awk \
+            -v offered="$metrics_offered" \
+            -v failed="$metrics_failed" \
+            -v shed="$metrics_shed" \
+            -v achieved="$metrics_achieved_rate" \
+            -v target="{{inputs.parameters.rate}}" \
+            -v maxfail="$maxfail" \
+            -v maxshed="$maxshed" \
+            -v pct="$pct" '
+              BEGIN {
+                if (offered <= 0 || target <= 0) {
+                  print "false"
+                } else if ((failed * 100 / offered) <= maxfail &&
+                           (shed * 100 / offered) <= maxshed &&
+                           (achieved * 100 / target) >= pct) {
+                  print "true"
+                } else {
+                  print "false"
+                }
+              }')
           # Escape the brace; ${var%}} does not trim the final JSON object brace in bash.
-          decrypt_metrics="${decrypt_metrics%\}}${network_metrics}}"
+          limit_metrics=",\"parameter_set\":\"${parameter_set}\",\"within_parameter_set\":${within_parameter_set},\"allowed_failure\":${allowed_failure}"
+          decrypt_metrics="${decrypt_metrics%\}}${network_metrics}${limit_metrics}}"
 
-          # Task success means "measurement exists"; the summary applies perf limits.
+          # Task success means "measurement exists"; capacity-ok gates the next rung.
           if [ "$test_exit" -eq 0 ] && [ "$metrics_valid" = "true" ]; then
             status="passed"
-            capacity_ok="true"
           else
             status="failed"
+          fi
+          if [ "$status" = "passed" ] && [ "$within_parameter_set" = "true" ]; then
+            capacity_ok="true"
+          else
             capacity_ok="false"
           fi
 
@@ -888,33 +971,6 @@ spec:
             esac
           }
 
-          allowed_failure_for_rate() {
-            case "$1:$2" in
-              pdec:1200|udec:2750) return 0 ;;
-              *) return 1 ;;
-            esac
-          }
-
-          parameter_set_for_rate() {
-            case "$1:$2" in
-              # maxfail/maxshed are percentages of offered requests, not counts.
-              # pct is the minimum achieved_rate/target_rate percentage.
-              pdec:500) echo "maxfail=0,maxshed=0,pct=98" ;;
-              pdec:1000) echo "maxfail=1,maxshed=1,pct=90" ;;
-              # 1.2k is an exploratory public-decrypt probe and may warn.
-              pdec:1200) echo "maxfail=10,maxshed=25,pct=70" ;;
-              udec:2400) echo "maxfail=0,maxshed=0,pct=98" ;;
-              udec:2700) echo "maxfail=1,maxshed=1,pct=95" ;;
-              # 2.75k probes just above the clean 2.7k run; outside-set results warn.
-              udec:2750) echo "maxfail=10,maxshed=25,pct=70" ;;
-              *) echo "maxfail=0,maxshed=0,pct=100" ;;
-            esac
-          }
-
-          parameter_value() {
-            echo "$1" | tr ',' '\n' | sed -n "s/^$2=//p" | head -n 1
-          }
-
           summarize_decrypt_rates() {
             kind="$1"
             display="$2"
@@ -967,6 +1023,9 @@ spec:
               network_tx_dropped=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].network.tx_dropped // 0' "$result")
               network_rx_errors=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].network.rx_errors // 0' "$result")
               network_tx_errors=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].network.tx_errors // 0' "$result")
+              parameter_set=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].parameter_set // empty' "$result")
+              within_parameter_set=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].within_parameter_set // false' "$result")
+              allowed_failure=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].allowed_failure // false' "$result")
               extra_failed=$(jq -r --arg k "$metrics_key" --arg f "$extra_failed_key" '.performance_metrics[$k][$f] // 0' "$result")
               p50=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].latency_ms.p50 // empty' "$result")
               p95=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].latency_ms.p95 // empty' "$result")
@@ -989,29 +1048,6 @@ spec:
               network_rx_short="$(fmt_1 "$network_rx_gbps")"
               network_tx_short="$(fmt_1 "$network_tx_gbps")"
 
-              # Parameter sets are per-rate because the top probe is intentionally near capacity.
-              parameter_set=$(parameter_set_for_rate "$kind" "$rate")
-              maxfail=$(parameter_value "$parameter_set" maxfail)
-              maxshed=$(parameter_value "$parameter_set" maxshed)
-              pct=$(parameter_value "$parameter_set" pct)
-
-              # Any single limit outside the parameter set fails the scenario.
-              within_parameter_set=$(jq -n \
-                --argjson offered "$offered" \
-                --argjson failed_requests "$failed_requests" \
-                --argjson shed "$shed" \
-                --argjson achieved_rate "$achieved_rate" \
-                --argjson target_rate "$target_rate" \
-                --argjson maxfail "$maxfail" \
-                --argjson maxshed "$maxshed" \
-                --argjson pct "$pct" '
-                  def pct_of($num; $den): if $den == 0 then 1000000 else ($num * 100 / $den) end;
-                  ($offered > 0)
-                  and (pct_of($failed_requests; $offered) <= $maxfail)
-                  and (pct_of($shed; $offered) <= $maxshed)
-                  and (($target_rate > 0) and (($achieved_rate * 100 / $target_rate) >= $pct))
-                ')
-
               # WARN is accepted-but-degraded. The top rate for each decrypt type
               # is an exploratory probe and can exceed its parameter set.
               if [ "$status" = "skipped" ]; then
@@ -1019,7 +1055,7 @@ spec:
                 inc_decrypt_counter "$kind" skipped
                 line="$(status_label "$outcome") ${target_rate}/s skipped"
               elif [ "$status" != "passed" ]; then
-                if allowed_failure_for_rate "$kind" "$rate"; then
+                if [ "$allowed_failure" = "true" ]; then
                   outcome=warned
                   inc_decrypt_counter "$kind" warned
                 else
@@ -1037,7 +1073,7 @@ spec:
                 fi
                 line="$(status_label "$outcome") ${target_rate}/s p50=${p50_short} p99=${p99_short}"
               else
-                if allowed_failure_for_rate "$kind" "$rate"; then
+                if [ "$allowed_failure" = "true" ]; then
                   outcome=warned
                   inc_decrypt_counter "$kind" warned
                 else

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -124,7 +124,7 @@ spec:
               - name: fhe-params
                 value: "Default"
 
-          - name: pdec-rate-1000
+          - name: pdec-rate-1100
             dependencies: ["crs-gen"]
             template: run-decrypt-rate
             arguments:
@@ -132,42 +132,42 @@ spec:
               - name: kind
                 value: "pdec"
               - name: rate
-                value: "1000"
+                value: "1100"
               - name: key_id
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
                 value: "true"
 
-          - name: pdec-rate-1200
-            dependencies: ["pdec-rate-1000"]
+          - name: pdec-rate-1300
+            dependencies: ["pdec-rate-1100"]
             template: run-decrypt-rate
             arguments:
               parameters:
               - name: kind
                 value: "pdec"
               - name: rate
-                value: "1200"
+                value: "1300"
               - name: key_id
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
-                value: "{{tasks.pdec-rate-1000.outputs.parameters.capacity-ok}}"
+                value: "{{tasks.pdec-rate-1100.outputs.parameters.capacity-ok}}"
 
-          - name: pdec-rate-1400
-            dependencies: ["pdec-rate-1200"]
+          - name: pdec-rate-1500
+            dependencies: ["pdec-rate-1300"]
             template: run-decrypt-rate
             arguments:
               parameters:
               - name: kind
                 value: "pdec"
               - name: rate
-                value: "1400"
+                value: "1500"
               - name: key_id
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
-                value: "{{tasks.pdec-rate-1200.outputs.parameters.capacity-ok}}"
+                value: "{{tasks.pdec-rate-1300.outputs.parameters.capacity-ok}}"
 
           - name: udec-rate-2400
-            dependencies: ["udec-key-gen", "pdec-rate-1400"]
+            dependencies: ["udec-key-gen", "pdec-rate-1500"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -215,9 +215,9 @@ spec:
               - "udec-preproc-key-gen"
               - "udec-key-gen"
               - "crs-gen"
-              - "pdec-rate-1000"
-              - "pdec-rate-1200"
-              - "pdec-rate-1400"
+              - "pdec-rate-1100"
+              - "pdec-rate-1300"
+              - "pdec-rate-1500"
               - "udec-rate-2400"
               - "udec-rate-2700"
               - "udec-rate-2750"
@@ -234,12 +234,12 @@ spec:
                 value: "{{tasks.udec-key-gen.outputs.parameters.test-result}}"
               - name: test-result-crs-gen
                 value: "{{tasks.crs-gen.outputs.parameters.test-result}}"
-              - name: test-result-pdec-1000
-                value: "{{tasks.pdec-rate-1000.outputs.parameters.test-result}}"
-              - name: test-result-pdec-1200
-                value: "{{tasks.pdec-rate-1200.outputs.parameters.test-result}}"
-              - name: test-result-pdec-1400
-                value: "{{tasks.pdec-rate-1400.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1100
+                value: "{{tasks.pdec-rate-1100.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1300
+                value: "{{tasks.pdec-rate-1300.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1500
+                value: "{{tasks.pdec-rate-1500.outputs.parameters.test-result}}"
               - name: test-result-udec-2400
                 value: "{{tasks.udec-rate-2400.outputs.parameters.test-result}}"
               - name: test-result-udec-2700
@@ -632,7 +632,7 @@ spec:
 
           allowed_failure_for_rate() {
             case "$1:$2" in
-              pdec:1400|udec:2750) return 0 ;;
+              pdec:1500|udec:2750) return 0 ;;
               *) return 1 ;;
             esac
           }
@@ -641,10 +641,10 @@ spec:
             case "$1:$2" in
               # maxfail/maxshed are percentages of offered requests, not counts.
               # pct is the minimum achieved_rate/target_rate percentage.
-              pdec:1000) echo "maxfail=0,maxshed=0,pct=98" ;;
-              pdec:1200) echo "maxfail=1,maxshed=1,pct=90" ;;
-              # 1.4k is an exploratory public-decrypt probe and may warn.
-              pdec:1400) echo "maxfail=10,maxshed=25,pct=70" ;;
+              pdec:1100) echo "maxfail=0,maxshed=0,pct=98" ;;
+              pdec:1300) echo "maxfail=1,maxshed=1,pct=90" ;;
+              # 1.5k is an exploratory public-decrypt probe and may warn.
+              pdec:1500) echo "maxfail=10,maxshed=25,pct=70" ;;
               udec:2400) echo "maxfail=0,maxshed=0,pct=98" ;;
               udec:2700) echo "maxfail=1,maxshed=1,pct=95" ;;
               # 2.75k probes just above the clean 2.7k run; outside-set results warn.
@@ -842,9 +842,9 @@ spec:
         - name: test-result-udec-preproc-key-gen
         - name: test-result-udec-key-gen
         - name: test-result-crs-gen
-        - name: test-result-pdec-1000
-        - name: test-result-pdec-1200
-        - name: test-result-pdec-1400
+        - name: test-result-pdec-1100
+        - name: test-result-pdec-1300
+        - name: test-result-pdec-1500
         - name: test-result-udec-2400
         - name: test-result-udec-2700
         - name: test-result-udec-2750
@@ -873,9 +873,9 @@ spec:
           echo '{{inputs.parameters.test-result-udec-preproc-key-gen}}' > /mnt/results/udec-preproc-key-gen.json
           echo '{{inputs.parameters.test-result-udec-key-gen}}' > /mnt/results/udec-key-gen.json
           echo '{{inputs.parameters.test-result-crs-gen}}' > /mnt/results/crs-gen.json
-          echo '{{inputs.parameters.test-result-pdec-1000}}' > /mnt/results/pdec-rate-1000.json
-          echo '{{inputs.parameters.test-result-pdec-1200}}' > /mnt/results/pdec-rate-1200.json
-          echo '{{inputs.parameters.test-result-pdec-1400}}' > /mnt/results/pdec-rate-1400.json
+          echo '{{inputs.parameters.test-result-pdec-1100}}' > /mnt/results/pdec-rate-1100.json
+          echo '{{inputs.parameters.test-result-pdec-1300}}' > /mnt/results/pdec-rate-1300.json
+          echo '{{inputs.parameters.test-result-pdec-1500}}' > /mnt/results/pdec-rate-1500.json
           echo '{{inputs.parameters.test-result-udec-2400}}' > /mnt/results/udec-rate-2400.json
           echo '{{inputs.parameters.test-result-udec-2700}}' > /mnt/results/udec-rate-2700.json
           echo '{{inputs.parameters.test-result-udec-2750}}' > /mnt/results/udec-rate-2750.json
@@ -1163,7 +1163,7 @@ spec:
           done
 
           echo ""
-          summarize_decrypt_rates pdec "Public decrypt" public_decrypt 1000 1200 1400
+          summarize_decrypt_rates pdec "Public decrypt" public_decrypt 1100 1300 1500
           summarize_decrypt_rates udec "User decrypt" user_decrypt 2400 2700 2750
 
           finite_total=$((keygen_total + crs_total))

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -138,16 +138,8 @@ spec:
               - name: previous-ok
                 value: "true"
 
-          - name: pause-pdec-1
-            dependencies: ["pdec-rate-1100"]
-            template: pause
-            arguments:
-              parameters:
-              - name: duration
-                value: "10"
-
           - name: pdec-rate-1300
-            dependencies: ["pause-pdec-1"]
+            dependencies: ["pdec-rate-1100"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -160,16 +152,8 @@ spec:
               - name: previous-ok
                 value: "{{tasks.pdec-rate-1100.outputs.parameters.capacity-ok}}"
 
-          - name: pause-pdec-2
-            dependencies: ["pdec-rate-1300"]
-            template: pause
-            arguments:
-              parameters:
-              - name: duration
-                value: "10"
-
           - name: pdec-rate-1500
-            dependencies: ["pause-pdec-2"]
+            dependencies: ["pdec-rate-1300"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -182,16 +166,8 @@ spec:
               - name: previous-ok
                 value: "{{tasks.pdec-rate-1300.outputs.parameters.capacity-ok}}"
 
-          - name: pause-inter-suite
-            dependencies: ["pdec-rate-1500"]
-            template: pause
-            arguments:
-              parameters:
-              - name: duration
-                value: "30"
-
           - name: udec-rate-2400
-            dependencies: ["udec-key-gen", "pause-inter-suite"]
+            dependencies: ["udec-key-gen", "pdec-rate-1500"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -203,17 +179,8 @@ spec:
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
                 value: "true"
-
-          - name: pause-udec-1
-            dependencies: ["udec-rate-2400"]
-            template: pause
-            arguments:
-              parameters:
-              - name: duration
-                value: "10"
-
           - name: udec-rate-2700
-            dependencies: ["pause-udec-1"]
+            dependencies: ["udec-rate-2400"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -225,17 +192,8 @@ spec:
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
                 value: "{{tasks.udec-rate-2400.outputs.parameters.capacity-ok}}"
-
-          - name: pause-udec-2
-            dependencies: ["udec-rate-2700"]
-            template: pause
-            arguments:
-              parameters:
-              - name: duration
-                value: "10"
-
           - name: udec-rate-2750
-            dependencies: ["pause-udec-2"]
+            dependencies: ["udec-rate-2700"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -873,13 +831,6 @@ spec:
           - name: FHE_PARAMETER
             value: 'Default'
         resources: *core-client-resources
-
-    - name: pause
-      inputs:
-        parameters:
-        - name: duration
-      suspend:
-        duration: "{{inputs.parameters.duration}}s"
 
     - name: summary-report
       inputs:

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -38,7 +38,7 @@ spec:
     - name: fhe-params
       value: "Test"
     - name: duration
-      value: "60"
+      value: "30"
     - name: max-in-flight
       value: "10000"
     - name: data-type
@@ -166,47 +166,48 @@ spec:
               - name: previous-ok
                 value: "{{tasks.pdec-rate-1000.outputs.parameters.capacity-ok}}"
 
-          - name: udec-rate-2400
-            dependencies: ["udec-key-gen", "pdec-rate-1200"]
-            template: run-decrypt-rate
-            arguments:
-              parameters:
-              - name: kind
-                value: "udec"
-              - name: rate
-                value: "2400"
-              - name: key_id
-                value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
-              - name: previous-ok
-                value: "true"
-
-          - name: udec-rate-2700
-            dependencies: ["udec-rate-2400"]
-            template: run-decrypt-rate
-            arguments:
-              parameters:
-              - name: kind
-                value: "udec"
-              - name: rate
-                value: "2700"
-              - name: key_id
-                value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
-              - name: previous-ok
-                value: "{{tasks.udec-rate-2400.outputs.parameters.capacity-ok}}"
-
-          - name: udec-rate-2750
-            dependencies: ["udec-rate-2700"]
-            template: run-decrypt-rate
-            arguments:
-              parameters:
-              - name: kind
-                value: "udec"
-              - name: rate
-                value: "2750"
-              - name: key_id
-                value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
-              - name: previous-ok
-                value: "{{tasks.udec-rate-2700.outputs.parameters.capacity-ok}}"
+          # Temporarily disabled while iterating on Slack report formatting.
+          # - name: udec-rate-2400
+          #   dependencies: ["udec-key-gen", "pdec-rate-1200"]
+          #   template: run-decrypt-rate
+          #   arguments:
+          #     parameters:
+          #     - name: kind
+          #       value: "udec"
+          #     - name: rate
+          #       value: "2400"
+          #     - name: key_id
+          #       value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
+          #     - name: previous-ok
+          #       value: "true"
+          #
+          # - name: udec-rate-2700
+          #   dependencies: ["udec-rate-2400"]
+          #   template: run-decrypt-rate
+          #   arguments:
+          #     parameters:
+          #     - name: kind
+          #       value: "udec"
+          #     - name: rate
+          #       value: "2700"
+          #     - name: key_id
+          #       value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
+          #     - name: previous-ok
+          #       value: "{{tasks.udec-rate-2400.outputs.parameters.capacity-ok}}"
+          #
+          # - name: udec-rate-2750
+          #   dependencies: ["udec-rate-2700"]
+          #   template: run-decrypt-rate
+          #   arguments:
+          #     parameters:
+          #     - name: kind
+          #       value: "udec"
+          #     - name: rate
+          #       value: "2750"
+          #     - name: key_id
+          #       value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
+          #     - name: previous-ok
+          #       value: "{{tasks.udec-rate-2700.outputs.parameters.capacity-ok}}"
 
           - name: summary
             dependencies:
@@ -218,9 +219,10 @@ spec:
               - "pdec-rate-500"
               - "pdec-rate-1000"
               - "pdec-rate-1200"
-              - "udec-rate-2400"
-              - "udec-rate-2700"
-              - "udec-rate-2750"
+              # Temporarily disabled while iterating on Slack report formatting.
+              # - "udec-rate-2400"
+              # - "udec-rate-2700"
+              # - "udec-rate-2750"
             template: summary-report
             arguments:
               parameters:
@@ -240,12 +242,13 @@ spec:
                 value: "{{tasks.pdec-rate-1000.outputs.parameters.test-result}}"
               - name: test-result-pdec-1200
                 value: "{{tasks.pdec-rate-1200.outputs.parameters.test-result}}"
-              - name: test-result-udec-2400
-                value: "{{tasks.udec-rate-2400.outputs.parameters.test-result}}"
-              - name: test-result-udec-2700
-                value: "{{tasks.udec-rate-2700.outputs.parameters.test-result}}"
-              - name: test-result-udec-2750
-                value: "{{tasks.udec-rate-2750.outputs.parameters.test-result}}"
+              # Temporarily disabled while iterating on Slack report formatting.
+              # - name: test-result-udec-2400
+              #   value: "{{tasks.udec-rate-2400.outputs.parameters.test-result}}"
+              # - name: test-result-udec-2700
+              #   value: "{{tasks.udec-rate-2700.outputs.parameters.test-result}}"
+              # - name: test-result-udec-2750
+              #   value: "{{tasks.udec-rate-2750.outputs.parameters.test-result}}"
               - name: tls
                 value: "{{workflow.parameters.tls}}"
               - name: run_url
@@ -845,9 +848,10 @@ spec:
         - name: test-result-pdec-500
         - name: test-result-pdec-1000
         - name: test-result-pdec-1200
-        - name: test-result-udec-2400
-        - name: test-result-udec-2700
-        - name: test-result-udec-2750
+        # Temporarily disabled while iterating on Slack report formatting.
+        # - name: test-result-udec-2400
+        # - name: test-result-udec-2700
+        # - name: test-result-udec-2750
         - name: tls
         - name: run_url
         - name: job_url
@@ -876,9 +880,10 @@ spec:
           echo '{{inputs.parameters.test-result-pdec-500}}' > /mnt/results/pdec-rate-500.json
           echo '{{inputs.parameters.test-result-pdec-1000}}' > /mnt/results/pdec-rate-1000.json
           echo '{{inputs.parameters.test-result-pdec-1200}}' > /mnt/results/pdec-rate-1200.json
-          echo '{{inputs.parameters.test-result-udec-2400}}' > /mnt/results/udec-rate-2400.json
-          echo '{{inputs.parameters.test-result-udec-2700}}' > /mnt/results/udec-rate-2700.json
-          echo '{{inputs.parameters.test-result-udec-2750}}' > /mnt/results/udec-rate-2750.json
+          # Temporarily disabled while iterating on Slack report formatting.
+          # echo '{ {inputs.parameters.test-result-udec-2400}}' > /mnt/results/udec-rate-2400.json
+          # echo '{ {inputs.parameters.test-result-udec-2700}}' > /mnt/results/udec-rate-2700.json
+          # echo '{ {inputs.parameters.test-result-udec-2750}}' > /mnt/results/udec-rate-2750.json
 
           echo "=========================================="
           echo "KMS PERFORMANCE SUMMARY"
@@ -1164,7 +1169,8 @@ spec:
 
           echo ""
           summarize_decrypt_rates pdec "Public decrypt" public_decrypt 500 1000 1200
-          summarize_decrypt_rates udec "User decrypt" user_decrypt 2400 2700 2750
+          # Temporarily disabled while iterating on Slack report formatting.
+          # summarize_decrypt_rates udec "User decrypt" user_decrypt 2400 2700 2750
 
           finite_total=$((keygen_total + crs_total))
           finite_passed=$((keygen_passed + crs_passed))

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -38,7 +38,7 @@ spec:
     - name: fhe-params
       value: "Test"
     - name: duration
-      value: "30"
+      value: "45"
     - name: max-in-flight
       value: "10000"
     - name: data-type

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -124,95 +124,55 @@ spec:
               - name: fhe-params
                 value: "Default"
 
-          - name: warmup-public-decrypt-euint64-req1
+          - name: pdec-rate-500
             dependencies: ["crs-gen"]
-            template: run-test
-            continueOn:
-              failed: true
+            template: run-decrypt-rate
             arguments:
               parameters:
-              - name: test-name
-                value: "warmup-public-decrypt-euint64-req1"
-              - name: test-command
-                value: "public-decrypt from-args -d euint64 -k {{tasks.udec-key-gen.outputs.parameters.request-id}} -e ffffffffffffffff --num-requests 1"
-              - name: fhe-params
-                value: "Default"
+              - name: kind
+                value: "pdec"
+              - name: rate
+                value: "500"
+              - name: key_id
+                value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
+              - name: previous-ok
+                value: "true"
 
-          - name: public-decrypt-euint64-req1
-            dependencies: ["warmup-public-decrypt-euint64-req1"]
-            template: run-test
-            continueOn:
-              failed: true
+          - name: pdec-rate-1000
+            dependencies: ["pdec-rate-500"]
+            template: run-decrypt-rate
             arguments:
               parameters:
-              - name: test-name
-                value: "public-decrypt-euint64-req1"
-              - name: test-command
-                value: "public-decrypt from-args -d euint64 -k {{tasks.udec-key-gen.outputs.parameters.request-id}} -e ffffffffffffffff --num-requests 1"
-              - name: fhe-params
-                value: "Default"
+              - name: kind
+                value: "pdec"
+              - name: rate
+                value: "1000"
+              - name: key_id
+                value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
+              - name: previous-ok
+                value: "{{tasks.pdec-rate-500.outputs.parameters.capacity-ok}}"
 
-          - name: public-decrypt-euint64-req10
-            dependencies: ["public-decrypt-euint64-req1"]
-            template: run-test
-            continueOn:
-              failed: true
+          - name: pdec-rate-1200
+            dependencies: ["pdec-rate-1000"]
+            template: run-decrypt-rate
             arguments:
               parameters:
-              - name: test-name
-                value: "public-decrypt-euint64-req10"
-              - name: test-command
-                value: "public-decrypt from-args -d euint64 -k {{tasks.udec-key-gen.outputs.parameters.request-id}} -e ffffffffffffffff --num-requests 10"
-              - name: fhe-params
-                value: "Default"
-
-          - name: public-decrypt-euint64-req100
-            dependencies: ["public-decrypt-euint64-req10"]
-            template: run-test
-            continueOn:
-              failed: true
-            arguments:
-              parameters:
-              - name: test-name
-                value: "public-decrypt-euint64-req100"
-              - name: test-command
-                value: "public-decrypt from-args -d euint64 -k {{tasks.udec-key-gen.outputs.parameters.request-id}} -e ffffffffffffffff --num-requests 100"
-              - name: fhe-params
-                value: "Default"
-
-          - name: public-decrypt-euint64-req500
-            dependencies: ["public-decrypt-euint64-req100"]
-            template: run-test
-            continueOn:
-              failed: true
-            arguments:
-              parameters:
-              - name: test-name
-                value: "public-decrypt-euint64-req500"
-              - name: test-command
-                value: "public-decrypt from-args -d euint64 -k {{tasks.udec-key-gen.outputs.parameters.request-id}} -e ffffffffffffffff --num-requests 500"
-              - name: fhe-params
-                value: "Default"
-
-          - name: public-decrypt-euint64-req1000
-            dependencies: ["public-decrypt-euint64-req500"]
-            template: run-test
-            continueOn:
-              failed: true
-            arguments:
-              parameters:
-              - name: test-name
-                value: "public-decrypt-euint64-req1000"
-              - name: test-command
-                value: "public-decrypt from-args -d euint64 -k {{tasks.udec-key-gen.outputs.parameters.request-id}} -e ffffffffffffffff --num-requests 1000"
-              - name: fhe-params
-                value: "Default"
+              - name: kind
+                value: "pdec"
+              - name: rate
+                value: "1200"
+              - name: key_id
+                value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
+              - name: previous-ok
+                value: "{{tasks.pdec-rate-1000.outputs.parameters.capacity-ok}}"
 
           - name: udec-rate-2400
-            dependencies: ["udec-key-gen", "public-decrypt-euint64-req1000"]
-            template: run-udec-rate
+            dependencies: ["udec-key-gen", "pdec-rate-1200"]
+            template: run-decrypt-rate
             arguments:
               parameters:
+              - name: kind
+                value: "udec"
               - name: rate
                 value: "2400"
               - name: key_id
@@ -222,9 +182,11 @@ spec:
 
           - name: udec-rate-2700
             dependencies: ["udec-rate-2400"]
-            template: run-udec-rate
+            template: run-decrypt-rate
             arguments:
               parameters:
+              - name: kind
+                value: "udec"
               - name: rate
                 value: "2700"
               - name: key_id
@@ -234,9 +196,11 @@ spec:
 
           - name: udec-rate-2750
             dependencies: ["udec-rate-2700"]
-            template: run-udec-rate
+            template: run-decrypt-rate
             arguments:
               parameters:
+              - name: kind
+                value: "udec"
               - name: rate
                 value: "2750"
               - name: key_id
@@ -251,11 +215,9 @@ spec:
               - "udec-preproc-key-gen"
               - "udec-key-gen"
               - "crs-gen"
-              - "public-decrypt-euint64-req1"
-              - "public-decrypt-euint64-req10"
-              - "public-decrypt-euint64-req100"
-              - "public-decrypt-euint64-req500"
-              - "public-decrypt-euint64-req1000"
+              - "pdec-rate-500"
+              - "pdec-rate-1000"
+              - "pdec-rate-1200"
               - "udec-rate-2400"
               - "udec-rate-2700"
               - "udec-rate-2750"
@@ -272,21 +234,17 @@ spec:
                 value: "{{tasks.udec-key-gen.outputs.parameters.test-result}}"
               - name: test-result-crs-gen
                 value: "{{tasks.crs-gen.outputs.parameters.test-result}}"
-              - name: test-result-public-decrypt-req1
-                value: "{{tasks.public-decrypt-euint64-req1.outputs.parameters.test-result}}"
-              - name: test-result-public-decrypt-req10
-                value: "{{tasks.public-decrypt-euint64-req10.outputs.parameters.test-result}}"
-              - name: test-result-public-decrypt-req100
-                value: "{{tasks.public-decrypt-euint64-req100.outputs.parameters.test-result}}"
-              - name: test-result-public-decrypt-req500
-                value: "{{tasks.public-decrypt-euint64-req500.outputs.parameters.test-result}}"
-              - name: test-result-public-decrypt-req1000
-                value: "{{tasks.public-decrypt-euint64-req1000.outputs.parameters.test-result}}"
-              - name: test-result-2400
+              - name: test-result-pdec-500
+                value: "{{tasks.pdec-rate-500.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1000
+                value: "{{tasks.pdec-rate-1000.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1200
+                value: "{{tasks.pdec-rate-1200.outputs.parameters.test-result}}"
+              - name: test-result-udec-2400
                 value: "{{tasks.udec-rate-2400.outputs.parameters.test-result}}"
-              - name: test-result-2700
+              - name: test-result-udec-2700
                 value: "{{tasks.udec-rate-2700.outputs.parameters.test-result}}"
-              - name: test-result-2750
+              - name: test-result-udec-2750
                 value: "{{tasks.udec-rate-2750.outputs.parameters.test-result}}"
               - name: tls
                 value: "{{workflow.parameters.tls}}"
@@ -495,9 +453,10 @@ spec:
             memory: "96Gi"
             cpu: "64"
 
-    - name: run-udec-rate
+    - name: run-decrypt-rate
       inputs:
         parameters:
+        - name: kind
         - name: rate
         - name: key_id
         - name: previous-ok
@@ -505,13 +464,13 @@ spec:
         parameters:
         - name: test-result
           valueFrom:
-            path: /tmp/artifacts/udec-rate-{{inputs.parameters.rate}}.json
+            path: /tmp/artifacts/{{inputs.parameters.kind}}-rate-{{inputs.parameters.rate}}.json
         - name: capacity-ok
           valueFrom:
-            path: /tmp/artifacts/udec-rate-{{inputs.parameters.rate}}.ok
+            path: /tmp/artifacts/{{inputs.parameters.kind}}-rate-{{inputs.parameters.rate}}.ok
       metadata:
         labels:
-          test: udec-rate-{{inputs.parameters.rate}}
+          test: "{{inputs.parameters.kind}}-rate-{{inputs.parameters.rate}}"
           app: kms-perf
       nodeSelector:
         karpenter.sh/nodepool: kms-pool
@@ -593,9 +552,29 @@ spec:
             object_folder="PUB-p13"
           EOF
 
-          test_name="udec-rate-{{inputs.parameters.rate}}"
+          kind="{{inputs.parameters.kind}}"
+          case "$kind" in
+            pdec)
+              command_name="public-decrypt"
+              metrics_marker="PUBLIC_DECRYPT_METRICS"
+              metrics_key="public_decrypt"
+              display_name="public decrypt"
+              ;;
+            udec)
+              command_name="user-decrypt"
+              metrics_marker="USER_DECRYPT_METRICS"
+              metrics_key="user_decrypt"
+              display_name="user decrypt"
+              ;;
+            *)
+              echo "Unsupported decrypt kind: $kind"
+              exit 1
+              ;;
+          esac
+
+          test_name="${kind}-rate-{{inputs.parameters.rate}}"
           key_id="{{inputs.parameters.key_id}}"
-          test_command="user-decrypt from-args -d {{workflow.parameters.data-type}} -k ${key_id} -e ffffffffffffffff --batch-size {{workflow.parameters.batch-size}} --rate {{inputs.parameters.rate}} --duration {{workflow.parameters.duration}} --max-in-flight {{workflow.parameters.max-in-flight}}"
+          test_command="${command_name} from-args -d {{workflow.parameters.data-type}} -k ${key_id} -e ffffffffffffffff --batch-size {{workflow.parameters.batch-size}} --rate {{inputs.parameters.rate}} --duration {{workflow.parameters.duration}} --max-in-flight {{workflow.parameters.max-in-flight}}"
           mkdir -p /tmp/artifacts
 
           capture_net_snapshot() {
@@ -652,26 +631,28 @@ spec:
           }
 
           if [ -z "$key_id" ]; then
-            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "failed",\n  "exit_code": 1,\n  "duration": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "user_decrypt": {\n      "target_rate": %s,\n      "failed": 1\n    }\n  }\n}\n' \
+            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "failed",\n  "exit_code": 1,\n  "duration": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": {\n      "target_rate": %s,\n      "failed": 1\n    }\n  }\n}\n' \
               "$test_name" \
               "$test_command" \
               "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+              "$metrics_key" \
               "{{inputs.parameters.rate}}" \
               > /tmp/artifacts/${test_name}.json
             echo "false" > /tmp/artifacts/${test_name}.ok
-            echo "Missing key_id from udec-key-gen; refusing to run user decrypt"
+            echo "Missing key_id from udec-key-gen; refusing to run $display_name"
             exit 0
           fi
 
           if [ "{{inputs.parameters.previous-ok}}" != "true" ]; then
-            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "skipped",\n  "exit_code": 0,\n  "duration": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "user_decrypt": {\n      "target_rate": %s\n    }\n  }\n}\n' \
+            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "skipped",\n  "exit_code": 0,\n  "duration": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": {\n      "target_rate": %s\n    }\n  }\n}\n' \
               "$test_name" \
               "$test_command" \
               "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+              "$metrics_key" \
               "{{inputs.parameters.rate}}" \
               > /tmp/artifacts/${test_name}.json
             echo "false" > /tmp/artifacts/${test_name}.ok
-            echo "Skipping $test_name because a lower user decrypt rate did not produce valid metrics"
+            echo "Skipping $test_name because a lower $display_name rate did not produce valid metrics"
             exit 0
           fi
 
@@ -698,24 +679,24 @@ spec:
           capture_net_snapshot /tmp/net-after.tsv
 
           # Keep the last valid metrics line; normal logs may contain many JSON records.
-          user_decrypt_metrics=""
+          decrypt_metrics=""
           while IFS= read -r metrics_line; do
-            candidate="${metrics_line#*USER_DECRYPT_METRICS }"
+            candidate="${metrics_line#*${metrics_marker} }"
             # Accept only the raw println! JSON, not an escaped copy inside tracing JSON logs.
             if [[ "$candidate" == \{\"* ]] && [[ "$candidate" =~ \"failed\":[0-9]+ ]] && [[ "$candidate" =~ \"shed\":[0-9]+ ]] && [[ "$candidate" =~ \"saturated\":(true|false) ]]; then
-              user_decrypt_metrics="$candidate"
+              decrypt_metrics="$candidate"
             fi
-          done < <(grep "USER_DECRYPT_METRICS " /tmp/test_logs.txt || true)
+          done < <(grep "$metrics_marker " /tmp/test_logs.txt || true)
 
-          if [[ -n "$user_decrypt_metrics" && "$user_decrypt_metrics" =~ \"failed\":([0-9]+) ]]; then
+          if [[ -n "$decrypt_metrics" && "$decrypt_metrics" =~ \"failed\":([0-9]+) ]]; then
             metrics_valid=true
             metrics_failed="${BASH_REMATCH[1]}"
-            if [[ "$user_decrypt_metrics" =~ \"shed\":([0-9]+) ]]; then
+            if [[ "$decrypt_metrics" =~ \"shed\":([0-9]+) ]]; then
               metrics_shed="${BASH_REMATCH[1]}"
             else
               metrics_shed=0
             fi
-            if [[ "$user_decrypt_metrics" =~ \"saturated\":(true|false) ]]; then
+            if [[ "$decrypt_metrics" =~ \"saturated\":(true|false) ]]; then
               metrics_saturated="${BASH_REMATCH[1]}"
             else
               metrics_saturated=true
@@ -725,12 +706,12 @@ spec:
             metrics_failed=1
             metrics_shed=0
             metrics_saturated=true
-            user_decrypt_metrics="{\"target_rate\":{{inputs.parameters.rate}},\"failed\":1,\"shed\":0,\"saturated\":true}"
-            echo "ERROR: no valid USER_DECRYPT_METRICS JSON with failed/shed/saturated found"
+            decrypt_metrics="{\"target_rate\":{{inputs.parameters.rate}},\"failed\":1,\"shed\":0,\"saturated\":true}"
+            echo "ERROR: no valid $metrics_marker JSON with failed/shed/saturated found"
           fi
           network_metrics="$(network_metrics_suffix "$duration")"
           # Escape the brace; ${var%}} does not trim the final JSON object brace in bash.
-          user_decrypt_metrics="${user_decrypt_metrics%\}}${network_metrics}}"
+          decrypt_metrics="${decrypt_metrics%\}}${network_metrics}}"
 
           # Task success means "measurement exists"; the summary applies perf limits.
           if [ "$test_exit" -eq 0 ] && [ "$metrics_valid" = "true" ]; then
@@ -741,14 +722,15 @@ spec:
             capacity_ok="false"
           fi
 
-          printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "%s",\n  "exit_code": %s,\n  "duration": %s,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "user_decrypt": %s\n  }\n}\n' \
+          printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "%s",\n  "exit_code": %s,\n  "duration": %s,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": %s\n  }\n}\n' \
             "$test_name" \
             "$test_command" \
             "$status" \
             "$test_exit" \
             "$duration" \
             "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-            "$user_decrypt_metrics" \
+            "$metrics_key" \
+            "$decrypt_metrics" \
             > /tmp/artifacts/${test_name}.json
           echo "$capacity_ok" > /tmp/artifacts/${test_name}.ok
 
@@ -777,14 +759,12 @@ spec:
         - name: test-result-udec-preproc-key-gen
         - name: test-result-udec-key-gen
         - name: test-result-crs-gen
-        - name: test-result-public-decrypt-req1
-        - name: test-result-public-decrypt-req10
-        - name: test-result-public-decrypt-req100
-        - name: test-result-public-decrypt-req500
-        - name: test-result-public-decrypt-req1000
-        - name: test-result-2400
-        - name: test-result-2700
-        - name: test-result-2750
+        - name: test-result-pdec-500
+        - name: test-result-pdec-1000
+        - name: test-result-pdec-1200
+        - name: test-result-udec-2400
+        - name: test-result-udec-2700
+        - name: test-result-udec-2750
         - name: tls
         - name: run_url
         - name: job_url
@@ -810,14 +790,12 @@ spec:
           echo '{{inputs.parameters.test-result-udec-preproc-key-gen}}' > /mnt/results/udec-preproc-key-gen.json
           echo '{{inputs.parameters.test-result-udec-key-gen}}' > /mnt/results/udec-key-gen.json
           echo '{{inputs.parameters.test-result-crs-gen}}' > /mnt/results/crs-gen.json
-          echo '{{inputs.parameters.test-result-public-decrypt-req1}}' > /mnt/results/public-decrypt-euint64-req1.json
-          echo '{{inputs.parameters.test-result-public-decrypt-req10}}' > /mnt/results/public-decrypt-euint64-req10.json
-          echo '{{inputs.parameters.test-result-public-decrypt-req100}}' > /mnt/results/public-decrypt-euint64-req100.json
-          echo '{{inputs.parameters.test-result-public-decrypt-req500}}' > /mnt/results/public-decrypt-euint64-req500.json
-          echo '{{inputs.parameters.test-result-public-decrypt-req1000}}' > /mnt/results/public-decrypt-euint64-req1000.json
-          echo '{{inputs.parameters.test-result-2400}}' > /mnt/results/udec-rate-2400.json
-          echo '{{inputs.parameters.test-result-2700}}' > /mnt/results/udec-rate-2700.json
-          echo '{{inputs.parameters.test-result-2750}}' > /mnt/results/udec-rate-2750.json
+          echo '{{inputs.parameters.test-result-pdec-500}}' > /mnt/results/pdec-rate-500.json
+          echo '{{inputs.parameters.test-result-pdec-1000}}' > /mnt/results/pdec-rate-1000.json
+          echo '{{inputs.parameters.test-result-pdec-1200}}' > /mnt/results/pdec-rate-1200.json
+          echo '{{inputs.parameters.test-result-udec-2400}}' > /mnt/results/udec-rate-2400.json
+          echo '{{inputs.parameters.test-result-udec-2700}}' > /mnt/results/udec-rate-2700.json
+          echo '{{inputs.parameters.test-result-udec-2750}}' > /mnt/results/udec-rate-2750.json
 
           echo "=========================================="
           echo "KMS PERFORMANCE SUMMARY"
@@ -825,7 +803,7 @@ spec:
           echo "Report generated: $(date -u)"
           echo "Payload: {{workflow.parameters.batch-size}} x {{workflow.parameters.data-type}} per request"
           echo "Preproc/keygen FHE params: {{workflow.parameters.fhe-params}}"
-          echo "UDEC decrypt FHE params: Default"
+          echo "Decrypt FHE params: Default"
           echo "Duration: {{inputs.parameters.duration}}s, max in-flight: {{inputs.parameters.max-in-flight}}"
           echo ""
 
@@ -841,8 +819,11 @@ spec:
 
           pdec_total=0
           pdec_passed=0
+          pdec_warned=0
           pdec_failed=0
+          pdec_skipped=0
           pdec_lines=""
+          pdec_raw_lines=""
 
           udec_total=0
           udec_passed=0
@@ -896,25 +877,36 @@ spec:
             esac
           }
 
-          append_udec_raw_line() {
-            udec_raw_lines="${udec_raw_lines}${1}\n"
+          inc_decrypt_counter() {
+            eval "${1}_${2}=\$((\${${1}_${2}} + 1))"
+          }
+
+          append_decrypt_raw_line() {
+            case "$1" in
+              pdec) pdec_raw_lines="${pdec_raw_lines}${2}\n" ;;
+              udec) udec_raw_lines="${udec_raw_lines}${2}\n" ;;
+            esac
           }
 
           allowed_failure_for_rate() {
-            case "$1" in
-              2750) return 0 ;;
+            case "$1:$2" in
+              pdec:1200|udec:2750) return 0 ;;
               *) return 1 ;;
             esac
           }
 
           parameter_set_for_rate() {
-            case "$1" in
+            case "$1:$2" in
               # maxfail/maxshed are percentages of offered requests, not counts.
               # pct is the minimum achieved_rate/target_rate percentage.
-              2400) echo "maxfail=0,maxshed=0,pct=98" ;;
-              2700) echo "maxfail=1,maxshed=1,pct=95" ;;
+              pdec:500) echo "maxfail=0,maxshed=0,pct=98" ;;
+              pdec:1000) echo "maxfail=1,maxshed=1,pct=90" ;;
+              # 1.2k is an exploratory public-decrypt probe and may warn.
+              pdec:1200) echo "maxfail=10,maxshed=25,pct=70" ;;
+              udec:2400) echo "maxfail=0,maxshed=0,pct=98" ;;
+              udec:2700) echo "maxfail=1,maxshed=1,pct=95" ;;
               # 2.75k probes just above the clean 2.7k run; outside-set results warn.
-              2750) echo "maxfail=10,maxshed=25,pct=70" ;;
+              udec:2750) echo "maxfail=10,maxshed=25,pct=70" ;;
               *) echo "maxfail=0,maxshed=0,pct=100" ;;
             esac
           }
@@ -923,18 +915,164 @@ spec:
             echo "$1" | tr ',' '\n' | sed -n "s/^$2=//p" | head -n 1
           }
 
-          echo "Keygen, CRS, and public decrypt perf tests:"
+          summarize_decrypt_rates() {
+            kind="$1"
+            display="$2"
+            metrics_key="$3"
+            shift 3
+
+            case "$kind" in
+              pdec)
+                extra_failed_key="verification_failed"
+                timing_key="verification_ms"
+                timing_label="verify"
+                ;;
+              udec)
+                extra_failed_key="reconstruction_failed"
+                timing_key="reconstruction_ms"
+                timing_label="recon"
+                ;;
+              *)
+                echo "Unsupported decrypt summary kind: $kind"
+                return 1
+                ;;
+            esac
+
+            echo "${display} perf tests:"
+            for rate in "$@"; do
+              result="/mnt/results/${kind}-rate-${rate}.json"
+              inc_decrypt_counter "$kind" total
+              if ! jq empty "$result" 2>/dev/null; then
+                inc_decrypt_counter "$kind" failed
+                line="$(status_label failed) ${rate}/s invalid result JSON"
+                echo "$line"
+                append_operation_line "$kind" "$line"
+                append_decrypt_raw_line "$kind" "$line"
+                continue
+              fi
+
+              status=$(jq -r '.status // empty' "$result")
+              target_rate=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].target_rate // empty' "$result")
+              offered=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].offered // empty' "$result")
+              completed=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].completed // empty' "$result")
+              failed_requests=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].failed // empty' "$result")
+              shed=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].shed // empty' "$result")
+              achieved_rate=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].achieved_rate // empty' "$result")
+              saturated=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k] | if has("saturated") then .saturated else "" end' "$result")
+              request_payload_mib_per_sec=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].request_payload_mib_per_sec // empty' "$result")
+              response_payload_mib_per_sec=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].response_payload_mib_per_sec // empty' "$result")
+              network_rx_gbps=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].network.rx_gbps // empty' "$result")
+              network_tx_gbps=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].network.tx_gbps // empty' "$result")
+              network_rx_dropped=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].network.rx_dropped // 0' "$result")
+              network_tx_dropped=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].network.tx_dropped // 0' "$result")
+              network_rx_errors=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].network.rx_errors // 0' "$result")
+              network_tx_errors=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].network.tx_errors // 0' "$result")
+              extra_failed=$(jq -r --arg k "$metrics_key" --arg f "$extra_failed_key" '.performance_metrics[$k][$f] // 0' "$result")
+              p50=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].latency_ms.p50 // empty' "$result")
+              p95=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].latency_ms.p95 // empty' "$result")
+              p99=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].latency_ms.p99 // empty' "$result")
+              timing_avg=$(jq -r --arg k "$metrics_key" --arg t "$timing_key" '.performance_metrics[$k][$t].avg // empty' "$result")
+              timing_p50=$(jq -r --arg k "$metrics_key" --arg t "$timing_key" '.performance_metrics[$k][$t].p50 // empty' "$result")
+              timing_p99=$(jq -r --arg k "$metrics_key" --arg t "$timing_key" '.performance_metrics[$k][$t].p99 // empty' "$result")
+
+              [ -n "$target_rate" ] || target_rate="$rate"
+              [ -n "$offered" ] || offered=0
+              [ -n "$completed" ] || completed=0
+              [ -n "$failed_requests" ] || failed_requests=0
+              [ -n "$shed" ] || shed=0
+              [ -n "$achieved_rate" ] || achieved_rate=0
+              [ -n "$saturated" ] || saturated=false
+              achieved_short="$(fmt_1 "$achieved_rate")"
+              p50_short="$(fmt_ms_2 "$p50")"
+              p95_short="$(fmt_ms_2 "$p95")"
+              p99_short="$(fmt_ms_2 "$p99")"
+              network_rx_short="$(fmt_1 "$network_rx_gbps")"
+              network_tx_short="$(fmt_1 "$network_tx_gbps")"
+
+              # Parameter sets are per-rate because the top probe is intentionally near capacity.
+              parameter_set=$(parameter_set_for_rate "$kind" "$rate")
+              maxfail=$(parameter_value "$parameter_set" maxfail)
+              maxshed=$(parameter_value "$parameter_set" maxshed)
+              pct=$(parameter_value "$parameter_set" pct)
+
+              # Any single limit outside the parameter set fails the scenario.
+              within_parameter_set=$(jq -n \
+                --argjson offered "$offered" \
+                --argjson failed_requests "$failed_requests" \
+                --argjson shed "$shed" \
+                --argjson achieved_rate "$achieved_rate" \
+                --argjson target_rate "$target_rate" \
+                --argjson maxfail "$maxfail" \
+                --argjson maxshed "$maxshed" \
+                --argjson pct "$pct" '
+                  def pct_of($num; $den): if $den == 0 then 1000000 else ($num * 100 / $den) end;
+                  ($offered > 0)
+                  and (pct_of($failed_requests; $offered) <= $maxfail)
+                  and (pct_of($shed; $offered) <= $maxshed)
+                  and (($target_rate > 0) and (($achieved_rate * 100 / $target_rate) >= $pct))
+                ')
+
+              # WARN is accepted-but-degraded. The top rate for each decrypt type
+              # is an exploratory probe and can exceed its parameter set.
+              if [ "$status" = "skipped" ]; then
+                outcome=skipped
+                inc_decrypt_counter "$kind" skipped
+                line="$(status_label "$outcome") ${target_rate}/s skipped"
+              elif [ "$status" != "passed" ]; then
+                if allowed_failure_for_rate "$kind" "$rate"; then
+                  outcome=warned
+                  inc_decrypt_counter "$kind" warned
+                else
+                  outcome=failed
+                  inc_decrypt_counter "$kind" failed
+                fi
+                line="$(status_label "$outcome") ${target_rate}/s measurement failed"
+              elif [ "$within_parameter_set" = "true" ]; then
+                if [ "$failed_requests" != "0" ] || [ "$shed" != "0" ] || [ "$saturated" = "true" ]; then
+                  outcome=warned
+                  inc_decrypt_counter "$kind" warned
+                else
+                  outcome=passed
+                  inc_decrypt_counter "$kind" passed
+                fi
+                line="$(status_label "$outcome") ${target_rate}/s p50=${p50_short} p99=${p99_short}"
+              else
+                if allowed_failure_for_rate "$kind" "$rate"; then
+                  outcome=warned
+                  inc_decrypt_counter "$kind" warned
+                else
+                  outcome=failed
+                  inc_decrypt_counter "$kind" failed
+                fi
+                line="$(status_label "$outcome") ${target_rate}/s outside params achieved=${achieved_short}/s p50=${p50_short} p99=${p99_short}"
+              fi
+
+              if [ -n "$network_rx_gbps" ] && [ "$network_rx_gbps" != "null" ]; then
+                line="${line} net_rx=${network_rx_short}Gbps net_tx=${network_tx_short}Gbps"
+              fi
+              if [ "$failed_requests" != "0" ] || [ "$shed" != "0" ] || [ "$saturated" = "true" ]; then
+                line="${line} fail=${failed_requests} shed=${shed} sat=${saturated}"
+              fi
+              if [ "$network_rx_errors" != "0" ] || [ "$network_tx_errors" != "0" ] || [ "$network_rx_dropped" != "0" ] || [ "$network_tx_dropped" != "0" ]; then
+                line="${line} net_err=${network_rx_errors}/${network_tx_errors} net_drop=${network_rx_dropped}/${network_tx_dropped}"
+              fi
+              if [ "$extra_failed" != "0" ]; then
+                line="${line} ${timing_label}_failed=${extra_failed}"
+              fi
+
+              echo "$line"
+              append_operation_line "$kind" "$line"
+              append_decrypt_raw_line "$kind" "$(status_label "$outcome") rate=${target_rate}/s achieved=${achieved_short}/s completed=${completed}/${offered} failed=${failed_requests} shed=${shed} p50=${p50_short} p95=${p95_short} p99=${p99_short} app_req=$(fmt_1 "$request_payload_mib_per_sec")MiB/s app_resp=$(fmt_1 "$response_payload_mib_per_sec")MiB/s ${timing_label}_avg=$(fmt_ms_2 "$timing_avg") ${timing_label}_p50=$(fmt_ms_2 "$timing_p50") ${timing_label}_p99=$(fmt_ms_2 "$timing_p99") net_rx=${network_rx_short}Gbps net_tx=${network_tx_short}Gbps params=${parameter_set}"
+            done
+          }
+
+          echo "Keygen and CRS perf tests:"
           for result in \
             /mnt/results/preproc-key-gen.json \
             /mnt/results/key-gen.json \
             /mnt/results/udec-preproc-key-gen.json \
             /mnt/results/udec-key-gen.json \
-            /mnt/results/crs-gen.json \
-            /mnt/results/public-decrypt-euint64-req1.json \
-            /mnt/results/public-decrypt-euint64-req10.json \
-            /mnt/results/public-decrypt-euint64-req100.json \
-            /mnt/results/public-decrypt-euint64-req500.json \
-            /mnt/results/public-decrypt-euint64-req1000.json; do
+            /mnt/results/crs-gen.json; do
             result_name="$(basename "$result" .json)"
             operation="$(operation_for_test "$result_name")"
             if ! jq empty "$result" 2>/dev/null; then
@@ -943,7 +1081,6 @@ spec:
               case "$operation" in
                 keygen) keygen_total=$((keygen_total + 1)); keygen_failed=$((keygen_failed + 1)) ;;
                 crs) crs_total=$((crs_total + 1)); crs_failed=$((crs_failed + 1)) ;;
-                pdec) pdec_total=$((pdec_total + 1)); pdec_failed=$((pdec_failed + 1)) ;;
               esac
               echo "$line"
               append_operation_line "$operation" "$line"
@@ -978,16 +1115,6 @@ spec:
                 if [ "$exit_code" = "0" ]; then crs_passed=$((crs_passed + 1)); else crs_failed=$((crs_failed + 1)); fi
                 line="${label} ${test_name} ${duration}s"
                 ;;
-              pdec)
-                pdec_total=$((pdec_total + 1))
-                if [ "$exit_code" = "0" ]; then pdec_passed=$((pdec_passed + 1)); else pdec_failed=$((pdec_failed + 1)); fi
-                short_name="$(echo "$test_name" | sed 's/^public-decrypt-[^-]*-//')"
-                if [ -n "$throughput" ] && [ "$throughput" != "null" ]; then
-                  line="${label} ${short_name} $(fmt_1 "$throughput")/s p50=$(fmt_ms_2 "$p50_latency") p99=$(fmt_ms_2 "$p99_latency")"
-                else
-                  line="${label} ${short_name} ${duration}s"
-                fi
-                ;;
               *)
                 line="${label} ${test_name} ${duration}s"
                 ;;
@@ -1000,145 +1127,18 @@ spec:
           done
 
           echo ""
-          echo "User decrypt perf tests:"
-          for rate in 2400 2700 2750; do
-            result="/mnt/results/udec-rate-${rate}.json"
-            udec_total=$((udec_total + 1))
-            if ! jq empty "$result" 2>/dev/null; then
-              udec_failed=$((udec_failed + 1))
-              line="$(status_label failed) ${rate}/s invalid result JSON"
-              echo "$line"
-              append_operation_line udec "$line"
-              append_udec_raw_line "$line"
-              continue
-            fi
+          summarize_decrypt_rates pdec "Public decrypt" public_decrypt 500 1000 1200
+          summarize_decrypt_rates udec "User decrypt" user_decrypt 2400 2700 2750
 
-            test_name=$(jq -r '.test_name // "unknown"' "$result")
-            status=$(jq -r '.status // empty' "$result")
-            exit_code=$(jq -r '.exit_code // "1"' "$result")
-            target_rate=$(jq -r '.performance_metrics.user_decrypt.target_rate // empty' "$result")
-            offered=$(jq -r '.performance_metrics.user_decrypt.offered // empty' "$result")
-            completed=$(jq -r '.performance_metrics.user_decrypt.completed // empty' "$result")
-            failed_requests=$(jq -r '.performance_metrics.user_decrypt.failed // empty' "$result")
-            shed=$(jq -r '.performance_metrics.user_decrypt.shed // empty' "$result")
-            achieved_rate=$(jq -r '.performance_metrics.user_decrypt.achieved_rate // empty' "$result")
-            saturated=$(jq -r '.performance_metrics.user_decrypt | if has("saturated") then .saturated else "" end' "$result")
-            request_payload_bytes=$(jq -r '.performance_metrics.user_decrypt.request_payload_bytes // empty' "$result")
-            request_payload_mib_per_sec=$(jq -r '.performance_metrics.user_decrypt.request_payload_mib_per_sec // empty' "$result")
-            request_payload_avg_bytes=$(jq -r '.performance_metrics.user_decrypt.request_payload_avg_bytes // empty' "$result")
-            response_payload_bytes=$(jq -r '.performance_metrics.user_decrypt.response_payload_bytes // empty' "$result")
-            response_payload_mib_per_sec=$(jq -r '.performance_metrics.user_decrypt.response_payload_mib_per_sec // empty' "$result")
-            response_payload_avg_bytes=$(jq -r '.performance_metrics.user_decrypt.response_payload_avg_bytes // empty' "$result")
-            network_rx_bytes=$(jq -r '.performance_metrics.user_decrypt.network.rx_bytes // empty' "$result")
-            network_tx_bytes=$(jq -r '.performance_metrics.user_decrypt.network.tx_bytes // empty' "$result")
-            network_rx_gbps=$(jq -r '.performance_metrics.user_decrypt.network.rx_gbps // empty' "$result")
-            network_tx_gbps=$(jq -r '.performance_metrics.user_decrypt.network.tx_gbps // empty' "$result")
-            network_rx_dropped=$(jq -r '.performance_metrics.user_decrypt.network.rx_dropped // 0' "$result")
-            network_tx_dropped=$(jq -r '.performance_metrics.user_decrypt.network.tx_dropped // 0' "$result")
-            network_rx_errors=$(jq -r '.performance_metrics.user_decrypt.network.rx_errors // 0' "$result")
-            network_tx_errors=$(jq -r '.performance_metrics.user_decrypt.network.tx_errors // 0' "$result")
-            reconstruction_failed=$(jq -r '.performance_metrics.user_decrypt.reconstruction_failed // 0' "$result")
-            p50=$(jq -r '.performance_metrics.user_decrypt.latency_ms.p50 // empty' "$result")
-            p95=$(jq -r '.performance_metrics.user_decrypt.latency_ms.p95 // empty' "$result")
-            p99=$(jq -r '.performance_metrics.user_decrypt.latency_ms.p99 // empty' "$result")
-            recon_avg=$(jq -r '.performance_metrics.user_decrypt.reconstruction_ms.avg // empty' "$result")
-            recon_p50=$(jq -r '.performance_metrics.user_decrypt.reconstruction_ms.p50 // empty' "$result")
-            recon_p99=$(jq -r '.performance_metrics.user_decrypt.reconstruction_ms.p99 // empty' "$result")
-            recon_wall=$(jq -r '.performance_metrics.user_decrypt.reconstruction_ms.wall // empty' "$result")
-
-            [ -n "$target_rate" ] || target_rate="$rate"
-            [ -n "$offered" ] || offered=0
-            [ -n "$completed" ] || completed=0
-            [ -n "$failed_requests" ] || failed_requests=0
-            [ -n "$shed" ] || shed=0
-            [ -n "$achieved_rate" ] || achieved_rate=0
-            [ -n "$saturated" ] || saturated=false
-            achieved_short="$(fmt_1 "$achieved_rate")"
-            p50_short="$(fmt_ms_2 "$p50")"
-            p95_short="$(fmt_ms_2 "$p95")"
-            p99_short="$(fmt_ms_2 "$p99")"
-            network_rx_short="$(fmt_1 "$network_rx_gbps")"
-            network_tx_short="$(fmt_1 "$network_tx_gbps")"
-
-            # Parameter sets are per-rate because the top probe is intentionally near capacity.
-            parameter_set=$(parameter_set_for_rate "$rate")
-            maxfail=$(parameter_value "$parameter_set" maxfail)
-            maxshed=$(parameter_value "$parameter_set" maxshed)
-            pct=$(parameter_value "$parameter_set" pct)
-
-            # Any single limit outside the parameter set fails the scenario.
-            within_parameter_set=$(jq -n \
-              --argjson offered "$offered" \
-              --argjson failed_requests "$failed_requests" \
-              --argjson shed "$shed" \
-              --argjson achieved_rate "$achieved_rate" \
-              --argjson target_rate "$target_rate" \
-              --argjson maxfail "$maxfail" \
-              --argjson maxshed "$maxshed" \
-              --argjson pct "$pct" '
-                def pct_of($num; $den): if $den == 0 then 1000000 else ($num * 100 / $den) end;
-                ($offered > 0)
-                and (pct_of($failed_requests; $offered) <= $maxfail)
-                and (pct_of($shed; $offered) <= $maxshed)
-                and (($target_rate > 0) and (($achieved_rate * 100 / $target_rate) >= $pct))
-              ')
-
-            # WARN is accepted-but-degraded. 2750/s is an exploratory probe and
-            # is allowed to exceed its parameter set without failing the workflow.
-            if [ "$status" = "skipped" ]; then
-              outcome=skipped
-              udec_skipped=$((udec_skipped + 1))
-              line="$(status_label "$outcome") ${target_rate}/s skipped"
-            elif [ "$status" != "passed" ]; then
-              if allowed_failure_for_rate "$rate"; then
-                outcome=warned
-                udec_warned=$((udec_warned + 1))
-              else
-                outcome=failed
-                udec_failed=$((udec_failed + 1))
-              fi
-              line="$(status_label "$outcome") ${target_rate}/s measurement failed"
-            elif [ "$within_parameter_set" = "true" ]; then
-              if [ "$failed_requests" != "0" ] || [ "$shed" != "0" ] || [ "$saturated" = "true" ]; then
-                outcome=warned
-                udec_warned=$((udec_warned + 1))
-              else
-                outcome=passed
-                udec_passed=$((udec_passed + 1))
-              fi
-              line="$(status_label "$outcome") ${target_rate}/s p50=${p50_short} p99=${p99_short}"
-            else
-              if allowed_failure_for_rate "$rate"; then
-                outcome=warned
-                udec_warned=$((udec_warned + 1))
-              else
-                outcome=failed
-                udec_failed=$((udec_failed + 1))
-              fi
-              line="$(status_label "$outcome") ${target_rate}/s outside params achieved=${achieved_short}/s p50=${p50_short} p99=${p99_short}"
-            fi
-
-            if [ -n "$network_rx_gbps" ] && [ "$network_rx_gbps" != "null" ]; then
-              line="${line} net_rx=${network_rx_short}Gbps net_tx=${network_tx_short}Gbps"
-            fi
-            if [ "$failed_requests" != "0" ] || [ "$shed" != "0" ] || [ "$saturated" = "true" ]; then
-              line="${line} fail=${failed_requests} shed=${shed} sat=${saturated}"
-            fi
-            if [ "$network_rx_errors" != "0" ] || [ "$network_tx_errors" != "0" ] || [ "$network_rx_dropped" != "0" ] || [ "$network_tx_dropped" != "0" ]; then
-              line="${line} net_err=${network_rx_errors}/${network_tx_errors} net_drop=${network_rx_dropped}/${network_tx_dropped}"
-            fi
-            if [ "$reconstruction_failed" != "0" ]; then
-              line="${line} recon_failed=${reconstruction_failed}"
-            fi
-
-            echo "$line"
-            append_operation_line udec "$line"
-            append_udec_raw_line "$(status_label "$outcome") rate=${target_rate}/s achieved=${achieved_short}/s completed=${completed}/${offered} failed=${failed_requests} shed=${shed} p50=${p50_short} p95=${p95_short} p99=${p99_short} app_req=$(fmt_1 "$request_payload_mib_per_sec")MiB/s app_resp=$(fmt_1 "$response_payload_mib_per_sec")MiB/s recon_avg=$(fmt_ms_2 "$recon_avg") recon_p50=$(fmt_ms_2 "$recon_p50") recon_p99=$(fmt_ms_2 "$recon_p99") net_rx=${network_rx_short}Gbps net_tx=${network_tx_short}Gbps params=${parameter_set}"
-          done
-
-          finite_total=$((keygen_total + crs_total + pdec_total))
-          finite_passed=$((keygen_passed + crs_passed + pdec_passed))
-          finite_failed=$((keygen_failed + crs_failed + pdec_failed))
+          finite_total=$((keygen_total + crs_total))
+          finite_passed=$((keygen_passed + crs_passed))
+          finite_failed=$((keygen_failed + crs_failed))
+          pdec_accepted=$((pdec_passed + pdec_warned))
+          if [ $pdec_total -gt 0 ]; then
+            pdec_success_rate=$(( (pdec_accepted * 100) / pdec_total ))
+          else
+            pdec_success_rate=0
+          fi
           udec_accepted=$((udec_passed + udec_warned))
           if [ $udec_total -gt 0 ]; then
             udec_success_rate=$(( (udec_accepted * 100) / udec_total ))
@@ -1149,13 +1149,13 @@ spec:
           echo "----------------------------------------"
           echo "Keygen: ${keygen_passed}/${keygen_total} passed"
           echo "CRS: ${crs_passed}/${crs_total} passed"
-          echo "Public decrypt: ${pdec_passed}/${pdec_total} passed"
+          echo "Public decrypt: ${pdec_passed} passed, ${pdec_warned} warned, ${pdec_failed} failed, ${pdec_skipped} skipped (${pdec_success_rate}% accepted)"
           echo "User decrypt: ${udec_passed} passed, ${udec_warned} warned, ${udec_failed} failed, ${udec_skipped} skipped (${udec_success_rate}% accepted)"
           echo "=========================================="
 
-          if [ $finite_failed -gt 0 ] || [ $udec_failed -gt 0 ]; then
+          if [ $finite_failed -gt 0 ] || [ $pdec_failed -gt 0 ] || [ $udec_failed -gt 0 ]; then
             title="KMS perf failed"
-          elif [ $udec_warned -gt 0 ]; then
+          elif [ $pdec_warned -gt 0 ] || [ $udec_warned -gt 0 ]; then
             title="KMS perf passed with warnings"
           else
             title="KMS perf passed"
@@ -1164,7 +1164,12 @@ spec:
           slack_webhook_url=$(cat /etc/slack/url)
           keygen_block="$(printf '*Keygen*\n%b' "${keygen_lines:-No keygen tests\n}")"
           crs_block="$(printf '*CRS*\n%b' "${crs_lines:-No CRS tests\n}")"
-          pdec_block="$(printf '*Public decrypt {{workflow.parameters.data-type}}*\n%b' "${pdec_lines:-No public decrypt tests\n}")"
+          pdec_raw_text="$(printf '%b' "$pdec_raw_lines" | head -c 2200)"
+          if [ -n "$pdec_raw_text" ]; then
+            pdec_block="$(printf '*Public decrypt {{workflow.parameters.data-type}}*\n%b\n*Raw data*\n```%s\n```' "${pdec_lines:-No public decrypt tests\n}" "$pdec_raw_text")"
+          else
+            pdec_block="$(printf '*Public decrypt {{workflow.parameters.data-type}}*\n%b' "${pdec_lines:-No public decrypt tests\n}")"
+          fi
           udec_raw_text="$(printf '%b' "$udec_raw_lines" | head -c 2200)"
           if [ -n "$udec_raw_text" ]; then
             udec_block="$(printf '*User decrypt {{workflow.parameters.data-type}}*\n%b\n*Raw data*\n```%s\n```' "${udec_lines:-No user decrypt tests\n}" "$udec_raw_text")"
@@ -1179,7 +1184,7 @@ spec:
           # (core-img/client-img ARE live: <version>/<client-version> are sed-substituted at submit.)
           # Two physical lines: the '\n' renders as a line break in the Slack context element.
           config_line=$(printf '%s\n%s' \
-            "payload={{workflow.parameters.batch-size}} x {{workflow.parameters.data-type}}, preproc/keygen params={{workflow.parameters.fhe-params}}, udec params=Default, duration={{inputs.parameters.duration}}s, max-in-flight={{inputs.parameters.max-in-flight}}, TLS={{inputs.parameters.tls}}" \
+            "payload={{workflow.parameters.batch-size}} x {{workflow.parameters.data-type}}, preproc/keygen params={{workflow.parameters.fhe-params}}, decrypt params=Default, duration={{inputs.parameters.duration}}s, max-in-flight={{inputs.parameters.max-in-flight}}, TLS={{inputs.parameters.tls}}" \
             "core=c7a.16xlarge, core-client=m5n, tokioWorkerThreads=10, rayonNumThreads=40, core-img=<version>, client-img=<client-version>")
           if echo "{{inputs.parameters.job_url}}" | grep -q '^http'; then
             run_line="<{{inputs.parameters.job_url}}|{{inputs.parameters.job_label}}>"
@@ -1218,7 +1223,7 @@ spec:
 
           curl -s -X POST -H "Content-type: application/json" -d "$slack_message" "$slack_webhook_url"
 
-          if [ $finite_failed -gt 0 ] || [ $udec_failed -gt 0 ]; then
+          if [ $finite_failed -gt 0 ] || [ $pdec_failed -gt 0 ] || [ $udec_failed -gt 0 ]; then
             exit 1
           fi
 

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -152,7 +152,7 @@ spec:
               - name: previous-ok
                 value: "{{tasks.pdec-rate-1500.outputs.parameters.capacity-ok}}"
 
-          - name: pdec-rate-2000
+          - name: pdec-rate-1950
             dependencies: ["pdec-rate-1800"]
             template: run-decrypt-rate
             arguments:
@@ -160,7 +160,7 @@ spec:
               - name: kind
                 value: "pdec"
               - name: rate
-                value: "2000"
+                value: "1950"
               - name: key_id
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
@@ -168,7 +168,7 @@ spec:
 
           # Temporarily disabled while iterating on Slack report formatting.
           # - name: udec-rate-2400
-          #   dependencies: ["udec-key-gen", "pdec-rate-2000"]
+          #   dependencies: ["udec-key-gen", "pdec-rate-1950"]
           #   template: run-decrypt-rate
           #   arguments:
           #     parameters:
@@ -218,7 +218,7 @@ spec:
               - "crs-gen"
               - "pdec-rate-1500"
               - "pdec-rate-1800"
-              - "pdec-rate-2000"
+              - "pdec-rate-1950"
               # Temporarily disabled while iterating on Slack report formatting.
               # - "udec-rate-2400"
               # - "udec-rate-2700"
@@ -240,8 +240,8 @@ spec:
                 value: "{{tasks.pdec-rate-1500.outputs.parameters.test-result}}"
               - name: test-result-pdec-1800
                 value: "{{tasks.pdec-rate-1800.outputs.parameters.test-result}}"
-              - name: test-result-pdec-2000
-                value: "{{tasks.pdec-rate-2000.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1950
+                value: "{{tasks.pdec-rate-1950.outputs.parameters.test-result}}"
               # Temporarily disabled while iterating on Slack report formatting.
               # - name: test-result-udec-2400
               #   value: "{{tasks.udec-rate-2400.outputs.parameters.test-result}}"
@@ -635,7 +635,7 @@ spec:
 
           allowed_failure_for_rate() {
             case "$1:$2" in
-              pdec:2000|udec:2750) return 0 ;;
+              pdec:1950|udec:2750) return 0 ;;
               *) return 1 ;;
             esac
           }
@@ -646,8 +646,8 @@ spec:
               # pct is the minimum achieved_rate/target_rate percentage.
               pdec:1500) echo "maxfail=0,maxshed=0,pct=98" ;;
               pdec:1800) echo "maxfail=1,maxshed=1,pct=90" ;;
-              # 2k is an exploratory public-decrypt probe and may warn.
-              pdec:2000) echo "maxfail=10,maxshed=25,pct=70" ;;
+              # 1.95k is an exploratory public-decrypt probe and may warn.
+              pdec:1950) echo "maxfail=10,maxshed=25,pct=70" ;;
               udec:2400) echo "maxfail=0,maxshed=0,pct=98" ;;
               udec:2700) echo "maxfail=1,maxshed=1,pct=95" ;;
               # 2.75k probes just above the clean 2.7k run; outside-set results warn.
@@ -847,7 +847,7 @@ spec:
         - name: test-result-crs-gen
         - name: test-result-pdec-1500
         - name: test-result-pdec-1800
-        - name: test-result-pdec-2000
+        - name: test-result-pdec-1950
         # Temporarily disabled while iterating on Slack report formatting.
         # - name: test-result-udec-2400
         # - name: test-result-udec-2700
@@ -879,7 +879,7 @@ spec:
           echo '{{inputs.parameters.test-result-crs-gen}}' > /mnt/results/crs-gen.json
           echo '{{inputs.parameters.test-result-pdec-1500}}' > /mnt/results/pdec-rate-1500.json
           echo '{{inputs.parameters.test-result-pdec-1800}}' > /mnt/results/pdec-rate-1800.json
-          echo '{{inputs.parameters.test-result-pdec-2000}}' > /mnt/results/pdec-rate-2000.json
+          echo '{{inputs.parameters.test-result-pdec-1950}}' > /mnt/results/pdec-rate-1950.json
           # Temporarily disabled while iterating on Slack report formatting.
           # echo '{ {inputs.parameters.test-result-udec-2400}}' > /mnt/results/udec-rate-2400.json
           # echo '{ {inputs.parameters.test-result-udec-2700}}' > /mnt/results/udec-rate-2700.json
@@ -1168,7 +1168,7 @@ spec:
           done
 
           echo ""
-          summarize_decrypt_rates pdec "Public decrypt" public_decrypt 1500 1800 2000
+          summarize_decrypt_rates pdec "Public decrypt" public_decrypt 1500 1800 1950
           # Temporarily disabled while iterating on Slack report formatting.
           # summarize_decrypt_rates udec "User decrypt" user_decrypt 2400 2700 2750
 

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -42,7 +42,7 @@ spec:
     - name: max-in-flight
       value: "10000"
     - name: data-type
-      value: "euint256"
+      value: "euint64"
     - name: batch-size
       value: "1"
     - name: s3-config-map-name
@@ -614,7 +614,7 @@ spec:
 
           test_name="${kind}-rate-{{inputs.parameters.rate}}"
           key_id="{{inputs.parameters.key_id}}"
-          test_command="${command_name} from-args -d {{workflow.parameters.data-type}} -k ${key_id} -e ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff --batch-size {{workflow.parameters.batch-size}} --rate {{inputs.parameters.rate}} --duration {{workflow.parameters.duration}} --max-in-flight {{workflow.parameters.max-in-flight}}"
+          test_command="${command_name} from-args -d {{workflow.parameters.data-type}} -k ${key_id} -e ffffffffffffffff --batch-size {{workflow.parameters.batch-size}} --rate {{inputs.parameters.rate}} --duration {{workflow.parameters.duration}} --max-in-flight {{workflow.parameters.max-in-flight}}"
           mkdir -p /tmp/artifacts
 
           capture_net_snapshot() {

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -42,7 +42,7 @@ spec:
     - name: max-in-flight
       value: "10000"
     - name: data-type
-      value: "euint64"
+      value: "euint256"
     - name: batch-size
       value: "1"
     - name: s3-config-map-name
@@ -614,7 +614,7 @@ spec:
 
           test_name="${kind}-rate-{{inputs.parameters.rate}}"
           key_id="{{inputs.parameters.key_id}}"
-          test_command="${command_name} from-args -d {{workflow.parameters.data-type}} -k ${key_id} -e ffffffffffffffff --batch-size {{workflow.parameters.batch-size}} --rate {{inputs.parameters.rate}} --duration {{workflow.parameters.duration}} --max-in-flight {{workflow.parameters.max-in-flight}}"
+          test_command="${command_name} from-args -d {{workflow.parameters.data-type}} -k ${key_id} -e ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff --batch-size {{workflow.parameters.batch-size}} --rate {{inputs.parameters.rate}} --duration {{workflow.parameters.duration}} --max-in-flight {{workflow.parameters.max-in-flight}}"
           mkdir -p /tmp/artifacts
 
           capture_net_snapshot() {

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -38,7 +38,7 @@ spec:
     - name: fhe-params
       value: "Test"
     - name: duration
-      value: "60"
+      value: "120"
     - name: max-in-flight
       value: "10000"
     - name: data-type
@@ -124,7 +124,7 @@ spec:
               - name: fhe-params
                 value: "Default"
 
-          - name: pdec-rate-1500
+          - name: pdec-rate-1000
             dependencies: ["crs-gen"]
             template: run-decrypt-rate
             arguments:
@@ -132,42 +132,42 @@ spec:
               - name: kind
                 value: "pdec"
               - name: rate
-                value: "1500"
+                value: "1000"
               - name: key_id
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
                 value: "true"
 
-          - name: pdec-rate-1800
-            dependencies: ["pdec-rate-1500"]
+          - name: pdec-rate-1200
+            dependencies: ["pdec-rate-1000"]
             template: run-decrypt-rate
             arguments:
               parameters:
               - name: kind
                 value: "pdec"
               - name: rate
-                value: "1800"
+                value: "1200"
               - name: key_id
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
-                value: "{{tasks.pdec-rate-1500.outputs.parameters.capacity-ok}}"
+                value: "{{tasks.pdec-rate-1000.outputs.parameters.capacity-ok}}"
 
-          - name: pdec-rate-1900
-            dependencies: ["pdec-rate-1800"]
+          - name: pdec-rate-1400
+            dependencies: ["pdec-rate-1200"]
             template: run-decrypt-rate
             arguments:
               parameters:
               - name: kind
                 value: "pdec"
               - name: rate
-                value: "1900"
+                value: "1400"
               - name: key_id
                 value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
               - name: previous-ok
-                value: "{{tasks.pdec-rate-1800.outputs.parameters.capacity-ok}}"
+                value: "{{tasks.pdec-rate-1200.outputs.parameters.capacity-ok}}"
 
           - name: udec-rate-2400
-            dependencies: ["udec-key-gen", "pdec-rate-1900"]
+            dependencies: ["udec-key-gen", "pdec-rate-1400"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -215,9 +215,9 @@ spec:
               - "udec-preproc-key-gen"
               - "udec-key-gen"
               - "crs-gen"
-              - "pdec-rate-1500"
-              - "pdec-rate-1800"
-              - "pdec-rate-1900"
+              - "pdec-rate-1000"
+              - "pdec-rate-1200"
+              - "pdec-rate-1400"
               - "udec-rate-2400"
               - "udec-rate-2700"
               - "udec-rate-2750"
@@ -234,12 +234,12 @@ spec:
                 value: "{{tasks.udec-key-gen.outputs.parameters.test-result}}"
               - name: test-result-crs-gen
                 value: "{{tasks.crs-gen.outputs.parameters.test-result}}"
-              - name: test-result-pdec-1500
-                value: "{{tasks.pdec-rate-1500.outputs.parameters.test-result}}"
-              - name: test-result-pdec-1800
-                value: "{{tasks.pdec-rate-1800.outputs.parameters.test-result}}"
-              - name: test-result-pdec-1900
-                value: "{{tasks.pdec-rate-1900.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1000
+                value: "{{tasks.pdec-rate-1000.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1200
+                value: "{{tasks.pdec-rate-1200.outputs.parameters.test-result}}"
+              - name: test-result-pdec-1400
+                value: "{{tasks.pdec-rate-1400.outputs.parameters.test-result}}"
               - name: test-result-udec-2400
                 value: "{{tasks.udec-rate-2400.outputs.parameters.test-result}}"
               - name: test-result-udec-2700
@@ -632,7 +632,7 @@ spec:
 
           allowed_failure_for_rate() {
             case "$1:$2" in
-              pdec:1900|udec:2750) return 0 ;;
+              pdec:1400|udec:2750) return 0 ;;
               *) return 1 ;;
             esac
           }
@@ -641,10 +641,10 @@ spec:
             case "$1:$2" in
               # maxfail/maxshed are percentages of offered requests, not counts.
               # pct is the minimum achieved_rate/target_rate percentage.
-              pdec:1500) echo "maxfail=0,maxshed=0,pct=98" ;;
-              pdec:1800) echo "maxfail=1,maxshed=1,pct=90" ;;
-              # 1.9k is an exploratory public-decrypt probe and may warn.
-              pdec:1900) echo "maxfail=10,maxshed=25,pct=70" ;;
+              pdec:1000) echo "maxfail=0,maxshed=0,pct=98" ;;
+              pdec:1200) echo "maxfail=1,maxshed=1,pct=90" ;;
+              # 1.4k is an exploratory public-decrypt probe and may warn.
+              pdec:1400) echo "maxfail=10,maxshed=25,pct=70" ;;
               udec:2400) echo "maxfail=0,maxshed=0,pct=98" ;;
               udec:2700) echo "maxfail=1,maxshed=1,pct=95" ;;
               # 2.75k probes just above the clean 2.7k run; outside-set results warn.
@@ -842,9 +842,9 @@ spec:
         - name: test-result-udec-preproc-key-gen
         - name: test-result-udec-key-gen
         - name: test-result-crs-gen
-        - name: test-result-pdec-1500
-        - name: test-result-pdec-1800
-        - name: test-result-pdec-1900
+        - name: test-result-pdec-1000
+        - name: test-result-pdec-1200
+        - name: test-result-pdec-1400
         - name: test-result-udec-2400
         - name: test-result-udec-2700
         - name: test-result-udec-2750
@@ -873,9 +873,9 @@ spec:
           echo '{{inputs.parameters.test-result-udec-preproc-key-gen}}' > /mnt/results/udec-preproc-key-gen.json
           echo '{{inputs.parameters.test-result-udec-key-gen}}' > /mnt/results/udec-key-gen.json
           echo '{{inputs.parameters.test-result-crs-gen}}' > /mnt/results/crs-gen.json
-          echo '{{inputs.parameters.test-result-pdec-1500}}' > /mnt/results/pdec-rate-1500.json
-          echo '{{inputs.parameters.test-result-pdec-1800}}' > /mnt/results/pdec-rate-1800.json
-          echo '{{inputs.parameters.test-result-pdec-1900}}' > /mnt/results/pdec-rate-1900.json
+          echo '{{inputs.parameters.test-result-pdec-1000}}' > /mnt/results/pdec-rate-1000.json
+          echo '{{inputs.parameters.test-result-pdec-1200}}' > /mnt/results/pdec-rate-1200.json
+          echo '{{inputs.parameters.test-result-pdec-1400}}' > /mnt/results/pdec-rate-1400.json
           echo '{{inputs.parameters.test-result-udec-2400}}' > /mnt/results/udec-rate-2400.json
           echo '{{inputs.parameters.test-result-udec-2700}}' > /mnt/results/udec-rate-2700.json
           echo '{{inputs.parameters.test-result-udec-2750}}' > /mnt/results/udec-rate-2750.json
@@ -1163,7 +1163,7 @@ spec:
           done
 
           echo ""
-          summarize_decrypt_rates pdec "Public decrypt" public_decrypt 1500 1800 1900
+          summarize_decrypt_rates pdec "Public decrypt" public_decrypt 1000 1200 1400
           summarize_decrypt_rates udec "User decrypt" user_decrypt 2400 2700 2750
 
           finite_total=$((keygen_total + crs_total))

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -138,8 +138,16 @@ spec:
               - name: previous-ok
                 value: "true"
 
-          - name: pdec-rate-1300
+          - name: pause-pdec-1
             dependencies: ["pdec-rate-1100"]
+            template: pause
+            arguments:
+              parameters:
+              - name: duration
+                value: "10"
+
+          - name: pdec-rate-1300
+            dependencies: ["pause-pdec-1"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -152,8 +160,16 @@ spec:
               - name: previous-ok
                 value: "{{tasks.pdec-rate-1100.outputs.parameters.capacity-ok}}"
 
-          - name: pdec-rate-1500
+          - name: pause-pdec-2
             dependencies: ["pdec-rate-1300"]
+            template: pause
+            arguments:
+              parameters:
+              - name: duration
+                value: "10"
+
+          - name: pdec-rate-1500
+            dependencies: ["pause-pdec-2"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -166,8 +182,16 @@ spec:
               - name: previous-ok
                 value: "{{tasks.pdec-rate-1300.outputs.parameters.capacity-ok}}"
 
+          - name: pause-inter-suite
+            dependencies: ["pdec-rate-1500"]
+            template: pause
+            arguments:
+              parameters:
+              - name: duration
+                value: "30"
+
           - name: udec-rate-2400
-            dependencies: ["udec-key-gen", "pdec-rate-1500"]
+            dependencies: ["udec-key-gen", "pause-inter-suite"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -180,8 +204,16 @@ spec:
               - name: previous-ok
                 value: "true"
 
-          - name: udec-rate-2700
+          - name: pause-udec-1
             dependencies: ["udec-rate-2400"]
+            template: pause
+            arguments:
+              parameters:
+              - name: duration
+                value: "10"
+
+          - name: udec-rate-2700
+            dependencies: ["pause-udec-1"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -194,8 +226,16 @@ spec:
               - name: previous-ok
                 value: "{{tasks.udec-rate-2400.outputs.parameters.capacity-ok}}"
 
-          - name: udec-rate-2750
+          - name: pause-udec-2
             dependencies: ["udec-rate-2700"]
+            template: pause
+            arguments:
+              parameters:
+              - name: duration
+                value: "10"
+
+          - name: udec-rate-2750
+            dependencies: ["pause-udec-2"]
             template: run-decrypt-rate
             arguments:
               parameters:
@@ -833,6 +873,13 @@ spec:
           - name: FHE_PARAMETER
             value: 'Default'
         resources: *core-client-resources
+
+    - name: pause
+      inputs:
+        parameters:
+        - name: duration
+      suspend:
+        duration: "{{inputs.parameters.duration}}s"
 
     - name: summary-report
       inputs:

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -38,7 +38,7 @@ spec:
     - name: fhe-params
       value: "Test"
     - name: duration
-      value: "30"
+      value: "60"
     - name: max-in-flight
       value: "10000"
     - name: data-type
@@ -166,48 +166,47 @@ spec:
               - name: previous-ok
                 value: "{{tasks.pdec-rate-1800.outputs.parameters.capacity-ok}}"
 
-          # Temporarily disabled while iterating on Slack report formatting.
-          # - name: udec-rate-2400
-          #   dependencies: ["udec-key-gen", "pdec-rate-1900"]
-          #   template: run-decrypt-rate
-          #   arguments:
-          #     parameters:
-          #     - name: kind
-          #       value: "udec"
-          #     - name: rate
-          #       value: "2400"
-          #     - name: key_id
-          #       value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
-          #     - name: previous-ok
-          #       value: "true"
-          #
-          # - name: udec-rate-2700
-          #   dependencies: ["udec-rate-2400"]
-          #   template: run-decrypt-rate
-          #   arguments:
-          #     parameters:
-          #     - name: kind
-          #       value: "udec"
-          #     - name: rate
-          #       value: "2700"
-          #     - name: key_id
-          #       value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
-          #     - name: previous-ok
-          #       value: "{{tasks.udec-rate-2400.outputs.parameters.capacity-ok}}"
-          #
-          # - name: udec-rate-2750
-          #   dependencies: ["udec-rate-2700"]
-          #   template: run-decrypt-rate
-          #   arguments:
-          #     parameters:
-          #     - name: kind
-          #       value: "udec"
-          #     - name: rate
-          #       value: "2750"
-          #     - name: key_id
-          #       value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
-          #     - name: previous-ok
-          #       value: "{{tasks.udec-rate-2700.outputs.parameters.capacity-ok}}"
+          - name: udec-rate-2400
+            dependencies: ["udec-key-gen", "pdec-rate-1900"]
+            template: run-decrypt-rate
+            arguments:
+              parameters:
+              - name: kind
+                value: "udec"
+              - name: rate
+                value: "2400"
+              - name: key_id
+                value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
+              - name: previous-ok
+                value: "true"
+
+          - name: udec-rate-2700
+            dependencies: ["udec-rate-2400"]
+            template: run-decrypt-rate
+            arguments:
+              parameters:
+              - name: kind
+                value: "udec"
+              - name: rate
+                value: "2700"
+              - name: key_id
+                value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
+              - name: previous-ok
+                value: "{{tasks.udec-rate-2400.outputs.parameters.capacity-ok}}"
+
+          - name: udec-rate-2750
+            dependencies: ["udec-rate-2700"]
+            template: run-decrypt-rate
+            arguments:
+              parameters:
+              - name: kind
+                value: "udec"
+              - name: rate
+                value: "2750"
+              - name: key_id
+                value: "{{tasks.udec-key-gen.outputs.parameters.request-id}}"
+              - name: previous-ok
+                value: "{{tasks.udec-rate-2700.outputs.parameters.capacity-ok}}"
 
           - name: summary
             dependencies:
@@ -219,10 +218,9 @@ spec:
               - "pdec-rate-1500"
               - "pdec-rate-1800"
               - "pdec-rate-1900"
-              # Temporarily disabled while iterating on Slack report formatting.
-              # - "udec-rate-2400"
-              # - "udec-rate-2700"
-              # - "udec-rate-2750"
+              - "udec-rate-2400"
+              - "udec-rate-2700"
+              - "udec-rate-2750"
             template: summary-report
             arguments:
               parameters:
@@ -242,13 +240,12 @@ spec:
                 value: "{{tasks.pdec-rate-1800.outputs.parameters.test-result}}"
               - name: test-result-pdec-1900
                 value: "{{tasks.pdec-rate-1900.outputs.parameters.test-result}}"
-              # Temporarily disabled while iterating on Slack report formatting.
-              # - name: test-result-udec-2400
-              #   value: "{{tasks.udec-rate-2400.outputs.parameters.test-result}}"
-              # - name: test-result-udec-2700
-              #   value: "{{tasks.udec-rate-2700.outputs.parameters.test-result}}"
-              # - name: test-result-udec-2750
-              #   value: "{{tasks.udec-rate-2750.outputs.parameters.test-result}}"
+              - name: test-result-udec-2400
+                value: "{{tasks.udec-rate-2400.outputs.parameters.test-result}}"
+              - name: test-result-udec-2700
+                value: "{{tasks.udec-rate-2700.outputs.parameters.test-result}}"
+              - name: test-result-udec-2750
+                value: "{{tasks.udec-rate-2750.outputs.parameters.test-result}}"
               - name: tls
                 value: "{{workflow.parameters.tls}}"
               - name: run_url
@@ -848,10 +845,9 @@ spec:
         - name: test-result-pdec-1500
         - name: test-result-pdec-1800
         - name: test-result-pdec-1900
-        # Temporarily disabled while iterating on Slack report formatting.
-        # - name: test-result-udec-2400
-        # - name: test-result-udec-2700
-        # - name: test-result-udec-2750
+        - name: test-result-udec-2400
+        - name: test-result-udec-2700
+        - name: test-result-udec-2750
         - name: tls
         - name: run_url
         - name: job_url
@@ -880,10 +876,9 @@ spec:
           echo '{{inputs.parameters.test-result-pdec-1500}}' > /mnt/results/pdec-rate-1500.json
           echo '{{inputs.parameters.test-result-pdec-1800}}' > /mnt/results/pdec-rate-1800.json
           echo '{{inputs.parameters.test-result-pdec-1900}}' > /mnt/results/pdec-rate-1900.json
-          # Temporarily disabled while iterating on Slack report formatting.
-          # echo '{ {inputs.parameters.test-result-udec-2400}}' > /mnt/results/udec-rate-2400.json
-          # echo '{ {inputs.parameters.test-result-udec-2700}}' > /mnt/results/udec-rate-2700.json
-          # echo '{ {inputs.parameters.test-result-udec-2750}}' > /mnt/results/udec-rate-2750.json
+          echo '{{inputs.parameters.test-result-udec-2400}}' > /mnt/results/udec-rate-2400.json
+          echo '{{inputs.parameters.test-result-udec-2700}}' > /mnt/results/udec-rate-2700.json
+          echo '{{inputs.parameters.test-result-udec-2750}}' > /mnt/results/udec-rate-2750.json
 
           echo "=========================================="
           echo "KMS PERFORMANCE SUMMARY"
@@ -1169,8 +1164,7 @@ spec:
 
           echo ""
           summarize_decrypt_rates pdec "Public decrypt" public_decrypt 1500 1800 1900
-          # Temporarily disabled while iterating on Slack report formatting.
-          # summarize_decrypt_rates udec "User decrypt" user_decrypt 2400 2700 2750
+          summarize_decrypt_rates udec "User decrypt" user_decrypt 2400 2700 2750
 
           finite_total=$((keygen_total + crs_total))
           finite_passed=$((keygen_passed + crs_passed))

--- a/ci/perf-testing/argo-workflow/thresholdWithEnclave-rolling-upgrade-workflow-kms-enclave-ci.yaml
+++ b/ci/perf-testing/argo-workflow/thresholdWithEnclave-rolling-upgrade-workflow-kms-enclave-ci.yaml
@@ -75,7 +75,7 @@ spec:
                 - name: test-name
                   value: "warmup-public-decrypt-euint64-req1"
                 - name: test-command
-                  value: "-a public-decrypt from-args -d euint64 -k {{workflow.parameters.key-id}} -e ffffffffffffffff --num-requests 1"
+                  value: "-a public-decrypt from-args -d euint64 -k {{workflow.parameters.key-id}} -e ffffffffffffffff"
                 - name: fhe-params
                   value: "Default"
           ##########################################################################
@@ -91,7 +91,7 @@ spec:
                 - name: test-name
                   value: "public-decrypt-euint64-req1"
                 - name: test-command
-                  value: "-a public-decrypt from-args -d euint64 -k {{workflow.parameters.key-id}} -e ffffffffffffffff --num-requests 1"
+                  value: "-a public-decrypt from-args -d euint64 -k {{workflow.parameters.key-id}} -e ffffffffffffffff"
                 - name: fhe-params
                   value: "Default"
           ##########################################################################
@@ -107,7 +107,7 @@ spec:
                 - name: test-name
                   value: "public-decrypt-euint64-req10"
                 - name: test-command
-                  value: "-a public-decrypt from-args -d euint64 -k {{workflow.parameters.key-id}} -e ffffffffffffffff --num-requests 10"
+                  value: "-a public-decrypt from-args -d euint64 -k {{workflow.parameters.key-id}} -e ffffffffffffffff --rate 10 --duration 1"
                 - name: fhe-params
                   value: "Default"
 
@@ -124,7 +124,7 @@ spec:
                 - name: test-name
                   value: "public-decrypt-euint64-req100"
                 - name: test-command
-                  value: "-a public-decrypt from-args -d euint64 -k {{workflow.parameters.key-id}} -e ffffffffffffffff --num-requests 100"
+                  value: "-a public-decrypt from-args -d euint64 -k {{workflow.parameters.key-id}} -e ffffffffffffffff --rate 100 --duration 1"
                 - name: fhe-params
                   value: "Default"
 

--- a/ci/perf-testing/threshold/kms-ci/kms-service/values-kms-ci.yaml
+++ b/ci/perf-testing/threshold/kms-ci/kms-service/values-kms-ci.yaml
@@ -130,7 +130,7 @@ kmsCoreClientTesting:
   # - fi
   # - key_id=$(cat /app/key-files/key-id.txt)
   # - crs_id=$(cat /app/key-files/crs-id.txt)
-  # - bin/kms-core-client --logs -f config.toml public-decrypt from-args -d euint64 -k $key_id -e ffffffffffffffff --precompute-sns --num-requests 100
+  # - bin/kms-core-client --logs -f config.toml public-decrypt from-args -d euint64 -k $key_id -e ffffffffffffffff --rate 100 --duration 60
   # - bin/kms-core-client --logs -f config.toml user-decrypt from-args -d euint64 -k $key_id -e ffffffffffffffff --precompute-sns --rate 100 --duration 1 --max-in-flight 1000
 podSecurityContext:
   # To set when the image will support non root user

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -448,6 +448,19 @@ async fn send_and_collect_public_decrypt(
     })
 }
 
+/// Deterministic ordering key for a public decryption response. Responses are collected
+/// concurrently, so their arrival order is non-deterministic; the `verification_key` is the
+/// only per-party identifier present on the response itself, so we sort by it to give a
+/// stable order. Both the single-shot path here and the `PublicDecryptResult` fetch path
+/// (`get_public_decrypt_responses`) sort by this key, so their formatted output matches.
+fn public_decrypt_response_sort_key(response: &PublicDecryptionResponse) -> &[u8] {
+    response
+        .payload
+        .as_ref()
+        .map(|payload| payload.verification_key.as_slice())
+        .unwrap_or_default()
+}
+
 async fn verify_public_decrypt(
     internal_client: Arc<RwLock<Client>>,
     kms_addrs: Vec<alloy_primitives::Address>,
@@ -458,7 +471,7 @@ async fn verify_public_decrypt(
     let CollectedPublicDecrypt {
         req_id,
         dec_req,
-        resp_response_vec,
+        mut resp_response_vec,
         collect_duration: _,
     } = collected;
     let verify_one_start = tokio::time::Instant::now();
@@ -470,6 +483,9 @@ async fn verify_public_decrypt(
         &kms_addrs,
         num_expected_responses,
     )?;
+    resp_response_vec.sort_unstable_by(|a, b| {
+        public_decrypt_response_sort_key(a).cmp(public_decrypt_response_sort_key(b))
+    });
     Ok((
         req_id,
         format!("{resp_response_vec:x?}"),
@@ -1534,11 +1550,13 @@ pub(crate) async fn get_public_decrypt_responses(
         "pdec resp"
     );
 
-    resp_response_vec.sort_by_key(|(conf, _)| conf.party_id);
-    let resp_response_vec: Vec<_> = resp_response_vec
+    let mut resp_response_vec: Vec<_> = resp_response_vec
         .into_iter()
         .map(|(_, resp)| resp)
         .collect();
+    resp_response_vec.sort_unstable_by(|a, b| {
+        public_decrypt_response_sort_key(a).cmp(public_decrypt_response_sort_key(b))
+    });
 
     // Verify when material is supplied; `None` returns the responses unverified (the perf harness
     // passes `None` and verifies in its own phase).

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -836,7 +836,7 @@ where
     let mut last_tick = Instant::now();
     let mut late_ticks = 0_u64;
 
-    // Until the deadline: on each tick, reap any finished requests and launch the tick's
+    // Until the deadline: on each tick, collect any finished requests and launch the tick's
     // share of new ones, skipping any that would exceed the in-flight cap.
     while Instant::now() < deadline {
         ticker.tick().await;

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -18,7 +18,7 @@ use kms_lib::{
 };
 use prost::Message as _;
 use rand::{CryptoRng, Rng};
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, future::Future, sync::Arc};
 use tokio::sync::RwLock;
 use tokio::task::JoinSet;
 use tonic::transport::Channel;
@@ -104,186 +104,52 @@ fn check_external_decryption_signature(
     Ok(())
 }
 
-#[expect(clippy::too_many_arguments)]
-pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
-    rng: &mut R,
-    num_requests: usize,
-    internal_client: Arc<RwLock<Client>>,
-    ct_batch: Vec<TypedCiphertext>,
-    key_id: KeyId,
-    context_id: Option<ContextId>,
-    epoch_id: Option<EpochId>,
-    core_endpoints_req: &HashMap<CoreConf, CoreServiceEndpointClient<Channel>>,
-    core_endpoints_resp: &HashMap<CoreConf, CoreServiceEndpointClient<Channel>>,
-    ptxt: TypedPlaintext,
-    num_parties: usize,
-    kms_addrs: Vec<alloy_primitives::Address>,
-    max_iter: usize,
-    num_expected_responses: usize,
-    inter_request_delay: tokio::time::Duration,
-    parallel_requests: usize,
-    domain: Eip712Domain,
-) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
-    // `extra_data` is always derived from the (resolved) context/epoch via
-    // `make_extra_data` (RFC-005 v2) — never user-supplied — matching the
-    // keygen/CRS request builders.
-    let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
-
-    // PHASE 0: build every request up front.
-    let mut requests = Vec::with_capacity(num_requests);
-    for _ in 0..num_requests {
-        let req_id = RequestId::new_random(rng);
-        let dec_req = internal_client.write().await.public_decryption_request(
-            ct_batch.clone(),
-            &domain,
-            &req_id,
-            context_id.as_ref(),
-            &key_id.into(),
-            epoch_id.as_ref(),
-            &extra_data,
-        )?;
-        requests.push((req_id, dec_req));
-    }
-
-    // PHASE 1: send the prebuilt requests and collect their responses.
-    let mut join_set: JoinSet<Result<_, anyhow::Error>> = JoinSet::new();
-    let mut durations_to_get_responses = Vec::new();
-    let start = tokio::time::Instant::now();
-
-    for (i, (req_id, dec_req)) in requests.into_iter().enumerate() {
-        // Sleep between parallel_requests requests if a non-zero delay is provided (skip before first)
-        if i > 0 && i.checked_rem(parallel_requests) == Some(0) && !inter_request_delay.is_zero() {
-            tracing::info!(
-                "Current status {i}/{num_requests}. Sleeping for {:?} before sending {parallel_requests} more parallel requests.",
-                inter_request_delay
-            );
-            tokio::time::sleep(inter_request_delay).await;
-        }
-        let internal_client = internal_client.clone();
-        let core_endpoints_req = core_endpoints_req.clone();
-        let core_endpoints_resp = core_endpoints_resp.clone();
-        let kms_addrs = kms_addrs.clone();
-
-        join_set.spawn(async move {
-            // start timing this request's collect window
-            let request_start = tokio::time::Instant::now();
-
-            // make parallel requests by calling [decrypt] in a thread
-            let mut req_tasks = JoinSet::new();
-
-            for ce in core_endpoints_req.values() {
-                let req_cloned = dec_req.clone();
-                let mut cur_client = ce.clone();
-                req_tasks.spawn(async move {
-                    cur_client
-                        .public_decrypt(tonic::Request::new(req_cloned))
-                        .await
-                });
-            }
-
-            let mut req_response_vec = Vec::new();
-            while let Some(inner) = req_tasks.join_next().await {
-                match inner {
-                    Ok(Ok(resp)) => req_response_vec.push(resp.into_inner()),
-                    Ok(Err(e)) => {
-                        tracing::warn!("Public decrypt request to a core failed: {e}");
-                    }
-                    Err(e) => {
-                        tracing::warn!("Public decrypt request task panicked: {e}");
-                    }
-                }
-            }
-            if req_response_vec.len() < num_expected_responses {
-                anyhow::bail!(
-                    "Only {}/{} public decrypt requests succeeded, need at least {}",
-                    req_response_vec.len(),
-                    num_parties,
-                    num_expected_responses
-                );
-            }
-
-            tracing::info!(
-                "{:?} ###! Sent {}/{} public decrypt requests successfully. Since start {:?}",
-                req_id.as_str(),
-                req_response_vec.len(),
-                num_parties,
-                start.elapsed()
-            );
-
-            // collect only — verification is deferred to phase 2 (below) so it stays out of the throughput window.
-            let (resp_response_vec, time_to_get_responses) = get_public_decrypt_responses(
-                &core_endpoints_resp,
-                None,
-                None,
-                req_id,
-                max_iter,
-                num_expected_responses,
-                &*internal_client.read().await,
-                &kms_addrs,
-                request_start,
-            )
-            .await?;
-
-            Ok((req_id, dec_req, resp_response_vec, time_to_get_responses))
-        });
-    }
-
-    // Drain phase 1: gather every request, its responses, and its collect-only latency.
-    let mut collected = Vec::with_capacity(num_requests);
-    while let Some(result) = join_set.join_next().await {
-        let (req_id, dec_req, resp_response_vec, time_to_get_responses) = result??;
-        durations_to_get_responses.push(time_to_get_responses);
-        collected.push((req_id, dec_req, resp_response_vec));
-    }
-    let collect_elapsed = start.elapsed();
-
-    // PHASE 2: verify each result in parallel. Measured and reported separately from the throughput figure.
-    let verify_start = tokio::time::Instant::now();
-    let mut verify_tasks: JoinSet<Result<(RequestId, String), anyhow::Error>> = JoinSet::new();
-    for (req_id, dec_req, resp_response_vec) in collected {
-        let internal_client = internal_client.clone();
-        let kms_addrs = kms_addrs.clone();
-        let ptxt = ptxt.clone();
-        verify_tasks.spawn(async move {
-            verify_public_decrypt_responses(
-                &resp_response_vec,
-                PubDecVerificationMaterial::Request(dec_req),
-                Some(ptxt),
-                &*internal_client.read().await,
-                &kms_addrs,
-                num_expected_responses,
-            )?;
-            Ok((req_id, format!("{resp_response_vec:x?}")))
-        });
-    }
-
-    let mut result_vec = Vec::with_capacity(durations_to_get_responses.len());
-    while let Some(res) = verify_tasks.join_next().await {
-        let (req_id, msg) = res??;
-        result_vec.push((Some(req_id), msg));
-    }
-    let verify_elapsed = verify_start.elapsed();
-
-    print_phased_timings(
-        "public decrypt",
-        collect_elapsed,
-        &durations_to_get_responses,
-        verify_elapsed,
-    );
-
-    Ok(result_vec)
-}
-
-struct CollectedUserDecrypt {
+struct CollectedPublicDecrypt {
     req_id: RequestId,
-    user_decrypt_req: UserDecryptionRequest,
-    enc_pk: UnifiedPublicEncKey,
-    enc_sk: UnifiedPrivateEncKey,
-    resp_response_vec: Vec<kms_grpc::kms::v1::UserDecryptionResponse>,
+    dec_req: PublicDecryptionRequest,
+    resp_response_vec: Vec<PublicDecryptionResponse>,
     collect_duration: tokio::time::Duration,
 }
 
-struct UserDecryptMetrics {
+trait CollectedDecryptRateResult {
+    fn collect_duration(&self) -> tokio::time::Duration;
+    fn response_payload_bytes(&self) -> u64;
+    fn response_payload_messages(&self) -> u64;
+}
+
+impl CollectedDecryptRateResult for CollectedPublicDecrypt {
+    fn collect_duration(&self) -> tokio::time::Duration {
+        self.collect_duration
+    }
+
+    fn response_payload_bytes(&self) -> u64 {
+        self.resp_response_vec
+            .iter()
+            .map(|response| response.encoded_len() as u64)
+            .sum()
+    }
+
+    fn response_payload_messages(&self) -> u64 {
+        self.resp_response_vec.len() as u64
+    }
+}
+
+struct DecryptRateCollection<T> {
+    collected: Vec<T>,
+    completed: u64,
+    durations_to_get_responses: Vec<tokio::time::Duration>,
+    collect_elapsed: tokio::time::Duration,
+    offered: u64,
+    failed: u64,
+    shed: u64,
+    saturated: bool,
+    request_payload_bytes: u64,
+    request_payload_messages: u64,
+    response_payload_bytes: u64,
+    response_payload_messages: u64,
+}
+
+struct DecryptRateMetrics {
     target_rate: u64,
     duration_secs: u64,
     max_in_flight: usize,
@@ -301,17 +167,14 @@ struct UserDecryptMetrics {
     response_payload_messages: u64,
     response_payload_mib_per_sec: f64,
     response_payload_avg_bytes: f64,
-    reconstruction_failed: u64,
+    post_process_failed: u64,
     latency_stat: crate::DurationStat,
-    reconstruction_stat: crate::DurationStat,
-    reconstruction_wall: tokio::time::Duration,
+    post_process_stat: crate::DurationStat,
+    post_process_wall: tokio::time::Duration,
 }
 
-/// Wire format for the `USER_DECRYPT_METRICS` line the CI harness parses.
-/// Serializing a dedicated struct keeps the JSON shape (field names, nesting)
-/// tied to the type instead of a hand-maintained `format!` string.
 #[derive(serde::Serialize)]
-struct UserDecryptMetricsJson {
+struct DecryptRateMetricsJson {
     target_rate: u64,
     #[serde(rename = "duration")]
     duration_secs: u64,
@@ -330,24 +193,11 @@ struct UserDecryptMetricsJson {
     response_payload_messages: u64,
     response_payload_mib_per_sec: f64,
     response_payload_avg_bytes: f64,
-    reconstruction_failed: u64,
     latency_ms: DurationStatMsJson,
-    reconstruction_ms: ReconstructionMsJson,
 }
 
 #[derive(serde::Serialize)]
-struct DurationStatMsJson {
-    avg: f64,
-    std_dev: f64,
-    p50: f64,
-    p95: f64,
-    p99: f64,
-    min: f64,
-    max: f64,
-}
-
-#[derive(serde::Serialize)]
-struct ReconstructionMsJson {
+struct PhaseMsJson {
     avg: f64,
     std_dev: f64,
     p50: f64,
@@ -358,22 +208,25 @@ struct ReconstructionMsJson {
     wall: f64,
 }
 
-fn duration_stat_ms(stat: &crate::DurationStat) -> DurationStatMsJson {
-    let ms = |d: tokio::time::Duration| d.as_secs_f64() * 1000.0;
-    DurationStatMsJson {
-        avg: ms(stat.avg),
-        std_dev: ms(stat.std_dev),
-        p50: ms(stat.p50),
-        p95: ms(stat.p95),
-        p99: ms(stat.p99),
-        min: ms(stat.min),
-        max: ms(stat.max),
+fn duration_stat_with_wall_ms(
+    stat: &crate::DurationStat,
+    wall: tokio::time::Duration,
+) -> PhaseMsJson {
+    let stat = duration_stat_ms(stat);
+    PhaseMsJson {
+        avg: stat.avg,
+        std_dev: stat.std_dev,
+        p50: stat.p50,
+        p95: stat.p95,
+        p99: stat.p99,
+        min: stat.min,
+        max: stat.max,
+        wall: wall.as_secs_f64() * 1000.0,
     }
 }
 
-impl From<&UserDecryptMetrics> for UserDecryptMetricsJson {
-    fn from(m: &UserDecryptMetrics) -> Self {
-        let recon = duration_stat_ms(&m.reconstruction_stat);
+impl From<&DecryptRateMetrics> for DecryptRateMetricsJson {
+    fn from(m: &DecryptRateMetrics) -> Self {
         Self {
             target_rate: m.target_rate,
             duration_secs: m.duration_secs,
@@ -392,28 +245,742 @@ impl From<&UserDecryptMetrics> for UserDecryptMetricsJson {
             response_payload_messages: m.response_payload_messages,
             response_payload_mib_per_sec: m.response_payload_mib_per_sec,
             response_payload_avg_bytes: m.response_payload_avg_bytes,
-            reconstruction_failed: m.reconstruction_failed,
             latency_ms: duration_stat_ms(&m.latency_stat),
-            reconstruction_ms: ReconstructionMsJson {
-                avg: recon.avg,
-                std_dev: recon.std_dev,
-                p50: recon.p50,
-                p95: recon.p95,
-                p99: recon.p99,
-                min: recon.min,
-                max: recon.max,
-                wall: m.reconstruction_wall.as_secs_f64() * 1000.0,
-            },
         }
     }
 }
 
-impl UserDecryptMetrics {
-    fn log_json(&self) {
-        match serde_json::to_string(&UserDecryptMetricsJson::from(self)) {
-            Ok(metrics) => println!("USER_DECRYPT_METRICS {metrics}"),
-            Err(e) => tracing::error!("failed to serialize user decrypt metrics: {e}"),
+impl DecryptRateMetrics {
+    fn to_json(
+        &self,
+        failed_field: &'static str,
+        timing_field: &'static str,
+    ) -> serde_json::Result<String> {
+        let mut value = serde_json::to_value(DecryptRateMetricsJson::from(self))?;
+        let object = value
+            .as_object_mut()
+            .expect("metrics JSON starts as an object");
+        object.insert(failed_field.to_owned(), self.post_process_failed.into());
+        object.insert(
+            timing_field.to_owned(),
+            serde_json::to_value(duration_stat_with_wall_ms(
+                &self.post_process_stat,
+                self.post_process_wall,
+            ))?,
+        );
+        serde_json::to_string(&value)
+    }
+
+    fn log_json(
+        &self,
+        marker: &'static str,
+        failed_field: &'static str,
+        timing_field: &'static str,
+    ) {
+        match self.to_json(failed_field, timing_field) {
+            Ok(metrics) => println!("{marker} {metrics}"),
+            Err(e) => tracing::error!("failed to serialize {marker} metrics: {e}"),
         }
+    }
+}
+
+fn endpoint_clients(
+    core_endpoints: &HashMap<CoreConf, CoreServiceEndpointClient<Channel>>,
+) -> CoreEndpointClients {
+    Arc::<[CoreEndpointClient]>::from(core_endpoints.values().cloned().collect::<Vec<_>>())
+}
+
+/// Collect responses from a set of already-spawned per-party fetch tasks, stopping as soon as
+/// `num_expected_responses` have arrived and draining the rest in the background. Shared by the
+/// public- and user-decrypt collectors, which differ only in how they build `resp_tasks`.
+async fn collect_decrypt_responses<Resp: Send + 'static>(
+    label: &'static str,
+    rate: u64,
+    request_start: tokio::time::Instant,
+    mut resp_tasks: JoinSet<anyhow::Result<Resp>>,
+    num_parties: usize,
+    num_expected_responses: usize,
+) -> anyhow::Result<(Vec<Resp>, tokio::time::Duration)> {
+    let mut resp_response_vec = Vec::new();
+    let mut collect_duration = None;
+    while let Some(resp) = resp_tasks.join_next().await {
+        match resp {
+            Ok(Ok(inner)) => resp_response_vec.push(inner),
+            Ok(Err(e)) => tracing::debug!("A core failed to return {label} result: {e}"),
+            Err(e) => tracing::debug!("{label} response task panicked: {e}"),
+        }
+        if resp_response_vec.len() >= num_expected_responses {
+            collect_duration = Some(request_start.elapsed());
+            break;
+        }
+    }
+    if resp_response_vec.len() < num_expected_responses {
+        anyhow::bail!(
+            "Only got {}/{} {label} responses, need at least {}",
+            resp_response_vec.len(),
+            num_parties,
+            num_expected_responses
+        );
+    }
+
+    let pending_response_tasks = resp_tasks.len();
+    if pending_response_tasks > 0 {
+        tokio::spawn(async move {
+            while let Some(resp) = resp_tasks.join_next().await {
+                match resp {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => tracing::debug!("Outstanding {label} response failed: {e}"),
+                    Err(e) => {
+                        tracing::debug!("Outstanding {label} response task panicked: {e}")
+                    }
+                }
+            }
+            tracing::debug!(
+                rate,
+                drained = pending_response_tasks,
+                "drained outstanding {label} resp tasks"
+            );
+        });
+    }
+
+    let collect_duration = collect_duration.expect("set once the response quota is met");
+    tracing::debug!(
+        rate,
+        got = resp_response_vec.len(),
+        needed = num_expected_responses,
+        elapsed = ?collect_duration,
+        "{label} resp"
+    );
+    Ok((resp_response_vec, collect_duration))
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn send_and_collect_public_decrypt(
+    rate: u64,
+    req_id: RequestId,
+    dec_req: PublicDecryptionRequest,
+    core_endpoints_req: CoreEndpointClients,
+    core_endpoints_resp: CoreEndpointClients,
+    num_parties: usize,
+    max_iter: usize,
+    num_expected_responses: usize,
+) -> anyhow::Result<CollectedPublicDecrypt> {
+    let request_start = tokio::time::Instant::now();
+
+    let mut req_tasks = JoinSet::new();
+    for ce in core_endpoints_req.iter() {
+        let req_cloned = dec_req.clone();
+        let mut cur_client = ce.clone();
+        req_tasks.spawn(async move {
+            cur_client
+                .public_decrypt(tonic::Request::new(req_cloned))
+                .await
+        });
+    }
+
+    let mut req_response_vec = Vec::new();
+    while let Some(inner) = req_tasks.join_next().await {
+        match inner {
+            Ok(Ok(resp)) => req_response_vec.push(resp.into_inner()),
+            Ok(Err(e)) => {
+                tracing::debug!("Public decrypt request to a core failed: {e}");
+            }
+            Err(e) => {
+                tracing::debug!("Public decrypt request task panicked: {e}");
+            }
+        }
+    }
+    if req_response_vec.len() < num_expected_responses {
+        anyhow::bail!(
+            "Only {}/{} public decrypt requests succeeded, need at least {}",
+            req_response_vec.len(),
+            num_parties,
+            num_expected_responses
+        );
+    }
+
+    let mut resp_tasks = JoinSet::new();
+    for ce in core_endpoints_resp.iter() {
+        let mut cur_client = ce.clone();
+        resp_tasks.spawn(async move {
+            let mut response = cur_client
+                .get_public_decryption_result(tonic::Request::new(req_id.into()))
+                .await;
+            let mut ctr = 0_usize;
+            while response.is_err()
+                && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
+            {
+                tokio::time::sleep(tokio::time::Duration::from_millis(
+                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                ))
+                .await;
+                if ctr >= max_iter {
+                    anyhow::bail!(
+                        "timeout while waiting for public decryption after {max_iter} retries."
+                    );
+                }
+                ctr += 1;
+                response = cur_client
+                    .get_public_decryption_result(tonic::Request::new(req_id.into()))
+                    .await;
+            }
+            let resp =
+                response.map_err(|e| anyhow::anyhow!("public decryption response failed: {e}"))?;
+            Ok(resp.into_inner())
+        });
+    }
+
+    let (resp_response_vec, collect_duration) = collect_decrypt_responses(
+        "public decrypt",
+        rate,
+        request_start,
+        resp_tasks,
+        num_parties,
+        num_expected_responses,
+    )
+    .await?;
+
+    Ok(CollectedPublicDecrypt {
+        req_id,
+        dec_req,
+        resp_response_vec,
+        collect_duration,
+    })
+}
+
+async fn verify_public_decrypt(
+    internal_client: Arc<RwLock<Client>>,
+    kms_addrs: Vec<alloy_primitives::Address>,
+    ptxt: TypedPlaintext,
+    num_expected_responses: usize,
+    collected: CollectedPublicDecrypt,
+) -> anyhow::Result<(RequestId, String, tokio::time::Duration)> {
+    let CollectedPublicDecrypt {
+        req_id,
+        dec_req,
+        resp_response_vec,
+        collect_duration: _,
+    } = collected;
+    let verify_one_start = tokio::time::Instant::now();
+    verify_public_decrypt_responses(
+        &resp_response_vec,
+        PubDecVerificationMaterial::Request(dec_req),
+        Some(ptxt.clone()),
+        &*internal_client.read().await,
+        &kms_addrs,
+        num_expected_responses,
+    )?;
+    Ok((
+        req_id,
+        format!("Public decrypted Plaintext {ptxt:?}"),
+        verify_one_start.elapsed(),
+    ))
+}
+
+#[expect(clippy::too_many_arguments)]
+pub(crate) async fn do_public_decrypt_once<R: Rng + CryptoRng>(
+    rng: &mut R,
+    internal_client: Arc<RwLock<Client>>,
+    ct_batch: Vec<TypedCiphertext>,
+    key_id: KeyId,
+    context_id: Option<ContextId>,
+    epoch_id: Option<EpochId>,
+    core_endpoints_req: &HashMap<CoreConf, CoreServiceEndpointClient<Channel>>,
+    core_endpoints_resp: &HashMap<CoreConf, CoreServiceEndpointClient<Channel>>,
+    ptxt: TypedPlaintext,
+    num_parties: usize,
+    kms_addrs: Vec<alloy_primitives::Address>,
+    max_iter: usize,
+    num_expected_responses: usize,
+    domain: Eip712Domain,
+) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
+    let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
+    let core_endpoints_req = endpoint_clients(core_endpoints_req);
+    let core_endpoints_resp = endpoint_clients(core_endpoints_resp);
+
+    let req_id = RequestId::new_random(rng);
+    let dec_req = internal_client.write().await.public_decryption_request(
+        ct_batch,
+        &domain,
+        &req_id,
+        context_id.as_ref(),
+        &key_id.into(),
+        epoch_id.as_ref(),
+        &extra_data,
+    )?;
+
+    let collected = send_and_collect_public_decrypt(
+        1,
+        req_id,
+        dec_req,
+        core_endpoints_req,
+        core_endpoints_resp,
+        num_parties,
+        max_iter,
+        num_expected_responses,
+    )
+    .await?;
+    let collect_duration = collected.collect_duration;
+
+    let verify_start = tokio::time::Instant::now();
+    let (req_id, msg, verify_duration) = verify_public_decrypt(
+        internal_client,
+        kms_addrs,
+        ptxt,
+        num_expected_responses,
+        collected,
+    )
+    .await?;
+    let verify_elapsed = verify_start.elapsed();
+
+    print_phased_timings(
+        "public decrypt",
+        collect_duration,
+        &[collect_duration],
+        verify_elapsed,
+    );
+    tracing::debug!(elapsed = ?verify_duration, "pdec verify");
+
+    Ok(vec![(Some(req_id), msg)])
+}
+
+#[expect(clippy::too_many_arguments)]
+pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
+    rng: &mut R,
+    rate: u64,
+    duration_secs: u64,
+    max_in_flight: usize,
+    drain_timeout_secs: u64,
+    internal_client: Arc<RwLock<Client>>,
+    ct_batch: Vec<TypedCiphertext>,
+    key_id: KeyId,
+    context_id: Option<ContextId>,
+    epoch_id: Option<EpochId>,
+    core_endpoints_req: &HashMap<CoreConf, CoreServiceEndpointClient<Channel>>,
+    core_endpoints_resp: &HashMap<CoreConf, CoreServiceEndpointClient<Channel>>,
+    ptxt: TypedPlaintext,
+    num_parties: usize,
+    kms_addrs: Vec<alloy_primitives::Address>,
+    max_iter: usize,
+    num_expected_responses: usize,
+    domain: Eip712Domain,
+) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
+    let total_requests = (rate * duration_secs) as usize;
+    let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
+    let core_endpoints_req = endpoint_clients(core_endpoints_req);
+    let core_endpoints_resp = endpoint_clients(core_endpoints_resp);
+
+    // PHASE 1: build the request batch before the timed launch window.
+    tracing::info!(
+        "Prebuilding {total_requests} public decrypt requests: rate={rate}/s, duration={duration_secs}s, max_in_flight={max_in_flight}"
+    );
+    let mut requests = Vec::with_capacity(total_requests);
+    for _ in 0..total_requests {
+        let req_id = RequestId::new_random(rng);
+        let dec_req = internal_client.write().await.public_decryption_request(
+            ct_batch.clone(),
+            &domain,
+            &req_id,
+            context_id.as_ref(),
+            &key_id.into(),
+            epoch_id.as_ref(),
+            &extra_data,
+        )?;
+        requests.push((req_id, dec_req));
+    }
+
+    let mut collection = collect_decrypt_rate(
+        "public decrypt",
+        rate,
+        duration_secs,
+        max_in_flight,
+        drain_timeout_secs,
+        total_requests,
+        requests.into_iter(),
+        core_endpoints_req.len(),
+        |(_req_id, dec_req)| dec_req.encoded_len() as u64,
+        |(req_id, dec_req)| {
+            let core_endpoints_req = Arc::clone(&core_endpoints_req);
+            let core_endpoints_resp = Arc::clone(&core_endpoints_resp);
+            send_and_collect_public_decrypt(
+                rate,
+                req_id,
+                dec_req,
+                core_endpoints_req,
+                core_endpoints_resp,
+                num_parties,
+                max_iter,
+                num_expected_responses,
+            )
+        },
+    )
+    .await;
+
+    let collected = std::mem::take(&mut collection.collected);
+
+    // PHASE 4: verify collected responses and emit metrics.
+    let verify_start = tokio::time::Instant::now();
+    let mut verify_tasks: JoinSet<Result<tokio::time::Duration, anyhow::Error>> = JoinSet::new();
+    for collected_result in collected {
+        let internal_client = internal_client.clone();
+        let kms_addrs = kms_addrs.clone();
+        let ptxt = ptxt.clone();
+        verify_tasks.spawn(async move {
+            verify_public_decrypt(
+                internal_client,
+                kms_addrs,
+                ptxt,
+                num_expected_responses,
+                collected_result,
+            )
+            .await
+            .map(|(_, _, duration)| duration)
+        });
+    }
+
+    let mut verification_durations =
+        Vec::with_capacity(collection.durations_to_get_responses.len());
+    let mut verification_failed = 0_u64;
+    while let Some(res) = verify_tasks.join_next().await {
+        match res {
+            Ok(Ok(verify_duration)) => {
+                verification_durations.push(verify_duration);
+            }
+            Ok(Err(e)) => {
+                verification_failed += 1;
+                tracing::debug!("Public decrypt verification failed: {e}");
+            }
+            Err(e) => {
+                verification_failed += 1;
+                tracing::warn!("Public decrypt verification task panicked: {e}");
+            }
+        }
+    }
+    let verify_elapsed = verify_start.elapsed();
+
+    let metrics = decrypt_rate_metrics(
+        rate,
+        duration_secs,
+        max_in_flight,
+        &collection,
+        verification_failed,
+        &verification_durations,
+        verify_elapsed,
+    );
+    metrics.log_json(
+        "PUBLIC_DECRYPT_METRICS",
+        "verification_failed",
+        "verification_ms",
+    );
+    if verification_failed > 0 {
+        tracing::warn!(verification_failed, "public decrypt verification failures");
+    }
+
+    print_phased_timings(
+        "public decrypt",
+        collection.collect_elapsed,
+        &collection.durations_to_get_responses,
+        verify_elapsed,
+    );
+
+    if verification_failed > 0 {
+        anyhow::bail!("{verification_failed} public decrypt verifications failed");
+    }
+
+    Ok(Vec::new())
+}
+
+struct CollectedUserDecrypt {
+    req_id: RequestId,
+    user_decrypt_req: UserDecryptionRequest,
+    enc_pk: UnifiedPublicEncKey,
+    enc_sk: UnifiedPrivateEncKey,
+    resp_response_vec: Vec<kms_grpc::kms::v1::UserDecryptionResponse>,
+    collect_duration: tokio::time::Duration,
+}
+
+impl CollectedDecryptRateResult for CollectedUserDecrypt {
+    fn collect_duration(&self) -> tokio::time::Duration {
+        self.collect_duration
+    }
+
+    fn response_payload_bytes(&self) -> u64 {
+        self.resp_response_vec
+            .iter()
+            .map(|response| response.encoded_len() as u64)
+            .sum()
+    }
+
+    fn response_payload_messages(&self) -> u64 {
+        self.resp_response_vec.len() as u64
+    }
+}
+
+#[derive(serde::Serialize)]
+struct DurationStatMsJson {
+    avg: f64,
+    std_dev: f64,
+    p50: f64,
+    p95: f64,
+    p99: f64,
+    min: f64,
+    max: f64,
+}
+
+fn duration_stat_ms(stat: &crate::DurationStat) -> DurationStatMsJson {
+    let ms = |d: tokio::time::Duration| d.as_secs_f64() * 1000.0;
+    DurationStatMsJson {
+        avg: ms(stat.avg),
+        std_dev: ms(stat.std_dev),
+        p50: ms(stat.p50),
+        p95: ms(stat.p95),
+        p99: ms(stat.p99),
+        min: ms(stat.min),
+        max: ms(stat.max),
+    }
+}
+
+fn drain_finished_decrypts<T: CollectedDecryptRateResult + 'static>(
+    label: &'static str,
+    join_set: &mut JoinSet<Result<T, anyhow::Error>>,
+    collected: &mut Vec<T>,
+    durations: &mut Vec<tokio::time::Duration>,
+    failed: &mut u64,
+) {
+    while let Some(result) = join_set.try_join_next() {
+        match result {
+            Ok(Ok(collected_result)) => {
+                durations.push(collected_result.collect_duration());
+                collected.push(collected_result);
+            }
+            Ok(Err(e)) => {
+                *failed += 1;
+                tracing::debug!("{label} request failed: {e}");
+            }
+            Err(e) => {
+                *failed += 1;
+                tracing::warn!("{label} task panicked: {e}");
+            }
+        }
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn collect_decrypt_rate<Req, Requests, T, Fut, Spawn, PayloadBytes>(
+    label: &'static str,
+    rate: u64,
+    duration_secs: u64,
+    max_in_flight: usize,
+    drain_timeout_secs: u64,
+    total_requests: usize,
+    mut requests: Requests,
+    payload_targets_per_request: usize,
+    mut request_payload_bytes: PayloadBytes,
+    mut spawn_request: Spawn,
+) -> DecryptRateCollection<T>
+where
+    Requests: Iterator<Item = Req>,
+    T: CollectedDecryptRateResult + Send + 'static,
+    Fut: Future<Output = anyhow::Result<T>> + Send + 'static,
+    Spawn: FnMut(Req) -> Fut,
+    PayloadBytes: FnMut(&Req) -> u64,
+{
+    let mut join_set: JoinSet<Result<T, anyhow::Error>> = JoinSet::new();
+    let mut collected = Vec::with_capacity(total_requests);
+    let mut durations_to_get_responses = Vec::with_capacity(total_requests);
+    let mut offered = 0_u64;
+    let mut failed = 0_u64;
+    let mut shed = 0_u64;
+    let mut saturated = false;
+    let mut request_payload_bytes_total = 0_u64;
+    let mut request_payload_messages = 0_u64;
+
+    // PHASE 2: launch requests at the configured rate and collect completed work.
+    let run_start = tokio::time::Instant::now();
+    let deadline = run_start + tokio::time::Duration::from_secs(duration_secs);
+    let tick_period = tokio::time::Duration::from_millis(5);
+    let mut ticker = tokio::time::interval(tick_period);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut launch_accumulator = 0_u64;
+    // The accumulator assumes a steady 200 ticks/s. With MissedTickBehavior::Delay a
+    // stalled iteration pushes ticks late instead of catching up, so the offered rate
+    // can quietly fall below target. Count late ticks so that shortfall is observable.
+    let mut last_tick = tokio::time::Instant::now();
+    let mut late_ticks = 0_u64;
+
+    while tokio::time::Instant::now() < deadline {
+        ticker.tick().await;
+        let tick_now = tokio::time::Instant::now();
+        if tick_now.duration_since(last_tick) > tick_period * 2 {
+            late_ticks += 1;
+            if late_ticks == 1 {
+                tracing::warn!(
+                    rate,
+                    behind_ms = tick_now.duration_since(last_tick).as_millis() as u64,
+                    "{label} ticker fell behind; offered rate may drop below target - underpowered test runner?"
+                );
+            }
+        }
+        last_tick = tick_now;
+        drain_finished_decrypts(
+            label,
+            &mut join_set,
+            &mut collected,
+            &mut durations_to_get_responses,
+            &mut failed,
+        );
+
+        launch_accumulator = launch_accumulator.saturating_add(rate);
+        let launches = launch_accumulator / 200;
+        launch_accumulator %= 200;
+
+        for _ in 0..launches {
+            let Some(request) = requests.next() else {
+                break;
+            };
+            offered += 1;
+            if join_set.len() >= max_in_flight {
+                // Shed: client drops this arrival because the in-flight cap says saturated.
+                shed += 1;
+                saturated = true;
+                continue;
+            }
+            request_payload_bytes_total +=
+                request_payload_bytes(&request) * payload_targets_per_request as u64;
+            request_payload_messages += payload_targets_per_request as u64;
+            join_set.spawn(spawn_request(request));
+        }
+    }
+
+    if late_ticks > 0 {
+        tracing::warn!(
+            rate,
+            late_ticks,
+            offered,
+            target = total_requests,
+            "{label} ticker fell behind; offered rate likely below target - underpowered test runner?"
+        );
+    }
+
+    // PHASE 3: drain in-flight requests for a bounded period.
+    let drain_deadline =
+        tokio::time::Instant::now() + tokio::time::Duration::from_secs(drain_timeout_secs);
+    while !join_set.is_empty() && tokio::time::Instant::now() < drain_deadline {
+        if let Ok(Some(result)) =
+            tokio::time::timeout_at(drain_deadline, join_set.join_next()).await
+        {
+            match result {
+                Ok(Ok(collected_result)) => {
+                    durations_to_get_responses.push(collected_result.collect_duration());
+                    collected.push(collected_result);
+                }
+                Ok(Err(e)) => {
+                    failed += 1;
+                    tracing::debug!("{label} request failed: {e}");
+                }
+                Err(e) => {
+                    failed += 1;
+                    tracing::warn!("{label} task panicked: {e}");
+                }
+            }
+        } else {
+            break;
+        }
+    }
+    if !join_set.is_empty() {
+        saturated = true;
+        let remaining = join_set.len();
+        failed += remaining as u64;
+        tracing::warn!("{label} drain timed out with {remaining} requests still in flight");
+        join_set.abort_all();
+    }
+
+    let collect_elapsed = run_start.elapsed();
+    let response_payload_bytes = collected
+        .iter()
+        .map(CollectedDecryptRateResult::response_payload_bytes)
+        .sum();
+    let response_payload_messages = collected
+        .iter()
+        .map(CollectedDecryptRateResult::response_payload_messages)
+        .sum();
+
+    let completed = collected.len() as u64;
+    DecryptRateCollection {
+        collected,
+        completed,
+        durations_to_get_responses,
+        collect_elapsed,
+        offered,
+        failed,
+        shed,
+        saturated,
+        request_payload_bytes: request_payload_bytes_total,
+        request_payload_messages,
+        response_payload_bytes,
+        response_payload_messages,
+    }
+}
+
+fn decrypt_rate_metrics<T>(
+    rate: u64,
+    duration_secs: u64,
+    max_in_flight: usize,
+    collection: &DecryptRateCollection<T>,
+    post_process_failed: u64,
+    post_process_durations: &[tokio::time::Duration],
+    post_process_wall: tokio::time::Duration,
+) -> DecryptRateMetrics {
+    let request_payload_mib_per_sec = if collection.collect_elapsed.is_zero() {
+        0.0
+    } else {
+        collection.request_payload_bytes as f64
+            / 1024.0
+            / 1024.0
+            / collection.collect_elapsed.as_secs_f64()
+    };
+    let request_payload_avg_bytes = if collection.request_payload_messages == 0 {
+        0.0
+    } else {
+        collection.request_payload_bytes as f64 / collection.request_payload_messages as f64
+    };
+    let response_payload_mib_per_sec = if collection.collect_elapsed.is_zero() {
+        0.0
+    } else {
+        collection.response_payload_bytes as f64
+            / 1024.0
+            / 1024.0
+            / collection.collect_elapsed.as_secs_f64()
+    };
+    let response_payload_avg_bytes = if collection.response_payload_messages == 0 {
+        0.0
+    } else {
+        collection.response_payload_bytes as f64 / collection.response_payload_messages as f64
+    };
+
+    DecryptRateMetrics {
+        target_rate: rate,
+        duration_secs,
+        max_in_flight,
+        offered: collection.offered,
+        completed: collection.completed,
+        failed: collection.failed,
+        shed: collection.shed,
+        // TODO: consider also reporting completed / duration_secs; this includes drain time.
+        achieved_rate: collection.completed as f64 / collection.collect_elapsed.as_secs_f64(),
+        saturated: collection.saturated,
+        request_payload_bytes: collection.request_payload_bytes,
+        request_payload_messages: collection.request_payload_messages,
+        request_payload_mib_per_sec,
+        request_payload_avg_bytes,
+        response_payload_bytes: collection.response_payload_bytes,
+        response_payload_messages: collection.response_payload_messages,
+        response_payload_mib_per_sec,
+        response_payload_avg_bytes,
+        post_process_failed,
+        latency_stat: crate::compute_stat_on_durations(&collection.durations_to_get_responses),
+        post_process_stat: crate::compute_stat_on_durations(post_process_durations),
+        post_process_wall,
     }
 }
 
@@ -497,67 +1064,19 @@ async fn send_and_collect_user_decrypt(
             }
             let resp =
                 response.map_err(|e| anyhow::anyhow!("user decryption response failed: {e}"))?;
-            Ok((req_id_clone, resp.into_inner()))
+            Ok(resp.into_inner())
         });
     }
 
-    let mut resp_response_vec = Vec::new();
-    let mut collect_duration = None;
-    while let Some(resp) = resp_tasks.join_next().await {
-        match resp {
-            Ok(Ok((_req_id, inner))) => {
-                resp_response_vec.push(inner);
-            }
-            Ok(Err(e)) => {
-                tracing::debug!("A core failed to return user decryption result: {e}");
-            }
-            Err(e) => {
-                tracing::debug!("User decryption response task panicked: {e}");
-            }
-        }
-        if resp_response_vec.len() >= num_expected_responses {
-            collect_duration = Some(request_start.elapsed());
-            break;
-        }
-    }
-    if resp_response_vec.len() < num_expected_responses {
-        anyhow::bail!(
-            "Only got {}/{} user decryption responses, need at least {}",
-            resp_response_vec.len(),
-            num_parties,
-            num_expected_responses
-        );
-    }
-    let pending_response_tasks = resp_tasks.len();
-    if pending_response_tasks > 0 {
-        tokio::spawn(async move {
-            while let Some(resp) = resp_tasks.join_next().await {
-                match resp {
-                    Ok(Ok((_req_id, _inner))) => {}
-                    Ok(Err(e)) => {
-                        tracing::debug!("Outstanding user decryption response failed: {e}");
-                    }
-                    Err(e) => {
-                        tracing::debug!("Outstanding user decryption response task panicked: {e}");
-                    }
-                }
-            }
-            tracing::debug!(
-                rate,
-                drained = pending_response_tasks,
-                "drained outstanding udec resp tasks"
-            );
-        });
-    }
-
-    let collect_duration = collect_duration.expect("set once the response quota is met");
-    tracing::debug!(
+    let (resp_response_vec, collect_duration) = collect_decrypt_responses(
+        "user decrypt",
         rate,
-        got = resp_response_vec.len(),
-        needed = num_expected_responses,
-        elapsed = ?collect_duration,
-        "udec resp"
-    );
+        request_start,
+        resp_tasks,
+        num_parties,
+        num_expected_responses,
+    )
+    .await?;
 
     Ok(CollectedUserDecrypt {
         req_id,
@@ -567,30 +1086,6 @@ async fn send_and_collect_user_decrypt(
         resp_response_vec,
         collect_duration,
     })
-}
-
-fn drain_finished_user_decrypts(
-    join_set: &mut JoinSet<Result<CollectedUserDecrypt, anyhow::Error>>,
-    collected: &mut Vec<CollectedUserDecrypt>,
-    durations: &mut Vec<tokio::time::Duration>,
-    failed: &mut u64,
-) {
-    while let Some(result) = join_set.try_join_next() {
-        match result {
-            Ok(Ok(collected_result)) => {
-                durations.push(collected_result.collect_duration);
-                collected.push(collected_result);
-            }
-            Ok(Err(e)) => {
-                *failed += 1;
-                tracing::debug!("User decrypt request failed: {e}");
-            }
-            Err(e) => {
-                *failed += 1;
-                tracing::warn!("User decrypt task panicked: {e}");
-            }
-        }
-    }
 }
 
 async fn reconstruct_user_decrypt(
@@ -666,11 +1161,8 @@ pub(crate) async fn do_user_decrypt_once<R: Rng + CryptoRng>(
 ) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
     let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
     let expected = TestingPlaintext::try_from(ptxt)?;
-    let core_endpoints_req =
-        Arc::<[CoreEndpointClient]>::from(core_endpoints_req.values().cloned().collect::<Vec<_>>());
-    let core_endpoints_resp = Arc::<[CoreEndpointClient]>::from(
-        core_endpoints_resp.values().cloned().collect::<Vec<_>>(),
-    );
+    let core_endpoints_req = endpoint_clients(core_endpoints_req);
+    let core_endpoints_resp = endpoint_clients(core_endpoints_resp);
 
     let req_id = RequestId::new_random(rng);
     let (user_decrypt_req, enc_pk, enc_sk) =
@@ -738,12 +1230,10 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
     let total_requests = (rate * duration_secs) as usize;
     let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
     let expected = TestingPlaintext::try_from(ptxt)?;
-    let core_endpoints_req =
-        Arc::<[CoreEndpointClient]>::from(core_endpoints_req.values().cloned().collect::<Vec<_>>());
-    let core_endpoints_resp = Arc::<[CoreEndpointClient]>::from(
-        core_endpoints_resp.values().cloned().collect::<Vec<_>>(),
-    );
+    let core_endpoints_req = endpoint_clients(core_endpoints_req);
+    let core_endpoints_resp = endpoint_clients(core_endpoints_resp);
 
+    // PHASE 1: build the request batch before the timed launch window.
     tracing::info!(
         "Prebuilding {total_requests} user decrypt requests: rate={rate}/s, duration={duration_secs}s, max_in_flight={max_in_flight}"
     );
@@ -763,71 +1253,20 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
         requests.push((req_id, user_decrypt_req, enc_pk, enc_sk));
     }
 
-    let mut request_iter = requests.into_iter();
-    let mut join_set: JoinSet<Result<CollectedUserDecrypt, anyhow::Error>> = JoinSet::new();
-    let mut collected = Vec::with_capacity(total_requests);
-    let mut durations_to_get_responses = Vec::with_capacity(total_requests);
-    let mut offered = 0_u64;
-    let mut failed = 0_u64;
-    let mut shed = 0_u64;
-    let mut saturated = false;
-    let mut request_payload_bytes = 0_u64;
-    let mut request_payload_messages = 0_u64;
-
-    let run_start = tokio::time::Instant::now();
-    let deadline = run_start + tokio::time::Duration::from_secs(duration_secs);
-    let tick_period = tokio::time::Duration::from_millis(5);
-    let mut ticker = tokio::time::interval(tick_period);
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-    let mut launch_accumulator = 0_u64;
-    // The accumulator assumes a steady 200 ticks/s. With MissedTickBehavior::Delay a
-    // stalled iteration pushes ticks late instead of catching up, so the offered rate
-    // can quietly fall below target. Count late ticks so that shortfall is observable.
-    let mut last_tick = tokio::time::Instant::now();
-    let mut late_ticks = 0_u64;
-
-    while tokio::time::Instant::now() < deadline {
-        ticker.tick().await;
-        let tick_now = tokio::time::Instant::now();
-        if tick_now.duration_since(last_tick) > tick_period * 2 {
-            late_ticks += 1;
-            if late_ticks == 1 {
-                tracing::warn!(
-                    rate,
-                    behind_ms = tick_now.duration_since(last_tick).as_millis() as u64,
-                    "user decrypt ticker fell behind; offered rate may drop below target - underpowered test runner?"
-                );
-            }
-        }
-        last_tick = tick_now;
-        drain_finished_user_decrypts(
-            &mut join_set,
-            &mut collected,
-            &mut durations_to_get_responses,
-            &mut failed,
-        );
-
-        launch_accumulator = launch_accumulator.saturating_add(rate);
-        let launches = launch_accumulator / 200;
-        launch_accumulator %= 200;
-
-        for _ in 0..launches {
-            let Some((req_id, user_decrypt_req, enc_pk, enc_sk)) = request_iter.next() else {
-                break;
-            };
-            offered += 1;
-            if join_set.len() >= max_in_flight {
-                // Shed: client drops this arrival because the in-flight cap says saturated.
-                shed += 1;
-                saturated = true;
-                continue;
-            }
-            request_payload_bytes +=
-                user_decrypt_req.encoded_len() as u64 * core_endpoints_req.len() as u64;
-            request_payload_messages += core_endpoints_req.len() as u64;
+    let mut collection = collect_decrypt_rate(
+        "user decrypt",
+        rate,
+        duration_secs,
+        max_in_flight,
+        drain_timeout_secs,
+        total_requests,
+        requests.into_iter(),
+        core_endpoints_req.len(),
+        |(_req_id, user_decrypt_req, _enc_pk, _enc_sk)| user_decrypt_req.encoded_len() as u64,
+        |(req_id, user_decrypt_req, enc_pk, enc_sk)| {
             let core_endpoints_req = Arc::clone(&core_endpoints_req);
             let core_endpoints_resp = Arc::clone(&core_endpoints_resp);
-            join_set.spawn(send_and_collect_user_decrypt(
+            send_and_collect_user_decrypt(
                 rate,
                 req_id,
                 user_decrypt_req,
@@ -838,85 +1277,14 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
                 num_parties,
                 max_iter,
                 num_expected_responses,
-            ));
-        }
-    }
+            )
+        },
+    )
+    .await;
 
-    if late_ticks > 0 {
-        tracing::warn!(
-            rate,
-            late_ticks,
-            offered,
-            target = total_requests,
-            "user decrypt ticker fell behind; offered rate likely below target - underpowered test runner?"
-        );
-    }
+    let collected = std::mem::take(&mut collection.collected);
 
-    let drain_deadline =
-        tokio::time::Instant::now() + tokio::time::Duration::from_secs(drain_timeout_secs);
-    while !join_set.is_empty() && tokio::time::Instant::now() < drain_deadline {
-        if let Ok(Some(result)) =
-            tokio::time::timeout_at(drain_deadline, join_set.join_next()).await
-        {
-            match result {
-                Ok(Ok(collected_result)) => {
-                    durations_to_get_responses.push(collected_result.collect_duration);
-                    collected.push(collected_result);
-                }
-                Ok(Err(e)) => {
-                    failed += 1;
-                    tracing::debug!("User decrypt request failed: {e}");
-                }
-                Err(e) => {
-                    failed += 1;
-                    tracing::warn!("User decrypt task panicked: {e}");
-                }
-            }
-        } else {
-            break;
-        }
-    }
-    if !join_set.is_empty() {
-        saturated = true;
-        let remaining = join_set.len();
-        failed += remaining as u64;
-        tracing::warn!("User decrypt drain timed out with {remaining} requests still in flight");
-        join_set.abort_all();
-    }
-
-    let collect_elapsed = run_start.elapsed();
-    let completed = collected.len() as u64;
-    let latency_stat = crate::compute_stat_on_durations(&durations_to_get_responses);
-    let request_payload_mib_per_sec = if collect_elapsed.is_zero() {
-        0.0
-    } else {
-        request_payload_bytes as f64 / 1024.0 / 1024.0 / collect_elapsed.as_secs_f64()
-    };
-    let request_payload_avg_bytes = if request_payload_messages == 0 {
-        0.0
-    } else {
-        request_payload_bytes as f64 / request_payload_messages as f64
-    };
-    let response_payload_bytes = collected
-        .iter()
-        .flat_map(|collected| collected.resp_response_vec.iter())
-        .map(|response| response.encoded_len() as u64)
-        .sum();
-    let response_payload_messages = collected
-        .iter()
-        .map(|collected| collected.resp_response_vec.len() as u64)
-        .sum();
-    let response_payload_mib_per_sec = if collect_elapsed.is_zero() {
-        0.0
-    } else {
-        response_payload_bytes as f64 / 1024.0 / 1024.0 / collect_elapsed.as_secs_f64()
-    };
-    let response_payload_avg_bytes = if response_payload_messages == 0 {
-        0.0
-    } else {
-        response_payload_bytes as f64 / response_payload_messages as f64
-    };
-
+    // PHASE 4: reconstruct collected responses and emit metrics.
     let reconstruct_start = tokio::time::Instant::now();
     let mut recon_tasks: JoinSet<Result<tokio::time::Duration, anyhow::Error>> = JoinSet::new();
     for collected_result in collected {
@@ -928,7 +1296,8 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
         });
     }
 
-    let mut reconstruction_durations = Vec::with_capacity(durations_to_get_responses.len());
+    let mut reconstruction_durations =
+        Vec::with_capacity(collection.durations_to_get_responses.len());
     let mut reconstruction_failed = 0_u64;
     while let Some(res) = recon_tasks.join_next().await {
         match res {
@@ -946,33 +1315,21 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
         }
     }
     let reconstruct_elapsed = reconstruct_start.elapsed();
-    let reconstruction_stat = crate::compute_stat_on_durations(&reconstruction_durations);
 
-    let metrics = UserDecryptMetrics {
-        target_rate: rate,
+    let metrics = decrypt_rate_metrics(
+        rate,
         duration_secs,
         max_in_flight,
-        offered,
-        completed,
-        failed,
-        shed,
-        // TODO: consider also reporting completed / duration_secs; this includes drain time.
-        achieved_rate: completed as f64 / collect_elapsed.as_secs_f64(),
-        saturated,
-        request_payload_bytes,
-        request_payload_messages,
-        request_payload_mib_per_sec,
-        request_payload_avg_bytes,
-        response_payload_bytes,
-        response_payload_messages,
-        response_payload_mib_per_sec,
-        response_payload_avg_bytes,
+        &collection,
         reconstruction_failed,
-        latency_stat,
-        reconstruction_stat,
-        reconstruction_wall: reconstruct_elapsed,
-    };
-    metrics.log_json();
+        &reconstruction_durations,
+        reconstruct_elapsed,
+    );
+    metrics.log_json(
+        "USER_DECRYPT_METRICS",
+        "reconstruction_failed",
+        "reconstruction_ms",
+    );
     if reconstruction_failed > 0 {
         tracing::warn!(
             reconstruction_failed,
@@ -982,8 +1339,8 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
 
     print_phased_timings(
         "user decrypt",
-        collect_elapsed,
-        &durations_to_get_responses,
+        collection.collect_elapsed,
+        &collection.durations_to_get_responses,
         reconstruct_elapsed,
     );
 
@@ -1170,11 +1527,11 @@ pub(crate) async fn get_public_decrypt_responses(
     }
 
     let time_to_get_responses = start.elapsed();
-    tracing::info!(
-        "{:?} ###! Received {} public decrypt responses. Since start {:?}",
-        request_id.as_str(),
-        resp_response_vec.len(),
-        time_to_get_responses
+    tracing::debug!(
+        request_id = request_id.as_str(),
+        got = resp_response_vec.len(),
+        elapsed = ?time_to_get_responses,
+        "pdec resp"
     );
 
     resp_response_vec.sort_by_key(|(conf, _)| conf.party_id);
@@ -1194,15 +1551,15 @@ pub(crate) async fn get_public_decrypt_responses(
             kms_addrs,
             num_expected_responses,
         )?;
-        tracing::info!(
-            "{:?} ###! Verified public decrypt responses. Since start {:?}",
-            request_id.as_str(),
-            start.elapsed()
+        tracing::debug!(
+            request_id = request_id.as_str(),
+            elapsed = ?start.elapsed(),
+            "pdec verified"
         );
     } else {
         tracing::debug!(
-            "{:?} ###! Public decryption result fetched WITHOUT verification (no material supplied).",
-            request_id.as_str(),
+            request_id = request_id.as_str(),
+            "pdec fetched without verification"
         );
     }
 
@@ -1213,20 +1570,24 @@ pub(crate) async fn get_public_decrypt_responses(
 mod tests {
     use super::*;
 
-    fn sample_metrics(reconstruction_failed: u64) -> UserDecryptMetrics {
+    fn sample_metrics(
+        target_rate: u64,
+        offered: u64,
+        post_process_failed: u64,
+    ) -> DecryptRateMetrics {
         let sample = [
             tokio::time::Duration::from_millis(10),
             tokio::time::Duration::from_millis(20),
         ];
-        UserDecryptMetrics {
-            target_rate: 2400,
+        DecryptRateMetrics {
+            target_rate,
             duration_secs: 60,
             max_in_flight: 10_000,
-            offered: 144_000,
-            completed: 143_900,
-            failed: 100,
+            offered,
+            completed: offered - 100,
+            failed: 10,
             shed: 0,
-            achieved_rate: 2398.3,
+            achieved_rate: target_rate as f64 - 0.2,
             saturated: false,
             request_payload_bytes: 123,
             request_payload_messages: 4,
@@ -1236,11 +1597,39 @@ mod tests {
             response_payload_messages: 4,
             response_payload_mib_per_sec: 2.5,
             response_payload_avg_bytes: 114.0,
-            reconstruction_failed,
+            post_process_failed,
             latency_stat: crate::compute_stat_on_durations(&sample),
-            reconstruction_stat: crate::compute_stat_on_durations(&sample),
-            reconstruction_wall: tokio::time::Duration::from_millis(5),
+            post_process_stat: crate::compute_stat_on_durations(&sample),
+            post_process_wall: tokio::time::Duration::from_millis(5),
         }
+    }
+
+    // The `PUBLIC_DECRYPT_METRICS` JSON is parsed by
+    // ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml. Keep this
+    // in lockstep with that shell parser.
+    #[test]
+    fn public_decrypt_metrics_json_matches_ci_parser_contract() {
+        let json = sample_metrics(500, 30_000, 0)
+            .to_json("verification_failed", "verification_ms")
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["target_rate"], 500);
+        assert_eq!(v["duration"], 60);
+        assert_eq!(v["max_in_flight"], 10_000);
+        assert_eq!(v["offered"], 30_000);
+        assert!(v["achieved_rate"].is_number());
+        assert!(v["latency_ms"]["p50"].is_number());
+        assert!(v["latency_ms"]["p99"].is_number());
+        assert!(v["verification_ms"]["wall"].is_number());
+        assert_eq!(v["verification_failed"], 0);
+
+        let v_failed: serde_json::Value = serde_json::from_str(
+            &sample_metrics(500, 30_000, 3)
+                .to_json("verification_failed", "verification_ms")
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(v_failed["verification_failed"], 3);
     }
 
     // The `USER_DECRYPT_METRICS` JSON is parsed by
@@ -1248,8 +1637,9 @@ mod tests {
     // the field names/nesting so the serde refactor can't silently drift from that parser.
     #[test]
     fn user_decrypt_metrics_json_matches_ci_parser_contract() {
-        let json =
-            serde_json::to_string(&UserDecryptMetricsJson::from(&sample_metrics(0))).unwrap();
+        let json = sample_metrics(2400, 144_000, 0)
+            .to_json("reconstruction_failed", "reconstruction_ms")
+            .unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["target_rate"], 2400);
         assert_eq!(v["duration"], 60); // renamed from `duration_secs`
@@ -1262,7 +1652,9 @@ mod tests {
         assert_eq!(v["reconstruction_failed"], 0);
 
         let v_failed: serde_json::Value = serde_json::from_str(
-            &serde_json::to_string(&UserDecryptMetricsJson::from(&sample_metrics(3))).unwrap(),
+            &sample_metrics(2400, 144_000, 3)
+                .to_json("reconstruction_failed", "reconstruction_ms")
+                .unwrap(),
         )
         .unwrap();
         assert_eq!(v_failed["reconstruction_failed"], 3);

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -819,27 +819,31 @@ where
     let run_start = Instant::now();
     let deadline = run_start + Duration::from_secs(duration_secs);
     let tick_period = Duration::from_millis(5);
+    // Number of ticks per second implied by `tick_period` (e.g. 1000ms / 5ms = 200).
+    // Pacing works like a token bucket: each tick adds `rate` tokens to the accumulator
+    // and we launch one request per whole `ticks_per_sec` of tokens, carrying the
+    // remainder to the next tick. On-schedule ticks therefore offer exactly `rate`
+    // requests per second, spread evenly rather than in a burst.
+    let ticks_per_sec = (1000 / tick_period.as_millis()) as u64;
     let mut ticker = tokio::time::interval(tick_period);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut launch_accumulator = 0_u64;
-    // The accumulator assumes a steady 200 ticks/s. With MissedTickBehavior::Delay a
-    // stalled iteration pushes ticks late instead of catching up, so the offered rate
-    // can quietly fall below target. Count late ticks so that shortfall is observable.
+    // The pacing above only hits `rate` if ticks actually arrive `ticks_per_sec` times a
+    // second. `MissedTickBehavior::Delay` does not replay ticks skipped during a stalled
+    // iteration to catch up — it just lets the schedule slip. Fewer ticks per second means
+    // fewer launches per second, so the offered rate can silently fall below target. Count
+    // ticks that arrive late (a gap over 2x the period) so that shortfall is logged.
     let mut last_tick = Instant::now();
     let mut late_ticks = 0_u64;
 
+    // Until the deadline: on each tick, reap any finished requests and launch the tick's
+    // share of new ones, skipping any that would exceed the in-flight cap.
     while Instant::now() < deadline {
         ticker.tick().await;
         let tick_now = Instant::now();
+        // We consider a tick that fires 2 x tick period (10ms) as being "late".
         if tick_now.duration_since(last_tick) > tick_period * 2 {
             late_ticks += 1;
-            if late_ticks == 1 {
-                tracing::warn!(
-                    rate,
-                    behind_ms = tick_now.duration_since(last_tick).as_millis() as u64,
-                    "{label} ticker fell behind; offered rate may drop below target - underpowered test runner?"
-                );
-            }
         }
         last_tick = tick_now;
         drain_finished_decrypts(
@@ -850,9 +854,11 @@ where
             &mut failed,
         );
 
+        // Add this tick's `rate` tokens, launch one request per whole `ticks_per_sec` accumulated, and carry the
+        // fractional remainder to the next tick.
         launch_accumulator = launch_accumulator.saturating_add(rate);
-        let launches = launch_accumulator / 200;
-        launch_accumulator %= 200;
+        let launches = launch_accumulator / ticks_per_sec;
+        launch_accumulator %= ticks_per_sec;
 
         for _ in 0..launches {
             let Some(request) = requests.next() else {
@@ -860,7 +866,7 @@ where
             };
             offered += 1;
             if join_set.len() >= max_in_flight {
-                // Shed: client drops this arrival because the in-flight cap says saturated.
+                // Shed: client drops this req because the in-flight cap says saturated.
                 shed += 1;
                 saturated = true;
                 continue;
@@ -878,7 +884,7 @@ where
             late_ticks,
             offered,
             target = total_requests,
-            "{label} ticker fell behind; offered rate likely below target - underpowered test runner?"
+            "{label} ticker fell behind on {late_ticks} tick(s); offered rate likely below target - underpowered test runner?"
         );
     }
 
@@ -954,9 +960,7 @@ fn decrypt_rate_metrics<T>(
         0.0
     } else {
         collection.request_payload_bytes as f64
-            / 1024.0
-            / 1024.0
-            / collection.collect_elapsed.as_secs_f64()
+            / (1024.0 * 1024.0 * collection.collect_elapsed.as_secs_f64())
     };
     let request_payload_avg_bytes = if collection.request_payload_messages == 0 {
         0.0
@@ -967,9 +971,7 @@ fn decrypt_rate_metrics<T>(
         0.0
     } else {
         collection.response_payload_bytes as f64
-            / 1024.0
-            / 1024.0
-            / collection.collect_elapsed.as_secs_f64()
+            / (1024.0 * 1024.0 * collection.collect_elapsed.as_secs_f64())
     };
     let response_payload_avg_bytes = if collection.response_payload_messages == 0 {
         0.0

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -465,14 +465,14 @@ async fn verify_public_decrypt(
     verify_public_decrypt_responses(
         &resp_response_vec,
         PubDecVerificationMaterial::Request(dec_req),
-        Some(ptxt.clone()),
+        Some(ptxt),
         &*internal_client.read().await,
         &kms_addrs,
         num_expected_responses,
     )?;
     Ok((
         req_id,
-        format!("Public decrypted Plaintext {ptxt:?}"),
+        format!("{resp_response_vec:x?}"),
         verify_one_start.elapsed(),
     ))
 }

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -107,6 +107,7 @@ fn check_external_decryption_signature(
     Ok(())
 }
 
+/// One public-decrypt request paired with its responses and collection latency.
 struct CollectedPublicDecrypt {
     req_id: RequestId,
     dec_req: PublicDecryptionRequest,
@@ -137,6 +138,7 @@ impl CollectedDecryptRateResult for CollectedPublicDecrypt {
     }
 }
 
+/// Accumulated responses and counters from a single rate-test run.
 struct DecryptRateCollection<T> {
     collected: Vec<T>,
     completed: u64,
@@ -152,6 +154,7 @@ struct DecryptRateCollection<T> {
     response_payload_messages: u64,
 }
 
+/// Metrics computed from a rate-test run: throughput, payloads, and latency stats.
 struct DecryptRateMetrics {
     target_rate: u64,
     duration_secs: u64,
@@ -176,6 +179,7 @@ struct DecryptRateMetrics {
     post_process_wall: Duration,
 }
 
+/// JSON-serializable view of [`DecryptRateMetrics`] consumed by the CI parser.
 #[derive(serde::Serialize)]
 struct DecryptRateMetricsJson {
     target_rate: u64,
@@ -199,6 +203,7 @@ struct DecryptRateMetricsJson {
     latency_ms: DurationStatMsJson,
 }
 
+/// Per-phase latency percentiles in milliseconds, plus wall-clock duration.
 #[derive(serde::Serialize)]
 struct PhaseMsJson {
     avg: f64,
@@ -301,7 +306,7 @@ async fn collect_decrypt_responses<Resp: Send + 'static>(
     num_parties: usize,
     num_expected_responses: usize,
 ) -> anyhow::Result<(Vec<Resp>, Duration)> {
-    let mut resp_response_vec = Vec::new();
+    let mut resp_response_vec = Vec::with_capacity(num_expected_responses);
     let mut collect_duration = None;
     while let Some(resp) = resp_tasks.join_next().await {
         match resp {
@@ -378,7 +383,7 @@ async fn send_and_collect_public_decrypt(
         });
     }
 
-    let mut req_response_vec = Vec::new();
+    let mut req_response_vec = Vec::with_capacity(core_endpoints_req.len());
     while let Some(inner) = req_tasks.join_next().await {
         match inner {
             Ok(Ok(resp)) => req_response_vec.push(resp.into_inner()),
@@ -703,6 +708,7 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
     Ok(Vec::new())
 }
 
+/// One user-decrypt request paired with its keys, responses, and collection latency.
 struct CollectedUserDecrypt {
     req_id: RequestId,
     user_decrypt_req: UserDecryptionRequest,
@@ -729,6 +735,7 @@ impl CollectedDecryptRateResult for CollectedUserDecrypt {
     }
 }
 
+/// Latency percentiles in milliseconds, serialized into rate-test JSON.
 #[derive(serde::Serialize)]
 struct DurationStatMsJson {
     avg: f64,
@@ -1022,7 +1029,7 @@ async fn send_and_collect_user_decrypt(
         });
     }
 
-    let mut req_response_vec = Vec::new();
+    let mut req_response_vec = Vec::with_capacity(core_endpoints_req.len());
     while let Some(inner) = req_tasks.join_next().await {
         match inner {
             Ok(Ok(resp)) => req_response_vec.push(resp.into_inner()),
@@ -1508,7 +1515,7 @@ pub(crate) async fn get_public_decrypt_responses(
             Ok((core_conf, request_id, resp.into_inner()))
         });
     }
-    let mut resp_response_vec = Vec::new();
+    let mut resp_response_vec = Vec::with_capacity(core_endpoints.len());
     while let Some(resp) = resp_tasks.join_next().await {
         match resp {
             Ok(Ok((core_conf, _req_id, inner))) => {

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -19,8 +19,11 @@ use kms_lib::{
 use prost::Message as _;
 use rand::{CryptoRng, Rng};
 use std::{collections::HashMap, future::Future, sync::Arc};
-use tokio::sync::RwLock;
-use tokio::task::JoinSet;
+use tokio::{
+    sync::RwLock,
+    task::JoinSet,
+    time::{Duration, Instant},
+};
 use tonic::transport::Channel;
 
 type CoreEndpointClient = CoreServiceEndpointClient<Channel>;
@@ -108,17 +111,17 @@ struct CollectedPublicDecrypt {
     req_id: RequestId,
     dec_req: PublicDecryptionRequest,
     resp_response_vec: Vec<PublicDecryptionResponse>,
-    collect_duration: tokio::time::Duration,
+    collect_duration: Duration,
 }
 
 trait CollectedDecryptRateResult {
-    fn collect_duration(&self) -> tokio::time::Duration;
+    fn collect_duration(&self) -> Duration;
     fn response_payload_bytes(&self) -> u64;
     fn response_payload_messages(&self) -> u64;
 }
 
 impl CollectedDecryptRateResult for CollectedPublicDecrypt {
-    fn collect_duration(&self) -> tokio::time::Duration {
+    fn collect_duration(&self) -> Duration {
         self.collect_duration
     }
 
@@ -137,8 +140,8 @@ impl CollectedDecryptRateResult for CollectedPublicDecrypt {
 struct DecryptRateCollection<T> {
     collected: Vec<T>,
     completed: u64,
-    durations_to_get_responses: Vec<tokio::time::Duration>,
-    collect_elapsed: tokio::time::Duration,
+    durations_to_get_responses: Vec<Duration>,
+    collect_elapsed: Duration,
     offered: u64,
     failed: u64,
     shed: u64,
@@ -170,7 +173,7 @@ struct DecryptRateMetrics {
     post_process_failed: u64,
     latency_stat: crate::DurationStat,
     post_process_stat: crate::DurationStat,
-    post_process_wall: tokio::time::Duration,
+    post_process_wall: Duration,
 }
 
 #[derive(serde::Serialize)]
@@ -208,10 +211,7 @@ struct PhaseMsJson {
     wall: f64,
 }
 
-fn duration_stat_with_wall_ms(
-    stat: &crate::DurationStat,
-    wall: tokio::time::Duration,
-) -> PhaseMsJson {
+fn duration_stat_with_wall_ms(stat: &crate::DurationStat, wall: Duration) -> PhaseMsJson {
     let stat = duration_stat_ms(stat);
     PhaseMsJson {
         avg: stat.avg,
@@ -296,11 +296,11 @@ fn endpoint_clients(
 async fn collect_decrypt_responses<Resp: Send + 'static>(
     label: &'static str,
     rate: u64,
-    request_start: tokio::time::Instant,
+    request_start: Instant,
     mut resp_tasks: JoinSet<anyhow::Result<Resp>>,
     num_parties: usize,
     num_expected_responses: usize,
-) -> anyhow::Result<(Vec<Resp>, tokio::time::Duration)> {
+) -> anyhow::Result<(Vec<Resp>, Duration)> {
     let mut resp_response_vec = Vec::new();
     let mut collect_duration = None;
     while let Some(resp) = resp_tasks.join_next().await {
@@ -365,7 +365,7 @@ async fn send_and_collect_public_decrypt(
     max_iter: usize,
     num_expected_responses: usize,
 ) -> anyhow::Result<CollectedPublicDecrypt> {
-    let request_start = tokio::time::Instant::now();
+    let request_start = Instant::now();
 
     let mut req_tasks = JoinSet::new();
     for ce in core_endpoints_req.iter() {
@@ -410,10 +410,7 @@ async fn send_and_collect_public_decrypt(
             while response.is_err()
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
-                tokio::time::sleep(tokio::time::Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
-                ))
-                .await;
+                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
                         "timeout while waiting for public decryption after {max_iter} retries."
@@ -467,14 +464,14 @@ async fn verify_public_decrypt(
     ptxt: TypedPlaintext,
     num_expected_responses: usize,
     collected: CollectedPublicDecrypt,
-) -> anyhow::Result<(RequestId, String, tokio::time::Duration)> {
+) -> anyhow::Result<(RequestId, String, Duration)> {
     let CollectedPublicDecrypt {
         req_id,
         dec_req,
         mut resp_response_vec,
         collect_duration: _,
     } = collected;
-    let verify_one_start = tokio::time::Instant::now();
+    let verify_one_start = Instant::now();
     verify_public_decrypt_responses(
         &resp_response_vec,
         PubDecVerificationMaterial::Request(dec_req),
@@ -538,7 +535,7 @@ pub(crate) async fn do_public_decrypt_once<R: Rng + CryptoRng>(
     .await?;
     let collect_duration = collected.collect_duration;
 
-    let verify_start = tokio::time::Instant::now();
+    let verify_start = Instant::now();
     let (req_id, msg, verify_duration) = verify_public_decrypt(
         internal_client,
         kms_addrs,
@@ -635,8 +632,8 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
     let collected = std::mem::take(&mut collection.collected);
 
     // PHASE 4: verify collected responses and emit metrics.
-    let verify_start = tokio::time::Instant::now();
-    let mut verify_tasks: JoinSet<Result<tokio::time::Duration, anyhow::Error>> = JoinSet::new();
+    let verify_start = Instant::now();
+    let mut verify_tasks: JoinSet<Result<Duration, anyhow::Error>> = JoinSet::new();
     for collected_result in collected {
         let internal_client = internal_client.clone();
         let kms_addrs = kms_addrs.clone();
@@ -712,11 +709,11 @@ struct CollectedUserDecrypt {
     enc_pk: UnifiedPublicEncKey,
     enc_sk: UnifiedPrivateEncKey,
     resp_response_vec: Vec<kms_grpc::kms::v1::UserDecryptionResponse>,
-    collect_duration: tokio::time::Duration,
+    collect_duration: Duration,
 }
 
 impl CollectedDecryptRateResult for CollectedUserDecrypt {
-    fn collect_duration(&self) -> tokio::time::Duration {
+    fn collect_duration(&self) -> Duration {
         self.collect_duration
     }
 
@@ -744,7 +741,7 @@ struct DurationStatMsJson {
 }
 
 fn duration_stat_ms(stat: &crate::DurationStat) -> DurationStatMsJson {
-    let ms = |d: tokio::time::Duration| d.as_secs_f64() * 1000.0;
+    let ms = |d: Duration| d.as_secs_f64() * 1000.0;
     DurationStatMsJson {
         avg: ms(stat.avg),
         std_dev: ms(stat.std_dev),
@@ -760,7 +757,7 @@ fn drain_finished_decrypts<T: CollectedDecryptRateResult + 'static>(
     label: &'static str,
     join_set: &mut JoinSet<Result<T, anyhow::Error>>,
     collected: &mut Vec<T>,
-    durations: &mut Vec<tokio::time::Duration>,
+    durations: &mut Vec<Duration>,
     failed: &mut u64,
 ) {
     while let Some(result) = join_set.try_join_next() {
@@ -812,21 +809,21 @@ where
     let mut request_payload_messages = 0_u64;
 
     // PHASE 2: launch requests at the configured rate and collect completed work.
-    let run_start = tokio::time::Instant::now();
-    let deadline = run_start + tokio::time::Duration::from_secs(duration_secs);
-    let tick_period = tokio::time::Duration::from_millis(5);
+    let run_start = Instant::now();
+    let deadline = run_start + Duration::from_secs(duration_secs);
+    let tick_period = Duration::from_millis(5);
     let mut ticker = tokio::time::interval(tick_period);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut launch_accumulator = 0_u64;
     // The accumulator assumes a steady 200 ticks/s. With MissedTickBehavior::Delay a
     // stalled iteration pushes ticks late instead of catching up, so the offered rate
     // can quietly fall below target. Count late ticks so that shortfall is observable.
-    let mut last_tick = tokio::time::Instant::now();
+    let mut last_tick = Instant::now();
     let mut late_ticks = 0_u64;
 
-    while tokio::time::Instant::now() < deadline {
+    while Instant::now() < deadline {
         ticker.tick().await;
-        let tick_now = tokio::time::Instant::now();
+        let tick_now = Instant::now();
         if tick_now.duration_since(last_tick) > tick_period * 2 {
             late_ticks += 1;
             if late_ticks == 1 {
@@ -879,9 +876,8 @@ where
     }
 
     // PHASE 3: drain in-flight requests for a bounded period.
-    let drain_deadline =
-        tokio::time::Instant::now() + tokio::time::Duration::from_secs(drain_timeout_secs);
-    while !join_set.is_empty() && tokio::time::Instant::now() < drain_deadline {
+    let drain_deadline = Instant::now() + Duration::from_secs(drain_timeout_secs);
+    while !join_set.is_empty() && Instant::now() < drain_deadline {
         if let Ok(Some(result)) =
             tokio::time::timeout_at(drain_deadline, join_set.join_next()).await
         {
@@ -944,8 +940,8 @@ fn decrypt_rate_metrics<T>(
     max_in_flight: usize,
     collection: &DecryptRateCollection<T>,
     post_process_failed: u64,
-    post_process_durations: &[tokio::time::Duration],
-    post_process_wall: tokio::time::Duration,
+    post_process_durations: &[Duration],
+    post_process_wall: Duration,
 ) -> DecryptRateMetrics {
     let request_payload_mib_per_sec = if collection.collect_elapsed.is_zero() {
         0.0
@@ -1013,7 +1009,7 @@ async fn send_and_collect_user_decrypt(
     max_iter: usize,
     num_expected_responses: usize,
 ) -> anyhow::Result<CollectedUserDecrypt> {
-    let request_start = tokio::time::Instant::now();
+    let request_start = Instant::now();
 
     let mut req_tasks = JoinSet::new();
     for ce in core_endpoints_req.iter() {
@@ -1064,10 +1060,7 @@ async fn send_and_collect_user_decrypt(
             while response.is_err()
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
-                tokio::time::sleep(tokio::time::Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
-                ))
-                .await;
+                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
                         "timeout while waiting for user decryption after {max_iter} retries."
@@ -1108,7 +1101,7 @@ async fn reconstruct_user_decrypt(
     internal_client: Arc<RwLock<Client>>,
     expected: TestingPlaintext,
     collected: CollectedUserDecrypt,
-) -> anyhow::Result<(RequestId, String, tokio::time::Duration)> {
+) -> anyhow::Result<(RequestId, String, Duration)> {
     let CollectedUserDecrypt {
         req_id,
         user_decrypt_req,
@@ -1117,7 +1110,7 @@ async fn reconstruct_user_decrypt(
         resp_response_vec,
         collect_duration: _,
     } = collected;
-    let reconstruct_one_start = tokio::time::Instant::now();
+    let reconstruct_one_start = Instant::now();
     let client_request = ParsedUserDecryptionRequest::try_from(&user_decrypt_req)
         .map_err(|e| anyhow::anyhow!("failed to parse user decryption request: {e}"))?;
     let eip712_domain = protobuf_to_alloy_domain(
@@ -1207,7 +1200,7 @@ pub(crate) async fn do_user_decrypt_once<R: Rng + CryptoRng>(
     .await?;
     let collect_duration = collected.collect_duration;
 
-    let reconstruct_start = tokio::time::Instant::now();
+    let reconstruct_start = Instant::now();
     let (req_id, msg, reconstruct_duration) =
         reconstruct_user_decrypt(internal_client, expected, collected).await?;
     let reconstruct_elapsed = reconstruct_start.elapsed();
@@ -1301,8 +1294,8 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
     let collected = std::mem::take(&mut collection.collected);
 
     // PHASE 4: reconstruct collected responses and emit metrics.
-    let reconstruct_start = tokio::time::Instant::now();
-    let mut recon_tasks: JoinSet<Result<tokio::time::Duration, anyhow::Error>> = JoinSet::new();
+    let reconstruct_start = Instant::now();
+    let mut recon_tasks: JoinSet<Result<Duration, anyhow::Error>> = JoinSet::new();
     for collected_result in collected {
         let internal_client = internal_client.clone();
         recon_tasks.spawn(async move {
@@ -1476,8 +1469,8 @@ pub(crate) async fn get_public_decrypt_responses(
     num_expected_responses: usize,
     internal_client: &Client,
     kms_addrs: &[alloy_primitives::Address],
-    start: tokio::time::Instant,
-) -> anyhow::Result<(Vec<PublicDecryptionResponse>, tokio::time::Duration)> {
+    start: Instant,
+) -> anyhow::Result<(Vec<PublicDecryptionResponse>, Duration)> {
     // get all responses
     let mut resp_tasks = JoinSet::new();
     //We use enumerate to be able to sort the responses so they are determinstic for a given config
@@ -1493,7 +1486,7 @@ pub(crate) async fn get_public_decrypt_responses(
             while response.is_err()
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
-                tokio::time::sleep(tokio::time::Duration::from_millis(
+                tokio::time::sleep(Duration::from_millis(
                     SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
@@ -1593,10 +1586,7 @@ mod tests {
         offered: u64,
         post_process_failed: u64,
     ) -> DecryptRateMetrics {
-        let sample = [
-            tokio::time::Duration::from_millis(10),
-            tokio::time::Duration::from_millis(20),
-        ];
+        let sample = [Duration::from_millis(10), Duration::from_millis(20)];
         DecryptRateMetrics {
             target_rate,
             duration_secs: 60,
@@ -1618,7 +1608,7 @@ mod tests {
             post_process_failed,
             latency_stat: crate::compute_stat_on_durations(&sample),
             post_process_stat: crate::compute_stat_on_durations(&sample),
-            post_process_wall: tokio::time::Duration::from_millis(5),
+            post_process_wall: Duration::from_millis(5),
         }
     }
 

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -19,8 +19,8 @@ use crate::backup::{
 };
 use crate::crsgen::{do_abort_crs_gen, do_crsgen, fetch_and_check_crsgen, get_crsgen_responses};
 use crate::decrypt::{
-    PubDecVerificationMaterial, do_public_decrypt, do_user_decrypt, do_user_decrypt_once,
-    get_public_decrypt_responses,
+    PubDecVerificationMaterial, do_public_decrypt, do_public_decrypt_once, do_user_decrypt,
+    do_user_decrypt_once, get_public_decrypt_responses,
 };
 use crate::keygen::{
     do_abort_key_gen, do_keygen, do_partial_preproc, do_preproc, fetch_and_check_keygen,
@@ -69,7 +69,7 @@ use validator::{Validate, ValidationError};
 
 // time to sleep between `get_result` poll requests in milliseconds
 const SLEEP_TIME_BETWEEN_REQUESTS_MS: u64 = 500;
-const USER_DECRYPT_DRAIN_TIMEOUT_SECS: u64 = 30;
+const DECRYPT_RATE_DRAIN_TIMEOUT_SECS: u64 = 30;
 
 /// Retries a function a given number of times with a given interval between retries.
 macro_rules! retry {
@@ -332,27 +332,14 @@ fn validate_core_client_conf(conf: &CoreClientConfig) -> Result<(), ValidationEr
     Ok(())
 }
 
-fn validate_cipher_args(cf: &CipherArguments) -> anyhow::Result<()> {
-    if cf.get_num_requests() == 0 {
-        return Err(anyhow::anyhow!("Number of requests cannot be zero."));
-    }
-
-    if cf.get_batch_size() == 0 {
-        return Err(anyhow::anyhow!("Batch size cannot be zero."));
-    }
-
-    if cf.get_parallel_requests() > cf.get_num_requests() {
-        return Err(anyhow::anyhow!(
-            "Number of parallel requests ({}) cannot be > total number of requests ({}).",
-            cf.get_parallel_requests(),
-            cf.get_num_requests()
-        ));
-    }
-
-    Ok(())
+trait DecryptRateArgs {
+    fn get_batch_size(&self) -> usize;
+    fn get_rate(&self) -> Option<u64>;
+    fn get_duration(&self) -> Option<u64>;
+    fn get_max_in_flight(&self) -> Option<usize>;
 }
 
-fn validate_user_decrypt_args(cf: &UserDecryptArguments) -> anyhow::Result<()> {
+fn validate_decrypt_rate_args(cf: &impl DecryptRateArgs) -> anyhow::Result<()> {
     if cf.get_batch_size() == 0 {
         return Err(anyhow::anyhow!("Batch size cannot be zero."));
     }
@@ -604,85 +591,70 @@ pub fn parse_hex(arg: &str) -> anyhow::Result<Vec<u8>> {
     Ok(hex::decode(hex_str)?)
 }
 
+/// Decryption input source and optional rate-mode controls (shared by public and user decrypt).
 #[derive(Debug, Subcommand, Clone)]
-pub enum CipherArguments {
-    FromFile(CipherFile),
-    FromArgs(CipherParameters),
+pub enum DecryptArguments {
+    /// Load an existing ciphertext from disk before asking KMS cores for decryption.
+    FromFile(DecryptFile),
+    /// Encrypt CLI-provided plaintext before asking KMS cores for decryption.
+    FromArgs(DecryptParameters),
 }
 
-impl CipherArguments {
-    pub fn get_batch_size(&self) -> usize {
+impl DecryptRateArgs for DecryptArguments {
+    fn get_batch_size(&self) -> usize {
         match self {
-            CipherArguments::FromFile(cipher_file) => cipher_file.batch_size,
-            CipherArguments::FromArgs(cipher_parameters) => cipher_parameters.batch_size,
+            DecryptArguments::FromFile(cipher_file) => cipher_file.batch_size,
+            DecryptArguments::FromArgs(cipher_parameters) => cipher_parameters.batch_size,
         }
     }
 
-    pub fn get_num_requests(&self) -> usize {
+    fn get_rate(&self) -> Option<u64> {
         match self {
-            CipherArguments::FromFile(cipher_file) => cipher_file.num_requests,
-            CipherArguments::FromArgs(cipher_parameters) => cipher_parameters.num_requests,
+            DecryptArguments::FromFile(cipher_file) => cipher_file.rate_options.rate,
+            DecryptArguments::FromArgs(cipher_parameters) => cipher_parameters.rate_options.rate,
         }
     }
 
-    pub fn get_parallel_requests(&self) -> usize {
+    fn get_duration(&self) -> Option<u64> {
         match self {
-            CipherArguments::FromFile(cipher_file) => cipher_file.parallel_requests,
-            CipherArguments::FromArgs(cipher_parameters) => cipher_parameters.parallel_requests,
-        }
-    }
-
-    pub fn get_inter_request_delay_ms(&self) -> Duration {
-        match self {
-            CipherArguments::FromFile(cipher_file) => {
-                tokio::time::Duration::from_millis(cipher_file.inter_request_delay_ms)
-            }
-            CipherArguments::FromArgs(cipher_parameters) => {
-                tokio::time::Duration::from_millis(cipher_parameters.inter_request_delay_ms)
+            DecryptArguments::FromFile(cipher_file) => cipher_file.rate_options.duration,
+            DecryptArguments::FromArgs(cipher_parameters) => {
+                cipher_parameters.rate_options.duration
             }
         }
     }
-}
 
-#[derive(Debug, Subcommand, Clone)]
-pub enum UserDecryptArguments {
-    FromFile(UserDecryptFile),
-    FromArgs(UserDecryptParameters),
-}
-
-impl UserDecryptArguments {
-    pub fn get_batch_size(&self) -> usize {
+    fn get_max_in_flight(&self) -> Option<usize> {
         match self {
-            UserDecryptArguments::FromFile(cipher_file) => cipher_file.batch_size,
-            UserDecryptArguments::FromArgs(cipher_parameters) => cipher_parameters.batch_size,
+            DecryptArguments::FromFile(cipher_file) => cipher_file.rate_options.max_in_flight,
+            DecryptArguments::FromArgs(cipher_parameters) => {
+                cipher_parameters.rate_options.max_in_flight
+            }
         }
+    }
+}
+
+impl DecryptArguments {
+    pub fn get_batch_size(&self) -> usize {
+        DecryptRateArgs::get_batch_size(self)
     }
 
     pub fn get_rate(&self) -> Option<u64> {
-        match self {
-            UserDecryptArguments::FromFile(cipher_file) => cipher_file.rate,
-            UserDecryptArguments::FromArgs(cipher_parameters) => cipher_parameters.rate,
-        }
+        DecryptRateArgs::get_rate(self)
     }
 
     pub fn get_duration(&self) -> Option<u64> {
-        match self {
-            UserDecryptArguments::FromFile(cipher_file) => cipher_file.duration,
-            UserDecryptArguments::FromArgs(cipher_parameters) => cipher_parameters.duration,
-        }
+        DecryptRateArgs::get_duration(self)
     }
 
     pub fn get_max_in_flight(&self) -> Option<usize> {
-        match self {
-            UserDecryptArguments::FromFile(cipher_file) => cipher_file.max_in_flight,
-            UserDecryptArguments::FromArgs(cipher_parameters) => cipher_parameters.max_in_flight,
-        }
+        DecryptRateArgs::get_max_in_flight(self)
     }
 }
 
 #[derive(Debug, Args, Clone, Serialize, Deserialize)]
 pub struct CipherParameters {
-    /// Hex value to encrypt for encryption/public-decryption commands.
+    /// Hex value to encrypt for encryption/decryption commands.
     /// The value will be converted from a little endian hex string to a `Vec<u8>`.
     /// Can optionally have a "0x" prefix.
     #[clap(long, short = 'e')]
@@ -699,7 +671,7 @@ pub struct CipherParameters {
     /// Default: False, i.e. the SnS is precomputed on the core client.
     #[clap(long, alias = "ns")]
     pub no_precompute_sns: bool,
-    /// Key identifier to use for public decryption.
+    /// Key identifier to use for decryption.
     #[clap(long, short = 'k')]
     pub key_id: KeyId,
     /// Optionally specify the context ID to use for the decryption.
@@ -715,48 +687,15 @@ pub struct CipherParameters {
     #[serde(skip_serializing, skip_deserializing)]
     #[clap(long, short = 'b', default_value_t = 1)]
     pub batch_size: usize,
-    /// Numbers of requests to process at once.
-    /// Each request uses a copy of the same batch.
-    #[serde(skip_serializing, skip_deserializing)]
-    #[clap(long, short = 'n', default_value_t = 1)]
-    pub num_requests: usize,
     /// Optionally dump the ciphertext to a file.
     #[serde(skip_serializing, skip_deserializing)]
     #[clap(long)]
     pub ciphertext_output_path: Option<PathBuf>,
-    /// Delay (in ms) between consecutive requests for decrypt operations
-    #[serde(skip_serializing, skip_deserializing)]
-    #[clap(long, short = 'i', default_value_t = 0)]
-    pub inter_request_delay_ms: u64,
-    /// Number of requests to be sent in parallel (at most num_requests) before waiting for inter_request_delay_ms.
-    #[serde(skip_serializing, skip_deserializing)]
-    #[clap(long, short = 'p', default_value_t = 0)]
-    pub parallel_requests: usize,
 }
 
 #[derive(Debug, Args, Clone)]
-pub struct CipherFile {
-    /// Input file of the ciphertext.
-    #[clap(long)]
-    pub input_path: PathBuf,
-    /// Number of copies of the ciphertext to process in a single request.
-    #[clap(long, short = 'b', default_value_t = 1)]
-    pub batch_size: usize,
-    /// Numbers of requests to process at once.
-    /// Each request uses a copy of the same batch.
-    #[clap(long, short = 'n', default_value_t = 1)]
-    pub num_requests: usize,
-    /// Delay (in ms) between consecutive requests for decrypt operations
-    #[clap(long, default_value_t = 0)]
-    pub inter_request_delay_ms: u64,
-    /// Number of requests to be sent in parallel (at most num_requests) before waiting for inter_request_delay_ms.
-    #[clap(long, short = 'p', default_value_t = 0)]
-    pub parallel_requests: usize,
-}
-
-#[derive(Debug, Args, Clone)]
-pub struct UserDecryptParameters {
-    /// Hex value to encrypt and request a user decryption.
+pub struct DecryptParameters {
+    /// Hex value to encrypt and request a decryption.
     /// The value will be converted from a little endian hex string to a `Vec<u8>`.
     /// Can optionally have a "0x" prefix.
     #[clap(long, short = 'e')]
@@ -773,7 +712,7 @@ pub struct UserDecryptParameters {
     /// Default: False, i.e. the SnS is precomputed on the core client.
     #[clap(long, alias = "ns")]
     pub no_precompute_sns: bool,
-    /// Key identifier to use for user decryption.
+    /// Key identifier to use for decryption.
     #[clap(long, short = 'k')]
     pub key_id: KeyId,
     /// Optionally specify the context ID to use for the decryption.
@@ -787,18 +726,14 @@ pub struct UserDecryptParameters {
     /// Number of copies of the ciphertext to process in a single request.
     #[clap(long, short = 'b', default_value_t = 1)]
     pub batch_size: usize,
-    /// Request launch rate, in requests per second. Must be used together with `--duration`.
+    /// Optionally dump the ciphertext to a file.
     #[clap(long)]
-    pub rate: Option<u64>,
-    /// Rate-mode duration, in seconds. Must be used together with `--rate`.
-    #[clap(long)]
-    pub duration: Option<u64>,
-    /// Maximum number of in-flight requests allowed during a rate-mode run.
-    #[clap(long)]
-    pub max_in_flight: Option<usize>,
+    pub ciphertext_output_path: Option<PathBuf>,
+    #[clap(flatten)]
+    pub rate_options: DecryptRateOptions,
 }
 
-impl UserDecryptParameters {
+impl DecryptParameters {
     fn to_cipher_parameters(&self) -> CipherParameters {
         CipherParameters {
             to_encrypt: self.to_encrypt.clone(),
@@ -809,22 +744,13 @@ impl UserDecryptParameters {
             context_id: self.context_id,
             epoch_id: self.epoch_id,
             batch_size: self.batch_size,
-            num_requests: 1,
-            ciphertext_output_path: None,
-            inter_request_delay_ms: 0,
-            parallel_requests: 0,
+            ciphertext_output_path: self.ciphertext_output_path.clone(),
         }
     }
 }
 
-#[derive(Debug, Args, Clone)]
-pub struct UserDecryptFile {
-    /// Input file of the ciphertext.
-    #[clap(long)]
-    pub input_path: PathBuf,
-    /// Number of copies of the ciphertext to process in a single request.
-    #[clap(long, short = 'b', default_value_t = 1)]
-    pub batch_size: usize,
+#[derive(Debug, Args, Clone, Copy, Default)]
+pub struct DecryptRateOptions {
     /// Request launch rate, in requests per second. Must be used together with `--duration`.
     #[clap(long)]
     pub rate: Option<u64>,
@@ -834,6 +760,18 @@ pub struct UserDecryptFile {
     /// Maximum number of in-flight requests allowed during a rate-mode run.
     #[clap(long)]
     pub max_in_flight: Option<usize>,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct DecryptFile {
+    /// Input file of the ciphertext.
+    #[clap(long)]
+    pub input_path: PathBuf,
+    /// Number of copies of the ciphertext to process in a single request.
+    #[clap(long, short = 'b', default_value_t = 1)]
+    pub batch_size: usize,
+    #[clap(flatten)]
+    pub rate_options: DecryptRateOptions,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1211,10 +1149,10 @@ pub enum CCCommand {
     InsecureKeyGenResult(KeyGenResultParameters),
     Encrypt(CipherParameters),
     #[clap(subcommand)]
-    PublicDecrypt(CipherArguments),
+    PublicDecrypt(DecryptArguments),
     PublicDecryptResult(PublicDecryptResultParameters),
     #[clap(subcommand)]
-    UserDecrypt(UserDecryptArguments),
+    UserDecrypt(DecryptArguments),
     CrsGen(CrsParameters),
     CrsGenResult(CrsGenResultParameters),
     AbortCrsGen(AbortParameters),
@@ -2033,7 +1971,7 @@ pub async fn execute_cmd(
     // Execute the command
     let res = match command {
         CCCommand::PublicDecrypt(cipher_args) => {
-            validate_cipher_args(cipher_args)?;
+            validate_decrypt_rate_args(cipher_args)?;
             let internal_client = Arc::new(RwLock::new(internal_client.unwrap()));
             let num_expected_responses = if expect_all_responses {
                 num_parties
@@ -2048,10 +1986,10 @@ pub async fn execute_cmd(
                 context_id,
                 epoch_id,
             } = match cipher_args {
-                CipherArguments::FromFile(cipher_file) => {
+                DecryptArguments::FromFile(cipher_file) => {
                     fetch_ctxt_from_file(cipher_file.input_path.clone()).await?
                 }
-                CipherArguments::FromArgs(cipher_parameters) => {
+                DecryptArguments::FromArgs(cipher_parameters) => {
                     //Only need to fetch tfhe keys if we are not sourcing the ctxt from file
                     let party_confs = fetch_keys_auto_detect(
                         &cipher_parameters.key_id.as_str(),
@@ -2071,7 +2009,7 @@ pub async fn execute_cmd(
                     encrypt(
                         destination_prefix,
                         storage_prefix,
-                        cipher_parameters.clone(),
+                        cipher_parameters.to_cipher_parameters(),
                     )
                     .await?
                 }
@@ -2092,29 +2030,57 @@ pub async fn execute_cmd(
                     })
                     .collect();
 
-            do_public_decrypt(
-                &mut rng,
-                cipher_args.get_num_requests(),
-                internal_client,
-                ct_batch,
-                key_id,
-                context_id,
-                epoch_id,
-                &core_endpoints_req,
-                &core_endpoints_resp,
-                ptxt,
-                num_parties,
-                kms_addrs.to_vec(),
-                max_iter,
-                num_expected_responses,
-                cipher_args.get_inter_request_delay_ms(),
-                cipher_args.get_parallel_requests(),
-                cc_conf.default_domain()?,
-            )
-            .await?
+            match (cipher_args.get_rate(), cipher_args.get_duration()) {
+                (Some(rate), Some(duration)) => {
+                    let max_in_flight = cipher_args
+                        .get_max_in_flight()
+                        .unwrap_or_else(|| (rate as usize).saturating_mul(10).max(1));
+                    do_public_decrypt(
+                        &mut rng,
+                        rate,
+                        duration,
+                        max_in_flight,
+                        DECRYPT_RATE_DRAIN_TIMEOUT_SECS,
+                        internal_client,
+                        ct_batch,
+                        key_id,
+                        context_id,
+                        epoch_id,
+                        &core_endpoints_req,
+                        &core_endpoints_resp,
+                        ptxt,
+                        num_parties,
+                        kms_addrs.to_vec(),
+                        max_iter,
+                        num_expected_responses,
+                        cc_conf.default_domain()?,
+                    )
+                    .await?
+                }
+                (None, None) => {
+                    do_public_decrypt_once(
+                        &mut rng,
+                        internal_client,
+                        ct_batch,
+                        key_id,
+                        context_id,
+                        epoch_id,
+                        &core_endpoints_req,
+                        &core_endpoints_resp,
+                        ptxt,
+                        num_parties,
+                        kms_addrs.to_vec(),
+                        max_iter,
+                        num_expected_responses,
+                        cc_conf.default_domain()?,
+                    )
+                    .await?
+                }
+                _ => unreachable!("public-decrypt rate arguments are validated before dispatch"),
+            }
         }
         CCCommand::UserDecrypt(cipher_args) => {
-            validate_user_decrypt_args(cipher_args)?;
+            validate_decrypt_rate_args(cipher_args)?;
             let internal_client = Arc::new(RwLock::new(
                 internal_client.expect("UserDecrypt requires a KMS client"),
             ));
@@ -2132,10 +2098,10 @@ pub async fn execute_cmd(
                 context_id,
                 epoch_id,
             } = match cipher_args {
-                UserDecryptArguments::FromFile(cipher_file) => {
+                DecryptArguments::FromFile(cipher_file) => {
                     fetch_ctxt_from_file(cipher_file.input_path.clone()).await?
                 }
-                UserDecryptArguments::FromArgs(cipher_parameters) => {
+                DecryptArguments::FromArgs(cipher_parameters) => {
                     //Only need to fetch tfhe keys if we are not sourcing the ctxt from file
                     let party_confs = fetch_keys_auto_detect(
                         &cipher_parameters.key_id.as_str(),
@@ -2181,7 +2147,7 @@ pub async fn execute_cmd(
                         rate,
                         duration,
                         max_in_flight,
-                        USER_DECRYPT_DRAIN_TIMEOUT_SECS,
+                        DECRYPT_RATE_DRAIN_TIMEOUT_SECS,
                         internal_client,
                         ct_batch,
                         key_id,
@@ -3020,109 +2986,70 @@ mod tests {
         assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
-    fn test_cipher_parameters() -> CipherParameters {
-        CipherParameters {
+    fn test_decrypt_parameters() -> DecryptParameters {
+        DecryptParameters {
             to_encrypt: "0x1".to_string(),
             data_type: FheType::Ebool,
             no_compression: false,
             no_precompute_sns: true,
-            key_id: derive_request_id("user_decrypt_args").unwrap().into(),
+            key_id: derive_request_id("decrypt_args").unwrap().into(),
             context_id: None,
             epoch_id: None,
             batch_size: 1,
-            num_requests: 1,
-            inter_request_delay_ms: 0,
             ciphertext_output_path: None,
-            parallel_requests: 0,
-        }
-    }
-
-    fn test_user_decrypt_parameters() -> UserDecryptParameters {
-        UserDecryptParameters {
-            to_encrypt: "0x1".to_string(),
-            data_type: FheType::Ebool,
-            no_compression: false,
-            no_precompute_sns: true,
-            key_id: derive_request_id("user_decrypt_args").unwrap().into(),
-            context_id: None,
-            epoch_id: None,
-            batch_size: 1,
-            rate: Some(10),
-            duration: Some(10),
-            max_in_flight: None,
+            rate_options: DecryptRateOptions {
+                rate: Some(10),
+                duration: Some(10),
+                max_in_flight: None,
+            },
         }
     }
 
     #[test]
-    fn test_cipher_args_validation() {
-        let assert_error_contains = |params: CipherParameters, expected: &str| {
-            let err = validate_cipher_args(&CipherArguments::FromArgs(params)).unwrap_err();
+    fn test_decrypt_args_validation() {
+        let assert_error_contains = |params: DecryptParameters, expected: &str| {
+            let err = validate_decrypt_rate_args(&DecryptArguments::FromArgs(params)).unwrap_err();
             assert!(err.to_string().contains(expected));
         };
 
-        let mut params = test_cipher_parameters();
-        params.num_requests = 0;
-        assert_error_contains(params, "Number of requests");
+        let params = test_decrypt_parameters();
+        validate_decrypt_rate_args(&DecryptArguments::FromArgs(params)).unwrap();
 
-        let mut params = test_cipher_parameters();
+        let mut params = test_decrypt_parameters();
+        params.rate_options.rate = None;
+        params.rate_options.duration = None;
+        validate_decrypt_rate_args(&DecryptArguments::FromArgs(params)).unwrap();
+
+        let mut params = test_decrypt_parameters();
         params.batch_size = 0;
         assert_error_contains(params, "Batch size");
 
-        let mut params = test_cipher_parameters();
-        params.num_requests = 1;
-        params.parallel_requests = 1;
-        validate_cipher_args(&CipherArguments::FromArgs(params.clone())).unwrap();
-
-        params.parallel_requests = 2;
-        assert_error_contains(params, "parallel requests");
-    }
-
-    #[test]
-    fn test_user_decrypt_args_validation() {
-        let assert_error_contains = |params: UserDecryptParameters, expected: &str| {
-            let err =
-                validate_user_decrypt_args(&UserDecryptArguments::FromArgs(params)).unwrap_err();
-            assert!(err.to_string().contains(expected));
-        };
-
-        let params = test_user_decrypt_parameters();
-        validate_user_decrypt_args(&UserDecryptArguments::FromArgs(params)).unwrap();
-
-        let mut params = test_user_decrypt_parameters();
-        params.rate = None;
-        params.duration = None;
-        validate_user_decrypt_args(&UserDecryptArguments::FromArgs(params)).unwrap();
-
-        let mut params = test_user_decrypt_parameters();
-        params.batch_size = 0;
-        assert_error_contains(params, "Batch size");
-
-        let mut params = test_user_decrypt_parameters();
-        params.rate = Some(0);
+        let mut params = test_decrypt_parameters();
+        params.rate_options.rate = Some(0);
         assert_error_contains(params, "Rate");
 
-        let mut params = test_user_decrypt_parameters();
-        params.duration = Some(0);
+        let mut params = test_decrypt_parameters();
+        params.rate_options.duration = Some(0);
         assert_error_contains(params, "Duration");
 
-        let mut params = test_user_decrypt_parameters();
-        params.max_in_flight = Some(0);
+        let mut params = test_decrypt_parameters();
+        params.rate_options.max_in_flight = Some(0);
         assert_error_contains(params, "Max in-flight");
 
-        let mut params = test_user_decrypt_parameters();
-        params.rate = Some(10);
-        params.duration = None;
+        let mut params = test_decrypt_parameters();
+        params.rate_options.rate = Some(10);
+        params.rate_options.duration = None;
         assert_error_contains(params, "--duration");
 
-        let mut params = test_user_decrypt_parameters();
-        params.rate = None;
-        params.duration = Some(10);
+        let mut params = test_decrypt_parameters();
+        params.rate_options.rate = None;
+        params.rate_options.duration = Some(10);
         assert_error_contains(params, "--rate");
 
-        let mut params = test_user_decrypt_parameters();
-        params.rate = None;
-        params.duration = None;
-        params.max_in_flight = Some(10);
+        let mut params = test_decrypt_parameters();
+        params.rate_options.rate = None;
+        params.rate_options.duration = None;
+        params.rate_options.max_in_flight = Some(10);
         assert_error_contains(params, "--max-in-flight");
     }
 

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1218,9 +1218,7 @@ async fn integration_test_commands(
         CCCommand::PublicDecrypt(DecryptArguments::FromFile(DecryptFile {
             input_path: ctxt_path.clone(),
             batch_size: 2,
-            num_requests: 2,
-            parallel_requests: 1,
-            inter_request_delay_ms: 0,
+            rate_options: DecryptRateOptions::default(),
         })),
         CCCommand::UserDecrypt(DecryptArguments::FromFile(user_decrypt_file(
             ctxt_path.clone(),
@@ -1268,14 +1266,14 @@ async fn integration_test_commands(
         // Production format: `BigCompressed` (compressed + SnS precomputed). The other blocks
         // cover Small*/BigExpanded; this is the format real deployments actually run, so the
         // suite must exercise it explicitly.
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(cp(
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
             FheType::Euint256,
             2,
             false,
             false,
         ))),
-        CCCommand::UserDecrypt(UserDecryptArguments::FromArgs(ucp(
+        CCCommand::UserDecrypt(DecryptArguments::FromArgs(ucp(
             "0xC9BF913158B2F39228DF1CA037D537E521CE14B95D225928E4E9B5305EC4592F",
             FheType::Euint256,
             2,
@@ -1294,9 +1292,7 @@ async fn integration_test_commands(
         CCCommand::PublicDecrypt(DecryptArguments::FromFile(DecryptFile {
             input_path: ctxt_with_sns_path.clone(),
             batch_size: 2,
-            num_requests: 2,
-            parallel_requests: 1,
-            inter_request_delay_ms: 0,
+            rate_options: DecryptRateOptions::default(),
         })),
         CCCommand::UserDecrypt(DecryptArguments::FromFile(user_decrypt_file(
             ctxt_with_sns_path.clone(),
@@ -1313,14 +1309,12 @@ async fn integration_test_commands(
             false,
             Some(compressed_ctxt_with_sns_path.clone()),
         )),
-        CCCommand::PublicDecrypt(CipherArguments::FromFile(CipherFile {
+        CCCommand::PublicDecrypt(DecryptArguments::FromFile(DecryptFile {
             input_path: compressed_ctxt_with_sns_path.clone(),
             batch_size: 2,
-            num_requests: 2,
-            parallel_requests: 1,
-            inter_request_delay_ms: 0,
+            rate_options: DecryptRateOptions::default(),
         })),
-        CCCommand::UserDecrypt(UserDecryptArguments::FromFile(user_decrypt_file(
+        CCCommand::UserDecrypt(DecryptArguments::FromFile(user_decrypt_file(
             compressed_ctxt_with_sns_path,
             2,
         ))),
@@ -2460,7 +2454,7 @@ async fn test_threshold_mpc_context_switch() -> Result<()> {
     // Verify that a public-decrypt request succeeds in the new context.
     // Uses `BigCompressed` (no_compression=false, no_precompute_sns=false) — the production
     // format and the fast decrypt path; this test exercises the context switch, not ciphertext types.
-    let mut params = cipher_params(
+    let mut params = public_decrypt_params(
         "0x1",
         FheType::Ebool,
         KeyId::from_str(&key_id)?,
@@ -3102,7 +3096,7 @@ async fn test_threshold_reshare() -> Result<()> {
         &config_path,
         // `BigCompressed` (production format, fast path) — this test exercises reshare, not
         // ciphertext types.
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(CipherParameters {
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(DecryptParameters {
             to_encrypt: "0x123456".to_string(),
             data_type: FheType::Euint64,
             no_compression: false,

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1036,7 +1036,7 @@ fn public_decrypt_params(
     }
 }
 
-/// Build `DecryptParameters` with a tiny rate-based run for integration tests.
+/// Build `DecryptParameters` for a single non-rate user decrypt.
 fn user_decrypt_params(
     to_encrypt: &str,
     data_type: FheType,
@@ -1055,11 +1055,7 @@ fn user_decrypt_params(
         epoch_id: None,
         batch_size,
         ciphertext_output_path: None,
-        rate_options: DecryptRateOptions {
-            rate: Some(1),
-            duration: Some(1),
-            max_in_flight: Some(10),
-        },
+        rate_options: DecryptRateOptions::default(),
     }
 }
 
@@ -1067,11 +1063,7 @@ fn user_decrypt_file(input_path: PathBuf, batch_size: usize) -> DecryptFile {
     DecryptFile {
         input_path,
         batch_size,
-        rate_options: DecryptRateOptions {
-            rate: Some(1),
-            duration: Some(1),
-            max_in_flight: Some(10),
-        },
+        rate_options: DecryptRateOptions::default(),
     }
 }
 
@@ -1329,12 +1321,8 @@ async fn integration_test_commands(
 
         // Validate result count matches expected requests
         match &command {
-            CCCommand::PublicDecrypt(_) => {
+            CCCommand::PublicDecrypt(_) | CCCommand::UserDecrypt(_) => {
                 assert_eq!(results.len(), 1);
-            }
-            CCCommand::UserDecrypt(_) => {
-                assert!(results.is_empty());
-                continue;
             }
             _ => {}
         }
@@ -1475,12 +1463,8 @@ async fn integration_test_commands_default_keys(
             .map_err(|e| anyhow::anyhow!("{}", e))?;
 
         match &command {
-            CCCommand::PublicDecrypt(_) => {
+            CCCommand::PublicDecrypt(_) | CCCommand::UserDecrypt(_) => {
                 assert_eq!(results.len(), 1);
-            }
-            CCCommand::UserDecrypt(_) => {
-                assert!(results.is_empty());
-                continue;
             }
             _ => {}
         }

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1008,23 +1008,21 @@ fn cipher_params(
         context_id: None,
         epoch_id: None,
         batch_size,
-        num_requests: 1,
-        parallel_requests: 1,
         ciphertext_output_path,
-        inter_request_delay_ms: 0,
     }
 }
 
-/// Build `UserDecryptParameters` with a tiny rate-based run for integration tests.
-fn user_decrypt_params(
+/// Build a `DecryptParameters` with sensible defaults, overriding only what varies per test case.
+fn public_decrypt_params(
     to_encrypt: &str,
     data_type: FheType,
     key_id: KeyId,
     batch_size: usize,
     no_compression: bool,
     no_precompute_sns: bool,
-) -> UserDecryptParameters {
-    UserDecryptParameters {
+    ciphertext_output_path: Option<PathBuf>,
+) -> DecryptParameters {
+    DecryptParameters {
         to_encrypt: to_encrypt.to_string(),
         data_type,
         no_compression,
@@ -1033,19 +1031,47 @@ fn user_decrypt_params(
         context_id: None,
         epoch_id: None,
         batch_size,
-        rate: Some(1),
-        duration: Some(1),
-        max_in_flight: Some(10),
+        ciphertext_output_path,
+        rate_options: DecryptRateOptions::default(),
     }
 }
 
-fn user_decrypt_file(input_path: PathBuf, batch_size: usize) -> UserDecryptFile {
-    UserDecryptFile {
+/// Build `DecryptParameters` with a tiny rate-based run for integration tests.
+fn user_decrypt_params(
+    to_encrypt: &str,
+    data_type: FheType,
+    key_id: KeyId,
+    batch_size: usize,
+    no_compression: bool,
+    no_precompute_sns: bool,
+) -> DecryptParameters {
+    DecryptParameters {
+        to_encrypt: to_encrypt.to_string(),
+        data_type,
+        no_compression,
+        no_precompute_sns,
+        key_id,
+        context_id: None,
+        epoch_id: None,
+        batch_size,
+        ciphertext_output_path: None,
+        rate_options: DecryptRateOptions {
+            rate: Some(1),
+            duration: Some(1),
+            max_in_flight: Some(10),
+        },
+    }
+}
+
+fn user_decrypt_file(input_path: PathBuf, batch_size: usize) -> DecryptFile {
+    DecryptFile {
         input_path,
         batch_size,
-        rate: Some(1),
-        duration: Some(1),
-        max_in_flight: Some(10),
+        rate_options: DecryptRateOptions {
+            rate: Some(1),
+            duration: Some(1),
+            max_in_flight: Some(10),
+        },
     }
 }
 
@@ -1150,8 +1176,8 @@ async fn integration_test_commands(
     let ctxt_path = keys_folder.join("test_encrypt_cipher.txt");
     let ctxt_with_sns_path = keys_folder.join("test_encrypt_cipher_with_sns.txt");
 
-    let cp = |val: &str, dt: FheType, bs: usize, no_comp: bool, no_sns: bool| {
-        cipher_params(val, dt, key_id, bs, no_comp, no_sns, None)
+    let pdp = |val: &str, dt: FheType, bs: usize, no_comp: bool, no_sns: bool| {
+        public_decrypt_params(val, dt, key_id, bs, no_comp, no_sns, None)
     };
     let ucp = |val: &str, dt: FheType, bs: usize, no_comp: bool, no_sns: bool| {
         user_decrypt_params(val, dt, key_id, bs, no_comp, no_sns)
@@ -1159,49 +1185,49 @@ async fn integration_test_commands(
 
     // Commands without SnS precompute (no_precompute_sns=true)
     let commands = vec![
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(cp(
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0x1",
             FheType::Ebool,
             1,
             false,
             true,
         ))),
-        CCCommand::UserDecrypt(UserDecryptArguments::FromArgs(ucp(
+        CCCommand::UserDecrypt(DecryptArguments::FromArgs(ucp(
             "0x1",
             FheType::Ebool,
             1,
             false,
             true,
         ))),
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(cp(
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0x6F",
             FheType::Euint8,
             3,
             true,
             true,
         ))),
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(cp(
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0x6F",
             FheType::Euint8,
             3,
             false,
             true,
         ))),
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(cp(
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0xFFFF",
             FheType::Euint16,
             3,
             false,
             true,
         ))),
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(cp(
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0x96BF913158B2F39228DF1CA037D537E521CE14B95D225928E4E9B5305EC4592B",
             FheType::Euint256,
             3,
             false,
             true,
         ))),
-        CCCommand::UserDecrypt(UserDecryptArguments::FromArgs(ucp(
+        CCCommand::UserDecrypt(DecryptArguments::FromArgs(ucp(
             "0xC958D835E4B1922CE9B13BAD322CF67D81CE14B95D225928E4E9B5305EC4592C",
             FheType::Euint256,
             3,
@@ -1217,14 +1243,12 @@ async fn integration_test_commands(
             true,
             Some(ctxt_path.clone()),
         )),
-        CCCommand::PublicDecrypt(CipherArguments::FromFile(CipherFile {
+        CCCommand::PublicDecrypt(DecryptArguments::FromFile(DecryptFile {
             input_path: ctxt_path.clone(),
             batch_size: 3,
-            num_requests: 3,
-            parallel_requests: 1,
-            inter_request_delay_ms: 0,
+            rate_options: DecryptRateOptions::default(),
         })),
-        CCCommand::UserDecrypt(UserDecryptArguments::FromFile(user_decrypt_file(
+        CCCommand::UserDecrypt(DecryptArguments::FromFile(user_decrypt_file(
             ctxt_path.clone(),
             3,
         ))),
@@ -1232,42 +1256,42 @@ async fn integration_test_commands(
 
     // Commands with SnS precompute (no_precompute_sns=false)
     let commands_for_sns_precompute = vec![
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(cp(
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0x1",
             FheType::Ebool,
             2,
             true,
             false,
         ))),
-        CCCommand::UserDecrypt(UserDecryptArguments::FromArgs(ucp(
+        CCCommand::UserDecrypt(DecryptArguments::FromArgs(ucp(
             "0x78",
             FheType::Euint8,
             2,
             true,
             false,
         ))),
-        CCCommand::UserDecrypt(UserDecryptArguments::FromArgs(ucp(
+        CCCommand::UserDecrypt(DecryptArguments::FromArgs(ucp(
             "0x1",
             FheType::Ebool,
             1,
             true,
             false,
         ))),
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(cp(
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0x6F",
             FheType::Euint8,
             3,
             true,
             false,
         ))),
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(cp(
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0xC958D835E4B1922CE9B13BAD322CF67D8E06CDA1B9ECF03956822D0D186F7820",
             FheType::Euint256,
             3,
             true,
             false,
         ))),
-        CCCommand::UserDecrypt(UserDecryptArguments::FromArgs(ucp(
+        CCCommand::UserDecrypt(DecryptArguments::FromArgs(ucp(
             "0xC9BF913158B2F39228DF1CA037D537E521CE14B95D225928E4E9B5305EC4592F",
             FheType::Euint256,
             3,
@@ -1283,14 +1307,12 @@ async fn integration_test_commands(
             false,
             Some(ctxt_with_sns_path.clone()),
         )),
-        CCCommand::PublicDecrypt(CipherArguments::FromFile(CipherFile {
+        CCCommand::PublicDecrypt(DecryptArguments::FromFile(DecryptFile {
             input_path: ctxt_with_sns_path.clone(),
             batch_size: 3,
-            num_requests: 3,
-            parallel_requests: 1,
-            inter_request_delay_ms: 0,
+            rate_options: DecryptRateOptions::default(),
         })),
-        CCCommand::UserDecrypt(UserDecryptArguments::FromFile(user_decrypt_file(
+        CCCommand::UserDecrypt(DecryptArguments::FromFile(user_decrypt_file(
             ctxt_with_sns_path.clone(),
             3,
         ))),
@@ -1307,9 +1329,8 @@ async fn integration_test_commands(
 
         // Validate result count matches expected requests
         match &command {
-            CCCommand::PublicDecrypt(cipher_arguments) => {
-                let num_expected_results = cipher_arguments.get_num_requests();
-                assert_eq!(results.len(), num_expected_results);
+            CCCommand::PublicDecrypt(_) => {
+                assert_eq!(results.len(), 1);
             }
             CCCommand::UserDecrypt(_) => {
                 assert!(results.is_empty());
@@ -1412,33 +1433,33 @@ async fn integration_test_commands_default_keys(
 ) -> Result<()> {
     let key_id = KeyId::from_str(&key_id)?;
 
-    let cp = |val: &str, dt: FheType, bs: usize, no_sns: bool| {
-        cipher_params(val, dt, key_id, bs, false, no_sns, None)
+    let pdp = |val: &str, dt: FheType, bs: usize, no_sns: bool| {
+        public_decrypt_params(val, dt, key_id, bs, false, no_sns, None)
     };
     let ucp = |val: &str, dt: FheType, bs: usize, no_sns: bool| {
         user_decrypt_params(val, dt, key_id, bs, false, no_sns)
     };
 
     let commands = vec![
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(cp(
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0x1",
             FheType::Ebool,
             2,
             true,
         ))),
-        CCCommand::UserDecrypt(UserDecryptArguments::FromArgs(ucp(
+        CCCommand::UserDecrypt(DecryptArguments::FromArgs(ucp(
             "0x78",
             FheType::Euint8,
             2,
             true,
         ))),
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(cp(
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0x6F",
             FheType::Euint8,
             3,
             false,
         ))),
-        CCCommand::UserDecrypt(UserDecryptArguments::FromArgs(ucp(
+        CCCommand::UserDecrypt(DecryptArguments::FromArgs(ucp(
             "0xC958D835E4B1922CE9B13BAD322CF67D81CE14B95D225928E4E9B5305EC4592C",
             FheType::Euint256,
             3,
@@ -1454,9 +1475,8 @@ async fn integration_test_commands_default_keys(
             .map_err(|e| anyhow::anyhow!("{}", e))?;
 
         match &command {
-            CCCommand::PublicDecrypt(cipher_arguments) => {
-                let num_expected_results = cipher_arguments.get_num_requests();
-                assert_eq!(results.len(), num_expected_results);
+            CCCommand::PublicDecrypt(_) => {
+                assert_eq!(results.len(), 1);
             }
             CCCommand::UserDecrypt(_) => {
                 assert!(results.is_empty());
@@ -2584,7 +2604,7 @@ async fn test_threshold_mpc_context_switch() -> Result<()> {
     new_mpc_context(&config_path, &context_path, test_path).await?;
 
     // Verify that a public-decrypt request succeeds in the new context
-    let mut params = cipher_params(
+    let mut params = public_decrypt_params(
         "0x1",
         FheType::Ebool,
         KeyId::from_str(&key_id)?,
@@ -2596,7 +2616,7 @@ async fn test_threshold_mpc_context_switch() -> Result<()> {
     params.context_id = Some(context_id);
     let ddec_config = cmd_config(
         &config_path,
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(params)),
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(params)),
         200,
     );
     let results = execute_cmd(&ddec_config, test_path)
@@ -3224,7 +3244,7 @@ async fn test_threshold_reshare() -> Result<()> {
     assert_eq!(resharing_result.len(), 2);
     let ddec_config = cmd_config(
         &config_path,
-        CCCommand::PublicDecrypt(CipherArguments::FromArgs(CipherParameters {
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(DecryptParameters {
             to_encrypt: "0x123456".to_string(),
             data_type: FheType::Euint64,
             no_compression: false,
@@ -3233,10 +3253,8 @@ async fn test_threshold_reshare() -> Result<()> {
             context_id: Some(context_id),
             epoch_id: Some(new_epoch_id),
             batch_size: 1,
-            num_requests: 1,
             ciphertext_output_path: None,
-            parallel_requests: 1,
-            inter_request_delay_ms: 0,
+            rate_options: DecryptRateOptions::default(),
         })),
         200,
     );

--- a/core-client/tests/kind-testing/kubernetes_test_threshold.rs
+++ b/core-client/tests/kind-testing/kubernetes_test_threshold.rs
@@ -207,10 +207,7 @@ impl K8sTestContext {
             context_id: None,
             epoch_id: None,
             batch_size: 1,
-            num_requests: 1,
-            parallel_requests: 1,
             ciphertext_output_path: Some(cipher_path.clone()),
-            inter_request_delay_ms: 0,
         }))
         .await;
 
@@ -241,13 +238,11 @@ impl K8sTestContext {
         let start = std::time::Instant::now();
 
         let results = self
-            .execute(CCCommand::PublicDecrypt(CipherArguments::FromFile(
-                CipherFile {
+            .execute(CCCommand::PublicDecrypt(DecryptArguments::FromFile(
+                DecryptFile {
                     input_path: enc.cipher_path.clone(),
                     batch_size: 1,
-                    num_requests: 1,
-                    inter_request_delay_ms: 0,
-                    parallel_requests: 1,
+                    rate_options: DecryptRateOptions::default(),
                 },
             )))
             .await;

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -598,7 +598,7 @@ Optional arguments:
  - `--epoch-id <EPOCH_ID>`: Epoch ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default epoch when omitted; must match the epoch of the original request or verification fails.
  - `--no-verify`: Skip all verification of the fetched responses (both the internal KMS-node signatures and the external signature) and just return them.
 
-Upon success, both the commands to decrypt _and_ the command to fetch the result will print `Vec<PublicDecryptionResponse> - <REQUEST_ID>`, where the `Vec` size depends on the number of received responses (specified via `num_majority` in the configuration file). To run a fixed-rate load test, provide both `--rate` and `--duration`.
+Upon success, `public-decrypt` prints phased timing lines and a result line formatted as `<message> - "request_id": "<REQUEST_ID>"`. In rate mode (`--rate`/`--duration`), it prints `PUBLIC_DECRYPT_METRICS {json}` (and does not print per-request response vectors).
 
 Recall that `PublicDecryptionResponse` follows this format:
 ```proto

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -598,7 +598,7 @@ Optional arguments:
  - `--epoch-id <EPOCH_ID>`: Epoch ID the original request was made with, used to derive the `extra_data` the external signature is bound to. Defaults to the built-in default epoch when omitted; must match the epoch of the original request or verification fails.
  - `--no-verify`: Skip all verification of the fetched responses (both the internal KMS-node signatures and the external signature) and just return them.
 
-Upon success, both the commands to decrypt _and_ the command to fetch the result, will result in a print of `Vec<PublicDecryptionResponse> - <REQUEST_ID>` where the `Vec` size depends on the number of received responses (specified via `num_majority` in the configuration file) for each request (specified via `--num-requests`).
+Upon success, both the commands to decrypt _and_ the command to fetch the result will print `Vec<PublicDecryptionResponse> - <REQUEST_ID>`, where the `Vec` size depends on the number of received responses (specified via `num_majority` in the configuration file). To run a fixed-rate load test, provide both `--rate` and `--duration`.
 
 Recall that `PublicDecryptionResponse` follows this format:
 ```proto
@@ -647,17 +647,14 @@ Options shared by public and user decryption are:
  - `--epoch-id <EPOCH_ID>`: optionally specify the epoch ID to use for the decryption. Defaults to the default epoch if not specified.
 
 Public-decrypt-only options are:
- - `-n`/`--num-requests <NUM_REQUESTS>`: the number of requests that are sent in total. This will create `NUM_REQUESTS` copies of the same request (each with a different `REQUEST_ID`)
  - `--ciphertext-output-path <FILENAME>`: optionally write the ciphertext (the encryption of `to-encrypt`) to file
- - `-i`/`--inter-request-delay-ms <DELAY>`: delay in milliseconds between consecutive decrypt requests (default: `0`, i.e. no waiting between requests)
- - `-p`/`--parallel-requests <NUM>`: number of requests to be sent in parallel before waiting `<DELAY>` specified with `-i` (default: `0`, i.e. all requests are sent at once)
 
-User-decrypt-only options are:
+Public/user-decrypt rate-mode options are:
  - `--rate <REQUESTS_PER_SECOND>`: request launch rate. Must be used together with `--duration`.
  - `--duration <SECONDS>`: load-test duration. Must be used together with `--rate`.
  - `--max-in-flight <NUM>`: optional rate-mode cap for in-flight requests before the client starts shedding requests.
 
- __NOTE__: For public decrypt from file, only `-b`/`--batch-size <BATCH_SIZE>`, `-n`/`--num-requests <NUM_REQUESTS>`, `--inter-request-delay-ms <DELAY>`, and `-p`/`--parallel-requests <NUM>` are supported. For user decrypt from file, only `-b`/`--batch-size <BATCH_SIZE>`, `--rate <REQUESTS_PER_SECOND>`, `--duration <SECONDS>`, and `--max-in-flight <NUM>` are supported.
+ __NOTE__: For public and user decrypt from file, only `-b`/`--batch-size <BATCH_SIZE>`, `--rate <REQUESTS_PER_SECOND>`, `--duration <SECONDS>`, and `--max-in-flight <NUM>` are supported.
 
 ### Custodian context
 

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -645,8 +645,6 @@ Options shared by public and user decryption are:
  - `--no-precompute-sns` / `--ns`: Disables precomputation of the switch and squash on the core client. Setting this flag causes transmission of smaller ciphertexts and runs the SnS computation on the cores. (default: False = SnS precomputation enabled)
  - `--context-id <CONTEXT_ID>`: optionally specify the context ID to use for the decryption. Defaults to the default context if not specified.
  - `--epoch-id <EPOCH_ID>`: optionally specify the epoch ID to use for the decryption. Defaults to the default epoch if not specified.
-
-Public-decrypt-only options are:
  - `--ciphertext-output-path <FILENAME>`: optionally write the ciphertext (the encryption of `to-encrypt`) to file
 
 Public/user-decrypt rate-mode options are:


### PR DESCRIPTION
As a follow-up to [PR 678](https://github.com/zama-ai/kms/pull/678), this PR does the same to public decryption benchmarks, along with some tweaks to the Slack report (see below).

Runs the public decrypt benchmark tests with three rates (1100, 1300 and 1500req/s), where the last is a "probe" that is expected and allowed to fail. If/when we make things faster, the "probe" will turn green and we'll know we've done something right.

There seems to be some sort of artificial limit on outgoing traffic from our core-client  runner, which means that nor this PR or the previous one actually proves anything about the KMS's performance ceiling. Just that we can do *at least* 1300 public decryptions per second. Latencies also look very comfy at ~10ms per pdec.

<img width="1198" height="925" alt="Screenshot 2026-07-08 at 17 31 04" src="https://github.com/user-attachments/assets/246353d1-d457-49de-9d53-cd53f3268349" />

Fixes https://github.com/zama-ai/kms-internal/issues/3077
