### PR TITLE
chore!: backward compatible PRSS hotfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "error-utils"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "anyhow",
  "tracing",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "experiments"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "aes-prng",
  "anyhow",
@@ -3387,7 +3387,7 @@ checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
 
 [[package]]
 name = "generate-test-material"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "kms"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "kms-core-client"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "aes-prng",
  "alloy-primitives",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "kms-grpc"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4393,7 +4393,7 @@ dependencies = [
 
 [[package]]
 name = "kms-health-check"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "anyhow",
  "axum",
@@ -7404,7 +7404,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -7415,11 +7415,11 @@ dependencies = [
 
 [[package]]
 name = "test-utils-cc"
-version = "0.13.21"
+version = "0.13.22"
 
 [[package]]
 name = "test-utils-service"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -7590,7 +7590,7 @@ dependencies = [
 
 [[package]]
 name = "thread-handles"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "anyhow",
  "error-utils",
@@ -7620,7 +7620,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-algebra"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "aes-prng",
  "anyhow",
@@ -7647,7 +7647,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-bgv"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "aes-prng",
  "anyhow",
@@ -7675,7 +7675,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-execution"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "aes",
  "aes-prng",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-hashing"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -7734,7 +7734,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-networking"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7771,7 +7771,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-types"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ authors = ["Zama"]
 publish = true
 edition = "2024"
 license = "BSD-3-Clause-Clear"
-version = "0.13.21"
+version = "0.13.22"
 repository = "https://github.com/zama-ai/kms"
 description = "Key Management System for the Zama Protocol."
 

--- a/charts/kms-core/Chart.yaml
+++ b/charts/kms-core/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-core
 description: A helm chart to distribute and deploy the Zama KMS core service.
-version: 1.6.0
+version: 1.6.1
 appVersion: 0.13.20   # Minimum kms version to run this chart
 apiVersion: v2
 keywords:

--- a/charts/kms-core/Chart.yaml
+++ b/charts/kms-core/Chart.yaml
@@ -1,7 +1,7 @@
 name: kms-core
 description: A helm chart to distribute and deploy the Zama KMS core service.
 version: 1.6.1
-appVersion: 0.13.20   # Minimum kms version to run this chart
+appVersion: 0.13.22   # Minimum kms version to run this chart
 apiVersion: v2
 keywords:
   - kms-service

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -113,8 +113,12 @@ data:
     decryption_mode = {{ .Values.kmsCore.thresholdMode.decryptionMode | quote }}
 
     {{- /* Issue#3089: temporary PRSS-Mask schedule activation thresholds, see values.yaml.*/}}
-    legacy_prss_mask_before_public_decrypt_id = {{ required "kmsCore.legacyPrssMask.beforePublicDecryptId is mandatory" .Values.kmsCore.legacyPrssMask.beforePublicDecryptId | quote }}
-    legacy_prss_mask_before_user_decrypt_id = {{ required "kmsCore.legacyPrssMask.beforeUserDecryptId is mandatory" .Values.kmsCore.legacyPrssMask.beforeUserDecryptId | quote }}
+    {{- with .Values.kmsCore.legacyPrssMask.beforePublicDecryptId }}
+    legacy_prss_mask_before_public_decrypt_id = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.kmsCore.legacyPrssMask.beforeUserDecryptId }}
+    legacy_prss_mask_before_user_decrypt_id = {{ . | quote }}
+    {{- end }}
 
     [threshold.core_to_core_net]
     message_limit = 70

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -112,6 +112,15 @@ data:
     num_sessions_preproc = {{ int .Values.kmsCore.thresholdMode.numSessionsPreproc }}
     decryption_mode = {{ .Values.kmsCore.thresholdMode.decryptionMode | quote }}
 
+    {{- /* Issue#3089: temporary PRSS-Mask schedule activation thresholds, see values.yaml.
+    Part of the TOML (not pod env) so the values also reach Nitro-enclave deployments. */}}
+    {{- with .Values.kmsCore.legacyPrssMask.beforePublicDecryptId }}
+    legacy_prss_mask_before_public_decrypt_id = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.kmsCore.legacyPrssMask.beforeUserDecryptId }}
+    legacy_prss_mask_before_user_decrypt_id = {{ . | quote }}
+    {{- end }}
+
     [threshold.core_to_core_net]
     message_limit = 70
     multiplier = {{ float64 .Values.kmsCore.thresholdMode.multiplier }}

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -112,14 +112,9 @@ data:
     num_sessions_preproc = {{ int .Values.kmsCore.thresholdMode.numSessionsPreproc }}
     decryption_mode = {{ .Values.kmsCore.thresholdMode.decryptionMode | quote }}
 
-    {{- /* Issue#3089: temporary PRSS-Mask schedule activation thresholds, see values.yaml.
-    Part of the TOML (not pod env) so the values also reach Nitro-enclave deployments. */}}
-    {{- with .Values.kmsCore.legacyPrssMask.beforePublicDecryptId }}
-    legacy_prss_mask_before_public_decrypt_id = {{ . | quote }}
-    {{- end }}
-    {{- with .Values.kmsCore.legacyPrssMask.beforeUserDecryptId }}
-    legacy_prss_mask_before_user_decrypt_id = {{ . | quote }}
-    {{- end }}
+    {{- /* Issue#3089: temporary PRSS-Mask schedule activation thresholds, see values.yaml.*/}}
+    legacy_prss_mask_before_public_decrypt_id = {{ required "kmsCore.legacyPrssMask.beforePublicDecryptId is mandatory" .Values.kmsCore.legacyPrssMask.beforePublicDecryptId | quote }}
+    legacy_prss_mask_before_user_decrypt_id = {{ required "kmsCore.legacyPrssMask.beforeUserDecryptId is mandatory" .Values.kmsCore.legacyPrssMask.beforeUserDecryptId | quote }}
 
     [threshold.core_to_core_net]
     message_limit = 70

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -112,11 +112,15 @@ data:
     num_sessions_preproc = {{ int .Values.kmsCore.thresholdMode.numSessionsPreproc }}
     decryption_mode = {{ .Values.kmsCore.thresholdMode.decryptionMode | quote }}
 
-    {{- /* Issue#3089: temporary PRSS-Mask schedule activation thresholds, see values.yaml.*/}}
-    {{- with .Values.kmsCore.legacyPrssMask.beforePublicDecryptId }}
+    {{- /* Issue#3089: temporary PRSS-Mask schedule activation thresholds, see values.yaml.
+           Safe navigation (parenthesized) so the traversal returns nil rather than erroring when
+           legacyPrssMask is absent — e.g. on a `helm upgrade --reuse-values` from a pre-1.6.1
+           release, where the reused values snapshot has no legacyPrssMask key and chart defaults
+           are not re-merged. */}}
+    {{- with ((.Values.kmsCore).legacyPrssMask).beforePublicDecryptId }}
     legacy_prss_mask_before_public_decrypt_id = {{ . | quote }}
     {{- end }}
-    {{- with .Values.kmsCore.legacyPrssMask.beforeUserDecryptId }}
+    {{- with ((.Values.kmsCore).legacyPrssMask).beforeUserDecryptId }}
     legacy_prss_mask_before_user_decrypt_id = {{ . | quote }}
     {{- end }}
 

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -52,9 +52,11 @@ kmsCore:
   # with enough margin for the slowest party to upgrade before the counters reach
   # them. ALWAYS quote the values (they are 256-bit integers, decimal or 0x-prefixed hex;
   # unquoted large YAML numbers get mangled). Remove once the migration is complete.
+  # Default to "100" for testing purpose and because we've already had more requests on mainnet so
+  # that's a safe value to use for now. Needs to be revisited for deployment!!.
   legacyPrssMask:
-    beforePublicDecryptId: "0"
-    beforeUserDecryptId: "0"
+    beforePublicDecryptId: "100"
+    beforeUserDecryptId: "100"
   # Add the following to enable threshold mode:
   thresholdMode:
     enabled: false

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -45,15 +45,16 @@ kmsCore:
   # Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
   # fix (#663). Requests with an ID strictly below the configured value run the legacy
   # (pre-#663) schedule for interop with unpatched peers; requests at or above it run the
-  # fixed schedule. Leave unset to always use the fixed schedule.
+  # fixed schedule. MANDATORY fields of the server config (chart rendering fails if nulled);
+  # "0" means the fixed schedule is always used.
   #
   # ALL MPC parties MUST configure identical values, chosen
   # with enough margin for the slowest party to upgrade before the counters reach
   # them. ALWAYS quote the values (they are 256-bit integers, decimal or 0x-prefixed hex;
   # unquoted large YAML numbers get mangled). Remove once the migration is complete.
   legacyPrssMask:
-    beforePublicDecryptId:
-    beforeUserDecryptId:
+    beforePublicDecryptId: "0"
+    beforeUserDecryptId: "0"
   # Add the following to enable threshold mode:
   thresholdMode:
     enabled: false

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -52,11 +52,14 @@ kmsCore:
   # with enough margin for the slowest party to upgrade before the counters reach
   # them. ALWAYS quote the values (they are 256-bit integers, decimal or 0x-prefixed hex;
   # unquoted large YAML numbers get mangled). Remove once the migration is complete.
-  # Default to "100" for testing purpose and because we've already had more requests on mainnet so
-  # that's a safe value to use for now. Needs to be revisited for deployment!!.
+  # PRSS-Mask legacy-schedule activation thresholds (Issue#3089). Left EMPTY by default so the
+  # config omits the fields entirely — pre-#663 binaries reject unknown config keys, so during a
+  # rolling upgrade these must stay unset until every party runs the new binary, then be enabled
+  # in a second pass (see ci/scripts/rolling_upgrade.sh). Empty => new binary defaults to "0"
+  # (always the fixed schedule). Set to a decimal/0x-hex request-ID threshold to activate.
   legacyPrssMask:
-    beforePublicDecryptId: "100"
-    beforeUserDecryptId: "100"
+    beforePublicDecryptId: ""
+    beforeUserDecryptId: ""
   # Add the following to enable threshold mode:
   thresholdMode:
     enabled: false

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -42,6 +42,18 @@ kmsCore:
         backupVaultKeychainAWSKMSRootKeyID: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
   rateLimiter:
     bucketSize: 50000
+  # Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+  # fix (#663). Requests with an ID strictly below the configured value run the legacy
+  # (pre-#663) schedule for interop with unpatched peers; requests at or above it run the
+  # fixed schedule. Leave unset to always use the fixed schedule.
+  #
+  # ALL MPC parties MUST configure identical values, chosen
+  # with enough margin for the slowest party to upgrade before the counters reach
+  # them. ALWAYS quote the values (they are 256-bit integers, decimal or 0x-prefixed hex;
+  # unquoted large YAML numbers get mangled). Remove once the migration is complete.
+  legacyPrssMask:
+    beforePublicDecryptId:
+    beforeUserDecryptId:
   # Add the following to enable threshold mode:
   thresholdMode:
     enabled: false

