### PR TITLE
fix(storage): sweep orphaned .partial temp files on startup

### DIFF
--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -88,6 +88,9 @@ serde_json.workspace = true
 signature.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
+# pid-liveness check for the startup sweep of orphaned partial-write files in
+# vault/storage; already a production dependency via `observability`.
+sysinfo = { workspace = true, optional = true }
 tfhe = { workspace = true, features = [
     "boolean",
     "shortint",
@@ -138,7 +141,6 @@ proptest.workspace = true
 rstest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 syn = { workspace = true }
-sysinfo.workspace = true
 tempfile.workspace = true
 test-utils-service = { path = "./test-utils-service" }
 tracing-subscriber = { workspace = true, features = ["fmt", "std"] }
@@ -162,6 +164,7 @@ non-wasm = [
     "dep:observability",
     "dep:rustls-webpki",
     "dep:rcgen",
+    "dep:sysinfo",
     "dep:tempfile",
     "dep:test-utils",
     "dep:thread-handles",

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -1,11 +1,168 @@
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use std::path::Path;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use tfhe::named::Named;
 use tfhe::safe_serialization::{safe_deserialize, safe_serialize};
 use tfhe::{Unversionize, Versionize};
 
 use crate::consts::SAFE_SER_SIZE_LIMIT;
+
+/// Process-wide sequence for partial-write temp names; together with the pid
+/// it makes `.<name>.partial.<pid>.<seq>` unique among live writers.
+static PARTIAL_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// `.<final_name>.partial.<pid>.<seq>` — the temp-name grammar shared by the
+/// writer and [`sweep_stale_partials`]; `OsString` so non-UTF-8 destination
+/// names keep working.
+pub(crate) fn partial_file_name(final_name: &OsStr, pid: u32, seq: u64) -> OsString {
+    let mut name = OsString::from(".");
+    name.push(final_name);
+    name.push(format!(".partial.{pid}.{seq}"));
+    name
+}
+
+/// Strictly parse a directory-entry name as a partial-write temp file,
+/// returning the embedded writer pid. Parses from the end so a destination
+/// name that itself contains ".partial." cannot confuse it.
+fn parse_partial_owner_pid(file_name: &str) -> Option<u32> {
+    let rest = file_name.strip_prefix('.')?;
+    let (rest, seq) = rest.rsplit_once('.')?;
+    seq.parse::<u64>().ok()?;
+    let (rest, pid) = rest.rsplit_once('.')?;
+    let pid = pid.parse::<u32>().ok()?;
+    let name = rest.strip_suffix(".partial")?;
+    if name.is_empty() {
+        return None;
+    }
+    Some(pid)
+}
+
+/// Create the partial-write temp file for `final_name`, reclaiming a same-name
+/// orphan on collision. Reclaiming is safe: pids are unique among live
+/// processes and [`PARTIAL_SEQ`] is process-wide, so an existing file carrying
+/// our own pid can only be a dead predecessor's leftover (e.g. the server
+/// being pid 1 on every container restart).
+fn create_partial_tempfile(
+    parent: &Path,
+    final_name: &OsStr,
+    pid: u32,
+    seq: u64,
+) -> std::io::Result<tempfile::NamedTempFile> {
+    let tmp_name = partial_file_name(final_name, pid, seq);
+    let build = || {
+        tempfile::Builder::new()
+            .prefix(&tmp_name)
+            .rand_bytes(0)
+            .tempfile_in(parent)
+    };
+    match build() {
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            tracing::warn!(
+                "reclaiming orphaned partial file {} left by a dead process with reused pid {pid}",
+                parent.join(&tmp_name).display()
+            );
+            std::fs::remove_file(parent.join(&tmp_name))?;
+            build()
+        }
+        res => res,
+    }
+}
+
+/// Directory layout is at most `{root}/{data_type}/{epoch_id}/{file}`; one
+/// extra level of headroom.
+const MAX_SWEEP_DEPTH: usize = 4;
+
+/// Best-effort removal of `.<name>.partial.<pid>.<seq>` files orphaned under
+/// `root` by hard-crashed processes (on a clean failure the temp file's drop
+/// guard removes it). Only files whose embedded pid is neither our own nor a
+/// live process are deleted, so in-flight writes of concurrent writers are
+/// never touched; IO errors are logged and never propagated.
+pub(crate) fn sweep_stale_partials(root: &Path) {
+    let mut candidates: Vec<(PathBuf, u32)> = Vec::new();
+    collect_partial_files(root, 0, &mut candidates);
+    if candidates.is_empty() {
+        return;
+    }
+    if !sysinfo::IS_SUPPORTED_SYSTEM {
+        tracing::warn!(
+            "cannot check process liveness on this platform; keeping {} partial file(s) under {}",
+            candidates.len(),
+            root.display()
+        );
+        return;
+    }
+    let own_pid = std::process::id();
+    let mut pids: Vec<sysinfo::Pid> = candidates
+        .iter()
+        .filter(|(_, pid)| *pid != own_pid)
+        .map(|(_, pid)| sysinfo::Pid::from_u32(*pid))
+        .collect();
+    pids.sort_unstable();
+    pids.dedup();
+    // One batched liveness query for all encountered pids.
+    let mut system = sysinfo::System::new_with_specifics(sysinfo::RefreshKind::nothing());
+    system.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::Some(&pids),
+        false,
+        sysinfo::ProcessRefreshKind::nothing(),
+    );
+    for (path, pid) in candidates {
+        if pid == own_pid || system.process(sysinfo::Pid::from_u32(pid)).is_some() {
+            // In-flight write of this or another live process.
+            continue;
+        }
+        match std::fs::remove_file(&path) {
+            Ok(()) => tracing::info!(
+                "removed stale partial file {} of dead process {pid}",
+                path.display()
+            ),
+            // A concurrent sweeper of the same root won the race.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => tracing::warn!(
+                "failed to remove stale partial file {}: {e}",
+                path.display()
+            ),
+        }
+    }
+}
+
+/// Recursively collect partial-write files under `dir` for
+/// [`sweep_stale_partials`]; depth-limited, does not follow symlinks, skips
+/// unreadable entries.
+fn collect_partial_files(dir: &Path, depth: usize, out: &mut Vec<(PathBuf, u32)>) {
+    if depth > MAX_SWEEP_DEPTH {
+        tracing::warn!(
+            "partial-file sweep stopping at unexpected directory depth {depth} in {}",
+            dir.display()
+        );
+        return;
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!("partial-file sweep cannot read {}: {e}", dir.display());
+            }
+            return;
+        }
+    };
+    for entry in entries {
+        let Ok(entry) = entry else { continue };
+        // `file_type` does not follow symlinks, so linked dirs are not recursed.
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            collect_partial_files(&entry.path(), depth + 1, out);
+        } else if file_type.is_file()
+            && let Some(pid) = entry.file_name().to_str().and_then(parse_partial_owner_pid)
+        {
+            out.push((entry.path(), pid));
+        }
+    }
+}
 
 /// Write some bytes to a file without serialization. Works for ASCII text without extra thought too.
 pub async fn write_bytes<P: AsRef<Path>>(file_path: P, bytes: &[u8]) -> anyhow::Result<()> {
@@ -33,9 +190,9 @@ pub async fn safe_write_element_versioned<
     element: &T,
 ) -> anyhow::Result<()> {
     let file_path = file_path.as_ref();
-    if file_path.file_name().is_none() {
+    let Some(file_name) = file_path.file_name() else {
         anyhow::bail!("invalid file path: {}", file_path.display());
-    }
+    };
     // Create the parent directories of the file path if they don't exist
     if let Some(p) = file_path.parent() {
         tokio::fs::create_dir_all(p).await?
@@ -44,14 +201,16 @@ pub async fn safe_write_element_versioned<
     // over `file_path`, so a crash mid-write cannot leave a partial file there
     // (rename alone is not a durability barrier). The temp file must live in
     // the same directory (rename cannot cross filesystems); its dot-prefixed
-    // name is skipped by directory listings (`FileStorage::all_data_ids`
-    // parses every non-hidden name as a `RequestId`) and is unique per writer,
-    // so concurrent writers to the same path cannot collide.
+    // name (`.<name>.partial.<pid>.<seq>`) is skipped by directory listings
+    // (`FileStorage::all_data_ids` parses every non-hidden name as a
+    // `RequestId`), unique among live writers, and pid-attributable so
+    // `sweep_stale_partials` can reclaim it if this process hard-crashes.
     let parent = match file_path.parent() {
         Some(p) if !p.as_os_str().is_empty() => p,
         _ => Path::new("."),
     };
-    let tmp = tempfile::NamedTempFile::new_in(parent)
+    let seq = PARTIAL_SEQ.fetch_add(1, Ordering::Relaxed);
+    let tmp = create_partial_tempfile(parent, file_name, std::process::id(), seq)
         .map_err(|e| anyhow::anyhow!("failed to create temp file in {}: {e}", parent.display()))?;
     let mut writer = std::io::BufWriter::new(tmp);
     safe_serialize(element, &mut writer, SAFE_SER_SIZE_LIMIT).map_err(|e| {
@@ -120,11 +279,23 @@ pub async fn read_element<T: DeserializeOwned + Serialize, P: AsRef<Path>>(
 #[cfg(test)]
 mod tests {
     use crate::util::file_handling::{
-        read_element, safe_read_element_versioned, safe_write_element_versioned, write_bytes,
-        write_element,
+        create_partial_tempfile, parse_partial_owner_pid, partial_file_name, read_element,
+        safe_read_element_versioned, safe_write_element_versioned, sweep_stale_partials,
+        write_bytes, write_element,
     };
     use crate::vault::storage::tests::TestType;
+    use std::ffi::OsStr;
     use tokio::fs::remove_file;
+
+    /// Larger than any real pid (Linux `pid_max` <= 2^22, macOS ~10^5) yet
+    /// still positive when converted to the platform's i32 pid representation.
+    const NEVER_LIVE_PID: u32 = 999_999_999;
+
+    fn plant_partial(dir: &std::path::Path, final_name: &str, pid: u32) -> std::path::PathBuf {
+        let path = dir.join(partial_file_name(OsStr::new(final_name), pid, 0));
+        std::fs::write(&path, b"partial junk").unwrap();
+        path
+    }
 
     #[tokio::test]
     async fn read_write_text() {
@@ -242,5 +413,128 @@ mod tests {
         // The destination still holds the original element, never a partial file.
         let read_back: TestType = safe_read_element_versioned(&path).await.unwrap();
         assert_eq!(read_back, original);
+    }
+
+    // The writer and the sweep share the name grammar; a drift breaks the sweep.
+    #[test]
+    fn partial_name_roundtrip() {
+        let name = partial_file_name(OsStr::new("element"), 123, 7);
+        assert_eq!(name.to_str().unwrap(), ".element.partial.123.7");
+        assert_eq!(parse_partial_owner_pid(name.to_str().unwrap()), Some(123));
+    }
+
+    #[test]
+    fn parse_partial_rejects_non_matching() {
+        for name in [
+            "element",                  // regular data file
+            ".hidden",                  // plain dotfile
+            ".gitkeep",                 // plain dotfile
+            ".tmpAbC123",               // old NamedTempFile naming
+            ".name.partial.abc.1",      // non-numeric pid
+            ".name.partial.12",         // missing seq
+            ".partial.12.1",            // empty destination name
+            ".name.partial.12.1x",      // non-numeric seq
+            ".name.partial..1",         // empty pid
+            ".n.partial.99999999999.1", // pid exceeds u32
+            ".name.partiality.12.1",    // marker is a substring, not ".partial"
+        ] {
+            assert_eq!(parse_partial_owner_pid(name), None, "must reject {name}");
+        }
+        // A destination name containing ".partial." itself still parses to the
+        // trailing pid, never to the embedded number.
+        assert_eq!(
+            parse_partial_owner_pid(".a.partial.1.b.partial.12.1"),
+            Some(12)
+        );
+    }
+
+    #[test]
+    fn create_partial_tempfile_reclaims_same_name_orphan() {
+        let dir = tempfile::tempdir().unwrap();
+        let name = partial_file_name(OsStr::new("element"), 42, 7);
+        std::fs::write(dir.path().join(&name), b"stale orphan").unwrap();
+
+        let tmp = create_partial_tempfile(dir.path(), OsStr::new("element"), 42, 7).unwrap();
+        assert_eq!(tmp.path().file_name().unwrap(), name.as_os_str());
+        // The orphan was replaced by a fresh empty file, not appended to.
+        assert_eq!(std::fs::metadata(tmp.path()).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn sweep_removes_dead_pid_partials_recursively() {
+        let dir = tempfile::tempdir().unwrap();
+        let type_dir = dir.path().join("t");
+        let epoch_dir = type_dir.join("epoch1");
+        std::fs::create_dir_all(&epoch_dir).unwrap();
+        let orphans = [
+            plant_partial(dir.path(), "a", NEVER_LIVE_PID),
+            plant_partial(&type_dir, "b", NEVER_LIVE_PID),
+            plant_partial(&epoch_dir, "c", NEVER_LIVE_PID),
+        ];
+        let keepers = [
+            type_dir.join("realdata"),
+            type_dir.join(".gitkeep"),
+            type_dir.join(".tmpAbC123"),
+        ];
+        for keeper in &keepers {
+            std::fs::write(keeper, b"keep me").unwrap();
+        }
+
+        sweep_stale_partials(dir.path());
+
+        for orphan in &orphans {
+            assert!(!orphan.exists(), "orphan not swept: {}", orphan.display());
+        }
+        for keeper in &keepers {
+            assert!(keeper.exists(), "non-partial deleted: {}", keeper.display());
+        }
+    }
+
+    #[test]
+    fn sweep_keeps_own_pid_partials() {
+        let dir = tempfile::tempdir().unwrap();
+        // Another vault instance in this process may be mid-write.
+        let inflight = plant_partial(dir.path(), "element", std::process::id());
+        sweep_stale_partials(dir.path());
+        assert!(inflight.exists());
+    }
+
+    // The sweep must never remove a live foreign process' in-flight write.
+    #[cfg(unix)]
+    #[test]
+    fn sweep_keeps_live_foreign_pid_partials() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let inflight = plant_partial(dir.path(), "element", child.id());
+
+        sweep_stale_partials(dir.path());
+        let kept = inflight.exists();
+        child.kill().unwrap();
+        child.wait().unwrap();
+        assert!(kept, "live foreign process' partial was removed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sweep_removes_partial_of_exited_process() {
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        child.wait().unwrap();
+        // Pid reuse between wait() and the sweep is practically impossible
+        // (allocation is sequential); NEVER_LIVE_PID tests carry the
+        // deterministic burden.
+        let dir = tempfile::tempdir().unwrap();
+        let orphan = plant_partial(dir.path(), "element", child.id());
+
+        sweep_stale_partials(dir.path());
+        assert!(!orphan.exists(), "dead process' partial was kept");
+    }
+
+    #[test]
+    fn sweep_of_missing_root_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        sweep_stale_partials(&dir.path().join("does-not-exist"));
     }
 }

--- a/core/service/src/util/file_handling.rs
+++ b/core/service/src/util/file_handling.rs
@@ -14,8 +14,8 @@ use crate::consts::SAFE_SER_SIZE_LIMIT;
 static PARTIAL_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// `.<final_name>.partial.<pid>.<seq>` — the temp-name grammar shared by the
-/// writer and [`sweep_stale_partials`]; `OsString` so non-UTF-8 destination
-/// names keep working.
+/// writer and [`sweep_stale_partials`]; `OsStr` in and out because that is
+/// what `Path::file_name` yields (the sweep only parses UTF-8 names).
 pub(crate) fn partial_file_name(final_name: &OsStr, pid: u32, seq: u64) -> OsString {
     let mut name = OsString::from(".");
     name.push(final_name);
@@ -63,22 +63,30 @@ fn create_partial_tempfile(
                 "reclaiming orphaned partial file {} left by a dead process with reused pid {pid}",
                 parent.join(&tmp_name).display()
             );
-            std::fs::remove_file(parent.join(&tmp_name))?;
+            if let Err(e) = std::fs::remove_file(parent.join(&tmp_name))
+                // NotFound: a concurrent sweeper of the same root won the race.
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                return Err(e);
+            }
             build()
         }
         res => res,
     }
 }
 
-/// Directory layout is at most `{root}/{data_type}/{epoch_id}/{file}`; one
-/// extra level of headroom.
+/// Directory layout is at most `{root}/{data_type}/{epoch_id}/{file}`, i.e.
+/// recursion depth 2; two extra levels of headroom.
 const MAX_SWEEP_DEPTH: usize = 4;
 
 /// Best-effort removal of `.<name>.partial.<pid>.<seq>` files orphaned under
 /// `root` by hard-crashed processes (on a clean failure the temp file's drop
-/// guard removes it). Only files whose embedded pid is neither our own nor a
-/// live process are deleted, so in-flight writes of concurrent writers are
-/// never touched; IO errors are logged and never propagated.
+/// guard removes it). A file is deleted only if its embedded pid is dead, or
+/// live but younger than the file — a writer's file cannot predate the writer,
+/// while a pid reused after a crash (e.g. the server being pid 1 on every
+/// container restart) carries a fresh start time. In-flight writes are thus
+/// never touched, assuming all writers to `root` share this process' pid
+/// namespace and clock. IO errors are logged and never propagated.
 pub(crate) fn sweep_stale_partials(root: &Path) {
     let mut candidates: Vec<(PathBuf, u32)> = Vec::new();
     collect_partial_files(root, 0, &mut candidates);
@@ -93,15 +101,14 @@ pub(crate) fn sweep_stale_partials(root: &Path) {
         );
         return;
     }
-    let own_pid = std::process::id();
     let mut pids: Vec<sysinfo::Pid> = candidates
         .iter()
-        .filter(|(_, pid)| *pid != own_pid)
         .map(|(_, pid)| sysinfo::Pid::from_u32(*pid))
         .collect();
     pids.sort_unstable();
     pids.dedup();
-    // One batched liveness query for all encountered pids.
+    // One batched liveness query for all encountered pids, our own included:
+    // its start time is what ages out a dead predecessor's same-pid files.
     let mut system = sysinfo::System::new_with_specifics(sysinfo::RefreshKind::nothing());
     system.refresh_processes_specifics(
         sysinfo::ProcessesToUpdate::Some(&pids),
@@ -109,13 +116,12 @@ pub(crate) fn sweep_stale_partials(root: &Path) {
         sysinfo::ProcessRefreshKind::nothing(),
     );
     for (path, pid) in candidates {
-        if pid == own_pid || system.process(sysinfo::Pid::from_u32(pid)).is_some() {
-            // In-flight write of this or another live process.
+        if may_be_in_flight(&system, pid, &path) {
             continue;
         }
         match std::fs::remove_file(&path) {
             Ok(()) => tracing::info!(
-                "removed stale partial file {} of dead process {pid}",
+                "removed stale partial file {} orphaned by pid {pid}",
                 path.display()
             ),
             // A concurrent sweeper of the same root won the race.
@@ -126,6 +132,24 @@ pub(crate) fn sweep_stale_partials(root: &Path) {
             ),
         }
     }
+}
+
+/// Whether `path` may be the in-flight write of a live process owning `pid`:
+/// the pid is alive and the file is not older than that process. Start times
+/// are whole seconds, so same-second counts as not older; an unknown start
+/// time or mtime also counts as in-flight to stay on the safe side.
+fn may_be_in_flight(system: &sysinfo::System, pid: u32, path: &Path) -> bool {
+    let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) else {
+        return false;
+    };
+    let start = process.start_time();
+    if start == 0 {
+        return true;
+    }
+    let Ok(mtime) = std::fs::metadata(path).and_then(|m| m.modified()) else {
+        return true;
+    };
+    mtime >= std::time::UNIX_EPOCH + std::time::Duration::from_secs(start)
 }
 
 /// Recursively collect partial-write files under `dir` for
@@ -497,6 +521,23 @@ mod tests {
         let inflight = plant_partial(dir.path(), "element", std::process::id());
         sweep_stale_partials(dir.path());
         assert!(inflight.exists());
+    }
+
+    #[test]
+    fn sweep_removes_own_pid_partials_older_than_process_start() {
+        let dir = tempfile::tempdir().unwrap();
+        let orphan = plant_partial(dir.path(), "element", std::process::id());
+        // Backdate to before this process started: a dead predecessor's
+        // leftover carrying our reused pid (pid 1 on every container restart).
+        std::fs::File::options()
+            .write(true)
+            .open(&orphan)
+            .unwrap()
+            .set_modified(std::time::UNIX_EPOCH + std::time::Duration::from_secs(1))
+            .unwrap();
+
+        sweep_stale_partials(dir.path());
+        assert!(!orphan.exists(), "predecessor's same-pid partial was kept");
     }
 
     // The sweep must never remove a live foreign process' in-flight write.

--- a/core/service/src/vault/storage/file.rs
+++ b/core/service/src/vault/storage/file.rs
@@ -57,8 +57,6 @@ impl FileStorage {
         };
         fs::create_dir_all(&path)?;
         let path = path.canonicalize()?;
-        // Best-effort cleanup of partials orphaned by hard crashes; never
-        // fails construction.
         sweep_stale_partials(&path);
         Ok(Self { path })
     }

--- a/core/service/src/vault/storage/file.rs
+++ b/core/service/src/vault/storage/file.rs
@@ -1,7 +1,7 @@
 use super::{Storage, StorageReader, StorageType, StoreWriteOutcome};
 use crate::consts::KEY_PATH_PREFIX;
 use crate::util::file_handling::{
-    safe_read_element_versioned, safe_write_element_versioned, write_bytes,
+    safe_read_element_versioned, safe_write_element_versioned, sweep_stale_partials, write_bytes,
 };
 use crate::vault::storage::{StorageExt, StorageReaderExt, all_data_ids_from_all_epochs_impl};
 use crate::vault::storage_prefix_safety;
@@ -37,6 +37,8 @@ impl FileStorage {
     /// {extra_prefix} is {storage_prefix} if it is Some,
     /// otherwise it is set to {storage_type}.
     /// All missing paths are created during this process.
+    /// Construction also sweeps stale partial-write temp files left under the
+    /// storage root by hard-crashed processes (see `sweep_stale_partials`).
     pub fn new(
         path: Option<&Path>,
         storage_type: StorageType,
@@ -54,9 +56,11 @@ impl FileStorage {
             None => env::current_dir()?.join(KEY_PATH_PREFIX).join(extra_prefix),
         };
         fs::create_dir_all(&path)?;
-        Ok(Self {
-            path: path.canonicalize()?,
-        })
+        let path = path.canonicalize()?;
+        // Best-effort cleanup of partials orphaned by hard crashes; never
+        // fails construction.
+        sweep_stale_partials(&path);
+        Ok(Self { path })
     }
 
     fn item_path(&self, data_id: &RequestId, data_type: &str) -> PathBuf {
@@ -702,5 +706,51 @@ pub mod tests {
             !epoch_dir.exists(),
             "Epoch directory should be removed after deleting the last file"
         );
+    }
+
+    #[tokio::test]
+    async fn filestorage_new_sweeps_stale_partials() {
+        use crate::util::file_handling::partial_file_name;
+        use std::ffi::OsStr;
+        // Cannot be a live pid; see the twin constant in the file_handling tests.
+        const NEVER_LIVE_PID: u32 = 999_999_999;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut storage = FileStorage::new(Some(temp_dir.path()), StorageType::PRIV, None).unwrap();
+        let data = TestType { i: 13 };
+        let data_type = "TestType";
+        let req_id = derive_request_id("sweep_plain").unwrap();
+        storage.store_data(&data, &req_id, data_type).await.unwrap();
+
+        // Plant orphans of a dead process next to plain and epoch data, plus an
+        // in-flight partial of this very process.
+        let type_dir = storage.root_dir().join(data_type);
+        let epoch_dir = type_dir.join("epoch1");
+        fs::create_dir_all(&epoch_dir).unwrap();
+        let orphan_plain =
+            type_dir.join(partial_file_name(OsStr::new("orphan"), NEVER_LIVE_PID, 3));
+        let orphan_epoch =
+            epoch_dir.join(partial_file_name(OsStr::new("orphan"), NEVER_LIVE_PID, 4));
+        let inflight = type_dir.join(partial_file_name(
+            OsStr::new("inflight"),
+            std::process::id(),
+            5,
+        ));
+        for planted in [&orphan_plain, &orphan_epoch, &inflight] {
+            fs::write(planted, b"junk").unwrap();
+        }
+
+        // Re-opening the same root sweeps dead-pid partials only.
+        let storage2 = FileStorage::new(Some(temp_dir.path()), StorageType::PRIV, None).unwrap();
+        assert!(!orphan_plain.exists(), "plain orphan not swept");
+        assert!(!orphan_epoch.exists(), "epoch orphan not swept");
+        assert!(inflight.exists(), "in-flight partial of a live pid removed");
+
+        // Real data survives and listings are unchanged.
+        let read_back: TestType = storage2.read_data(&req_id, data_type).await.unwrap();
+        assert_eq!(read_back, data);
+        let ids = storage2.all_data_ids(data_type).await.unwrap();
+        assert!(ids.contains(&req_id));
+        assert_eq!(ids.len(), 1);
     }
 }


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->

`safe_write_element_versioned` streams versioned data through a hidden sibling
temp file (`.<name>.partial.<pid>.<seq>`), fsyncs it, then atomically renames it
into place. A clean failure removes the temp via its drop guard, but a **hard
crash** (SIGKILL, OOM-kill, power loss) leaves it orphaned. Because the names are
dot-prefixed:

- they can pin multi-GiB of near-complete private key material on disk indefinitely;
- `all_data_ids` skips them, so they're invisible to normal operation and disk-usage intuition;
- `delete_data_at_epoch` removes only exact item paths, so orphans survive key
  purges and, as non-empty-dir blockers, silently prevent best-effort epoch-dir removal.

### Fix
A best-effort **startup sweep** in `FileStorage::new` (`sweep_stale_partials`)
that reclaims stale partials under the storage root.

The sweep is **pid-aware** — temp names embed the writer's pid precisely because
multiple processes (e.g. `kms-custodian`) may legitimately write to the same
directory. A partial is removed only if its embedded pid is:
- **dead**, or
- **alive but younger than the file** — a writer's file cannot predate the
  writer, so a same-pid file older than the process start is a dead
  predecessor's leftover (the server is pid 1 on every container restart).

A live process's genuine in-flight write is therefore never removed. 

Write-time collision handling: `create_partial_tempfile` silently reclaims a
same-name orphan (a same pid+seq collision is harmless — creation truncates). A
write-time same-name *warning* was considered and rejected in review: the
collision is harmless and wouldn't catch orphans with other pids anyway.

### Changes
- `util/file_handling.rs`: `sweep_stale_partials`, pid-aware `may_be_in_flight`,
  depth-limited symlink-safe `collect_partial_files`, and the shared
  `partial_file_name` / `parse_partial_owner_pid` name grammar.
- `vault/storage/file.rs`: sweep on `FileStorage::new`.
- `Cargo.toml`: promote `sysinfo` from dev-dependency to an optional dependency
  under the `non-wasm` feature (pid-liveness check). No version change; already a
  production dependency transitively via `observability`.

### Testing
Unit tests cover: recursive dead-pid removal; keeping own-pid and live-foreign
in-flight partials; aging out a reused-pid predecessor's partial; removing an
exited process's partial; missing-root no-op; name round-trip and strict-parse
rejection; same-name orphan reclaim; and an end-to-end `FileStorage::new` sweep
that leaves real data and listings intact.

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

Closes https://github.com/zama-ai/kms-internal/issues/3039

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
