### PR TITLE
chore(dependabot): ignore backward-compatibility dir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     open-pull-requests-limit: 0
     cooldown:
       default-days: 4 # set to zizmor's minimum as we are not opening PR
+    exclude-paths:
+      - "backward-compatibility/**" # we are testing older crate versions here and do not use these in prod
   - package-ecosystem: "github-actions"
     directory: "/"
     # Check for updates every Monday


### PR DESCRIPTION
## Description
This tells dependabot to ignore the `backward-compatibility` directory and its sub-directories.
This is fine, as this dir is only used for tests and is not used in production, so we don't need to worry about outdated dependencies in there.

### Related issue(s)
None. Issues raised under[ Security and quality.](https://github.com/zama-ai/kms/security)

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