--- a/ci/scripts/rolling_upgrade.sh
+++ b/ci/scripts/rolling_upgrade.sh
@@ -214,6 +214,46 @@ main() {
         "${OLD_KMS_CHART_VERSION}" \
         "${NEW_KMS_CHART_VERSION}"
 
+    #=========================================================================
+    # Step 4 (phase 2): Enable the PRSS-Mask legacy-schedule threshold on the
+    # upgraded parties, AFTER their new binary is running.
+    #
+    # The threshold lives in the core-service config (TOML over vsock — pod env
+    # does not reach the enclave). Pre-#663 binaries reject the unknown field
+    # (`deny_unknown_fields`, config read fresh at start), so it must be absent
+    # until every upgraded party runs the new binary — which Step 3 guarantees
+    # by deploying them with the field off (chart value empty). We now set it via
+    # a second helm upgrade on the upgraded parties only; the configmap change
+    # bumps `checksum/config`, restarting the (already-new) pod to pick it up.
+    # Non-upgraded (old) parties are never touched, so no old binary ever sees it.
+    #=========================================================================
+    local threshold="${LEGACY_PRSS_MASK_THRESHOLD:-100}"
+    log_info "Step 4: Enabling PRSS-Mask threshold=${threshold} on upgraded parties [${ALL_UPGRADED_PARTIES}]..."
+
+    local new_chart_loc="${REPO_ROOT}/charts/kms-core"
+    local new_version_args=()
+    if [[ "${NEW_KMS_CHART_VERSION}" != "repository" ]]; then
+        new_chart_loc="oci://hub.zama.org/ghcr/zama-ai/kms/charts/kms-core"
+        new_version_args=(--version "${NEW_KMS_CHART_VERSION}")
+    fi
+
+    IFS=',' read -ra _prss_ids <<< "${ALL_UPGRADED_PARTIES}"
+    for _id in "${_prss_ids[@]}"; do
+        local i; i="$(echo "${_id}" | tr -d ' ')"
+        [[ -z "${i}" ]] && continue
+        log_info "  Party ${i}: helm upgrade (reuse-values) + PRSS threshold..."
+        helm upgrade --install "${HELM_RELEASE_PREFIX}-${i}" "${new_chart_loc}" \
+            "${new_version_args[@]}" \
+            --namespace "${NAMESPACE}" \
+            --reuse-values \
+            --set kmsGenCertAndKeys.enabled=false \
+            --set "kmsCore.legacyPrssMask.beforePublicDecryptId=${threshold}" \
+            --set "kmsCore.legacyPrssMask.beforeUserDecryptId=${threshold}" \
+            --wait --wait-for-jobs --timeout=1200s &
+    done
+    wait
+    log_info "PRSS-Mask threshold enabled on all upgraded parties."
+
     log_info "========================================="
     log_info "Rolling Upgrade Complete!"
     log_info "========================================="

--- a/ci/scripts/rolling_upgrade.sh
+++ b/ci/scripts/rolling_upgrade.sh
@@ -237,7 +237,11 @@ main() {
         new_version_args=(--version "${NEW_KMS_CHART_VERSION}")
     fi
 
+    # Run the upgrades in parallel but track each PID → party, and fail the step if ANY of them
+    # fails (a bare `wait` only returns the exit status of the last backgrounded job).
     IFS=',' read -ra _prss_ids <<< "${ALL_UPGRADED_PARTIES}"
+    local -a _prss_pids=()
+    local -a _prss_parties=()
     for _id in "${_prss_ids[@]}"; do
         local i; i="$(echo "${_id}" | tr -d ' ')"
         [[ -z "${i}" ]] && continue
@@ -250,8 +254,20 @@ main() {
             --set "kmsCore.legacyPrssMask.beforePublicDecryptId=${threshold}" \
             --set "kmsCore.legacyPrssMask.beforeUserDecryptId=${threshold}" \
             --wait --wait-for-jobs --timeout=1200s &
+        _prss_pids+=("$!")
+        _prss_parties+=("${i}")
     done
-    wait
+
+    local _prss_failed=()
+    for _idx in "${!_prss_pids[@]}"; do
+        if ! wait "${_prss_pids[$_idx]}"; then
+            _prss_failed+=("${_prss_parties[$_idx]}")
+        fi
+    done
+    if [[ "${#_prss_failed[@]}" -gt 0 ]]; then
+        log_error "PRSS-Mask threshold rollout failed for parties: ${_prss_failed[*]}"
+        exit 1
+    fi
     log_info "PRSS-Mask threshold enabled on all upgraded parties."
 
     log_info "========================================="

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -139,6 +139,8 @@ fn build_test_core_config(
             peers: Some(peers),
             core_to_core_net: None,
             decryption_mode: DecryptionMode::NoiseFloodSmall,
+            legacy_prss_mask_before_public_decrypt_id: "0".to_string(),
+            legacy_prss_mask_before_user_decrypt_id: "0".to_string(),
         }),
         internal_config: None,
         mock_enclave: Some(true),

--- a/core/service/config/compose_1.toml
+++ b/core/service/config/compose_1.toml
@@ -27,6 +27,15 @@ path = "./backup_vault"
 prefix = "BACKUP-p1"
 
 [threshold]
+
+# Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+# fix (#663). Requests with a raw request ID (interpreted as a big-endian integer) strictly
+# below the value run the legacy (pre-#663) schedule; requests at or above it run the fixed
+# one. Mandatory; decimal or 0x-prefixed hex string, up to 256 bits. Consensus constants:
+# all MPC parties must configure identical values. Use "0" to always run the fixed schedule.
+# Remove once the migration is complete.
+legacy_prss_mask_before_public_decrypt_id = "0"
+legacy_prss_mask_before_user_decrypt_id = "0"
 listen_address = "0.0.0.0"
 listen_port = 50001
 

--- a/core/service/config/compose_2.toml
+++ b/core/service/config/compose_2.toml
@@ -27,6 +27,15 @@ path = "./backup_vault"
 prefix = "BACKUP-p2"
 
 [threshold]
+
+# Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+# fix (#663). Requests with a raw request ID (interpreted as a big-endian integer) strictly
+# below the value run the legacy (pre-#663) schedule; requests at or above it run the fixed
+# one. Mandatory; decimal or 0x-prefixed hex string, up to 256 bits. Consensus constants:
+# all MPC parties must configure identical values. Use "0" to always run the fixed schedule.
+# Remove once the migration is complete.
+legacy_prss_mask_before_public_decrypt_id = "0"
+legacy_prss_mask_before_user_decrypt_id = "0"
 listen_address = "0.0.0.0"
 listen_port = 50002
 

--- a/core/service/config/compose_3.toml
+++ b/core/service/config/compose_3.toml
@@ -27,6 +27,15 @@ path = "./backup_vault"
 prefix = "BACKUP-p3"
 
 [threshold]
+
+# Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+# fix (#663). Requests with a raw request ID (interpreted as a big-endian integer) strictly
+# below the value run the legacy (pre-#663) schedule; requests at or above it run the fixed
+# one. Mandatory; decimal or 0x-prefixed hex string, up to 256 bits. Consensus constants:
+# all MPC parties must configure identical values. Use "0" to always run the fixed schedule.
+# Remove once the migration is complete.
+legacy_prss_mask_before_public_decrypt_id = "0"
+legacy_prss_mask_before_user_decrypt_id = "0"
 listen_address = "0.0.0.0"
 listen_port = 50003
 

--- a/core/service/config/compose_4.toml
+++ b/core/service/config/compose_4.toml
@@ -27,6 +27,15 @@ path = "./backup_vault"
 prefix = "BACKUP-p4"
 
 [threshold]
+
+# Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+# fix (#663). Requests with a raw request ID (interpreted as a big-endian integer) strictly
+# below the value run the legacy (pre-#663) schedule; requests at or above it run the fixed
+# one. Mandatory; decimal or 0x-prefixed hex string, up to 256 bits. Consensus constants:
+# all MPC parties must configure identical values. Use "0" to always run the fixed schedule.
+# Remove once the migration is complete.
+legacy_prss_mask_before_public_decrypt_id = "0"
+legacy_prss_mask_before_user_decrypt_id = "0"
 listen_address = "0.0.0.0"
 listen_port = 50004
 

--- a/core/service/config/compose_5.toml
+++ b/core/service/config/compose_5.toml
@@ -27,6 +27,15 @@ path = "./backup_vault"
 prefix = "BACKUP-p5"
 
 [threshold]
+
+# Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+# fix (#663). Requests with a raw request ID (interpreted as a big-endian integer) strictly
+# below the value run the legacy (pre-#663) schedule; requests at or above it run the fixed
+# one. Mandatory; decimal or 0x-prefixed hex string, up to 256 bits. Consensus constants:
+# all MPC parties must configure identical values. Use "0" to always run the fixed schedule.
+# Remove once the migration is complete.
+legacy_prss_mask_before_public_decrypt_id = "0"
+legacy_prss_mask_before_user_decrypt_id = "0"
 listen_address = "0.0.0.0"
 listen_port = 50005
 

--- a/core/service/config/compose_6.toml
+++ b/core/service/config/compose_6.toml
@@ -27,6 +27,15 @@ path = "./backup_vault"
 prefix = "BACKUP-p6"
 
 [threshold]
+
+# Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+# fix (#663). Requests with a raw request ID (interpreted as a big-endian integer) strictly
+# below the value run the legacy (pre-#663) schedule; requests at or above it run the fixed
+# one. Mandatory; decimal or 0x-prefixed hex string, up to 256 bits. Consensus constants:
+# all MPC parties must configure identical values. Use "0" to always run the fixed schedule.
+# Remove once the migration is complete.
+legacy_prss_mask_before_public_decrypt_id = "0"
+legacy_prss_mask_before_user_decrypt_id = "0"
 listen_address = "0.0.0.0"
 listen_port = 50006
 

--- a/core/service/config/default_1.toml
+++ b/core/service/config/default_1.toml
@@ -91,6 +91,15 @@ prefix = "BACKUP-p1"
 # Not needed when running in centralized mode.
 [threshold]
 
+# Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+# fix (#663). Requests with a raw request ID (interpreted as a big-endian integer) strictly
+# below the value run the legacy (pre-#663) schedule; requests at or above it run the fixed
+# one. Mandatory; decimal or 0x-prefixed hex string, up to 256 bits. Consensus constants:
+# all MPC parties must configure identical values. Use "0" to always run the fixed schedule.
+# Remove once the migration is complete.
+legacy_prss_mask_before_public_decrypt_id = "0"
+legacy_prss_mask_before_user_decrypt_id = "0"
+
 # Address and port that the TCP listener binds to for inter‑core communication.
 # The threshold.listen_port must differ from service.listen_port.
 listen_address = "0.0.0.0"

--- a/core/service/config/default_2.toml
+++ b/core/service/config/default_2.toml
@@ -24,6 +24,15 @@ path = "./backup_vault"
 prefix = "BACKUP-p2"
 
 [threshold]
+
+# Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+# fix (#663). Requests with a raw request ID (interpreted as a big-endian integer) strictly
+# below the value run the legacy (pre-#663) schedule; requests at or above it run the fixed
+# one. Mandatory; decimal or 0x-prefixed hex string, up to 256 bits. Consensus constants:
+# all MPC parties must configure identical values. Use "0" to always run the fixed schedule.
+# Remove once the migration is complete.
+legacy_prss_mask_before_public_decrypt_id = "0"
+legacy_prss_mask_before_user_decrypt_id = "0"
 listen_address = "0.0.0.0"
 listen_port = 50002
 

--- a/core/service/config/default_3.toml
+++ b/core/service/config/default_3.toml
@@ -24,6 +24,15 @@ path = "./backup_vault"
 prefix = "BACKUP-p3"
 
 [threshold]
+
+# Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+# fix (#663). Requests with a raw request ID (interpreted as a big-endian integer) strictly
+# below the value run the legacy (pre-#663) schedule; requests at or above it run the fixed
+# one. Mandatory; decimal or 0x-prefixed hex string, up to 256 bits. Consensus constants:
+# all MPC parties must configure identical values. Use "0" to always run the fixed schedule.
+# Remove once the migration is complete.
+legacy_prss_mask_before_public_decrypt_id = "0"
+legacy_prss_mask_before_user_decrypt_id = "0"
 listen_address = "0.0.0.0"
 listen_port = 50003
 

--- a/core/service/config/default_4.toml
+++ b/core/service/config/default_4.toml
@@ -24,6 +24,15 @@ path = "./backup_vault"
 prefix = "BACKUP-p4"
 
 [threshold]
+
+# Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+# fix (#663). Requests with a raw request ID (interpreted as a big-endian integer) strictly
+# below the value run the legacy (pre-#663) schedule; requests at or above it run the fixed
+# one. Mandatory; decimal or 0x-prefixed hex string, up to 256 bits. Consensus constants:
+# all MPC parties must configure identical values. Use "0" to always run the fixed schedule.
+# Remove once the migration is complete.
+legacy_prss_mask_before_public_decrypt_id = "0"
+legacy_prss_mask_before_user_decrypt_id = "0"
 listen_address = "0.0.0.0"
 listen_port = 50004
 

--- a/core/service/src/client/test_tools.rs
+++ b/core/service/src/client/test_tools.rs
@@ -140,6 +140,8 @@ pub async fn setup_threshold_no_client<
                 .as_ref()
                 .and_then(|t| t.core_to_core_net),
             decryption_mode,
+            legacy_prss_mask_before_public_decrypt_id: None,
+            legacy_prss_mask_before_user_decrypt_id: None,
         };
         core_config.threshold = Some(threshold_party_config);
         core_config.rate_limiter_conf = rate_limiter_conf.clone();
@@ -367,6 +369,8 @@ pub async fn setup_threshold_with_custom_peers<
                 .as_ref()
                 .and_then(|t| t.core_to_core_net),
             decryption_mode,
+            legacy_prss_mask_before_public_decrypt_id: None,
+            legacy_prss_mask_before_user_decrypt_id: None,
         };
         core_config.threshold = Some(threshold_party_config);
         core_config.rate_limiter_conf = rate_limiter_conf.clone();

--- a/core/service/src/client/test_tools.rs
+++ b/core/service/src/client/test_tools.rs
@@ -140,8 +140,8 @@ pub async fn setup_threshold_no_client<
                 .as_ref()
                 .and_then(|t| t.core_to_core_net),
             decryption_mode,
-            legacy_prss_mask_before_public_decrypt_id: None,
-            legacy_prss_mask_before_user_decrypt_id: None,
+            legacy_prss_mask_before_public_decrypt_id: "0".to_string(),
+            legacy_prss_mask_before_user_decrypt_id: "0".to_string(),
         };
         core_config.threshold = Some(threshold_party_config);
         core_config.rate_limiter_conf = rate_limiter_conf.clone();
@@ -369,8 +369,8 @@ pub async fn setup_threshold_with_custom_peers<
                 .as_ref()
                 .and_then(|t| t.core_to_core_net),
             decryption_mode,
-            legacy_prss_mask_before_public_decrypt_id: None,
-            legacy_prss_mask_before_user_decrypt_id: None,
+            legacy_prss_mask_before_public_decrypt_id: "0".to_string(),
+            legacy_prss_mask_before_user_decrypt_id: "0".to_string(),
         };
         core_config.threshold = Some(threshold_party_config);
         core_config.rate_limiter_conf = rate_limiter_conf.clone();

--- a/core/service/src/client/tests/threshold/public_decryption_tests.rs
+++ b/core/service/src/client/tests/threshold/public_decryption_tests.rs
@@ -498,7 +498,7 @@ pub async fn run_decryption_threshold_optionally_fail(
 async fn test_decryption_threshold_legacy_prss_switch() {
     use crate::engine::threshold::service::prss_compat::{
         DecryptKind,
-        test_prs_compat::{LEGACY_PRSS_DECISIONS, LegacyThresholdGuard},
+        test_prss_compat::{LEGACY_PRSS_DECISIONS, LegacyThresholdGuard},
     };
     use alloy_primitives::U256;
     use std::sync::atomic::Ordering;

--- a/core/service/src/client/tests/threshold/public_decryption_tests.rs
+++ b/core/service/src/client/tests/threshold/public_decryption_tests.rs
@@ -475,3 +475,95 @@ pub async fn run_decryption_threshold_optionally_fail(
         }
     }
 }
