### PR TITLE
ci: add basic core-side cpu sampling

### DIFF
--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -438,6 +438,15 @@ jobs:
           ###################################################################
           echo "Starting performance testing workflow..."
 
+          # Sample per-core (kms-core pod) CPU throughout the run so we can correlate
+          # core CPU% against the rate rungs by timestamp (pairs with the eth0
+          # diagnostics to distinguish CPU-bound vs network-bound at the top rungs).
+          # Backgrounded here so it lives for this step's shell; killed on exit
+          # (incl. the exit-1 path). Failures are non-fatal — it must never break the run.
+          bash ci/scripts/sample_core_cpu.sh "${NAMESPACE}" > core-cpu-samples.log 2>&1 &
+          CPU_SAMPLER_PID=$!
+          trap 'kill "${CPU_SAMPLER_PID}" 2>/dev/null || true' EXIT
+
           # Convert TLS boolean to enabled/disabled string
           if [[ "${TLS}" == "true" ]]; then
             TLS_STATUS="enabled"
@@ -501,6 +510,17 @@ jobs:
           fi
 
           echo "Workflow completed."
+
+      - name: Report core CPU samples
+        if: always()
+        run: |
+          if [ ! -s core-cpu-samples.log ]; then
+            echo "[cpu] no samples captured — check metrics-server pod-metrics RBAC for the CI identity in ${NAMESPACE}"
+            exit 0
+          fi
+          echo "[cpu] per-core CPU via metrics-server (~15s resolution); cores request 48 vCPU (=48000m)."
+          echo "[cpu] correlate the timestamps below with the rung timestamps in the Argo log above."
+          cat core-cpu-samples.log
 
       - name: Capture network diagnostics after perf
         if: always()

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -519,8 +519,9 @@ jobs:
             exit 0
           fi
           echo "[cpu] per-core CPU via metrics-server (~15s resolution); cores request 48 vCPU (=48000m)."
-          echo "[cpu] correlate the timestamps below with the rung timestamps in the Argo log above."
-          cat core-cpu-samples.log
+          echo "[cpu] full timeseries is in the core-cpu-samples artifact; correlate its timestamps with the rung timestamps in the Argo log."
+          echo "[cpu] $(wc -l < core-cpu-samples.log) sample lines captured; last 500 below (the sampler loop is uncapped, so the full dump is unbounded — hence the tail + artifact):"
+          tail -n 500 core-cpu-samples.log
 
       - name: Capture network diagnostics after perf
         if: always()
@@ -536,6 +537,14 @@ jobs:
         with:
           name: argo-workflow-logs.txt
           path: argo-workflow-logs.txt
+          retention-days: 30
+
+      - name: Upload core CPU samples
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: core-cpu-samples.log
+          path: core-cpu-samples.log
           retention-days: 30
 
       # ======================================================================

--- a/ci/scripts/README.md
+++ b/ci/scripts/README.md
@@ -143,6 +143,52 @@ The build process will:
 
 ## Testing
 
+### Performance testing
+
+The performance-testing workflow collects network counters before and after a run,
+and samples KMS Core CPU and memory while it is running. Both scripts use the
+current Kubernetes context and default to the `kms-ci` namespace.
+
+#### Network diagnostics
+
+`collect_network_diagnostics.sh` captures per-interface counters from each running `kms-core-<party>-core-<core>`
+pod. Run it once before and once after a performance test to produce per-pod and
+aggregate `eth0` traffic deltas:
+
+```bash
+bash collect_network_diagnostics.sh before-perf <namespace>
+# Run the performance test.
+bash collect_network_diagnostics.sh after-perf <namespace>
+```
+
+Results are written to `network-diagnostics/<phase>/`. The `after-perf` call also
+writes `network-diagnostics/pod-interface-counter-delta.tsv` and prints the
+transfer volume, average throughput, errors, and dropped packets. Set
+`NETWORK_DIAGNOSTICS_DIR` to store the results elsewhere.
+
+#### KMS Core CPU samples
+
+`sample_core_cpu.sh` continuously records CPU and memory for KMS Core pods using
+`kubectl top`. Its output is one space-separated line per pod per sample:
+
+```text
+<UTC timestamp> <pod> <CPU> <memory>
+```
+
+Start it in the background for the duration of a test and stop it when the test
+finishes:
+
+```bash
+bash sample_core_cpu.sh <namespace> <interval-seconds> > core-cpu-samples.log &
+CPU_SAMPLER_PID=$!
+# Run the performance test.
+kill "${CPU_SAMPLER_PID}"
+```
+
+The namespace defaults to `kms-ci` and the interval defaults to 10 seconds. The
+cluster must have metrics-server available and the current identity must be able
+to run `kubectl top pod` in that namespace.
+
 ### Debugging
 
 Enable verbose mode to see all function calls:

--- a/ci/scripts/README.md
+++ b/ci/scripts/README.md
@@ -1,4 +1,4 @@
-# KMS Deployment Scripts
+# KMS Deployment/management Scripts
 
 ## Overview
 
