### PR TITLE
chore: core-client reqid

### DIFF
--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -100,7 +100,7 @@ fn check_external_decryption_signature(
 pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
     rng: &mut R,
     num_requests: usize,
-    request_id: Option<RequestId>,
+    request_ids: Vec<RequestId>,
     internal_client: Arc<RwLock<Client>>,
     ct_batch: Vec<TypedCiphertext>,
     key_id: KeyId,
@@ -131,9 +131,13 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
             );
             tokio::time::sleep(inter_request_delay).await;
         }
-        // Use the explicitly provided request ID if there is one (only allowed for a single
-        // request, enforced at CLI validation), otherwise sample a random one.
-        let req_id = request_id.unwrap_or_else(|| RequestId::new_random(rng));
+        // Use the explicitly provided request ID for this request if there is one (the list
+        // length matches num_requests, enforced at CLI validation), otherwise sample a
+        // random one.
+        let req_id = request_ids
+            .get(i)
+            .copied()
+            .unwrap_or_else(|| RequestId::new_random(rng));
         let internal_client = internal_client.clone();
         let ct_batch = ct_batch.clone();
         let core_endpoints_req = core_endpoints_req.clone();
@@ -239,7 +243,7 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
 pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
     rng: &mut R,
     num_requests: usize,
-    request_id: Option<RequestId>,
+    request_ids: Vec<RequestId>,
     internal_client: Arc<RwLock<Client>>,
     ct_batch: Vec<TypedCiphertext>,
     key_id: KeyId,
@@ -269,9 +273,13 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
             );
             tokio::time::sleep(inter_request_delay).await;
         }
-        // Use the explicitly provided request ID if there is one (only allowed for a single
-        // request, enforced at CLI validation), otherwise sample a random one.
-        let req_id = request_id.unwrap_or_else(|| RequestId::new_random(rng));
+        // Use the explicitly provided request ID for this request if there is one (the list
+        // length matches num_requests, enforced at CLI validation), otherwise sample a
+        // random one.
+        let req_id = request_ids
+            .get(i)
+            .copied()
+            .unwrap_or_else(|| RequestId::new_random(rng));
         let internal_client = internal_client.clone();
         let ct_batch = ct_batch.clone();
         let core_endpoints_req = core_endpoints_req.clone();

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -100,6 +100,7 @@ fn check_external_decryption_signature(
 pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
     rng: &mut R,
     num_requests: usize,
+    request_id: Option<RequestId>,
     internal_client: Arc<RwLock<Client>>,
     ct_batch: Vec<TypedCiphertext>,
     key_id: KeyId,
@@ -130,7 +131,9 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
             );
             tokio::time::sleep(inter_request_delay).await;
         }
-        let req_id = RequestId::new_random(rng);
+        // Use the explicitly provided request ID if there is one (only allowed for a single
+        // request, enforced at CLI validation), otherwise sample a random one.
+        let req_id = request_id.unwrap_or_else(|| RequestId::new_random(rng));
         let internal_client = internal_client.clone();
         let ct_batch = ct_batch.clone();
         let core_endpoints_req = core_endpoints_req.clone();
@@ -236,6 +239,7 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
 pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
     rng: &mut R,
     num_requests: usize,
+    request_id: Option<RequestId>,
     internal_client: Arc<RwLock<Client>>,
     ct_batch: Vec<TypedCiphertext>,
     key_id: KeyId,
@@ -265,7 +269,9 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
             );
             tokio::time::sleep(inter_request_delay).await;
         }
-        let req_id = RequestId::new_random(rng);
+        // Use the explicitly provided request ID if there is one (only allowed for a single
+        // request, enforced at CLI validation), otherwise sample a random one.
+        let req_id = request_id.unwrap_or_else(|| RequestId::new_random(rng));
         let internal_client = internal_client.clone();
         let ct_batch = ct_batch.clone();
         let core_endpoints_req = core_endpoints_req.clone();

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -249,11 +249,21 @@ fn validate_cipher_args(cf: &CipherArguments) -> anyhow::Result<()> {
         ));
     }
 