+
+/// Issue#3089: check that the request-ID-gated switch between the legacy (pre-#663) and the
+/// fixed PRSS-Mask counter schedule happens as expected for public decryption.
+///
+/// The request ID used by [`decryption_threshold`] is deterministic, so the test recomputes it
+/// and places the activation threshold right around it (via the scoped test override — the
+/// process env vars are never mutated, only their parsing is unit-tested separately):
+/// - threshold = ID + 1: the request is strictly below it, so every party must select the
+///   legacy schedule (asserted via a test-only decision counter, since the decryption outcome
+///   is identical under both schedules when all parties agree), and decryption must still
+///   succeed with correct plaintexts (the legacy path works end-to-end);
+/// - threshold = ID: strictly-below semantics, so the fixed schedule must be selected and
+///   decryption must again succeed.
+///
+/// The user-decryption threshold is simultaneously set to 0 in the first phase to check that
+/// the public stream is gated by its own threshold only. A multi-block plaintext (U16) is used
+/// so the batched PRSS-Mask path (amount > 1), where the two schedules actually differ, is
+/// exercised.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_decryption_threshold_legacy_prss_switch() {
+    use crate::engine::threshold::service::prss_compat::{
+        DecryptKind,
+        test_prs_compat::{LEGACY_PRSS_DECISIONS, LegacyThresholdGuard},
+    };
+    use alloy_primitives::U256;
+    use std::sync::atomic::Ordering;
+
+    let amount_parties = 4;
+    let key_id: &RequestId = &TEST_THRESHOLD_KEY_ID_4P;
+    let msgs = vec![TestingPlaintext::U16(444)];
+    let enc_config = EncryptionConfig {
+        compression: true,
+        precompute_sns: false,
+    };
+
+    // Recompute the deterministic request ID that decryption_threshold (parallelism = 1, so
+    // j = 0) will use, and interpret it as a big-endian integer like the gate does.
+    let request_id = derive_request_id(&format!("TEST_DEC_ID_0_KEY_{key_id}_{msgs:?}")).unwrap();
+    let id_value = U256::try_from_be_slice(request_id.as_bytes()).unwrap();
+
+    // Phase 1: threshold strictly above the request ID => legacy schedule on every party,
+    // decryption still succeeds. The user-decryption threshold is set to 0 at the same time
+    // to check that it does not affect the public stream.
+    let decisions_before = LEGACY_PRSS_DECISIONS.load(Ordering::SeqCst);
+    {
+        let _public_guard = LegacyThresholdGuard::set(
+            DecryptKind::Public,
+            Some(id_value.checked_add(U256::from(1u64)).unwrap()),
+        );
+        let _user_guard = LegacyThresholdGuard::set(DecryptKind::User, Some(U256::ZERO));
+        decryption_threshold(
+            TEST_PARAM,
+            key_id,
+            msgs.clone(),
+            enc_config,
+            1,
+            amount_parties,
+            None,
+            Some(DecryptionMode::NoiseFloodSmall),
+        )
+        .await;
+    }
+    let legacy_decisions = LEGACY_PRSS_DECISIONS.load(Ordering::SeqCst) - decisions_before;
+    assert_eq!(
+        legacy_decisions, amount_parties as u64,
+        "every party must have selected the legacy PRSS-Mask schedule exactly once"
+    );
+
+    // Phase 2: threshold equal to the request ID => strictly-below semantics select the fixed
+    // schedule, decryption still succeeds.
+    let decisions_before = LEGACY_PRSS_DECISIONS.load(Ordering::SeqCst);
+    {
+        let _public_guard = LegacyThresholdGuard::set(DecryptKind::Public, Some(id_value));
+        decryption_threshold(
+            TEST_PARAM,
+            key_id,
+            msgs.clone(),
+            enc_config,
+            1,
+            amount_parties,
+            None,
+            Some(DecryptionMode::NoiseFloodSmall),
+        )
+        .await;
+    }
+    let legacy_decisions = LEGACY_PRSS_DECISIONS.load(Ordering::SeqCst) - decisions_before;
+    assert_eq!(
+        legacy_decisions, 0,
+        "a request ID equal to the threshold must already use the fixed PRSS-Mask schedule"
+    );
+}