@@ -11,8 +11,13 @@
 
 ```
 ci/scripts/
-├── deploy.sh                      # Main entry point (143 lines)
+├── backward_snapshot.sh           # Generate and compare backward-compatibility snapshots
+├── collect_network_diagnostics.sh # Capture per-pod network interface counters
+├── deploy.sh                      # Main deployment entry point
+├── local_docs_link_check.py       # Check Markdown links to local files
 ├── manage_lifecycle.sh            # Lifecycle management
+├── rolling_upgrade.sh             # Partially upgrade enclave KMS parties
+├── sample_core_cpu.sh             # Sample KMS core CPU and memory during benchmarks
 └── lib/                           # Modular libraries
     ├── common.sh                  # Logging, parsing, utilities (277 lines)
     ├── context.sh                 # Kubernetes context setup (87 lines)
@@ -80,8 +85,11 @@ The build process will:
 | Need to modify... | Edit this file |
 |------------------|----------------|
 | **Logging or argument parsing** | `lib/common.sh` |
+| **Backward-compatibility snapshots** | `backward_snapshot.sh` |
+| **Benchmark network diagnostics** | `collect_network_diagnostics.sh` |
 | **Kind cluster setup** | `lib/context.sh` |
 | **AWS/Tailscale config** | `lib/context.sh` |
+| **Local documentation link checks** | `local_docs_link_check.py` |
 | **LocalStack deployment** | `lib/infrastructure.sh` |
 | **TKMS/Crossplane** | `lib/infrastructure.sh` |
 | **Registry credentials** | `lib/infrastructure.sh` |
@@ -90,6 +98,8 @@ The build process will:
 | **Docker image building** | `lib/utils.sh` |
 | **Port forwarding** | `lib/utils.sh` |
 | **Log collection** | `lib/utils.sh` |
+| **Rolling KMS upgrades** | `rolling_upgrade.sh` |
+| **Core CPU/memory benchmark samples** | `sample_core_cpu.sh` |
 
 ### Module Details
 

--- a/ci/scripts/sample_core_cpu.sh
+++ b/ci/scripts/sample_core_cpu.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Sample per-party (kms-core pod) CPU + memory via metrics-server, timestamped,
+# every INTERVAL seconds until killed. Used by performance-testing.yml to
+# correlate core CPU against the decrypt rate rungs — pairs with the eth0
+# diagnostics (collect_network_diagnostics.sh) to show whether the cores are
+# CPU-bound or network-bound at the top rungs.
+#
+# metrics-server resolution is ~15s and `kubectl top` reports CPU as a rate over
+# that window, so sampling faster just re-reads the same value; ~10s is plenty.
+# Namespace-scoped pod metrics only (no cluster node-metrics RBAC needed).
+#
+# Each line: "<utc-ts> <pod> <cpu> <mem>", e.g. "2026-07-12T10:25:00Z kms-core-1-core-1 47800m 20480Mi".
+set -uo pipefail
+
+NS="${1:-kms-ci}"
+INTERVAL="${2:-10}"
+
+while true; do
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  kubectl top pod -n "${NS}" -l app=kms-core --no-headers 2>/dev/null \
+    | awk -v ts="${ts}" '{ print ts, $1, $2, $3 }' || true
+  sleep "${INTERVAL}"
+done

--- a/ci/scripts/sample_core_cpu.sh
+++ b/ci/scripts/sample_core_cpu.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
-# Sample per-party (kms-core pod) CPU + memory via metrics-server, timestamped,
-# every INTERVAL seconds until killed. Used by performance-testing.yml to
-# correlate core CPU against the decrypt rate rungs — pairs with the eth0
-# diagnostics (collect_network_diagnostics.sh) to show whether the cores are
-# CPU-bound or network-bound at the top rungs.
+# Basic bash script to sample CPUs on the core side during benchmarking so we can get an idea of how much pressure our
+# benchmarks are putting on the KMS cluster.
+# Samples per-party CPU + memory every INTERVAL seconds until killed. Used by performance-testing.yml to correlate core
+# CPU against performance tests in a similar way to the eth0 diagnostics (collect_network_diagnostics.sh).
 #
-# metrics-server resolution is ~15s and `kubectl top` reports CPU as a rate over
-# that window, so sampling faster just re-reads the same value; ~10s is plenty.
-# Namespace-scoped pod metrics only (no cluster node-metrics RBAC needed).
+# Kubernetes's metrics-server resolution is ~15s and `kubectl top` reports CPU as a rate over that window, so sampling
+# faster just re-reads the same value; ~10s is plenty.
 #
 # Each line: "<utc-ts> <pod> <cpu> <mem>", e.g. "2026-07-12T10:25:00Z kms-core-1-core-1 47800m 20480Mi".
 set -uo pipefail


### PR DESCRIPTION
Basic bash script to sample CPUs on the core side during benchmarking so we can get an idea of how much pressure our benchmarks are putting on the KMS cluster.

Adds `ci/scripts/sample_core_cpu.sh` and wires it up so that every 10s it runs `kubectl top pod -n <ns> -l app=kms-core`, emitting timestamped `<utc-ts> <pod> <cpu> <mem>` lines. Wired into "Run performance testing" and logged by a new "Report core CPU samples" step.

**NOTE**: not included in the Slack report, because this sampler runs on the GH runner (so it can use `kubectl`) and the Slack report is assembled in the k8s cluster so getting the data out is awkward. Fixing this is a bigger task, likely part of https://github.com/zama-ai/kms-internal/issues/3076

In the mean time, here's how to analyze it:

1. Either read the "Report core CPU samples" step log or download the full `core-cpu-samples.log` artifact. Lines are `<utc-ts> <pod> <cpu>m <mem>Mi` for all 13 core pods.
2. Get each run's window from "Run performance testing": they each end with `... Collected N results in 30s` at time T, so it ran ≈ [T−30s, T].
3. Slice CPU lines to that window; compare `<cpu>m` to `48000m` (the 48-vCPU request). Near 48000m ⇒ CPU-bound; well below ⇒ not.
4. Cross-check eth0 (rx/tx Gbps, drops) from the network-diagnostics step to separate CPU vs network.

(Strongly suggest letting the bots do that for you)

Fixes https://github.com/zama-ai/kms-internal/issues/3085