-    if cf.get_request_id().is_some() && cf.get_num_requests() > 1 {
-        return Err(anyhow::anyhow!(
-            "An explicit request ID can only be used with a single request (got --num-requests {}), since request IDs must be unique.",
-            cf.get_num_requests()
-        ));
+    let request_ids = cf.get_request_ids();
+    if !request_ids.is_empty() {
+        if request_ids.len() != cf.get_num_requests() {
+            return Err(anyhow::anyhow!(
+                "The number of explicit request IDs ({}) must match --num-requests ({}).",
+                request_ids.len(),
+                cf.get_num_requests()
+            ));
+        }
+        let unique: std::collections::HashSet<_> = request_ids.iter().collect();
+        if unique.len() != request_ids.len() {
+            return Err(anyhow::anyhow!(
+                "Explicit request IDs must be unique, but duplicates were provided."
+            ));
+        }
     }
 
     Ok(())
@@ -510,10 +520,10 @@ impl CipherArguments {
         parse_extra_data(hex_str)
     }
 
-    pub fn get_request_id(&self) -> Option<RequestId> {
+    pub fn get_request_ids(&self) -> Vec<RequestId> {
         match self {
-            CipherArguments::FromFile(cipher_file) => cipher_file.request_id,
-            CipherArguments::FromArgs(cipher_parameters) => cipher_parameters.request_id,
+            CipherArguments::FromFile(cipher_file) => cipher_file.request_ids.clone(),
+            CipherArguments::FromArgs(cipher_parameters) => cipher_parameters.request_ids.clone(),
         }
     }
 }
@@ -586,14 +596,14 @@ pub struct CipherParameters {
     #[serde(skip_serializing, skip_deserializing)]
     #[clap(long)]
     pub extra_data: Option<String>,
-    /// Optionally specify the request ID to use for the public/user decryption request
-    /// (hex string of 32 bytes, optionally 0x-prefixed).
-    /// If not specified, a random request ID is sampled for each request.
-    /// Only allowed together with `--num-requests 1`, since request IDs must be unique.
-    /// This is ignored for the encryption command.
+    /// Optionally specify the request IDs to use for the public/user decryption requests
+    /// (hex strings of 32 bytes, optionally 0x-prefixed). Pass the flag multiple times or
+    /// give a comma-separated list; the number of IDs must match `--num-requests`, request
+    /// `i` uses the `i`-th ID. If not specified, a random request ID is sampled for each
+    /// request. This is ignored for the encryption command.
     #[serde(skip_serializing, skip_deserializing)]
-    #[clap(long)]
-    pub request_id: Option<RequestId>,
+    #[clap(long = "request-id", value_delimiter = ',')]
+    pub request_ids: Vec<RequestId>,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -618,12 +628,13 @@ pub struct CipherFile {
     /// Can optionally have a "0x" prefix.
     #[clap(long)]
     pub extra_data: Option<String>,
-    /// Optionally specify the request ID to use for the public/user decryption request
-    /// (hex string of 32 bytes, optionally 0x-prefixed).
-    /// If not specified, a random request ID is sampled for each request.
-    /// Only allowed together with `--num-requests 1`, since request IDs must be unique.
-    #[clap(long)]
-    pub request_id: Option<RequestId>,
+    /// Optionally specify the request IDs to use for the public/user decryption requests
+    /// (hex strings of 32 bytes, optionally 0x-prefixed). Pass the flag multiple times or
+    /// give a comma-separated list; the number of IDs must match `--num-requests`, request
+    /// `i` uses the `i`-th ID. If not specified, a random request ID is sampled for each
+    /// request.
+    #[clap(long = "request-id", value_delimiter = ',')]
+    pub request_ids: Vec<RequestId>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1723,7 +1734,7 @@ pub async fn execute_cmd(
             do_public_decrypt(
                 &mut rng,
                 cipher_args.get_num_requests(),
-                cipher_args.get_request_id(),
+                cipher_args.get_request_ids(),
                 internal_client,
                 ct_batch,
                 key_id,
@@ -1801,7 +1812,7 @@ pub async fn execute_cmd(
             do_user_decrypt(
                 &mut rng,
                 cipher_args.get_num_requests(),
-                cipher_args.get_request_id(),
+                cipher_args.get_request_ids(),
                 internal_client,
                 ct_batch,
                 key_id,

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -249,6 +249,13 @@ fn validate_cipher_args(cf: &CipherArguments) -> anyhow::Result<()> {
         ));
     }
 
+    if cf.get_request_id().is_some() && cf.get_num_requests() > 1 {
+        return Err(anyhow::anyhow!(
+            "An explicit request ID can only be used with a single request (got --num-requests {}), since request IDs must be unique.",
+            cf.get_num_requests()
+        ));
+    }
+
     Ok(())
 }
 
@@ -502,6 +509,13 @@ impl CipherArguments {
         };
         parse_extra_data(hex_str)
     }
+
+    pub fn get_request_id(&self) -> Option<RequestId> {
+        match self {
+            CipherArguments::FromFile(cipher_file) => cipher_file.request_id,
+            CipherArguments::FromArgs(cipher_parameters) => cipher_parameters.request_id,
+        }
+    }
 }
 
 // Helper function to parse the extra data from the CLI arguments, with the same logic for both CipherParameters and CipherFile.
@@ -572,6 +586,14 @@ pub struct CipherParameters {
     #[serde(skip_serializing, skip_deserializing)]
     #[clap(long)]
     pub extra_data: Option<String>,
+    /// Optionally specify the request ID to use for the public/user decryption request
+    /// (hex string of 32 bytes, optionally 0x-prefixed).
+    /// If not specified, a random request ID is sampled for each request.
+    /// Only allowed together with `--num-requests 1`, since request IDs must be unique.
+    /// This is ignored for the encryption command.
+    #[serde(skip_serializing, skip_deserializing)]
+    #[clap(long)]
+    pub request_id: Option<RequestId>,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -596,6 +618,12 @@ pub struct CipherFile {
     /// Can optionally have a "0x" prefix.
     #[clap(long)]
     pub extra_data: Option<String>,
+    /// Optionally specify the request ID to use for the public/user decryption request
+    /// (hex string of 32 bytes, optionally 0x-prefixed).
+    /// If not specified, a random request ID is sampled for each request.
+    /// Only allowed together with `--num-requests 1`, since request IDs must be unique.
+    #[clap(long)]
+    pub request_id: Option<RequestId>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1695,6 +1723,7 @@ pub async fn execute_cmd(
             do_public_decrypt(
                 &mut rng,
                 cipher_args.get_num_requests(),
+                cipher_args.get_request_id(),
                 internal_client,
                 ct_batch,
                 key_id,
@@ -1772,6 +1801,7 @@ pub async fn execute_cmd(
             do_user_decrypt(
                 &mut rng,
                 cipher_args.get_num_requests(),
+                cipher_args.get_request_id(),
                 internal_client,
                 ct_batch,
                 key_id,

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1034,7 +1034,7 @@ fn cipher_params(
         inter_request_delay_ms: 0,
         uncompressed_keys,
         extra_data: None,
-        request_id: None,
+        request_ids: vec![],
     }
 }
 
@@ -1190,7 +1190,7 @@ async fn integration_test_commands(
             parallel_requests: 1,
             inter_request_delay_ms: 0,
             extra_data: None,
-            request_id: None,
+            request_ids: vec![],
         })),
         CCCommand::UserDecrypt(CipherArguments::FromFile(CipherFile {
             input_path: ctxt_path.clone(),
@@ -1199,7 +1199,7 @@ async fn integration_test_commands(
             parallel_requests: 1,
             inter_request_delay_ms: 0,
             extra_data: None,
-            request_id: None,
+            request_ids: vec![],
         })),
     ];
 
@@ -1264,7 +1264,7 @@ async fn integration_test_commands(
             parallel_requests: 1,
             inter_request_delay_ms: 0,
             extra_data: None,
-            request_id: None,
+            request_ids: vec![],
         })),
         CCCommand::UserDecrypt(CipherArguments::FromFile(CipherFile {
             input_path: ctxt_with_sns_path.clone(),
@@ -1273,7 +1273,7 @@ async fn integration_test_commands(
             parallel_requests: 1,
             inter_request_delay_ms: 0,
             extra_data: None,
-            request_id: None,
+            request_ids: vec![],
         })),
     ];
 
@@ -3212,7 +3212,7 @@ async fn test_threshold_reshare() -> Result<()> {
             inter_request_delay_ms: 0,
             uncompressed_keys: false,
             extra_data: None,
-            request_id: None,
+            request_ids: vec![],
         })),
         200,
     );

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1034,6 +1034,7 @@ fn cipher_params(
         inter_request_delay_ms: 0,
         uncompressed_keys,
         extra_data: None,
+        request_id: None,
     }
 }
 
