### PR TITLE
fix(solana): enforce chain kind in user decrypt

### DIFF
--- a/core/grpc/src/rpc_types.rs
+++ b/core/grpc/src/rpc_types.rs
@@ -727,7 +727,7 @@ fn handle_chain_id(handle: &[u8; 32]) -> u64 {
 /// width, chain kind, a common embedded chain ID, or equality with `host_chain_id`. New request
 /// boundaries must construct [`SolanaUserDecryptBinding`] and call its checked `compute_link`
 /// method instead.
-pub fn compute_link_solana(
+pub(crate) fn compute_link_solana(
     enc_key: &[u8],
     handles: &[[u8; 32]],
     solana_user_pubkey: &[u8; 32],

--- a/core/grpc/src/rpc_types.rs
+++ b/core/grpc/src/rpc_types.rs
@@ -526,6 +526,15 @@ impl crate::kms::v1::UserDecryptionRequest {
             anyhow::bail!(ERR_THERE_ARE_NO_HANDLES);
         }
 
+        for (index, handle) in handles.iter().enumerate() {
+            let chain_id = handle_chain_id(handle);
+            if chain_id & SOLANA_CHAIN_TYPE_BIT != 0 {
+                anyhow::bail!(
+                    "EVM ciphertext handle at index {index} embeds Solana chain ID {chain_id}"
+                );
+            }
+        }
+
         let client_address =
             alloy_primitives::Address::parse_checksummed(&self.client_address, None).map_err(
                 |e| anyhow::anyhow!("{ERR_PARSE_CHECKSUMMED}: {} - {e}", self.client_address),
@@ -550,6 +559,148 @@ impl crate::kms::v1::UserDecryptionRequest {
     }
 }
 
+/// Bit 63 distinguishes Solana host chain IDs from EVM host chain IDs.
+const SOLANA_CHAIN_TYPE_BIT: u64 = 1 << 63;
+
+const HANDLE_CHAIN_ID_START: usize = 22;
+const HANDLE_CHAIN_ID_END: usize = 30;
+
+/// A host chain ID that is valid for the Solana request path.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SolanaHostChainId(u64);
+
+impl SolanaHostChainId {
+    fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl TryFrom<u64> for SolanaHostChainId {
+    type Error = SolanaUserDecryptBindingError;
+
+    fn try_from(chain_id: u64) -> Result<Self, Self::Error> {
+        if chain_id & SOLANA_CHAIN_TYPE_BIT == 0 {
+            return Err(SolanaUserDecryptBindingError::InvalidDeclaredChainId { chain_id });
+        }
+        Ok(Self(chain_id))
+    }
+}
+
+/// Canonical Solana ciphertext handles and the common chain ID embedded in them.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SolanaUserDecryptBinding {
+    handles: Vec<[u8; 32]>,
+    chain_id: SolanaHostChainId,
+}
+
+impl SolanaUserDecryptBinding {
+    pub fn try_from_handle_bytes<'a>(
+        handles: impl IntoIterator<Item = &'a [u8]>,
+    ) -> Result<Self, SolanaUserDecryptBindingError> {
+        let mut canonical_handles = Vec::new();
+        let mut common_chain_id = None;
+
+        for (index, handle) in handles.into_iter().enumerate() {
+            let handle: [u8; 32] = handle.try_into().map_err(|_| {
+                SolanaUserDecryptBindingError::InvalidHandleLength {
+                    index,
+                    actual: handle.len(),
+                }
+            })?;
+            let chain_id = handle_chain_id(&handle);
+            if chain_id & SOLANA_CHAIN_TYPE_BIT == 0 {
+                return Err(SolanaUserDecryptBindingError::InvalidHandleChainId {
+                    index,
+                    chain_id,
+                });
+            }
+            if let Some(expected) = common_chain_id {
+                if chain_id != expected {
+                    return Err(SolanaUserDecryptBindingError::MixedChainIds {
+                        index,
+                        expected,
+                        actual: chain_id,
+                    });
+                }
+            } else {
+                common_chain_id = Some(chain_id);
+            }
+            canonical_handles.push(handle);
+        }
+
+        let chain_id = common_chain_id
+            .map(SolanaHostChainId)
+            .ok_or(SolanaUserDecryptBindingError::EmptyHandles)?;
+        Ok(Self {
+            handles: canonical_handles,
+            chain_id,
+        })
+    }
+
+    fn handles(&self) -> &[[u8; 32]] {
+        &self.handles
+    }
+
+    fn chain_id(&self) -> SolanaHostChainId {
+        self.chain_id
+    }
+
+    pub fn validate_declared_chain_id(
+        &self,
+        declared: u64,
+    ) -> Result<(), SolanaUserDecryptBindingError> {
+        let declared = SolanaHostChainId::try_from(declared)?;
+        if declared != self.chain_id {
+            return Err(SolanaUserDecryptBindingError::DeclaredChainIdMismatch {
+                declared: declared.get(),
+                embedded: self.chain_id.get(),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn compute_link(&self, enc_key: &[u8], solana_user_pubkey: &[u8; 32]) -> Vec<u8> {
+        compute_link_solana(
+            enc_key,
+            self.handles(),
+            solana_user_pubkey,
+            self.chain_id().get(),
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum SolanaUserDecryptBindingError {
+    #[error("Solana user-decrypt request contains no ciphertext handles")]
+    EmptyHandles,
+    #[error("Solana ciphertext handle at index {index} must be 32 bytes, got {actual}")]
+    InvalidHandleLength { index: usize, actual: usize },
+    #[error(
+        "Solana ciphertext handle at index {index} embeds chain ID {chain_id}, which does not set bit 63"
+    )]
+    InvalidHandleChainId { index: usize, chain_id: u64 },
+    #[error(
+        "Solana ciphertext handle at index {index} embeds chain ID {actual}, expected {expected}"
+    )]
+    MixedChainIds {
+        index: usize,
+        expected: u64,
+        actual: u64,
+    },
+    #[error("declared Solana host chain ID {chain_id} does not set bit 63")]
+    InvalidDeclaredChainId { chain_id: u64 },
+    #[error("declared Solana host chain ID {declared} does not match handle chain ID {embedded}")]
+    DeclaredChainIdMismatch { declared: u64, embedded: u64 },
+}
+
+fn handle_chain_id(handle: &[u8; 32]) -> u64 {
+    u64::from_be_bytes(
+        handle[HANDLE_CHAIN_ID_START..HANDLE_CHAIN_ID_END]
+            .try_into()
+            .expect("the chain ID range is eight bytes"),
+    )
+}
+
 /// Computes the Solana-native user-decryption request↔response link.
 ///
 /// On EVM, [`crate::kms::v1::UserDecryptionRequest::compute_link_checked`] binds the
@@ -569,6 +720,13 @@ impl crate::kms::v1::UserDecryptionRequest {
 ///
 /// Length-prefixed fields keep the preimage unambiguous; a version tag domain-separates
 /// it from every other keccak preimage on the Solana surface.
+///
+/// # Validation
+///
+/// This compatibility entry point only computes the preimage hash; it does not validate handle
+/// width, chain kind, a common embedded chain ID, or equality with `host_chain_id`. New request
+/// boundaries must construct [`SolanaUserDecryptBinding`] and call its checked `compute_link`
+/// method instead.
 pub fn compute_link_solana(
     enc_key: &[u8],
     handles: &[[u8; 32]],
@@ -590,44 +748,72 @@ pub fn compute_link_solana(
 
 #[cfg(test)]
 mod solana_link_tests {
-    use super::compute_link_solana;
+    use super::{
+        SOLANA_CHAIN_TYPE_BIT, SolanaHostChainId, SolanaUserDecryptBinding,
+        SolanaUserDecryptBindingError, compute_link_solana,
+    };
+
+    const SOLANA_POC_CHAIN_ID: u64 = SOLANA_CHAIN_TYPE_BIT | 12_345;
+
+    fn handle(chain_id: u64, discriminator: u8) -> [u8; 32] {
+        let mut handle = [discriminator; 32];
+        handle[22..30].copy_from_slice(&chain_id.to_be_bytes());
+        handle
+    }
+
+    fn binding(handles: &[[u8; 32]]) -> SolanaUserDecryptBinding {
+        SolanaUserDecryptBinding::try_from_handle_bytes(
+            handles.iter().map(|handle| handle.as_slice()),
+        )
+        .unwrap()
+    }
 
     #[test]
     fn solana_link_is_deterministic_and_field_sensitive() {
         let enc_key = vec![7u8; 800];
-        let handles = vec![[1u8; 32], [2u8; 32]];
+        let handles = vec![
+            handle(SOLANA_POC_CHAIN_ID, 1),
+            handle(SOLANA_POC_CHAIN_ID, 2),
+        ];
+        let base_binding = binding(&handles);
         let pubkey = [9u8; 32];
-        let chain_id = 9_223_372_036_854_788_153u64; // RFC-021 Solana host chain id
 
-        let base = compute_link_solana(&enc_key, &handles, &pubkey, chain_id);
+        let base = base_binding.compute_link(&enc_key, &pubkey);
         assert_eq!(base.len(), 32, "keccak256 output is 32 bytes");
-        // Deterministic.
+        // KMS wire-format regression vector for the exact fixture above. This must be promoted to
+        // a cross-repository specification vector before the Solana branch is upstreamed.
+        assert_eq!(
+            hex::encode(&base),
+            "ed19cee8b6b8e8da67f754547551297060ebfb057f93a423909791a7a0c34385"
+        );
         assert_eq!(
             base,
-            compute_link_solana(&enc_key, &handles, &pubkey, chain_id)
+            compute_link_solana(&enc_key, &handles, &pubkey, SOLANA_POC_CHAIN_ID,)
         );
+        // Deterministic.
+        assert_eq!(base, base_binding.compute_link(&enc_key, &pubkey));
 
         // Sensitive to every bound field.
         let mut other_pubkey = pubkey;
         other_pubkey[0] ^= 0xff;
+        assert_ne!(base, base_binding.compute_link(&enc_key, &other_pubkey));
+        let one_handle = binding(&handles[..1]);
         assert_ne!(
             base,
-            compute_link_solana(&enc_key, &handles, &other_pubkey, chain_id)
-        );
-        assert_ne!(
-            base,
-            compute_link_solana(&enc_key, &[[1u8; 32]], &pubkey, chain_id),
+            one_handle.compute_link(&enc_key, &pubkey),
             "dropping a handle must change the link"
         );
         assert_ne!(
             base,
-            compute_link_solana(&[7u8; 799], &handles, &pubkey, chain_id),
+            base_binding.compute_link(&[7u8; 799], &pubkey),
             "a different enc_key must change the link"
         );
-        assert_ne!(
-            base,
-            compute_link_solana(&enc_key, &handles, &pubkey, chain_id + 1)
-        );
+        let other_chain_handles = vec![
+            handle(SOLANA_POC_CHAIN_ID + 1, 1),
+            handle(SOLANA_POC_CHAIN_ID + 1, 2),
+        ];
+        let other_chain = binding(&other_chain_handles);
+        assert_ne!(base, other_chain.compute_link(&enc_key, &pubkey));
     }
 
     #[test]
@@ -636,11 +822,102 @@ mod solana_link_tests {
         // without length-prefixing; the count prefix must keep them distinct.
         let enc_key = vec![0u8; 4];
         let pubkey = [3u8; 32];
-        let two = compute_link_solana(&enc_key, &[[0xaa; 32], [0xbb; 32]], &pubkey, 1);
+        let two_handles = vec![
+            handle(SOLANA_POC_CHAIN_ID, 0xaa),
+            handle(SOLANA_POC_CHAIN_ID, 0xbb),
+        ];
+        let two = binding(&two_handles).compute_link(&enc_key, &pubkey);
         // One 32-byte handle plus enc_key shifted can't reproduce the two-handle preimage
         // because the handle count (2 vs 1) is hashed in.
-        let one = compute_link_solana(&enc_key, &[[0xaa; 32]], &pubkey, 1);
+        let one = binding(&two_handles[..1]).compute_link(&enc_key, &pubkey);
         assert_ne!(two, one);
+    }
+
+    #[test]
+    fn validates_the_solana_chain_kind_and_exact_handle_width() {
+        let valid = handle(SOLANA_POC_CHAIN_ID, 1);
+        let parsed = binding(&[valid]);
+        assert_eq!(parsed.chain_id().get(), 9_223_372_036_854_788_153);
+
+        assert_eq!(
+            SolanaHostChainId::try_from(12_345),
+            Err(SolanaUserDecryptBindingError::InvalidDeclaredChainId { chain_id: 12_345 })
+        );
+        assert_eq!(
+            SolanaUserDecryptBinding::try_from_handle_bytes(std::iter::once(&valid[..31])),
+            Err(SolanaUserDecryptBindingError::InvalidHandleLength {
+                index: 0,
+                actual: 31,
+            })
+        );
+        assert_eq!(
+            SolanaUserDecryptBinding::try_from_handle_bytes(std::iter::once(&[0u8; 33][..])),
+            Err(SolanaUserDecryptBindingError::InvalidHandleLength {
+                index: 0,
+                actual: 33,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_low_bit_and_mixed_chain_batches() {
+        let low_bit = handle(12_345, 2);
+        assert_eq!(
+            SolanaUserDecryptBinding::try_from_handle_bytes(std::iter::once(low_bit.as_slice())),
+            Err(SolanaUserDecryptBindingError::InvalidHandleChainId {
+                index: 0,
+                chain_id: 12_345,
+            })
+        );
+
+        let valid = handle(SOLANA_POC_CHAIN_ID, 1);
+        let later_low_bit = handle(12_345, 2);
+        assert_eq!(
+            SolanaUserDecryptBinding::try_from_handle_bytes([
+                valid.as_slice(),
+                later_low_bit.as_slice()
+            ]),
+            Err(SolanaUserDecryptBindingError::InvalidHandleChainId {
+                index: 1,
+                chain_id: 12_345,
+            })
+        );
+
+        let other = handle(SOLANA_POC_CHAIN_ID + 1, 2);
+        assert_eq!(
+            SolanaUserDecryptBinding::try_from_handle_bytes([valid.as_slice(), other.as_slice()]),
+            Err(SolanaUserDecryptBindingError::MixedChainIds {
+                index: 1,
+                expected: SOLANA_POC_CHAIN_ID,
+                actual: SOLANA_POC_CHAIN_ID + 1,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_empty_handles_and_declared_chain_id_mismatches() {
+        assert_eq!(
+            SolanaUserDecryptBinding::try_from_handle_bytes(std::iter::empty()),
+            Err(SolanaUserDecryptBindingError::EmptyHandles)
+        );
+
+        let valid = handle(SOLANA_POC_CHAIN_ID, 1);
+        let binding = binding(&[valid]);
+        assert_eq!(
+            binding.validate_declared_chain_id(SOLANA_POC_CHAIN_ID),
+            Ok(())
+        );
+        assert_eq!(
+            binding.validate_declared_chain_id(12_345),
+            Err(SolanaUserDecryptBindingError::InvalidDeclaredChainId { chain_id: 12_345 })
+        );
+        assert_eq!(
+            binding.validate_declared_chain_id(SOLANA_POC_CHAIN_ID + 1),
+            Err(SolanaUserDecryptBindingError::DeclaredChainIdMismatch {
+                declared: SOLANA_POC_CHAIN_ID + 1,
+                embedded: SOLANA_POC_CHAIN_ID,
+            })
+        );
     }
 }
 
@@ -1372,6 +1649,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: Some(context_id.into()),
                 epoch_id: None,
+                client_identity: None,
             };
             assert!(
                 req.compute_link_checked()
@@ -1393,6 +1671,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: Some(context_id.into()),
                 epoch_id: None,
+                client_identity: None,
             };
             assert!(
                 req.compute_link_checked()
@@ -1417,6 +1696,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: Some(context_id.into()),
                 epoch_id: None,
+                client_identity: None,
             };
 
             assert!(
@@ -1439,6 +1719,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: Some(context_id.into()),
                 epoch_id: None,
+                client_identity: None,
             };
             assert!(req.compute_link_checked().is_ok());
         }

--- a/core/service/src/client/js_api.rs
+++ b/core/service/src/client/js_api.rs
@@ -466,8 +466,9 @@ pub fn process_user_decryption_resp_solana_from_js(
             .map_err(|e| JsError::new(&format!("verification key parse failed: {e}")))?;
         server_pks.insert((i + 1) as u32, vk);
     }
-    let client_address =
-        alloy_primitives::Address::from_slice(&alloy_primitives::keccak256(solana_user_pubkey)[12..]);
+    let client_address = alloy_primitives::Address::from_slice(
+        &alloy_primitives::keccak256(solana_user_pubkey)[12..],
+    );
     let client = Client {
         server_identities: ServerIdentities::Pks(server_pks),
         client_address,

--- a/core/service/src/client/user_decryption_wasm.rs
+++ b/core/service/src/client/user_decryption_wasm.rs
@@ -25,8 +25,8 @@ use itertools::Itertools;
 use kms_grpc::kms::v1::{
     TypedPlaintext, UserDecryptionRequest, UserDecryptionResponse, UserDecryptionResponsePayload,
 };
-use kms_grpc::rpc_types::compute_link_solana;
 use kms_grpc::rpc_types::fhe_types_to_num_blocks;
+use kms_grpc::rpc_types::{SolanaUserDecryptBinding, SolanaUserDecryptBindingError};
 use kms_grpc::solidity_types::UserDecryptionLinker;
 use std::num::Wrapping;
 use tfhe::FheTypes;
@@ -39,6 +39,21 @@ use threshold_execution::tfhe_internals::parameters::AugmentedCiphertextParamete
 use threshold_types::role::Role;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsError, JsValue};
+
+fn compute_solana_user_decrypt_link(
+    request: &ParsedUserDecryptionRequest,
+    solana_user_pubkey: &[u8; 32],
+    declared_chain_id: u64,
+) -> Result<Vec<u8>, SolanaUserDecryptBindingError> {
+    let binding = SolanaUserDecryptBinding::try_from_handle_bytes(
+        request
+            .ciphertext_handles
+            .iter()
+            .map(|handle| handle.0.as_slice()),
+    )?;
+    binding.validate_declared_chain_id(declared_chain_id)?;
+    Ok(binding.compute_link(&request.enc_key, solana_user_pubkey))
+}
 
 impl Client {
     /// Processes the aggregated user decryption responses to attempt to decrypt
@@ -230,7 +245,8 @@ impl Client {
     ///
     /// Server authenticity is checked via the internal ECDSA signature over the response payload;
     /// the external EIP-712 certificate is the on-chain-consumable artifact and is not needed to
-    /// recover the plaintext client-side.
+    /// recover the plaintext client-side. Every handle must embed the same high-bit Solana chain
+    /// ID, and that ID must equal `host_chain_id`, before the link is computed.
     pub fn process_user_decryption_resp_solana(
         &self,
         request: &ParsedUserDecryptionRequest,
@@ -240,27 +256,10 @@ impl Client {
         dec_key: &UnifiedPrivateEncKey,
         agg_resp: &[UserDecryptionResponse],
     ) -> anyhow::Result<Vec<TypedPlaintext>> {
+        let link = compute_solana_user_decrypt_link(request, solana_user_pubkey, host_chain_id)?;
+
         let resp = some_or_err(agg_resp.last(), "Response does not exist".to_owned())?;
         let payload = some_or_err(resp.payload.clone(), "Payload does not exist".to_owned())?;
-
-        // Handles are 32 bytes on Solana; left-pad defensively to mirror the EVM consistency check.
-        let handles: Vec<[u8; 32]> = request
-            .ciphertext_handles
-            .iter()
-            .map(|c| {
-                let mut h = [0u8; 32];
-                let src = &c.0;
-                let take = src.len().min(32);
-                h[32 - take..].copy_from_slice(&src[src.len() - take..]);
-                h
-            })
-            .collect();
-        let link = compute_link_solana(
-            &request.enc_key,
-            &handles,
-            solana_user_pubkey,
-            host_chain_id,
-        );
         if link != payload.digest {
             return Err(anyhow_error_and_log(format!(
                 "solana link mismatch ({} != {})",
@@ -1065,6 +1064,71 @@ impl ParsedUserDecryptionRequest {
 
     pub fn extra_data(&self) -> &[u8] {
         &self.extra_data
+    }
+}
+
+#[cfg(test)]
+mod solana_request_link_tests {
+    use super::{
+        CiphertextHandle, ParsedUserDecryptionRequest, SolanaUserDecryptBindingError,
+        compute_solana_user_decrypt_link,
+    };
+
+    const SOLANA_CHAIN_ID: u64 = (1 << 63) | 12_345;
+
+    fn handle(chain_id: u64) -> Vec<u8> {
+        let mut handle = vec![0xabu8; 32];
+        handle[22..30].copy_from_slice(&chain_id.to_be_bytes());
+        handle
+    }
+
+    fn request(handles: Vec<Vec<u8>>) -> ParsedUserDecryptionRequest {
+        ParsedUserDecryptionRequest::new(
+            None,
+            alloy_primitives::Address::ZERO,
+            vec![0x33; 64],
+            handles.into_iter().map(CiphertextHandle::new).collect(),
+            alloy_primitives::Address::ZERO,
+            vec![],
+        )
+    }
+
+    #[test]
+    fn validates_the_declared_chain_id_before_processing_a_response() {
+        let request = request(vec![handle(SOLANA_CHAIN_ID)]);
+        let pubkey = [0x11; 32];
+        assert_eq!(
+            compute_solana_user_decrypt_link(&request, &pubkey, SOLANA_CHAIN_ID)
+                .unwrap()
+                .len(),
+            32
+        );
+        assert_eq!(
+            compute_solana_user_decrypt_link(&request, &pubkey, SOLANA_CHAIN_ID + 1),
+            Err(SolanaUserDecryptBindingError::DeclaredChainIdMismatch {
+                declared: SOLANA_CHAIN_ID + 1,
+                embedded: SOLANA_CHAIN_ID,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_handle_chain_ids_and_widths() {
+        let pubkey = [0x11; 32];
+        assert_eq!(
+            compute_solana_user_decrypt_link(&request(vec![handle(12_345)]), &pubkey, 12_345),
+            Err(SolanaUserDecryptBindingError::InvalidHandleChainId {
+                index: 0,
+                chain_id: 12_345,
+            })
+        );
+        assert_eq!(
+            compute_solana_user_decrypt_link(&request(vec![vec![0; 31]]), &pubkey, SOLANA_CHAIN_ID),
+            Err(SolanaUserDecryptBindingError::InvalidHandleLength {
+                index: 0,
+                actual: 31,
+            })
+        );
     }
 }
 

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -786,6 +786,7 @@ mod test_user_decryption {
             extra_data: vec![],
             context_id: None,
             epoch_id: None,
+            client_identity: None,
         };
 
         let _ = user_decrypt_impl(&kms, tonic::Request::new(request))
@@ -838,6 +839,7 @@ mod test_user_decryption {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
 
             let err = user_decrypt_impl(&kms, tonic::Request::new(request))
@@ -861,6 +863,7 @@ mod test_user_decryption {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
             let err = user_decrypt_impl(&kms, tonic::Request::new(request))
                 .await
@@ -880,6 +883,7 @@ mod test_user_decryption {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
             let err = user_decrypt_impl(&kms, tonic::Request::new(request))
                 .await
@@ -899,6 +903,7 @@ mod test_user_decryption {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
             let err = user_decrypt_impl(&kms, tonic::Request::new(request))
                 .await
@@ -931,6 +936,7 @@ mod test_user_decryption {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
 
             let err = user_decrypt_impl(&kms, tonic::Request::new(request))
@@ -975,6 +981,7 @@ mod test_user_decryption {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
             let err = user_decrypt_impl(&kms, tonic::Request::new(request))
                 .await
@@ -1004,6 +1011,7 @@ mod test_user_decryption {
             extra_data: vec![],
             context_id: None,
             epoch_id: None,
+            client_identity: None,
         };
 
         // first request should succeed

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -828,6 +828,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
                 epoch_id: Some(epoch_id.into()),
+                client_identity: None,
             });
             assert_eq!(
                 user_decryptor
@@ -851,6 +852,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
                 epoch_id: Some(epoch_id.into()),
+                client_identity: None,
             });
             assert_eq!(
                 user_decryptor
@@ -879,6 +881,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
                 epoch_id: Some(epoch_id.into()),
+                client_identity: None,
             });
             assert_eq!(
                 user_decryptor
@@ -907,6 +910,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
                 epoch_id: Some(epoch_id.into()),
+                client_identity: None,
             });
             assert_eq!(
                 user_decryptor
@@ -951,6 +955,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
                 epoch_id: Some(epoch_id.into()),
+                client_identity: None,
             });
             assert_eq!(
                 user_decryptor
@@ -989,6 +994,7 @@ mod tests {
             extra_data: vec![],
             context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
             epoch_id: Some(epoch_id.into()),
+            client_identity: None,
         });
         assert_eq!(
             user_decryptor
@@ -1029,6 +1035,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
                 epoch_id: Some(epoch_id.into()),
+                client_identity: None,
             });
             assert_eq!(
                 user_decryptor
@@ -1059,6 +1066,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
                 epoch_id: Some(bad_epoch_id.into()),
+                client_identity: None,
             });
             assert_eq!(
                 user_decryptor
@@ -1104,6 +1112,7 @@ mod tests {
             extra_data: vec![],
             context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
             epoch_id: Some(epoch_id.into()),
+            client_identity: None,
         };
         user_decryptor
             .user_decrypt(Request::new(request.clone()))
@@ -1147,6 +1156,7 @@ mod tests {
             extra_data: vec![],
             context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
             epoch_id: Some(epoch_id.into()),
+            client_identity: None,
         });
         user_decryptor.user_decrypt(request).await.unwrap();
         user_decryptor

--- a/core/service/src/engine/validation_non_wasm.rs
+++ b/core/service/src/engine/validation_non_wasm.rs
@@ -27,7 +27,7 @@ use kms_grpc::{
         PublicDecryptionRequest, PublicDecryptionResponse, PublicDecryptionResponsePayload,
         TypedCiphertext, TypedPlaintext, UserDecryptionRequest,
     },
-    rpc_types::{compute_link_solana, optional_protobuf_to_alloy_domain},
+    rpc_types::{SolanaUserDecryptBinding, optional_protobuf_to_alloy_domain},
 };
 use observability::metrics_names::{
     OP_KEYGEN_PREPROC_REQUEST, OP_NEW_EPOCH, OP_PUBLIC_DECRYPT_REQUEST, OP_USER_DECRYPT_REQUEST,
@@ -294,38 +294,24 @@ fn unpack_user_decrypt_req(
     // address. Legacy clients leave it unset and fall back to the `client_address` string overload.
     use kms_grpc::kms::v1::user_decryption_request::ClientIdentity;
     let solana_pubkey_opt: Option<[u8; 32]> = match &req.client_identity {
-        Some(ClientIdentity::SolanaPubkey(pk)) => Some(<[u8; 32]>::try_from(pk.as_slice()).map_err(
-            |_| {
+        Some(ClientIdentity::SolanaPubkey(pk)) => {
+            Some(<[u8; 32]>::try_from(pk.as_slice()).map_err(|_| {
                 anyhow::anyhow!(
                     "Solana client identity must be a 32-byte pubkey, got {} bytes",
                     pk.len()
                 )
-            },
-        )?),
+            })?)
+        }
         Some(ClientIdentity::EvmAddress(_)) => None,
         None => parse_solana_user_decrypt_pubkey(&req.client_address),
     };
     if let Some(solana_pubkey) = solana_pubkey_opt {
-        let mut handles = Vec::with_capacity(req.typed_ciphertexts.len());
-        for c in &req.typed_ciphertexts {
-            if c.external_handle.len() > 32 {
-                return Err(anyhow::anyhow!(
-                    "Solana user-decrypt external_handle too long: {} bytes (max 32)",
-                    c.external_handle.len()
-                )
-                .into());
-            }
-            let mut handle = [0u8; 32];
-            handle[32 - c.external_handle.len()..].copy_from_slice(&c.external_handle);
-            handles.push(handle);
-        }
-        // Handle byte-layout (canonical fhevm): chain id at bytes [22..30], big-endian.
-        let first = &handles[0];
-        let mut chain_id_bytes = [0u8; 8];
-        chain_id_bytes.copy_from_slice(&first[22..30]);
-        let host_chain_id = u64::from_be_bytes(chain_id_bytes);
-
-        let link = compute_link_solana(&req.enc_key, &handles, &solana_pubkey, host_chain_id);
+        let binding = SolanaUserDecryptBinding::try_from_handle_bytes(
+            req.typed_ciphertexts
+                .iter()
+                .map(|ciphertext| ciphertext.external_handle.as_slice()),
+        )?;
+        let link = binding.compute_link(&req.enc_key, &solana_pubkey);
         let client_verf_key = solana_user_decrypt_client_id(&solana_pubkey);
         let _client_enc_key =
             UnifiedPublicEncKey::deserialize_and_validate(&req.enc_key).map_err(|e| {
@@ -366,12 +352,14 @@ fn unpack_user_decrypt_req(
             })?;
             alloy_primitives::Address::from(bytes)
         }
-        _ => alloy_primitives::Address::parse_checksummed(&req.client_address, None).map_err(|e| {
-            anyhow::anyhow!(
-                "Error parsing checksummed client address: {} - {e}",
-                req.client_address
-            )
-        })?,
+        _ => alloy_primitives::Address::parse_checksummed(&req.client_address, None).map_err(
+            |e| {
+                anyhow::anyhow!(
+                    "Error parsing checksummed client address: {} - {e}",
+                    req.client_address
+                )
+            },
+        )?,
     };
 
     let domain = match verify_user_decrypt_eip712(req) {
@@ -1168,7 +1156,7 @@ mod tests {
             PublicDecryptionResponse, PublicDecryptionResponsePayload, TypedCiphertext,
             TypedPlaintext, UserDecryptionRequest,
         },
-        rpc_types::{ID_LENGTH, alloy_to_protobuf_domain},
+        rpc_types::{ID_LENGTH, SolanaUserDecryptBindingError, alloy_to_protobuf_domain},
     };
 
     use rand::SeedableRng;
@@ -1351,6 +1339,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
             assert!(
                 unpack_user_decrypt_req(&req)
@@ -1372,6 +1361,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
             assert!(
                 unpack_user_decrypt_req(&req)
@@ -1396,6 +1386,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
             assert!(
                 unpack_user_decrypt_req(&req)
@@ -1417,6 +1408,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
             assert!(
                 unpack_user_decrypt_req(&req)
@@ -1438,6 +1430,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
             assert!(
                 unpack_user_decrypt_req(&req).unwrap_err().to_string().contains(
@@ -1464,6 +1457,7 @@ mod tests {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
             assert!(
                 unpack_user_decrypt_req(&req)
@@ -1485,8 +1479,121 @@ mod tests {
                 extra_data: vec![],
                 context_id: None,
                 epoch_id: None,
+                client_identity: None,
             };
             assert!(unpack_user_decrypt_req(&req).is_ok());
+        }
+
+        // EVM routing rejects handles that carry the Solana chain-kind bit while preserving the
+        // existing EVM handle-padding behavior.
+        {
+            let mut evm_handle = [0xabu8; 32];
+            let solana_chain_id = (1u64 << 63) | 12_345;
+            evm_handle[22..30].copy_from_slice(&solana_chain_id.to_be_bytes());
+            let evm_req = UserDecryptionRequest {
+                request_id: Some(request_id.into()),
+                typed_ciphertexts: vec![TypedCiphertext {
+                    ciphertext: vec![],
+                    fhe_type: 0,
+                    external_handle: evm_handle.to_vec(),
+                    ciphertext_format: 0,
+                }],
+                key_id: Some(key_id.into()),
+                domain: Some(domain.clone()),
+                client_address: client_address.to_checksum(None),
+                enc_key: enc_pk_buf.clone(),
+                extra_data: vec![],
+                context_id: None,
+                epoch_id: None,
+                client_identity: None,
+            };
+            assert!(
+                unpack_user_decrypt_req(&evm_req)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("embeds Solana chain ID")
+            );
+
+            let mut typed_evm_req = evm_req;
+            typed_evm_req.client_identity =
+                Some(v1::user_decryption_request::ClientIdentity::EvmAddress(
+                    client_address.as_slice().to_vec(),
+                ));
+            assert!(
+                unpack_user_decrypt_req(&typed_evm_req)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("embeds Solana chain ID")
+            );
+        }
+
+        // Typed Solana requests require exact 32-byte handles with one common high-bit chain ID.
+        {
+            const SOLANA_CHAIN_ID: u64 = (1 << 63) | 12_345;
+            let mut handle = [0xabu8; 32];
+            handle[22..30].copy_from_slice(&SOLANA_CHAIN_ID.to_be_bytes());
+            let solana_req = UserDecryptionRequest {
+                request_id: Some(request_id.into()),
+                typed_ciphertexts: vec![TypedCiphertext {
+                    ciphertext: vec![],
+                    fhe_type: 0,
+                    external_handle: handle.to_vec(),
+                    ciphertext_format: 0,
+                }],
+                key_id: Some(key_id.into()),
+                domain: Some(domain.clone()),
+                client_address: String::new(),
+                enc_key: enc_pk_buf.clone(),
+                extra_data: vec![],
+                context_id: None,
+                epoch_id: None,
+                client_identity: Some(v1::user_decryption_request::ClientIdentity::SolanaPubkey(
+                    vec![0x11; 32],
+                )),
+            };
+            assert!(unpack_user_decrypt_req(&solana_req).is_ok());
+
+            let mut low_bit = solana_req.clone();
+            low_bit.typed_ciphertexts[0].external_handle[22..30]
+                .copy_from_slice(&12_345u64.to_be_bytes());
+            let error = unpack_user_decrypt_req(&low_bit).unwrap_err();
+            assert_eq!(
+                error.downcast_ref::<SolanaUserDecryptBindingError>(),
+                Some(&SolanaUserDecryptBindingError::InvalidHandleChainId {
+                    index: 0,
+                    chain_id: 12_345,
+                })
+            );
+
+            let mut mixed = solana_req.clone();
+            let mut other_handle = handle;
+            other_handle[22..30].copy_from_slice(&(SOLANA_CHAIN_ID + 1).to_be_bytes());
+            mixed.typed_ciphertexts.push(TypedCiphertext {
+                ciphertext: vec![],
+                fhe_type: 0,
+                external_handle: other_handle.to_vec(),
+                ciphertext_format: 0,
+            });
+            let error = unpack_user_decrypt_req(&mixed).unwrap_err();
+            assert_eq!(
+                error.downcast_ref::<SolanaUserDecryptBindingError>(),
+                Some(&SolanaUserDecryptBindingError::MixedChainIds {
+                    index: 1,
+                    expected: SOLANA_CHAIN_ID,
+                    actual: SOLANA_CHAIN_ID + 1,
+                })
+            );
+
+            let mut short = solana_req;
+            short.typed_ciphertexts[0].external_handle.pop();
+            let error = unpack_user_decrypt_req(&short).unwrap_err();
+            assert_eq!(
+                error.downcast_ref::<SolanaUserDecryptBindingError>(),
+                Some(&SolanaUserDecryptBindingError::InvalidHandleLength {
+                    index: 0,
+                    actual: 31,
+                })
+            );
         }
     }
 
@@ -1551,6 +1658,7 @@ mod tests {
             extra_data: vec![],
             context_id: None,
             epoch_id: None,
+            client_identity: None,
         };
 
         {

--- a/core/service/tests/js/test.js
+++ b/core/service/tests/js/test.js
@@ -18,6 +18,7 @@ const {
     ml_kem_pke_pk_len,
     ml_kem_pke_sk_len,
     process_user_decryption_resp_from_js,
+    process_user_decryption_resp_solana_from_js,
     u8vec_to_ml_kem_pke_pk,
     u8vec_to_ml_kem_pke_sk,
     new_client,
@@ -145,6 +146,37 @@ test('threshold user decryption response', (_t) => {
     const pt3 = process_user_decryption_resp_from_js(
         client, data.request, data.eip712_domain, data.responses, enc_pk, enc_sk, null, true);
     assertExpected(pt3, data.expected);
+});
+
+test('solana chain ID crosses the WASM boundary as an exact bigint', (_t) => {
+    const { data, enc_pk, enc_sk } = loadVector('test-central-wasm-transcript.8.json');
+    const solanaChainId = (1n << 63n) | 12345n;
+    const handle = new Uint8Array(32).fill(0xab);
+    for (let i = 0; i < 8; i++) {
+        handle[29 - i] = Number((solanaChainId >> BigInt(i * 8)) & 0xffn);
+    }
+    assert.equal(Buffer.from(handle.slice(22, 30)).toString('hex'), '8000000000003039');
+    const request = {
+        ...data.request,
+        ciphertext_handles: [Buffer.from(handle).toString('hex')],
+    };
+    const pubkey = new Uint8Array(32).fill(0x11);
+
+    assert.throws(
+        () => process_user_decryption_resp_solana_from_js(
+            request, pubkey, solanaChainId, [], enc_pk, enc_sk),
+        /Response does not exist/,
+    );
+    assert.throws(
+        () => process_user_decryption_resp_solana_from_js(
+            request, pubkey, solanaChainId + 1n, [], enc_pk, enc_sk),
+        /does not match handle chain ID/,
+    );
+    assert.throws(
+        () => process_user_decryption_resp_solana_from_js(
+            request, pubkey, Number(solanaChainId), [], enc_pk, enc_sk),
+        TypeError,
+    );
 });
 
 test('new client', (_t) => {


### PR DESCRIPTION
## Why

The merged [fhevm #3155](https://github.com/zama-ai/fhevm/pull/3155) establishes a cross-repository chain-kind invariant: Solana host chain IDs set bit 63, EVM host chain IDs leave it clear, and the complete value remains an exact `u64`/JavaScript `bigint` without masking or number conversion.
KMS is the cryptographic boundary, so a request must be rejected before linker computation or signcryption when its selected route disagrees with the chain kind embedded in its ciphertext handles.

PoC vector:

- Chain ID: `9223372036854788153`
- Hex: `0x8000000000003039`
- Big-endian bytes: `80 00 00 00 00 00 30 39`
- Handle location: bytes `[22..30]` of the canonical 32-byte ciphertext handle

## What changes

| Route | Accepted | Rejected |
| --- | --- | --- |
| Solana | Non-empty batch of exact 32-byte handles; every handle embeds the same high-bit `u64` chain ID | Low-bit IDs, mixed IDs, empty batches, 31/33-byte handles |
| Solana WASM client | Caller supplies the exact embedded chain ID as JavaScript `bigint` | Caller/handle mismatch, low-bit caller ID, JavaScript `number` |
| EVM | Existing `<= 32`-byte left-padding and low-bit behavior remain unchanged | Any normalized handle whose embedded chain ID sets bit 63 |

`SolanaUserDecryptBinding` is the checked representation used by both server and client boundaries; the raw `compute_link_solana(enc_key, handles, pubkey, chain_id)` helper is restricted to `kms-grpc` internals so downstream callers cannot bypass validation.
The Solana checks run before encryption-key deserialization, linker computation, response extraction, or signcryption; the EVM mirror check runs after its existing handle normalization.

## Review focus

- Confirm the full big-endian `u64` is read from every handle without masking.
- Confirm server and WASM paths can only compute a Solana link through a validated binding.
- Confirm the unchecked raw linker is not exposed outside `kms-grpc`.
- Confirm EVM short-handle padding semantics are unchanged apart from rejecting the Solana discriminator.
- Confirm the pinned KMS linker digest remains stable; it is intended to become a shared specification vector before eventual upstreaming.
- Confirm the prerequisite commit only initializes the existing `client_identity` field in branch test fixtures and applies rustfmt normalization.

## Validation

- `cargo test -p kms-grpc --all-features solana_link_tests`
- `cargo test -p kms test_validate_user_decrypt_req --lib`
- `cargo test -p kms solana_request_link_tests --lib`
- `cargo clippy -p kms-grpc --all-targets --all-features -- -D warnings`
- `cargo clippy -p kms --all-targets --all-features -- -D warnings`
- Node-target WASM build and `node --test`: 6/6
- Web-target WASM build
- Independent security, EVM-parity, and maintainability reviews with all actionable findings resolved

## Context and scope

- Cross-repository invariant: [zama-ai/fhevm#3155](https://github.com/zama-ai/fhevm/pull/3155), merged as [`857086a4`](https://github.com/zama-ai/fhevm/commit/857086a415dc3c15323d9f3aed9a585074fe0e13)
- KMS Solana reference branch/PR: [zama-ai/kms#665](https://github.com/zama-ai/kms/pull/665)
- Solana planning context: [Solana Q3 Plan to KR7.2/KR7.3 v0.15](https://app.notion.com/p/zamaai/Solana-Q3-Plan-to-KR7-2-KR7-3-v0-15-3955a7358d5e810f98d0c959ae4e2b7e?source=copy_link)
- Implementation base: [`feature/solana@047a6862`](https://github.com/zama-ai/kms/commit/047a6862330eca42b3c566d503fe4b9c0f7af906)

Legacy `solana:<hex>` routing remains supported but is forced through the same checked binding; removing that string overload belongs to the separate typed-identity cleanup.
This PR intentionally targets `feature/solana`, not `main`; eventual upstreaming remains deferred until the Solana specification and shared cross-repository vectors are ready.