### PR TITLE
refactor(solana): name validated user-decrypt request

### DIFF
--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -7,8 +7,8 @@ use crate::engine::centralized::central_kms::{
 use crate::engine::traits::{BackupOperator, BaseKms, ContextManager};
 use crate::engine::utils::MetricedError;
 use crate::engine::validation::{
-    DSEP_PUBLIC_DECRYPTION, DSEP_USER_DECRYPTION, RequestIdParsingErr, parse_grpc_request_id,
-    validate_public_decrypt_req, validate_user_decrypt_req,
+    DSEP_PUBLIC_DECRYPTION, DSEP_USER_DECRYPTION, RequestIdParsingErr, ValidatedUserDecryptRequest,
+    parse_grpc_request_id, validate_public_decrypt_req, validate_user_decrypt_req,
 };
 use crate::util::meta_store::{
     add_or_redo_failed_in_meta_store, retrieve_from_meta_store_with_timeout,
@@ -45,18 +45,18 @@ pub async fn user_decrypt_impl<
         .start();
 
     let inner = request.into_inner();
-    let (
+    let ValidatedUserDecryptRequest {
         typed_ciphertexts,
         link,
         client_enc_key_bytes,
-        client_address,
+        client_id: client_address,
         request_id,
         key_id,
         context_id,
         epoch_id,
         domain,
         extra_data,
-    ) = validate_user_decrypt_req(&inner)?;
+    } = validate_user_decrypt_req(&inner)?;
     if !service
         .context_manager
         .mpc_context_exists_in_cache(&context_id)

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -67,8 +67,8 @@ use crate::{
         traits::BaseKms,
         utils::MetricedError,
         validation::{
-            DSEP_USER_DECRYPTION, RequestIdParsingErr, parse_grpc_request_id,
-            validate_user_decrypt_req,
+            DSEP_USER_DECRYPTION, RequestIdParsingErr, ValidatedUserDecryptRequest,
+            parse_grpc_request_id, validate_user_decrypt_req,
         },
     },
     util::{
@@ -459,18 +459,18 @@ impl<
         let inner = Arc::new(request.into_inner());
         tracing::info!("{}", format_user_request(&inner));
 
-        let (
+        let ValidatedUserDecryptRequest {
             typed_ciphertexts,
             link,
-            client_enc_key_bytes_orig, // the original bytes for the encryption key
-            client_address,
-            req_id,
+            client_enc_key_bytes: client_enc_key_bytes_orig, // the original bytes for the encryption key
+            client_id: client_address,
+            request_id: req_id,
             key_id,
             context_id,
             epoch_id,
             domain,
             extra_data,
-        ) = validate_user_decrypt_req(inner.as_ref())?;
+        } = validate_user_decrypt_req(inner.as_ref())?;
         let my_role = validate_context_and_epoch(
             OP_USER_DECRYPT_REQUEST,
             &self.session_maker,

--- a/core/service/src/engine/validation_non_wasm.rs
+++ b/core/service/src/engine/validation_non_wasm.rs
@@ -209,29 +209,28 @@ fn solana_user_decrypt_client_id(solana_pubkey: &[u8; 32]) -> alloy_primitives::
     alloy_primitives::Address::from_slice(&alloy_primitives::keccak256(solana_pubkey)[12..])
 }
 
-/// Validates and unpacks a user decryption request and returns ciphertext, FheType, request digest, client
-/// encryption key, client verification key, key_id and request_id if valid.
+/// Validated fields required to execute a user-decryption request.
+#[derive(Debug)]
+pub(crate) struct ValidatedUserDecryptRequest {
+    pub(crate) typed_ciphertexts: Vec<TypedCiphertext>,
+    pub(crate) link: Vec<u8>,
+    pub(crate) client_enc_key_bytes: Vec<u8>,
+    pub(crate) client_id: alloy_primitives::Address,
+    pub(crate) request_id: RequestId,
+    pub(crate) key_id: KeyId,
+    pub(crate) context_id: ContextId,
+    pub(crate) epoch_id: EpochId,
+    pub(crate) domain: alloy_sol_types::Eip712Domain,
+    pub(crate) extra_data: Vec<u8>,
+}
+
+/// Validates and unpacks a user-decryption request into the fields required for execution.
 ///
 /// Observe that the validation is limited to checking the structure of the request and parsing data into the correct types,
 /// and does not check the existence of any of the referenced IDs (like request_id or key_id) or the consistency between them.
-#[expect(clippy::type_complexity)]
 pub(crate) fn validate_user_decrypt_req(
     req: &UserDecryptionRequest,
-) -> Result<
-    (
-        Vec<TypedCiphertext>,
-        Vec<u8>,
-        Vec<u8>,
-        alloy_primitives::Address,
-        RequestId,
-        KeyId,
-        ContextId,
-        EpochId,
-        alloy_sol_types::Eip712Domain,
-        Vec<u8>,
-    ),
-    MetricedError,
-> {
+) -> Result<ValidatedUserDecryptRequest, MetricedError> {
     unpack_user_decrypt_req(req).map_err(|e| {
         MetricedError::new(
             OP_USER_DECRYPT_REQUEST,
@@ -242,24 +241,9 @@ pub(crate) fn validate_user_decrypt_req(
     })
 }
 
-#[expect(clippy::type_complexity)]
 fn unpack_user_decrypt_req(
     req: &UserDecryptionRequest,
-) -> Result<
-    (
-        Vec<TypedCiphertext>,
-        Vec<u8>,
-        Vec<u8>,
-        alloy_primitives::Address,
-        RequestId,
-        KeyId,
-        ContextId,
-        EpochId,
-        alloy_sol_types::Eip712Domain,
-        Vec<u8>,
-    ),
-    Box<dyn std::error::Error + Send + Sync>,
-> {
+) -> Result<ValidatedUserDecryptRequest, Box<dyn std::error::Error + Send + Sync>> {
     let request_id =
         parse_optional_grpc_request_id(&req.request_id, RequestIdParsingErr::UserDecRequest)?;
     let key_id =
@@ -326,18 +310,18 @@ fn unpack_user_decrypt_req(
         // *authorization* seam differs (ed25519, already enforced by the connector), so there is
         // no user EIP-712 to verify here.
         let response_domain = optional_protobuf_to_alloy_domain(req.domain.as_ref())?;
-        return Ok((
-            req.typed_ciphertexts.clone(),
+        return Ok(ValidatedUserDecryptRequest {
+            typed_ciphertexts: req.typed_ciphertexts.clone(),
             link,
-            req.enc_key.clone(),
-            client_verf_key,
+            client_enc_key_bytes: req.enc_key.clone(),
+            client_id: client_verf_key,
             request_id,
             key_id,
             context_id,
             epoch_id,
-            response_domain,
-            req.extra_data.clone(),
-        ));
+            domain: response_domain,
+            extra_data: req.extra_data.clone(),
+        });
     }
 
     // EVM path: a typed `evm_address` (oneof) takes precedence and fails closed on a wrong length;
@@ -379,18 +363,18 @@ fn unpack_user_decrypt_req(
                 "Error deserializing UnifiedPublicEncKey from UserDecryptionRequest: {e}"
             )
         })?;
-    Ok((
-        req.typed_ciphertexts.clone(),
+    Ok(ValidatedUserDecryptRequest {
+        typed_ciphertexts: req.typed_ciphertexts.clone(),
         link,
-        req.enc_key.clone(),
-        client_verf_key,
+        client_enc_key_bytes: req.enc_key.clone(),
+        client_id: client_verf_key,
         request_id,
         key_id,
         context_id,
         epoch_id,
         domain,
-        req.extra_data.clone(),
-    ))
+        extra_data: req.extra_data.clone(),
+    })
 }
 
 /// Validates and unpacks a public decryption request and returns


### PR DESCRIPTION
## What

Replace the ten-element result tuple returned by shared user-decrypt validation with a named `ValidatedUserDecryptRequest`, then destructure the same fields in centralized and threshold execution.

## Why

This makes the EVM/Solana validation boundary reviewable by field name and is the first behavior-preserving prerequisite for the typed Solana identity cleanup tracked in [fhevm-internal #1727](https://github.com/zama-ai/fhevm-internal/issues/1727).

## Semantics and validation

EVM and Solana keep the same validation statements, branch order, errors, link computation, client identity, request/key/context/epoch IDs, response domain, extra data, and downstream execution values.

Validated with `cargo fmt --all --check`, focused shared and Solana user-decrypt validation tests, `cargo check -p kms --all-targets --all-features`, and `git diff --check`.