@@ -1189,6 +1190,7 @@ async fn integration_test_commands(
             parallel_requests: 1,
             inter_request_delay_ms: 0,
             extra_data: None,
+            request_id: None,
         })),
         CCCommand::UserDecrypt(CipherArguments::FromFile(CipherFile {
             input_path: ctxt_path.clone(),
@@ -1197,6 +1199,7 @@ async fn integration_test_commands(
             parallel_requests: 1,
             inter_request_delay_ms: 0,
             extra_data: None,
+            request_id: None,
         })),
     ];
 
@@ -1261,6 +1264,7 @@ async fn integration_test_commands(
             parallel_requests: 1,
             inter_request_delay_ms: 0,
             extra_data: None,
+            request_id: None,
         })),
         CCCommand::UserDecrypt(CipherArguments::FromFile(CipherFile {
             input_path: ctxt_with_sns_path.clone(),
@@ -1269,6 +1273,7 @@ async fn integration_test_commands(
             parallel_requests: 1,
             inter_request_delay_ms: 0,
             extra_data: None,
+            request_id: None,
         })),
     ];
 
@@ -3207,6 +3212,7 @@ async fn test_threshold_reshare() -> Result<()> {
             inter_request_delay_ms: 0,
             uncompressed_keys: false,
             extra_data: None,
+            request_id: None,
         })),
         200,
     );