--- a/core/service/src/client/tests/threshold/public_decryption_tests.rs
+++ b/core/service/src/client/tests/threshold/public_decryption_tests.rs
@@ -523,9 +523,9 @@ async fn test_decryption_threshold_legacy_prss_switch() {
     {
         let _public_guard = LegacyThresholdGuard::set(
             DecryptKind::Public,
-            Some(id_value.checked_add(U256::from(1u64)).unwrap()),
+            id_value.checked_add(U256::from(1u64)).unwrap(),
         );
-        let _user_guard = LegacyThresholdGuard::set(DecryptKind::User, Some(U256::ZERO));
+        let _user_guard = LegacyThresholdGuard::set(DecryptKind::User, U256::ZERO);
         decryption_threshold(
             TEST_PARAM,
             key_id,
@@ -548,7 +548,7 @@ async fn test_decryption_threshold_legacy_prss_switch() {
     // schedule, decryption still succeeds.
     let decisions_before = LEGACY_PRSS_DECISIONS.load(Ordering::SeqCst);
     {
-        let _public_guard = LegacyThresholdGuard::set(DecryptKind::Public, Some(id_value));
+        let _public_guard = LegacyThresholdGuard::set(DecryptKind::Public, id_value);
         decryption_threshold(
             TEST_PARAM,
             key_id,

--- a/core/service/src/client/tests/threshold/user_decryption_tests.rs
+++ b/core/service/src/client/tests/threshold/user_decryption_tests.rs
@@ -726,3 +726,103 @@ async fn get_server_private_keys(amount_parties: usize) -> HashMap<u32, PrivateS
     }
     server_private_keys
 }
+
+/// Issue#3089: check that the request-ID-gated switch between the legacy (pre-#663) and the
+/// fixed PRSS-Mask counter schedule happens as expected for user decryption.
+///
+/// The request ID used by [`user_decryption_threshold`] is deterministic, so the test
+/// recomputes it and places the activation threshold right around it (via the scoped test
+/// override — the process env vars are never mutated, only their parsing is unit-tested
+/// separately):
+/// - threshold = ID + 1: the request is strictly below it, so every party must select the
+///   legacy schedule (asserted via a test-only decision counter, since the decryption outcome
+///   is identical under both schedules when all parties agree), and user decryption must still
+///   succeed with correct plaintexts (the legacy path works end-to-end, including client-side
+///   reconstruction);
+/// - threshold = ID: strictly-below semantics, so the fixed schedule must be selected and user
+///   decryption must again succeed.
+///
+/// The public-decryption threshold is simultaneously set to 0 in the first phase to check
+/// that the user stream is gated by its own threshold only. A multi-block plaintext (U16) is
+/// used so the batched PRSS-Mask path (amount > 1), where the two schedules actually differ,
+/// is exercised.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_user_decryption_threshold_legacy_prss_switch() {
+    use crate::engine::threshold::service::prss_compat::{
+        DecryptKind,
+        test_prs_compat::{LEGACY_PRSS_DECISIONS, LegacyThresholdGuard},
+    };
+    use alloy_primitives::U256;
+    use std::sync::atomic::Ordering;
+
+    let amount_parties = 4;
+    let key_id: &RequestId = &TEST_THRESHOLD_KEY_ID_4P;
+    let msg = TestingPlaintext::U16(444);
+    let enc_config = EncryptionConfig {
+        compression: true,
+        precompute_sns: false,
+    };
+
+    // Recompute the deterministic request ID that user_decryption_threshold (parallelism = 1,
+    // so j = 0) will use, and interpret it as a big-endian integer like the gate does.
+    let request_id = derive_request_id("TEST_USER_DECRYPT_ID_0").unwrap();
+    let id_value = U256::try_from_be_slice(request_id.as_bytes()).unwrap();
+
+    // Phase 1: threshold strictly above the request ID => legacy schedule on every party,
+    // user decryption still succeeds. The public-decryption threshold is set to 0 at the same
+    // time to check that it does not affect the user stream.
+    let decisions_before = LEGACY_PRSS_DECISIONS.load(Ordering::SeqCst);
+    {
+        let _user_guard = LegacyThresholdGuard::set(
+            DecryptKind::User,
+            Some(id_value.checked_add(U256::from(1u64)).unwrap()),
+        );
+        let _public_guard = LegacyThresholdGuard::set(DecryptKind::Public, Some(U256::ZERO));
+        user_decryption_threshold(
+            TEST_PARAM,
+            key_id,
+            false,
+            msg,
+            enc_config,
+            1,
+            true,
+            amount_parties,
+            None,
+            None,
+            Some(DecryptionMode::NoiseFloodSmall),
+        )
+        .await;
+    }
+    let legacy_decisions = LEGACY_PRSS_DECISIONS.load(Ordering::SeqCst) - decisions_before;
+    assert_eq!(
+        legacy_decisions, amount_parties as u64,
+        "every party must have selected the legacy PRSS-Mask schedule exactly once"
+    );
+
+    // Phase 2: threshold equal to the request ID => strictly-below semantics select the fixed
+    // schedule, user decryption still succeeds.
+    let decisions_before = LEGACY_PRSS_DECISIONS.load(Ordering::SeqCst);
+    {
+        let _user_guard = LegacyThresholdGuard::set(DecryptKind::User, Some(id_value));
+        user_decryption_threshold(
+            TEST_PARAM,
+            key_id,
+            false,
+            msg,
+            enc_config,
+            1,
+            true,
+            amount_parties,
+            None,
+            None,
+            Some(DecryptionMode::NoiseFloodSmall),
+        )
+        .await;
+    }
+    let legacy_decisions = LEGACY_PRSS_DECISIONS.load(Ordering::SeqCst) - decisions_before;
+    assert_eq!(
+        legacy_decisions, 0,
+        "a request ID equal to the threshold must already use the fixed PRSS-Mask schedule"
+    );
+}

--- a/core/service/src/client/tests/threshold/user_decryption_tests.rs
+++ b/core/service/src/client/tests/threshold/user_decryption_tests.rs
@@ -751,7 +751,7 @@ async fn get_server_private_keys(amount_parties: usize) -> HashMap<u32, PrivateS
 async fn test_user_decryption_threshold_legacy_prss_switch() {
     use crate::engine::threshold::service::prss_compat::{
         DecryptKind,
-        test_prs_compat::{LEGACY_PRSS_DECISIONS, LegacyThresholdGuard},
+        test_prss_compat::{LEGACY_PRSS_DECISIONS, LegacyThresholdGuard},
     };
     use alloy_primitives::U256;
     use std::sync::atomic::Ordering;

--- a/core/service/src/client/tests/threshold/user_decryption_tests.rs
+++ b/core/service/src/client/tests/threshold/user_decryption_tests.rs
@@ -776,9 +776,9 @@ async fn test_user_decryption_threshold_legacy_prss_switch() {
     {
         let _user_guard = LegacyThresholdGuard::set(
             DecryptKind::User,
-            Some(id_value.checked_add(U256::from(1u64)).unwrap()),
+            id_value.checked_add(U256::from(1u64)).unwrap(),
         );
-        let _public_guard = LegacyThresholdGuard::set(DecryptKind::Public, Some(U256::ZERO));
+        let _public_guard = LegacyThresholdGuard::set(DecryptKind::Public, U256::ZERO);
         user_decryption_threshold(
             TEST_PARAM,
             key_id,
@@ -804,7 +804,7 @@ async fn test_user_decryption_threshold_legacy_prss_switch() {
     // schedule, user decryption still succeeds.
     let decisions_before = LEGACY_PRSS_DECISIONS.load(Ordering::SeqCst);
     {
-        let _user_guard = LegacyThresholdGuard::set(DecryptKind::User, Some(id_value));
+        let _user_guard = LegacyThresholdGuard::set(DecryptKind::User, id_value);
         user_decryption_threshold(
             TEST_PARAM,
             key_id,

--- a/core/service/src/conf/threshold.rs
+++ b/core/service/src/conf/threshold.rs
@@ -52,14 +52,14 @@ pub struct ThresholdPartyConf {
     /// big-endian integer, is strictly below the configured value run the legacy PRSS.
     /// Values are decimal or 0x-prefixed hex integers of up to 256 bits, given as
     /// strings. All MPC parties MUST configure identical values.
-    /// Absent means the fixed schedule is always used. Public and user decryption
-    /// request IDs come from separate counters, hence one threshold each.
-    /// Remove once the migration is complete.
-    #[serde(default)]
-    pub legacy_prss_mask_before_public_decrypt_id: Option<String>,
+    /// MANDATORY: must be provided explicitly, either in the config file or through the
+    /// config env layer (`KMS_CORE__THRESHOLD__LEGACY_PRSS_MASK_BEFORE_PUBLIC_DECRYPT_ID`);
+    /// config loading errors otherwise. Use "0" to always run the fixed schedule (no request
+    /// ID is strictly below 0). Public and user decryption request IDs come from separate
+    /// counters, hence one threshold each. Remove once the migration is complete.
+    pub legacy_prss_mask_before_public_decrypt_id: String,
     /// See [`Self::legacy_prss_mask_before_public_decrypt_id`].
-    #[serde(default)]
-    pub legacy_prss_mask_before_user_decrypt_id: Option<String>,
+    pub legacy_prss_mask_before_user_decrypt_id: String,
 }
 
 fn validate_threshold_party_conf(conf: &ThresholdPartyConf) -> Result<(), ValidationError> {
@@ -108,9 +108,7 @@ fn validate_threshold_party_conf(conf: &ThresholdPartyConf) -> Result<(), Valida
             &conf.legacy_prss_mask_before_user_decrypt_id,
         ),
     ] {
-        if let Some(raw) = value
-            && let Err(e) = parse_threshold(raw)
-        {
+        if let Err(e) = parse_threshold(value) {
             return Err(
                 ValidationError::new("Invalid PRSS-Mask schedule activation threshold")
                     .with_message(format!("{name}: {e}").into()),

--- a/core/service/src/conf/threshold.rs
+++ b/core/service/src/conf/threshold.rs
@@ -317,3 +317,53 @@ MEUCIEfh23uIR76K+tv+s5pi0uksEeleDonWm+tqStxeRFR5AiEAs4mw/Yi6aoDg
     // `into_pem` will deserialize the string inside `tls_cert`
     let _ = tls_cert.into_pem_with_sanity_check(1, &peers).unwrap();
 }
+
+/// Issue#3089: `validate_threshold_party_conf` must reject malformed PRSS-Mask schedule activation thresholds at config
+/// load. Complements the `parse_threshold` unit tests in `prss_compat` by covering the config-validation wiring (both
+/// fields), including the empty-string case that a templating mishap could produce.
+#[test]
+fn rejects_malformed_legacy_prss_mask_threshold() {
+    // Minimal conf with no peers (skips the peer/threshold checks), so only the PRSS-Mask
+    // threshold validation runs.
+    let conf_with = |public: &str, user: &str| ThresholdPartyConf {
+        listen_address: "0.0.0.0".to_string(),
+        listen_port: 5000,
+        tls: None,
+        threshold: 1,
+        my_id: None,
+        dec_capacity: 1,
+        min_dec_cache: 1,
+        preproc_redis: None,
+        num_sessions_preproc: None,
+        peers: None,
+        core_to_core_net: None,
+        decryption_mode: DecryptionMode::NoiseFloodSmall,
+        legacy_prss_mask_before_public_decrypt_id: public.to_string(),
+        legacy_prss_mask_before_user_decrypt_id: user.to_string(),
+    };
+
+    // Well-formed values (default "0", decimal, and 0x-hex) pass.
+    assert!(validate_threshold_party_conf(&conf_with("0", "0")).is_ok());
+    assert!(validate_threshold_party_conf(&conf_with("1234", "0x1f")).is_ok());
+
+    // A malformed value in either field is rejected, and the error names the offending field.
+    let err = validate_threshold_party_conf(&conf_with("nonsense", "0"))
+        .expect_err("a malformed public threshold must be rejected");
+    assert!(
+        err.message
+            .as_ref()
+            .is_some_and(|m| m.contains("legacy_prss_mask_before_public_decrypt_id")),
+        "unexpected error: {err:?}"
+    );
+    let err = validate_threshold_party_conf(&conf_with("0", "0xzz"))
+        .expect_err("a malformed user threshold must be rejected");
+    assert!(
+        err.message
+            .as_ref()
+            .is_some_and(|m| m.contains("legacy_prss_mask_before_user_decrypt_id")),
+        "unexpected error: {err:?}"
+    );
+
+    // An empty string (e.g. from a templating mishap) fails loudly rather than defaulting to 0.
+    assert!(validate_threshold_party_conf(&conf_with("", "0")).is_err());
+}

--- a/core/service/src/conf/threshold.rs
+++ b/core/service/src/conf/threshold.rs
@@ -52,14 +52,23 @@ pub struct ThresholdPartyConf {
     /// big-endian integer, is strictly below the configured value run the legacy PRSS.
     /// Values are decimal or 0x-prefixed hex integers of up to 256 bits, given as
     /// strings. All MPC parties MUST configure identical values.
-    /// MANDATORY: must be provided explicitly, either in the config file or through the
-    /// config env layer (`KMS_CORE__THRESHOLD__LEGACY_PRSS_MASK_BEFORE_PUBLIC_DECRYPT_ID`);
-    /// config loading errors otherwise. Use "0" to always run the fixed schedule (no request
-    /// ID is strictly below 0). Public and user decryption request IDs come from separate
-    /// counters, hence one threshold each. Remove once the migration is complete.
+    /// OPTIONAL: defaults to "0" (always run the fixed schedule, since no request ID is
+    /// strictly below 0) when absent. This lets a config written by an older chart — or a
+    /// rolling upgrade that enables the threshold only *after* the new binary is running —
+    /// parse cleanly, which is required because pre-#663 binaries reject the field entirely
+    /// (`deny_unknown_fields`) and the config is read fresh at process start. Public and user
+    /// decryption request IDs come from separate counters, hence one threshold each. Remove
+    /// once the migration is complete.
+    #[serde(default = "default_legacy_prss_mask_threshold")]
     pub legacy_prss_mask_before_public_decrypt_id: String,
     /// See [`Self::legacy_prss_mask_before_public_decrypt_id`].
+    #[serde(default = "default_legacy_prss_mask_threshold")]
     pub legacy_prss_mask_before_user_decrypt_id: String,
+}
+
+/// Default PRSS-Mask activation threshold ("0" = always use the fixed post-#663 schedule).
+fn default_legacy_prss_mask_threshold() -> String {
+    "0".to_string()
 }
 
 fn validate_threshold_party_conf(conf: &ThresholdPartyConf) -> Result<(), ValidationError> {

--- a/core/service/src/conf/threshold.rs
+++ b/core/service/src/conf/threshold.rs
@@ -1,4 +1,4 @@
-use crate::engine::base::derive_request_id;
+use crate::engine::{base::derive_request_id, threshold::service::prss_compat::parse_threshold};
 use alloy_primitives::Address;
 use kms_grpc::RequestId;
 use serde::{Deserialize, Serialize};
@@ -46,6 +46,20 @@ pub struct ThresholdPartyConf {
     pub peers: Option<Vec<PeerConf>>,
     pub core_to_core_net: Option<CoreToCoreNetworkConfig>,
     pub decryption_mode: DecryptionMode,
+
+    /// Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask
+    /// counter-schedule fix (#663). Requests whose raw request ID, interpreted as a
+    /// big-endian integer, is strictly below the configured value run the legacy PRSS.
+    /// Values are decimal or 0x-prefixed hex integers of up to 256 bits, given as
+    /// strings. All MPC parties MUST configure identical values.
+    /// Absent means the fixed schedule is always used. Public and user decryption
+    /// request IDs come from separate counters, hence one threshold each.
+    /// Remove once the migration is complete.
+    #[serde(default)]
+    pub legacy_prss_mask_before_public_decrypt_id: Option<String>,
+    /// See [`Self::legacy_prss_mask_before_public_decrypt_id`].
+    #[serde(default)]
+    pub legacy_prss_mask_before_user_decrypt_id: Option<String>,
 }
 
 fn validate_threshold_party_conf(conf: &ThresholdPartyConf) -> Result<(), ValidationError> {
@@ -81,6 +95,27 @@ fn validate_threshold_party_conf(conf: &ThresholdPartyConf) -> Result<(), Valida
         }
     } else {
         tracing::info!("No peer list provided; skipping threshold and party ID validation");
+    }
+
+    // Issue#3089: fail at config load on malformed PRSS-Mask schedule activation thresholds.
+    for (name, value) in [
+        (
+            "legacy_prss_mask_before_public_decrypt_id",
+            &conf.legacy_prss_mask_before_public_decrypt_id,
+        ),
+        (
+            "legacy_prss_mask_before_user_decrypt_id",
+            &conf.legacy_prss_mask_before_user_decrypt_id,
+        ),
+    ] {
+        if let Some(raw) = value
+            && let Err(e) = parse_threshold(raw)
+        {
+            return Err(
+                ValidationError::new("Invalid PRSS-Mask schedule activation threshold")
+                    .with_message(format!("{name}: {e}").into()),
+            );
+        }
     }
     Ok(())
 }

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -480,6 +480,9 @@ where
     let threshold_config = config.threshold.as_ref().ok_or_else(|| {
         anyhow_error_and_log("Threshold party configuration is required for threshold KMS")
     })?;
+    // Issue#3089: initialize the PRSS-Mask schedule activation thresholds before any
+    // decryption request can be served (fails fast on malformed values).
+    super::prss_compat::init_from_conf(threshold_config)?;
     let rate_limiter_conf = config.rate_limiter_conf.to_owned().unwrap_or_default();
     let telemetry_conf = config
         .telemetry

--- a/core/service/src/engine/threshold/service/mod.rs
+++ b/core/service/src/engine/threshold/service/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod epoch_manager;
 //mod initiator;
 mod key_generator;
 mod preprocessor;
-mod prss_compat;
+pub mod prss_compat;
 mod public_decryptor;
 pub(crate) mod reshare_utils;
 pub mod session;

--- a/core/service/src/engine/threshold/service/mod.rs
+++ b/core/service/src/engine/threshold/service/mod.rs
@@ -6,6 +6,7 @@
 // - key_generator.rs: RealKeyGenerator implementation for key generation
 // - kms_impl.rs: Server initialization functions
 // - preprocessor.rs: RealPreprocessor implementation for preprocessing
+// - prss_compat.rs: Issue#3089 temporary request-ID gate for the PRSS-Mask schedule fix
 // - public_decryptor.rs: RealPublicDecryptor implementation for public decryption
 // - session.rs: SessionPreparer implementation for session management
 // - user_decryptor.rs: RealUserDecryptor implementation for user decryption
@@ -20,6 +21,7 @@ pub(crate) mod epoch_manager;
 //mod initiator;
 mod key_generator;
 mod preprocessor;
+mod prss_compat;
 mod public_decryptor;
 pub(crate) mod reshare_utils;
 pub mod session;

--- a/core/service/src/engine/threshold/service/prss_compat.rs
+++ b/core/service/src/engine/threshold/service/prss_compat.rs
@@ -105,16 +105,32 @@ pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> any
         ),
         DecryptKind::User => (&LEGACY_BEFORE_USER, LEGACY_PRSS_BEFORE_USER_DECRYPT_ID_ENV),
     };
+    // In production the env var is read and parsed once and cached. Test builds first check
+    // the scoped override (see [`test_override`]), which avoids mutating process environment
+    // variables at runtime — that is unsafe with concurrently running threads and could
+    // corrupt tests running in parallel.
+    #[cfg(test)]
+    let threshold = match test_prs_compat::get(kind) {
+        Some(overridden) => overridden,
+        None => cell
+            .get_or_init(|| read_env_threshold(var))
+            .clone()
+            .map_err(|e| anyhow::anyhow!("{e}"))?,
+    };
+    #[cfg(not(test))]
     let threshold = cell
         .get_or_init(|| read_env_threshold(var))
-        .as_ref()
+        .clone()
         .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     Ok(match threshold {
         None => false,
         Some(threshold) => {
-            let legacy = is_before(req_id, threshold);
+            let legacy = is_before(req_id, &threshold);
             if legacy {
+                #[cfg(test)]
+                test_prs_compat::LEGACY_PRSS_DECISIONS
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 tracing::info!(
                     "Using legacy (pre-#663) PRSS-Mask schedule for {kind:?} decryption request {req_id} (ID < {var}={threshold})"
                 );
@@ -122,6 +138,60 @@ pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> any
             legacy
         }
     })
+}
+
+/// Scoped, test-only override of the activation thresholds. This replaces mutating the
+/// process environment in tests: `std::env::set_var` is unsafe with concurrently running
+/// threads (the tokio servers spawned by integration tests read the env), and a leaked env
+/// var would corrupt other tests. The override only substitutes the *source* of the
+/// threshold; everything downstream (comparison, counting, wiring) is the production code
+/// path, and env parsing itself is covered by the unit tests below.
+#[cfg(test)]
+pub(crate) mod test_prs_compat {
+    use super::DecryptKind;
+    use alloy_primitives::U256;
+    use std::sync::RwLock;
+
+    /// Test-only counter of how many times the gate selected the legacy schedule, so integration
+    /// tests can assert that the switch actually happened (decryption outcomes are identical under
+    /// both schedules when all parties agree, so success alone cannot distinguish them).
+    pub(crate) static LEGACY_PRSS_DECISIONS: std::sync::atomic::AtomicU64 =
+        std::sync::atomic::AtomicU64::new(0);
+
+    static OVERRIDE_PUBLIC: RwLock<Option<Option<U256>>> = RwLock::new(None);
+    static OVERRIDE_USER: RwLock<Option<Option<U256>>> = RwLock::new(None);
+
+    fn cell(kind: DecryptKind) -> &'static RwLock<Option<Option<U256>>> {
+        match kind {
+            DecryptKind::Public => &OVERRIDE_PUBLIC,
+            DecryptKind::User => &OVERRIDE_USER,
+        }
+    }
+
+    pub(super) fn get(kind: DecryptKind) -> Option<Option<U256>> {
+        *cell(kind).read().unwrap()
+    }
+
+    /// RAII guard that overrides the legacy-schedule activation threshold for one stream for
+    /// the duration of a test and clears it on drop (including on panic/unwind).
+    /// `Some(threshold)` behaves as if the env var were set to that value, `None` as unset.
+    /// The override is process-global state: only use it in `#[serial]` tests.
+    pub(crate) struct LegacyThresholdGuard {
+        kind: DecryptKind,
+    }
+
+    impl LegacyThresholdGuard {
+        pub(crate) fn set(kind: DecryptKind, threshold: Option<U256>) -> Self {
+            *cell(kind).write().unwrap() = Some(threshold);
+            Self { kind }
+        }
+    }
+
+    impl Drop for LegacyThresholdGuard {
+        fn drop(&mut self) {
+            *cell(self.kind).write().unwrap() = None;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/core/service/src/engine/threshold/service/prss_compat.rs
+++ b/core/service/src/engine/threshold/service/prss_compat.rs
@@ -10,34 +10,32 @@
 //! raw request ID ("activation height" pattern): requests with an ID strictly below the
 //! configured threshold run the legacy schedule (interoperable with unpatched peers), requests
 //! at or above it run the fixed one. Public and user decryption request IDs come from separate
-//! (monotonically increasing) gateway counters, hence one threshold per stream:
+//! (monotonically increasing) gateway counters, hence one threshold per stream, configured in
+//! the `[threshold]` section of the server configuration:
 //!
-//! - [`LEGACY_PRSS_BEFORE_PUBLIC_DECRYPT_ID_ENV`]
-//! - [`LEGACY_PRSS_BEFORE_USER_DECRYPT_ID_ENV`]
+//! - `legacy_prss_mask_before_public_decrypt_id`
+//! - `legacy_prss_mask_before_user_decrypt_id`
+//!
+//! (see [`crate::conf::threshold::ThresholdPartyConf`]). Going through the configuration file
+//! rather than dedicated env vars means the values also reach Nitro-enclave deployments, where
+//! the pod environment does not propagate into the enclave but the TOML does (over vsock). On
+//! non-enclave deployments they can still be overridden through the configuration env layer
+//! (`KMS_CORE__THRESHOLD__LEGACY_PRSS_MASK_BEFORE_PUBLIC_DECRYPT_ID`, etc.).
 //!
 //! Values are decimal or 0x-prefixed hex integers (up to 256 bits), and are consensus
-//! constants: all parties MUST configure identical values. Unset means the fixed PRSS schedule is
-//! always used. A malformed value fails every gated request (loudly) rather than silently
-//! picking a schedule.
+//! constants: all parties MUST configure identical values. Unset means the fixed PRSS schedule
+//! is always used. Malformed values fail at config load / server startup, never silently.
 //!
 //! NOTE: the comparison must be done on the raw request ID interpreted as a big-endian
 //! integer. Derived session IDs are hashes of it and carry no order.
 //!
-//! This module, the env vars and the legacy code path are temporary and should be removed
+//! This module, the config fields and the legacy code path are temporary and should be removed
 //! once both gateway counters have passed their thresholds fleet-wide.
 
+use crate::conf::threshold::ThresholdPartyConf;
 use alloy_primitives::U256;
 use kms_grpc::RequestId;
 use std::sync::OnceLock;
-
-/// Public decryption requests with an ID strictly below this value run the legacy PRSS-Mask
-/// schedule.
-pub const LEGACY_PRSS_BEFORE_PUBLIC_DECRYPT_ID_ENV: &str =
-    "KMS_PRSS_LEGACY_MASK_BEFORE_PUBLIC_DECRYPT_ID";
-/// User decryption requests with an ID strictly below this value run the legacy PRSS-Mask
-/// schedule.
-pub const LEGACY_PRSS_BEFORE_USER_DECRYPT_ID_ENV: &str =
-    "KMS_PRSS_LEGACY_MASK_BEFORE_USER_DECRYPT_ID";
 
 /// The two request streams gated by this module. They use separate gateway counters, so each
 /// has its own activation threshold.
@@ -47,11 +45,11 @@ pub(crate) enum DecryptKind {
     User,
 }
 
-static LEGACY_BEFORE_PUBLIC: OnceLock<Result<Option<U256>, String>> = OnceLock::new();
-static LEGACY_BEFORE_USER: OnceLock<Result<Option<U256>, String>> = OnceLock::new();
+static LEGACY_BEFORE_PUBLIC: OnceLock<Option<U256>> = OnceLock::new();
+static LEGACY_BEFORE_USER: OnceLock<Option<U256>> = OnceLock::new();
 
 /// Parse a threshold value as decimal or 0x-prefixed hex.
-fn parse_threshold(raw: &str) -> Result<U256, String> {
+pub(crate) fn parse_threshold(raw: &str) -> Result<U256, String> {
     let raw = raw.trim();
     let digits = raw
         .strip_prefix("0x")
@@ -59,8 +57,8 @@ fn parse_threshold(raw: &str) -> Result<U256, String> {
         .map(|hex| (hex, 16))
         .unwrap_or((raw, 10));
     // U256::from_str_radix parses an empty string as 0; reject it explicitly instead, so that
-    // an env var set to an empty value (e.g. by a templating mishap) fails loudly rather than
-    // silently configuring a threshold of 0.
+    // a value emptied by a templating mishap fails loudly rather than silently configuring a
+    // threshold of 0.
     if digits.0.is_empty() {
         return Err(format!(
             "expected a decimal or 0x-prefixed hex integer, got empty value {raw:?}"
@@ -70,16 +68,64 @@ fn parse_threshold(raw: &str) -> Result<U256, String> {
         .map_err(|e| format!("expected a decimal or 0x-prefixed hex integer, got {raw:?}: {e}"))
 }
 
-fn read_env_threshold(var: &str) -> Result<Option<U256>, String> {
-    match std::env::var(var) {
-        Err(std::env::VarError::NotPresent) => Ok(None),
-        Err(e) => Err(format!("could not read {var}: {e}")),
-        Ok(raw) => {
-            let threshold = parse_threshold(&raw).map_err(|e| format!("invalid {var}: {e}"))?;
-            tracing::info!(
-                "{var} is set: requests with ID < {threshold} will use the legacy (pre-#663) PRSS-Mask schedule"
-            );
-            Ok(Some(threshold))
+/// Initialize the activation thresholds from the threshold party configuration. Must be called
+/// during threshold server startup, before any decryption request is served. Fails on
+/// malformed values (also caught earlier by config validation) and on re-initialization with
+/// conflicting values (which can only happen with multiple in-process servers, e.g. in tests —
+/// those must all agree since the values are consensus constants anyway).
+///
+/// If never called (e.g. centralized KMS), the fixed schedule is always used.
+pub(crate) fn init_from_conf(conf: &ThresholdPartyConf) -> anyhow::Result<()> {
+    let parse = |name: &str, raw: &Option<String>| -> anyhow::Result<Option<U256>> {
+        raw.as_ref()
+            .map(|raw| {
+                parse_threshold(raw).map_err(|e| anyhow::anyhow!("invalid [threshold].{name}: {e}"))
+            })
+            .transpose()
+    };
+    let public = parse(
+        "legacy_prss_mask_before_public_decrypt_id",
+        &conf.legacy_prss_mask_before_public_decrypt_id,
+    )?;
+    let user = parse(
+        "legacy_prss_mask_before_user_decrypt_id",
+        &conf.legacy_prss_mask_before_user_decrypt_id,
+    )?;
+
+    set_or_check(&LEGACY_BEFORE_PUBLIC, public, "public decryption")?;
+    set_or_check(&LEGACY_BEFORE_USER, user, "user decryption")?;
+
+    if public.is_some() || user.is_some() {
+        tracing::info!(
+            "PRSS-Mask legacy schedule activation thresholds configured: requests with ID strictly below public={public:?} / user={user:?} will use the legacy (pre-#663) schedule"
+        );
+    }
+    Ok(())
+}
+
+fn set_or_check(
+    cell: &OnceLock<Option<U256>>,
+    value: Option<U256>,
+    name: &str,
+) -> anyhow::Result<()> {
+    match cell.set(value) {
+        Ok(()) => Ok(()),
+        // Already initialized: tolerate idempotent re-initialization with the identical value.
+        // This happens whenever several threshold servers run in one process (the integration
+        // test harness boots all parties in-process, so each party's startup calls
+        // init_from_conf against the same process-global cell). Only a *different* value is a
+        // real conflict — the thresholds are consensus constants.
+        Err(rejected) => {
+            let existing = cell
+                .get()
+                .expect("OnceLock::set failed, so it must be initialized");
+            if *existing == rejected {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!(
+                    "conflicting re-initialization of the {name} PRSS-Mask schedule threshold: already set to {existing:?}, refusing {rejected:?}"
+                ))
+            }
         }
     }
 }
@@ -94,36 +140,25 @@ fn is_before(req_id: &RequestId, threshold: &U256) -> bool {
 }
 
 /// Returns true iff the given request must use the legacy (pre-#663) overlapping PRSS-Mask
-/// counter schedule, i.e. iff the env var for `kind` is set and the raw request ID is strictly
-/// below it. Errors if the env var is set but malformed, failing the request rather than
-/// silently choosing a schedule.
-pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> anyhow::Result<bool> {
-    let (cell, var) = match kind {
-        DecryptKind::Public => (
-            &LEGACY_BEFORE_PUBLIC,
-            LEGACY_PRSS_BEFORE_PUBLIC_DECRYPT_ID_ENV,
-        ),
-        DecryptKind::User => (&LEGACY_BEFORE_USER, LEGACY_PRSS_BEFORE_USER_DECRYPT_ID_ENV),
+/// counter schedule, i.e. iff an activation threshold is configured for `kind` and the raw
+/// request ID is strictly below it.
+pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> bool {
+    let cell = match kind {
+        DecryptKind::Public => &LEGACY_BEFORE_PUBLIC,
+        DecryptKind::User => &LEGACY_BEFORE_USER,
     };
-    // In production the env var is read and parsed once and cached. Test builds first check
-    // the scoped override (see [`test_override`]), which avoids mutating process environment
-    // variables at runtime — that is unsafe with concurrently running threads and could
-    // corrupt tests running in parallel.
+    // Test builds first check the scoped override (see [`test_prs_compat`]), so integration
+    // tests can vary the threshold at runtime without touching the global configuration.
     #[cfg(test)]
     let threshold = match test_prs_compat::get(kind) {
         Some(overridden) => overridden,
-        None => cell
-            .get_or_init(|| read_env_threshold(var))
-            .clone()
-            .map_err(|e| anyhow::anyhow!("{e}"))?,
+        None => cell.get().copied().flatten(),
     };
+    // Uninitialized (centralized KMS) or configured-absent both mean: fixed schedule.
     #[cfg(not(test))]
-    let threshold = cell
-        .get_or_init(|| read_env_threshold(var))
-        .clone()
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let threshold = cell.get().copied().flatten();
 
-    Ok(match threshold {
+    match threshold {
         None => false,
         Some(threshold) => {
             let legacy = is_before(req_id, &threshold);
@@ -132,20 +167,19 @@ pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> any
                 test_prs_compat::LEGACY_PRSS_DECISIONS
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 tracing::info!(
-                    "Using legacy (pre-#663) PRSS-Mask schedule for {kind:?} decryption request {req_id} (ID < {var}={threshold})"
+                    "Using legacy (pre-#663) PRSS-Mask schedule for {kind:?} decryption request {req_id} (ID < {threshold})"
                 );
             }
             legacy
         }
-    })
+    }
 }
 
-/// Scoped, test-only override of the activation thresholds. This replaces mutating the
-/// process environment in tests: `std::env::set_var` is unsafe with concurrently running
-/// threads (the tokio servers spawned by integration tests read the env), and a leaked env
-/// var would corrupt other tests. The override only substitutes the *source* of the
-/// threshold; everything downstream (comparison, counting, wiring) is the production code
-/// path, and env parsing itself is covered by the unit tests below.
+/// Scoped, test-only override of the activation thresholds. This substitutes only the *source*
+/// of the threshold; everything downstream (comparison, counting, wiring) is the production
+/// code path, and config parsing itself is covered by the unit tests below. The override takes
+/// precedence over values set by [`init_from_conf`] (in-process test servers initialize with
+/// absent thresholds).
 #[cfg(test)]
 pub(crate) mod test_prs_compat {
     use super::DecryptKind;
@@ -174,8 +208,8 @@ pub(crate) mod test_prs_compat {
 
     /// RAII guard that overrides the legacy-schedule activation threshold for one stream for
     /// the duration of a test and clears it on drop (including on panic/unwind).
-    /// `Some(threshold)` behaves as if the env var were set to that value, `None` as unset.
-    /// The override is process-global state: only use it in `#[serial]` tests.
+    /// `Some(threshold)` behaves as if the config field were set to that value, `None` as
+    /// absent. The override is process-global state: only use it in `#[serial]` tests.
     pub(crate) struct LegacyThresholdGuard {
         kind: DecryptKind,
     }

--- a/core/service/src/engine/threshold/service/prss_compat.rs
+++ b/core/service/src/engine/threshold/service/prss_compat.rs
@@ -23,8 +23,9 @@
 //! (`KMS_CORE__THRESHOLD__LEGACY_PRSS_MASK_BEFORE_PUBLIC_DECRYPT_ID`, etc.).
 //!
 //! Values are decimal or 0x-prefixed hex integers (up to 256 bits), and are consensus
-//! constants: all parties MUST configure identical values. Unset means the fixed PRSS schedule
-//! is always used. Malformed values fail at config load / server startup, never silently.
+//! constants: all parties MUST configure identical values. The default of "0" means the fixed
+//! PRSS schedule is always used (no request ID is strictly below 0). Malformed values fail at
+//! config load / server startup, never silently.
 //!
 //! NOTE: the comparison must be done on the raw request ID interpreted as a big-endian
 //! integer. Derived session IDs are hashes of it and carry no order.
@@ -45,8 +46,8 @@ pub(crate) enum DecryptKind {
     User,
 }
 
-static LEGACY_BEFORE_PUBLIC: OnceLock<Option<U256>> = OnceLock::new();
-static LEGACY_BEFORE_USER: OnceLock<Option<U256>> = OnceLock::new();
+static LEGACY_BEFORE_PUBLIC: OnceLock<U256> = OnceLock::new();
+static LEGACY_BEFORE_USER: OnceLock<U256> = OnceLock::new();
 
 /// Parse a threshold value as decimal or 0x-prefixed hex.
 pub(crate) fn parse_threshold(raw: &str) -> Result<U256, String> {
@@ -74,14 +75,11 @@ pub(crate) fn parse_threshold(raw: &str) -> Result<U256, String> {
 /// conflicting values (which can only happen with multiple in-process servers, e.g. in tests —
 /// those must all agree since the values are consensus constants anyway).
 ///
-/// If never called (e.g. centralized KMS), the fixed schedule is always used.
+/// If never called (e.g. centralized KMS), or left at the config default of 0, the fixed
+/// schedule is always used.
 pub(crate) fn init_from_conf(conf: &ThresholdPartyConf) -> anyhow::Result<()> {
-    let parse = |name: &str, raw: &Option<String>| -> anyhow::Result<Option<U256>> {
-        raw.as_ref()
-            .map(|raw| {
-                parse_threshold(raw).map_err(|e| anyhow::anyhow!("invalid [threshold].{name}: {e}"))
-            })
-            .transpose()
+    let parse = |name: &str, raw: &str| -> anyhow::Result<U256> {
+        parse_threshold(raw).map_err(|e| anyhow::anyhow!("invalid [threshold].{name}: {e}"))
     };
     let public = parse(
         "legacy_prss_mask_before_public_decrypt_id",
@@ -95,19 +93,15 @@ pub(crate) fn init_from_conf(conf: &ThresholdPartyConf) -> anyhow::Result<()> {
     set_or_check(&LEGACY_BEFORE_PUBLIC, public, "public decryption")?;
     set_or_check(&LEGACY_BEFORE_USER, user, "user decryption")?;
 
-    if public.is_some() || user.is_some() {
+    if public != U256::ZERO || user != U256::ZERO {
         tracing::info!(
-            "PRSS-Mask legacy schedule activation thresholds configured: requests with ID strictly below public={public:?} / user={user:?} will use the legacy (pre-#663) schedule"
+            "PRSS-Mask legacy schedule activation thresholds configured: requests with ID strictly below public={public} / user={user} will use the legacy (pre-#663) schedule"
         );
     }
     Ok(())
 }
 
-fn set_or_check(
-    cell: &OnceLock<Option<U256>>,
-    value: Option<U256>,
-    name: &str,
-) -> anyhow::Result<()> {
+fn set_or_check(cell: &OnceLock<U256>, value: U256, name: &str) -> anyhow::Result<()> {
     match cell.set(value) {
         Ok(()) => Ok(()),
         // Already initialized: tolerate idempotent re-initialization with the identical value.
@@ -123,7 +117,7 @@ fn set_or_check(
                 Ok(())
             } else {
                 Err(anyhow::anyhow!(
-                    "conflicting re-initialization of the {name} PRSS-Mask schedule threshold: already set to {existing:?}, refusing {rejected:?}"
+                    "conflicting re-initialization of the {name} PRSS-Mask schedule threshold: already set to {existing}, refusing {rejected}"
                 ))
             }
         }
@@ -150,13 +144,11 @@ pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> boo
     // Test builds first check the scoped override (see [`test_prs_compat`]), so integration
     // tests can vary the threshold at runtime without touching the global configuration.
     #[cfg(test)]
-    let threshold = match test_prs_compat::get(kind) {
-        Some(overridden) => overridden,
-        None => cell.get().copied().flatten(),
-    };
-    // Uninitialized (centralized KMS) or configured-absent both mean: fixed schedule.
+    let threshold = test_prs_compat::get(kind).or_else(|| cell.get().copied());
+    // Uninitialized (centralized KMS) means: fixed schedule (as does the config default of 0,
+    // handled naturally by the strictly-below comparison).
     #[cfg(not(test))]
-    let threshold = cell.get().copied().flatten();
+    let threshold = cell.get().copied();
 
     match threshold {
         None => false,
@@ -179,7 +171,7 @@ pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> boo
 /// of the threshold; everything downstream (comparison, counting, wiring) is the production
 /// code path, and config parsing itself is covered by the unit tests below. The override takes
 /// precedence over values set by [`init_from_conf`] (in-process test servers initialize with
-/// absent thresholds).
+/// the default threshold of 0).
 #[cfg(test)]
 pub(crate) mod test_prs_compat {
     use super::DecryptKind;
@@ -192,30 +184,31 @@ pub(crate) mod test_prs_compat {
     pub(crate) static LEGACY_PRSS_DECISIONS: std::sync::atomic::AtomicU64 =
         std::sync::atomic::AtomicU64::new(0);
 
-    static OVERRIDE_PUBLIC: RwLock<Option<Option<U256>>> = RwLock::new(None);
-    static OVERRIDE_USER: RwLock<Option<Option<U256>>> = RwLock::new(None);
+    static OVERRIDE_PUBLIC: RwLock<Option<U256>> = RwLock::new(None);
+    static OVERRIDE_USER: RwLock<Option<U256>> = RwLock::new(None);
 
-    fn cell(kind: DecryptKind) -> &'static RwLock<Option<Option<U256>>> {
+    fn cell(kind: DecryptKind) -> &'static RwLock<Option<U256>> {
         match kind {
             DecryptKind::Public => &OVERRIDE_PUBLIC,
             DecryptKind::User => &OVERRIDE_USER,
         }
     }
 
-    pub(super) fn get(kind: DecryptKind) -> Option<Option<U256>> {
+    pub(super) fn get(kind: DecryptKind) -> Option<U256> {
         *cell(kind).read().unwrap()
     }
 
     /// RAII guard that overrides the legacy-schedule activation threshold for one stream for
-    /// the duration of a test and clears it on drop (including on panic/unwind).
-    /// `Some(threshold)` behaves as if the config field were set to that value, `None` as
-    /// absent. The override is process-global state: only use it in `#[serial]` tests.
+    /// the duration of a test and clears it on drop (including on panic/unwind). Behaves as if
+    /// the config field were set to that value; a threshold of 0 behaves like the config
+    /// default (fixed schedule always). The override is process-global state: only use it in
+    /// `#[serial]` tests.
     pub(crate) struct LegacyThresholdGuard {
         kind: DecryptKind,
     }
 
     impl LegacyThresholdGuard {
-        pub(crate) fn set(kind: DecryptKind, threshold: Option<U256>) -> Self {
+        pub(crate) fn set(kind: DecryptKind, threshold: U256) -> Self {
             *cell(kind).write().unwrap() = Some(threshold);
             Self { kind }
         }

--- a/core/service/src/engine/threshold/service/prss_compat.rs
+++ b/core/service/src/engine/threshold/service/prss_compat.rs
@@ -1,0 +1,162 @@
+//! Issue#3089: temporary request-ID gate for the PRSS-Mask counter-schedule fix (#663).
+//!
+//! PR #663 changed the counter schedule of the batched PRSS-Mask (`mask_next_vec`) to use
+//! disjoint counter pairs. The schedule is consensus-critical: if some MPC parties run the
+//! pre-fix schedule and others the fixed one, their mask shares diverge on every block after
+//! the first of a batch, and decryption of multi-block ciphertexts degrades (version minority
+//! <= t: silently error-corrected, consuming the whole fault budget) or fails (minority > t).
+//!
+//! To allow parties to upgrade asynchronously, the schedule is selected per request from the
+//! raw request ID ("activation height" pattern): requests with an ID strictly below the
+//! configured threshold run the legacy schedule (interoperable with unpatched peers), requests
+//! at or above it run the fixed one. Public and user decryption request IDs come from separate
+//! (monotonically increasing) gateway counters, hence one threshold per stream:
+//!
+//! - [`LEGACY_PRSS_BEFORE_PUBLIC_DECRYPT_ID_ENV`]
+//! - [`LEGACY_PRSS_BEFORE_USER_DECRYPT_ID_ENV`]
+//!
+//! Values are decimal or 0x-prefixed hex integers (up to 256 bits), and are consensus
+//! constants: all parties MUST configure identical values. Unset means the fixed PRSS schedule is
+//! always used. A malformed value fails every gated request (loudly) rather than silently
+//! picking a schedule.
+//!
+//! NOTE: the comparison must be done on the raw request ID interpreted as a big-endian
+//! integer. Derived session IDs are hashes of it and carry no order.
+//!
+//! This module, the env vars and the legacy code path are temporary and should be removed
+//! once both gateway counters have passed their thresholds fleet-wide.
+
+use alloy_primitives::U256;
+use kms_grpc::RequestId;
+use std::sync::OnceLock;
+
+/// Public decryption requests with an ID strictly below this value run the legacy PRSS-Mask
+/// schedule.
+pub const LEGACY_PRSS_BEFORE_PUBLIC_DECRYPT_ID_ENV: &str =
+    "KMS_PRSS_LEGACY_MASK_BEFORE_PUBLIC_DECRYPT_ID";
+/// User decryption requests with an ID strictly below this value run the legacy PRSS-Mask
+/// schedule.
+pub const LEGACY_PRSS_BEFORE_USER_DECRYPT_ID_ENV: &str =
+    "KMS_PRSS_LEGACY_MASK_BEFORE_USER_DECRYPT_ID";
+
+/// The two request streams gated by this module. They use separate gateway counters, so each
+/// has its own activation threshold.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum DecryptKind {
+    Public,
+    User,
+}
+
+static LEGACY_BEFORE_PUBLIC: OnceLock<Result<Option<U256>, String>> = OnceLock::new();
+static LEGACY_BEFORE_USER: OnceLock<Result<Option<U256>, String>> = OnceLock::new();
+
+/// Parse a threshold value as decimal or 0x-prefixed hex.
+fn parse_threshold(raw: &str) -> Result<U256, String> {
+    let raw = raw.trim();
+    let digits = raw
+        .strip_prefix("0x")
+        .or_else(|| raw.strip_prefix("0X"))
+        .map(|hex| (hex, 16))
+        .unwrap_or((raw, 10));
+    // U256::from_str_radix parses an empty string as 0; reject it explicitly instead, so that
+    // an env var set to an empty value (e.g. by a templating mishap) fails loudly rather than
+    // silently configuring a threshold of 0.
+    if digits.0.is_empty() {
+        return Err(format!(
+            "expected a decimal or 0x-prefixed hex integer, got empty value {raw:?}"
+        ));
+    }
+    U256::from_str_radix(digits.0, digits.1)
+        .map_err(|e| format!("expected a decimal or 0x-prefixed hex integer, got {raw:?}: {e}"))
+}
+
+fn read_env_threshold(var: &str) -> Result<Option<U256>, String> {
+    match std::env::var(var) {
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(e) => Err(format!("could not read {var}: {e}")),
+        Ok(raw) => {
+            let threshold = parse_threshold(&raw).map_err(|e| format!("invalid {var}: {e}"))?;
+            tracing::info!(
+                "{var} is set: requests with ID < {threshold} will use the legacy (pre-#663) PRSS-Mask schedule"
+            );
+            Ok(Some(threshold))
+        }
+    }
+}
+
+/// Pure comparison helper: true iff `req_id`, interpreted as a big-endian integer, is strictly
+/// below `threshold`.
+fn is_before(req_id: &RequestId, threshold: &U256) -> bool {
+    // A RequestId is exactly 32 bytes, so the conversion cannot fail.
+    U256::try_from_be_slice(req_id.as_bytes())
+        .map(|id| id < *threshold)
+        .unwrap_or(false)
+}
+
+/// Returns true iff the given request must use the legacy (pre-#663) overlapping PRSS-Mask
+/// counter schedule, i.e. iff the env var for `kind` is set and the raw request ID is strictly
+/// below it. Errors if the env var is set but malformed, failing the request rather than
+/// silently choosing a schedule.
+pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> anyhow::Result<bool> {
+    let (cell, var) = match kind {
+        DecryptKind::Public => (
+            &LEGACY_BEFORE_PUBLIC,
+            LEGACY_PRSS_BEFORE_PUBLIC_DECRYPT_ID_ENV,
+        ),
+        DecryptKind::User => (&LEGACY_BEFORE_USER, LEGACY_PRSS_BEFORE_USER_DECRYPT_ID_ENV),
+    };
+    let threshold = cell
+        .get_or_init(|| read_env_threshold(var))
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    Ok(match threshold {
+        None => false,
+        Some(threshold) => {
+            let legacy = is_before(req_id, threshold);
+            if legacy {
+                tracing::info!(
+                    "Using legacy (pre-#663) PRSS-Mask schedule for {kind:?} decryption request {req_id} (ID < {var}={threshold})"
+                );
+            }
+            legacy
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn parse_decimal_and_hex_thresholds() {
+        assert_eq!(parse_threshold("1234"), Ok(U256::from(1234u64)));
+        assert_eq!(parse_threshold(" 1234 "), Ok(U256::from(1234u64)));
+        assert_eq!(parse_threshold("0x10"), Ok(U256::from(16u64)));
+        assert_eq!(parse_threshold("0X10"), Ok(U256::from(16u64)));
+        assert!(parse_threshold("").is_err());
+        assert!(parse_threshold("   ").is_err());
+        assert!(parse_threshold("0x").is_err());
+        assert!(parse_threshold("nonsense").is_err());
+        assert!(parse_threshold("0xzz").is_err());
+        assert!(parse_threshold("-3").is_err());
+    }
+
+    #[test]
+    fn boundary_is_strictly_below() {
+        // Request IDs are 32-byte big-endian values; build them from the numeric threshold.
+        let threshold = U256::from(1000u64);
+        let req_id_from =
+            |v: u64| RequestId::from_str(&hex::encode(U256::from(v).to_be_bytes::<32>())).unwrap();
+
+        assert!(is_before(&req_id_from(0), &threshold));
+        assert!(is_before(&req_id_from(999), &threshold));
+        // ID == threshold must already use the fixed schedule.
+        assert!(!is_before(&req_id_from(1000), &threshold));
+        assert!(!is_before(&req_id_from(1001), &threshold));
+        // Random/hash-style (huge) IDs always get the fixed schedule.
+        let huge = RequestId::from_str(&"ff".repeat(32)).unwrap();
+        assert!(!is_before(&huge, &threshold));
+    }
+}

--- a/core/service/src/engine/threshold/service/prss_compat.rs
+++ b/core/service/src/engine/threshold/service/prss_compat.rs
@@ -146,10 +146,10 @@ pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> boo
         DecryptKind::Public => &LEGACY_BEFORE_PUBLIC,
         DecryptKind::User => &LEGACY_BEFORE_USER,
     };
-    // Test builds first check the scoped override (see [`test_prs_compat`]), so integration
+    // Test builds first check the scoped override (see [`test_prss_compat`]), so integration
     // tests can vary the threshold at runtime without touching the global configuration.
     #[cfg(test)]
-    let threshold = test_prs_compat::get(kind).or_else(|| cell.get().copied());
+    let threshold = test_prss_compat::get(kind).or_else(|| cell.get().copied());
     // Uninitialized (centralized KMS) means: fixed schedule (as does the config default of 0,
     // handled naturally by the strictly-below comparison).
     #[cfg(not(test))]
@@ -161,7 +161,7 @@ pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> boo
             let legacy = is_before(req_id, &threshold);
             if legacy {
                 #[cfg(test)]
-                test_prs_compat::LEGACY_PRSS_DECISIONS
+                test_prss_compat::LEGACY_PRSS_DECISIONS
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 tracing::info!(
                     "Using legacy (pre-#663) PRSS-Mask schedule for {kind:?} decryption request {req_id} (ID < {threshold})"
@@ -178,7 +178,7 @@ pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> boo
 /// precedence over values set by [`init_from_conf`] (in-process test servers initialize with
 /// the default threshold of 0).
 #[cfg(test)]
-pub(crate) mod test_prs_compat {
+pub(crate) mod test_prss_compat {
     use super::DecryptKind;
     use alloy_primitives::U256;
     use std::sync::RwLock;

--- a/core/service/src/engine/threshold/service/prss_compat.rs
+++ b/core/service/src/engine/threshold/service/prss_compat.rs
@@ -260,5 +260,35 @@ mod tests {
         // Random/hash-style (huge) IDs always get the fixed schedule.
         let huge = RequestId::from_str(&"ff".repeat(32)).unwrap();
         assert!(!is_before(&huge, &threshold));
+
+        // A threshold of 0 (the config default) means the fixed schedule always: no request
+        // ID is strictly below 0, including the all-zero ID.
+        let zero = U256::ZERO;
+        assert!(!is_before(&req_id_from(0), &zero));
+        assert!(!is_before(&req_id_from(1), &zero));
+        assert!(!is_before(&huge, &zero));
+    }
+
+    #[test]
+    fn set_or_check_idempotent_and_conflict() {
+        // A fresh cell accepts its first value.
+        let cell = OnceLock::new();
+        assert!(set_or_check(&cell, U256::from(5u64), "public decryption").is_ok());
+        assert_eq!(cell.get(), Some(&U256::from(5u64)));
+
+        // Re-initializing with the identical value is tolerated (in-process test servers each
+        // call init_from_conf against the same process-global cell).
+        assert!(set_or_check(&cell, U256::from(5u64), "public decryption").is_ok());
+        assert_eq!(cell.get(), Some(&U256::from(5u64)));
+
+        // Re-initializing with a different value is a real conflict (consensus constant) and
+        // must be rejected, leaving the original value untouched.
+        let err = set_or_check(&cell, U256::from(6u64), "public decryption")
+            .expect_err("a conflicting re-initialization must be rejected");
+        assert!(
+            err.to_string().contains("conflicting"),
+            "unexpected error message: {err}"
+        );
+        assert_eq!(cell.get(), Some(&U256::from(5u64)));
     }
 }

--- a/core/service/src/engine/threshold/service/prss_compat.rs
+++ b/core/service/src/engine/threshold/service/prss_compat.rs
@@ -136,6 +136,11 @@ fn is_before(req_id: &RequestId, threshold: &U256) -> bool {
 /// Returns true iff the given request must use the legacy (pre-#663) overlapping PRSS-Mask
 /// counter schedule, i.e. iff an activation threshold is configured for `kind` and the raw
 /// request ID is strictly below it.
+///
+/// This gate applies to *decryption* only. Other PRSS consumers — notably key generation and
+/// resharing — are NOT gated and always run the fixed schedule, so they are only safe once the
+/// whole fleet runs the fixed schedule. Consequently key generation must not be attempted while
+/// the cluster is mixed-version; wait until every party is upgraded (QA/runbook note).
 pub(crate) fn use_legacy_prss_mask(req_id: &RequestId, kind: DecryptKind) -> bool {
     let cell = match kind {
         DecryptKind::Public => &LEGACY_BEFORE_PUBLIC,

--- a/core/service/src/engine/threshold/service/public_decryptor.rs
+++ b/core/service/src/engine/threshold/service/public_decryptor.rs
@@ -51,7 +51,10 @@ use crate::{
             deserialize_to_low_level,
         },
         threshold::{
-            service::session::{ImmutableSessionMaker, validate_context_and_epoch},
+            service::{
+                prss_compat::{DecryptKind, use_legacy_prss_mask},
+                session::{ImmutableSessionMaker, validate_context_and_epoch},
+            },
             traits::PublicDecryptor,
         },
         traits::BaseKms,
@@ -169,6 +172,7 @@ impl<
             ThresholdFheKeys,
         >,
         dec_mode: DecryptionMode,
+        use_legacy_prss: bool,
     ) -> anyhow::Result<T>
     where
         T: tfhe::integer::block_decomposition::Recomposable
@@ -190,7 +194,7 @@ impl<
 
         let dec = match dec_mode {
             DecryptionMode::NoiseFloodSmall => {
-                let session = session_maker
+                let mut session = session_maker
                     .make_small_async_session_z128(session_id, context_id, epoch_id)
                     .await
                     .map_err(|e| {
@@ -198,6 +202,9 @@ impl<
                             "Could not prepare ddec data for noiseflood decryption: {e}",
                         )
                     })?;
+                // Issue#3089: masks for this session must follow the schedule agreed for
+                // this request ID, identically across all parties.
+                session.prss_state.set_run_legacy_prss(use_legacy_prss);
                 let mut noiseflood_session = SmallOfflineNoiseFloodSession::new(session);
 
                 Dec::decrypt(
@@ -341,6 +348,19 @@ impl<
         // collect decryption results in async mgmt task so we can return from this call without waiting for the decryption(s) to finish
         let mut dec_tasks = Vec::new();
 
+        // Issue#3089: decide once per request whether the legacy (pre-#663) PRSS-Mask
+        // schedule must be used, based on the raw request ID (session IDs are hashes of it
+        // and carry no order).
+        let use_legacy_prss =
+            use_legacy_prss_mask(&req_id, DecryptKind::Public).map_err(|e| {
+                MetricedError::new(
+                    OP_PUBLIC_DECRYPT_REQUEST,
+                    Some(req_id),
+                    e,
+                    tonic::Code::FailedPrecondition,
+                )
+            })?;
+
         // iterate over ciphertexts in this batch and decrypt each in their own session (so that it happens in parallel)
         for (ctr, typed_ciphertext) in ciphertexts.into_iter().enumerate() {
             let inner_timer = metrics::METRICS
@@ -406,6 +426,7 @@ impl<
                         ct_format,
                         fhe_keys_rlock,
                         dec_mode,
+                        use_legacy_prss,
                     )
                     .await
                     .map(TypedPlaintext::from_u2048),
@@ -421,6 +442,7 @@ impl<
                         ct_format,
                         fhe_keys_rlock,
                         dec_mode,
+                        use_legacy_prss,
                     )
                     .await
                     .map(TypedPlaintext::from_u1024),
@@ -436,6 +458,7 @@ impl<
                         ct_format,
                         fhe_keys_rlock,
                         dec_mode,
+                        use_legacy_prss,
                     )
                     .await
                     .map(TypedPlaintext::from_u512),
@@ -451,6 +474,7 @@ impl<
                         ct_format,
                         fhe_keys_rlock,
                         dec_mode,
+                        use_legacy_prss,
                     )
                     .await
                     .map(TypedPlaintext::from_u256),
@@ -466,6 +490,7 @@ impl<
                         ct_format,
                         fhe_keys_rlock,
                         dec_mode,
+                        use_legacy_prss,
                     )
                     .await
                     .map(TypedPlaintext::from_u160),
@@ -480,6 +505,7 @@ impl<
                             ct_format,
                             fhe_keys_rlock,
                             dec_mode,
+                            use_legacy_prss,
                         )
                         .await
                         .map(|x| TypedPlaintext::new(x, fhe_type))
@@ -495,6 +521,7 @@ impl<
                             ct_format,
                             fhe_keys_rlock,
                             dec_mode,
+                            use_legacy_prss,
                         )
                         .await
                         .map(TypedPlaintext::from_u80)
@@ -515,6 +542,7 @@ impl<
                             ct_format,
                             fhe_keys_rlock,
                             dec_mode,
+                            use_legacy_prss,
                         )
                         .await
                         .map(|x| TypedPlaintext::new(x as u128, fhe_type))

--- a/core/service/src/engine/threshold/service/public_decryptor.rs
+++ b/core/service/src/engine/threshold/service/public_decryptor.rs
@@ -351,15 +351,7 @@ impl<
         // Issue#3089: decide once per request whether the legacy (pre-#663) PRSS-Mask
         // schedule must be used, based on the raw request ID (session IDs are hashes of it
         // and carry no order).
-        let use_legacy_prss =
-            use_legacy_prss_mask(&req_id, DecryptKind::Public).map_err(|e| {
-                MetricedError::new(
-                    OP_PUBLIC_DECRYPT_REQUEST,
-                    Some(req_id),
-                    e,
-                    tonic::Code::FailedPrecondition,
-                )
-            })?;
+        let use_legacy_prss = use_legacy_prss_mask(&req_id, DecryptKind::Public);
 
         // iterate over ciphertexts in this batch and decrypt each in their own session (so that it happens in parallel)
         for (ctr, typed_ciphertext) in ciphertexts.into_iter().enumerate() {

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -60,7 +60,10 @@ use crate::{
     engine::{
         base::{BaseKmsStruct, UserDecryptCallValues, deserialize_to_low_level},
         threshold::{
-            service::session::{ImmutableSessionMaker, validate_context_and_epoch},
+            service::{
+                prss_compat::{DecryptKind, use_legacy_prss_mask},
+                session::{ImmutableSessionMaker, validate_context_and_epoch},
+            },
             traits::UserDecryptor,
         },
         traits::BaseKms,
@@ -198,6 +201,11 @@ impl<
     ) -> anyhow::Result<(UserDecryptionResponsePayload, Vec<u8>, Vec<u8>)> {
         let keys = fhe_keys;
 
+        // Issue#3089: decide once per request whether the legacy (pre-#663) PRSS-Mask
+        // schedule must be used, based on the raw request ID (session IDs are hashes of it
+        // and carry no order).
+        let use_legacy_prss = use_legacy_prss_mask(req_id, DecryptKind::User)?;
+
         let mut all_signcrypted_cts = vec![];
 
         let rng = Arc::new(Mutex::new(rng));
@@ -237,7 +245,7 @@ impl<
 
             let pdec: Result<(Vec<u8>, u32, std::time::Duration), anyhow::Error> = match dec_mode {
                 DecryptionMode::NoiseFloodSmall => {
-                    let session = session_maker
+                    let mut session = session_maker
                         .make_small_async_session_z128(session_id, context_id, epoch_id)
                         .await
                         .map_err(|e| {
@@ -245,6 +253,9 @@ impl<
                                 "Could not prepare ddec data for noiseflood decryption: {e}",
                             )
                         })?;
+                    // Issue#3089: masks for this session must follow the schedule agreed for
+                    // this request ID, identically across all parties.
+                    session.prss_state.set_run_legacy_prss(use_legacy_prss);
                     let mut noiseflood_session = Dec::Prep::new(session);
 
                     let pdec = Dec::partial_decrypt(

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -204,7 +204,7 @@ impl<
         // Issue#3089: decide once per request whether the legacy (pre-#663) PRSS-Mask
         // schedule must be used, based on the raw request ID (session IDs are hashes of it
         // and carry no order).
-        let use_legacy_prss = use_legacy_prss_mask(req_id, DecryptKind::User)?;
+        let use_legacy_prss = use_legacy_prss_mask(req_id, DecryptKind::User);
 
         let mut all_signcrypted_cts = vec![];
 

--- a/core/threshold-execution/src/malicious_execution/small_execution/malicious_prss.rs
+++ b/core/threshold-execution/src/malicious_execution/small_execution/malicious_prss.rs
@@ -212,6 +212,7 @@ impl<
             prss_setup: honest_state.prss_setup,
             prfs: honest_state.prfs,
             broadcast: self.broadcast.clone(),
+            run_legacy_prss: honest_state.run_legacy_prss,
         };
 
         Self {
@@ -375,6 +376,7 @@ impl<
             prss_setup: honest_state.prss_setup,
             prfs: honest_state.prfs,
             broadcast: self.broadcast.clone(),
+            run_legacy_prss: honest_state.run_legacy_prss,
         };
 
         // Deterministically derive seed from sid by xoring the MSB to the LSB

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -1648,7 +1648,9 @@ mod tests {
                 .enumerate()
                 .map(|(i, r)| Share::new(*r, per_party[i][block]))
                 .collect::<Vec<_>>();
-            ShamirSharings::create(shares).reconstruct(threshold).unwrap()
+            ShamirSharings::create(shares)
+                .reconstruct(threshold)
+                .unwrap()
         };
 
         // Block 0 is identical under both schedules (same counter pair mask_ctr, mask_ctr+1).
@@ -1695,7 +1697,9 @@ mod tests {
                 .enumerate()
                 .map(|(i, r)| Share::new(*r, fixed[i][block]))
                 .collect::<Vec<_>>();
-            ShamirSharings::create(shares).reconstruct(threshold).unwrap()
+            ShamirSharings::create(shares)
+                .reconstruct(threshold)
+                .unwrap()
         };
 
         // Reconstruct `block` with the first `num_legacy` parties on the legacy schedule and the

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -542,6 +542,21 @@ pub struct PRSSState<Z: Default + Clone + Serialize, B: Broadcast> {
     /// the initialized PRFs for each set
     pub(crate) prfs: Arc<Vec<PrfAes>>,
     pub(crate) broadcast: B,
+    /// Issue#3089: Temporary flag to run PRSS pre-fix during a transition period.
+    pub(crate) run_legacy_prss: bool,
+}
+
+impl<Z: Default + Clone + Serialize, B: Broadcast> PRSSState<Z, B> {
+    /// Issue#3089: Enable (or disable) the legacy, pre-#663 overlapping counter schedule for
+    /// PRSS-Mask in this session, for interoperability with unpatched peers during the
+    /// transition period. The counter advance is identical in both schedules, so switching
+    /// per session is safe and requires no state migration.
+    ///
+    /// Defaults to `false` (the fixed, disjoint schedule). Must be set to the same value by
+    /// all parties of a session, before the first call to `mask_next`/`mask_next_vec`.
+    pub fn set_run_legacy_prss(&mut self, run_legacy: bool) {
+        self.run_legacy_prss = run_legacy;
+    }
 }
 
 impl<Z: Default + Clone + Serialize, B: Broadcast> ProtocolDescription for PRSSState<Z, B> {
@@ -632,13 +647,22 @@ where
         let prss_setup = self.prss_setup.clone();
         let mask_ctr = self.counters.mask_ctr;
 
+        let run_legacy = self.run_legacy_prss;
         let res = spawn_compute_bound(move || {
         // Element `idx` consumes a disjoint counter pair (mask_ctr + 2*idx, +1), matching one
         // scalar mask_next() call. The pairs must NOT overlap: iterating the counter by 1 would
         // make adjacent elements share a phi value, diverging from repeated scalar calls and
         // reducing the independence of the noise-flooding masks.
+        // Issue#3089: the legacy branch deliberately reproduces the pre-#663 overlapping
+        // schedule (element `idx` uses counters mask_ctr + idx and mask_ctr + idx + 1) for
+        // interop with unpatched peers during the transition period. Both schedules advance
+        // `mask_ctr` by 2 per element below, so state stays aligned across versions.
         (0..amount as u128).map(|idx| {
-        let ctr = mask_ctr + 2 * idx;
+        let ctr = if run_legacy {
+            mask_ctr + idx
+        } else {
+            mask_ctr + 2 * idx
+        };
         let mut res = Z::ZERO;
         for (i, set) in prss_setup.sets.iter().enumerate() {
             if set.parties.contains(&party_role) {
@@ -1116,6 +1140,7 @@ impl<Z: RingWithExceptionalSequence + Invert + PRSSConversions> DerivePRSSState<
             prss_setup: self.clone(),
             prfs: Arc::new(prfs),
             broadcast: SyncReliableBroadcast::default(),
+            run_legacy_prss: false,
         }
     }
 }
@@ -1481,6 +1506,80 @@ mod tests {
         assert_eq!(
             batch_state.counters.przs_ctr,
             scalar_state.counters.przs_ctr
+        );
+    }
+
+    #[tokio::test]
+    #[rstest]
+    #[case(1)]
+    #[case(2)]
+    #[case(23)]
+    #[case(1025)]
+    // Issue#3089: with `run_legacy_prss` enabled, mask_next_vec() must reproduce the pre-#663
+    // overlapping counter schedule exactly: element `idx` uses counters (mask_ctr + idx,
+    // mask_ctr + idx + 1), so that patched parties can interoperate with unpatched v0.13.x
+    // peers during the transition period. The counter advance must remain identical to the
+    // fixed schedule so per-session state stays aligned across versions.
+    async fn test_prss_mask_next_vec_legacy_schedule(#[case] amount: usize) {
+        let num_parties = 4;
+        let threshold = 1;
+
+        let sid = SessionId::from(23425);
+
+        let role_one = Role::indexed_from_one(1);
+        let prss: PRSSSetup<ResiduePolyF4Z128> =
+            PRSSSetup::testing_party_epoch_init(num_parties, threshold, role_one)
+                .await
+                .unwrap();
+
+        let mut legacy_state = prss.new_prss_session_state(sid);
+        legacy_state.set_run_legacy_prss(true);
+        let mut fixed_state = prss.new_prss_session_state(sid);
+
+        let legacy_values = legacy_state
+            .mask_next_vec(role_one, B_SWITCH_SQUASH, amount)
+            .await
+            .unwrap();
+
+        // Recompute the expected values with the pre-#663 formula, directly from the session
+        // PRFs: element `idx` = sum over sets A containing the party of
+        // f_A(alpha) * (phi(idx) + phi(idx + 1)), i.e. counter pairs overlap between
+        // adjacent elements (initial mask_ctr is 0 in a fresh session state).
+        let bd1 = B_SWITCH_SQUASH << STATSEC;
+        for (idx, value) in legacy_values.iter().enumerate() {
+            let mut expected = ResiduePolyF4Z128::ZERO;
+            for (i, set) in legacy_state.prss_setup.sets.iter().enumerate() {
+                let aes_prf = legacy_state.prfs.get(i).unwrap();
+                let phi0 = phi(&aes_prf.phi_aes, idx as u128, bd1).unwrap();
+                let phi1 = phi(&aes_prf.phi_aes, idx as u128 + 1, bd1).unwrap();
+                let f_a = set.f_a_points[&role_one];
+                expected += f_a * ResiduePolyF4Z128::from_i128(phi0 + phi1);
+            }
+            assert_eq!(
+                *value, expected,
+                "legacy schedule mismatch at element {idx}"
+            );
+        }
+
+        // The fixed schedule must agree on the first element and (for phi != 0) diverge
+        // afterwards, and both schedules must advance the counters identically.
+        let fixed_values = fixed_state
+            .mask_next_vec(role_one, B_SWITCH_SQUASH, amount)
+            .await
+            .unwrap();
+        assert_eq!(fixed_values[0], legacy_values[0]);
+        assert_eq!(
+            legacy_state.counters.mask_ctr,
+            fixed_state.counters.mask_ctr
+        );
+        assert_eq!(legacy_state.counters.mask_ctr, 2 * amount as u128);
+        assert_eq!(
+            legacy_state.counters.prss_ctr,
+            fixed_state.counters.prss_ctr
+        );
+        assert_eq!(
+            legacy_state.counters.przs_ctr,
+            fixed_state.counters.przs_ctr
         );
     }
 

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -554,6 +554,13 @@ impl<Z: Default + Clone + Serialize, B: Broadcast> PRSSState<Z, B> {
     ///
     /// Defaults to `false` (the fixed, disjoint schedule). Must be set to the same value by
     /// all parties of a session, before the first call to `mask_next`/`mask_next_vec`.
+    ///
+    /// The default is deliberately the *fixed* schedule, not the legacy one: `PRSSState` backs
+    /// every PRSS use (key generation, resharing, …), and all of those must use the correct
+    /// post-#663 schedule.
+    /// Only below-threshold *decryption* requests opt into the legacy schedule, and they do so
+    /// explicitly per request via this setter (see `prss_compat::use_legacy_prss_mask` in the
+    /// service crate).
     pub fn set_run_legacy_prss(&mut self, run_legacy: bool) {
         self.run_legacy_prss = run_legacy;
     }

--- a/core/threshold-execution/src/small_execution/prss.rs
+++ b/core/threshold-execution/src/small_execution/prss.rs
@@ -1590,6 +1590,147 @@ mod tests {
         );
     }
 
+    /// Issue#3089 test helper: every party derives its batched PRSS-Mask shares for one session
+    /// under the given schedule. Returns `per_party[party_index][block]`.
+    async fn party_mask_vectors(
+        num_parties: usize,
+        threshold: usize,
+        sid: SessionId,
+        amount: usize,
+        run_legacy: bool,
+    ) -> Vec<Vec<ResiduePolyF4Z128>> {
+        let all_roles = (1..=num_parties)
+            .map(Role::indexed_from_one)
+            .collect::<Vec<_>>();
+        join_all(all_roles.iter().map(|p| async {
+            let prss_setup = PRSSSetup::<ResiduePolyF4Z128>::testing_party_epoch_init(
+                num_parties,
+                threshold,
+                *p,
+            )
+            .await
+            .unwrap();
+            let mut state = prss_setup.new_prss_session_state(sid);
+            state.set_run_legacy_prss(run_legacy);
+            state
+                .mask_next_vec(*p, B_SWITCH_SQUASH, amount)
+                .await
+                .unwrap()
+        }))
+        .await
+    }
+
+    #[tokio::test]
+    #[rstest]
+    #[case(2)]
+    #[case(8)]
+    // Issue#3089: cluster-level proof that the request-ID gate changes the *reconstructed*
+    // PRSS-Mask, not merely which branch each party takes. Reconstruct the batched masks across
+    // ALL parties under the legacy and the fixed schedule: the two agree only on the first block
+    // (element 0 uses the same counter pair in both) and diverge on every subsequent block, so a
+    // cluster split across schedules masks genuinely different values — the root of the drift bug.
+    async fn test_prss_mask_next_vec_schedule_diverges(#[case] amount: usize) {
+        let num_parties = 4;
+        let threshold = 1;
+        let sid = SessionId::from(23425);
+        let all_roles = (1..=num_parties)
+            .map(Role::indexed_from_one)
+            .collect::<Vec<_>>();
+
+        let legacy = party_mask_vectors(num_parties, threshold, sid, amount, true).await;
+        let fixed = party_mask_vectors(num_parties, threshold, sid, amount, false).await;
+
+        // Reconstruct one block's mask from every party's share (all parties on one schedule, so
+        // the shares are consistent and reconstruction with zero error tolerance succeeds).
+        let reconstruct_block = |per_party: &[Vec<ResiduePolyF4Z128>], block: usize| {
+            let shares = all_roles
+                .iter()
+                .enumerate()
+                .map(|(i, r)| Share::new(*r, per_party[i][block]))
+                .collect::<Vec<_>>();
+            ShamirSharings::create(shares).reconstruct(threshold).unwrap()
+        };
+
+        // Block 0 is identical under both schedules (same counter pair mask_ctr, mask_ctr+1).
+        assert_eq!(
+            reconstruct_block(&legacy, 0),
+            reconstruct_block(&fixed, 0),
+            "the two schedules must reconstruct the same mask for the first block"
+        );
+        // Every later block diverges: the schedules mask different values.
+        for block in 1..amount {
+            assert_ne!(
+                reconstruct_block(&legacy, block),
+                reconstruct_block(&fixed, block),
+                "legacy and fixed schedules must reconstruct different masks for block {block}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    // Issue#3089: share-level analogue of the mixed-version drift failure. On a 4-party / t=1
+    // cluster, mixing schedules across parties for a diverging block yields shares that no longer
+    // lie on one degree-t polynomial. Gao reconstruction (err_reconstruct with max_errs = t) then
+    // behaves exactly as observed end-to-end (rolling-upgrade run 29369227341):
+    //   - a single divergent party (minority == t) is silently error-corrected to the majority
+    //     schedule's mask, consuming the whole fault budget;
+    //   - two divergent parties (minority == t+1 > t) exceed the budget and reconstruction fails.
+    async fn test_prss_mask_mixed_schedule_reconstruction() {
+        let num_parties = 4;
+        let threshold = 1;
+        let amount = 2; // need a diverging block (block index >= 1)
+        let block = 1;
+        let sid = SessionId::from(99);
+        let all_roles = (1..=num_parties)
+            .map(Role::indexed_from_one)
+            .collect::<Vec<_>>();
+
+        let legacy = party_mask_vectors(num_parties, threshold, sid, amount, true).await;
+        let fixed = party_mask_vectors(num_parties, threshold, sid, amount, false).await;
+
+        // The all-fixed reconstruction is the reference "correct" mask for this block.
+        let fixed_mask = {
+            let shares = all_roles
+                .iter()
+                .enumerate()
+                .map(|(i, r)| Share::new(*r, fixed[i][block]))
+                .collect::<Vec<_>>();
+            ShamirSharings::create(shares).reconstruct(threshold).unwrap()
+        };
+
+        // Reconstruct `block` with the first `num_legacy` parties on the legacy schedule and the
+        // rest on the fixed one, using Gao error-correction that tolerates up to t errors (the
+        // honest decryption path).
+        let mixed = |num_legacy: usize| {
+            let shares = all_roles
+                .iter()
+                .enumerate()
+                .map(|(i, r)| {
+                    let v = if i < num_legacy {
+                        legacy[i][block]
+                    } else {
+                        fixed[i][block]
+                    };
+                    Share::new(*r, v)
+                })
+                .collect::<Vec<_>>();
+            ShamirSharings::create(shares).err_reconstruct(threshold, threshold)
+        };
+
+        // Minority == t (1 legacy vs 3 fixed): error-corrected to the fixed majority.
+        assert_eq!(
+            mixed(1).unwrap(),
+            fixed_mask,
+            "a single divergent party (== t) must be error-corrected to the majority mask"
+        );
+        // Minority == t+1 (2 vs 2): exceeds the fault budget → decode fails (the Gao failure a
+        // mixed-version cluster hits on multi-block ciphertexts).
+        assert!(
+            mixed(2).is_err(),
+            "two divergent parties (> t) must exceed the correction budget and fail to reconstruct"
+        );
+    }
+
     #[tokio::test]
     #[rstest]
     #[case(4, 1)]


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->
Allows request below some RequestId threshold to use the "legacy" PRSS path and switch to the new PRSS from a fixed RequestId (note that RequestIds are monotonically increasing at the SC level).

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->
https://github.com/zama-ai/kms-internal/issues/3089
## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
