### PR TITLE
fix: unbreak non-enclave threshold gen-keys configuration assembly

### DIFF
--- a/charts/kms-core/Chart.yaml
+++ b/charts/kms-core/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-core
 description: A helm chart to distribute and deploy the Zama KMS core service.
-version: 1.8.2
+version: 1.8.3
 appVersion: 0.14.0   # Minimum kms version to run this chart
 apiVersion: v2
 keywords:

--- a/charts/kms-core/templates/kms-core-statefulset.yaml
+++ b/charts/kms-core/templates/kms-core-statefulset.yaml
@@ -52,6 +52,10 @@ spec:
           args:
             - -c
             - |
+              # Fail loudly on any assembly error (e.g. a socat image without
+              # `envsubst`) instead of silently writing empty kms-*.toml and
+              # letting the core/gen-keys start with no config.
+              set -e
               {{- include "kmsCoreInitEnvVars" . | nindent 14 }}
               envsubst < /var/lib/kms-core/config/kms-server.toml > kms-server.toml
               envsubst < /var/lib/kms-core/config/aws.toml >> kms-server.toml

--- a/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
+++ b/charts/kms-core/templates/kms-gen-cert-and-keys-job.yaml
@@ -39,6 +39,10 @@ spec:
           args:
             - -c
             - |
+              # Fail loudly on any assembly error (e.g. a socat image without
+              # `envsubst`) instead of silently writing empty kms-*.toml and
+              # letting the core/gen-keys start with no config.
+              set -e
               {{ include "kmsCoreInitEnvVars" . | indent 14 | trim }}
               envsubst < /var/lib/kms-core/config/kms-gen-keys.toml > kms-gen-keys.toml
               envsubst < /var/lib/kms-core/config/aws.toml >> kms-gen-keys.toml

--- a/ci/perf-testing/threshold/kms-ci/kms-service/values-kms-ci.yaml
+++ b/ci/perf-testing/threshold/kms-ci/kms-service/values-kms-ci.yaml
@@ -92,10 +92,11 @@ tracing:
   enabled: false
   endpoint: "http://observability-zws-dev-observability-alloy.observability.svc.cluster.local:4317"
 
-socat:
-  image:
-    name: alpine/socat
-    tag: latest
+# NOTE: do NOT override socat.image with a stock image (e.g. alpine/socat). The
+# config init container (kms-core-init-load-env) runs `envsubst`, which
+# alpine/socat lacks — that silently emitted empty kms-*.toml and broke
+# non-enclave threshold deploys (gen-keys got no config). Inherit the chart
+# default (Zama socat, has envsubst), same as the enclave path.
 rustLog: info
 minio:
   enabled: false


### PR DESCRIPTION
Perf-tests  were broken then running them outside the  enclave and tls=false.

The threshold perf values pinned socat.image=alpine/socat, which lacks `envsubst`. The kms-core-init-load-env container assembles kms-*.toml with `envsubst`; those calls failed silently (no `set -e`), leaving config files empty,
so kms-gen-keys/kms-server started with no config and during deploys nodes crashed. 

Enclave was unaffected (no socat override -> chart-default socat).

**Changes**:

- Drop the alpine/socat override so it inherits the envsubst-capable default.
- Add 'set -e' to init-load-env so assembly failures abort loudly.
- Bump chart 1.8.2 -> 1.8.3