--- a/core-client/tests/kind-testing/kubernetes_test_threshold.rs
+++ b/core-client/tests/kind-testing/kubernetes_test_threshold.rs
@@ -192,7 +192,7 @@ impl K8sTestContext {
             inter_request_delay_ms: 0,
             uncompressed_keys: false,
             extra_data: None,
-            request_id: None,
+            request_ids: vec![],
         }))
         .await;
 
@@ -231,7 +231,7 @@ impl K8sTestContext {
                     inter_request_delay_ms: 0,
                     parallel_requests: 1,
                     extra_data: None,
-                    request_id: None,
+                    request_ids: vec![],
                 },
             )))
             .await;

--- a/core-client/tests/kind-testing/kubernetes_test_threshold.rs
+++ b/core-client/tests/kind-testing/kubernetes_test_threshold.rs
@@ -192,6 +192,7 @@ impl K8sTestContext {
             inter_request_delay_ms: 0,
             uncompressed_keys: false,
             extra_data: None,
+            request_id: None,
         }))
         .await;
 
@@ -230,6 +231,7 @@ impl K8sTestContext {
                     inter_request_delay_ms: 0,
                     parallel_requests: 1,
                     extra_data: None,
+                    request_id: None,
                 },
             )))
             .await;


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->
Allow to specify requestId for decryptions request in core-client
### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
