### PR TITLE
refactor(solana): isolate user decrypt validation

### DIFF
--- a/core/service/src/engine/mod.rs
+++ b/core/service/src/engine/mod.rs
@@ -26,6 +26,8 @@ pub mod utils;
 
 #[cfg(feature = "non-wasm")]
 mod validation_non_wasm;
+#[cfg(feature = "non-wasm")]
+mod validation_solana;
 mod validation_wasm;
 
 // This is the only one that is allowed to be compiled with wasm

--- a/core/service/src/engine/validation_non_wasm.rs
+++ b/core/service/src/engine/validation_non_wasm.rs
@@ -27,7 +27,7 @@ use kms_grpc::{
         PublicDecryptionRequest, PublicDecryptionResponse, PublicDecryptionResponsePayload,
         TypedCiphertext, TypedPlaintext, UserDecryptionRequest,
     },
-    rpc_types::{SolanaUserDecryptBinding, optional_protobuf_to_alloy_domain},
+    rpc_types::optional_protobuf_to_alloy_domain,
 };
 use observability::metrics_names::{
     OP_KEYGEN_PREPROC_REQUEST, OP_NEW_EPOCH, OP_PUBLIC_DECRYPT_REQUEST, OP_USER_DECRYPT_REQUEST,
@@ -182,14 +182,6 @@ pub(crate) fn parse_grpc_request_id<'a, O: TryFrom<&'a kms_grpc::kms::v1::Reques
     })
 }
 
-/// Derives the stable 20-byte signcryption `client_id` from a 32-byte Solana pubkey as
-/// `keccak256(pubkey)[12..]`, mirroring EVM address derivation. The client reproduces this
-/// to de-signcrypt the response; it is a deterministic label, not an authorization input
-/// (Solana user-decrypt authorization is enforced by the kms-connector before this call).
-fn solana_user_decrypt_client_id(solana_pubkey: &[u8; 32]) -> alloy_primitives::Address {
-    alloy_primitives::Address::from_slice(&alloy_primitives::keccak256(solana_pubkey)[12..])
-}
-
 /// Validates and unpacks a user decryption request and returns ciphertext, FheType, request digest, client
 /// encryption key, client verification key, key_id and request_id if valid.
 ///
@@ -261,56 +253,9 @@ fn unpack_user_decrypt_req(
         return Err(anyhow::anyhow!(ERR_VALIDATE_USER_DECRYPTION_EMPTY_CTS).into());
     }
 
-    // Solana-native user decryption: the client identity is a typed 32-byte ed25519 pubkey and
-    // there is no EVM
-    // verifying contract. Authorization (RPC-verified on-chain ACL + ed25519 signMessage) is
-    // enforced by the kms-connector before this call — exactly as the gateway enforces the EVM
-    // ACL before the EVM path — so here we only bind the response to the request via the Solana
-    // link (`compute_link_solana`). The link is passed opaquely into signcryption, so the
-    // binding is sound as long as the client recomputes the same link. The response cert is the
-    // standard secp256k1 EIP-712 the gateway verifies, signed under the gateway's `Decryption`
-    // domain (`req.domain`) — see the domain note at the return below.
-    // Only the typed pubkey selects Solana. An unset pubkey follows the unchanged EVM route;
-    // `client_address` is never inspected for a Solana prefix.
-    let solana_pubkey_opt: Option<[u8; 32]> = req
-        .solana_pubkey
-        .as_deref()
-        .map(|pubkey| {
-            <[u8; 32]>::try_from(pubkey).map_err(|_| {
-                anyhow::anyhow!(
-                    "Solana client identity must be a 32-byte pubkey, got {} bytes",
-                    pubkey.len()
-                )
-            })
-        })
-        .transpose()?;
-    if let Some(solana_pubkey) = solana_pubkey_opt {
-        if !req.client_address.is_empty() {
-            return Err(anyhow::anyhow!(
-                "Solana user decryption request must not set client_address"
-            )
-            .into());
-        }
-        let binding = SolanaUserDecryptBinding::try_from_handle_bytes(
-            req.typed_ciphertexts
-                .iter()
-                .map(|ciphertext| ciphertext.external_handle.as_slice()),
-        )?;
-        let link = binding.compute_link(&req.enc_key, &solana_pubkey);
-        let client_verf_key = solana_user_decrypt_client_id(&solana_pubkey);
-        let _client_enc_key =
-            UnifiedPublicEncKey::deserialize_and_validate(&req.enc_key).map_err(|e| {
-                anyhow::anyhow!(
-                    "Error deserializing UnifiedPublicEncKey from Solana UserDecryptionRequest: {e}"
-                )
-            })?;
-        // The KMS signs `UserDecryptResponseVerification` under the gateway's `Decryption`
-        // EIP-712 domain (name/version/chainId/verifyingContract, carried in `req.domain`) so the
-        // gateway's `userDecryptionResponse` recovers the registered KMS signer on-chain. The
-        // response cert is the standard secp256k1 EIP-712 — identical to EVM; only the user
-        // *authorization* seam differs (ed25519, already enforced by the connector), so there is
-        // no user EIP-712 to verify here.
-        let response_domain = optional_protobuf_to_alloy_domain(req.domain.as_ref())?;
+    if let Some((link, client_verf_key, response_domain)) =
+        super::validation_solana::validate_user_decrypt_req(req)?
+    {
         return Ok((
             req.typed_ciphertexts.clone(),
             link,
@@ -1063,23 +1008,6 @@ fn unpack_new_mpc_epoch_req(req: NewMpcEpochRequest) -> anyhow::Result<VerifiedN
         resharing,
         extra_data: req.extra_data,
     })
-}
-
-#[cfg(test)]
-mod solana_user_decrypt_tests {
-    use super::solana_user_decrypt_client_id;
-
-    #[test]
-    fn client_id_is_keccak_derived_and_deterministic() {
-        let pubkey = [0x22u8; 32];
-        let id = solana_user_decrypt_client_id(&pubkey);
-        assert_eq!(id, solana_user_decrypt_client_id(&pubkey));
-        let expected = &alloy_primitives::keccak256(pubkey)[12..];
-        assert_eq!(id.as_slice(), expected);
-        let mut other = pubkey;
-        other[0] ^= 0xff;
-        assert_ne!(id, solana_user_decrypt_client_id(&other));
-    }
 }
 
 #[cfg(test)]

--- a/core/service/src/engine/validation_solana.rs
+++ b/core/service/src/engine/validation_solana.rs
@@ -1,0 +1,72 @@
+use crate::cryptography::encryption::UnifiedPublicEncKey;
+use alloy_primitives::Address;
+use kms_grpc::{
+    kms::v1::UserDecryptionRequest,
+    rpc_types::{SolanaUserDecryptBinding, optional_protobuf_to_alloy_domain},
+};
+
+type SolanaUserDecryptValidation = (Vec<u8>, Address, alloy_sol_types::Eip712Domain);
+
+/// Validates the Solana-owned fields of a user-decryption request.
+///
+/// An unset Solana pubkey leaves the request on the unchanged EVM path. Solana authorization is
+/// enforced by the connector before this call; this validation binds the KMS response to the
+/// typed pubkey, encryption key, ciphertext handles, and response-signing domain.
+pub(super) fn validate_user_decrypt_req(
+    req: &UserDecryptionRequest,
+) -> Result<Option<SolanaUserDecryptValidation>, Box<dyn std::error::Error + Send + Sync>> {
+    let Some(pubkey) = req.solana_pubkey.as_deref() else {
+        return Ok(None);
+    };
+    let pubkey = <[u8; 32]>::try_from(pubkey).map_err(|_| {
+        anyhow::anyhow!(
+            "Solana client identity must be a 32-byte pubkey, got {} bytes",
+            pubkey.len()
+        )
+    })?;
+    if !req.client_address.is_empty() {
+        return Err(
+            anyhow::anyhow!("Solana user decryption request must not set client_address").into(),
+        );
+    }
+
+    let binding = SolanaUserDecryptBinding::try_from_handle_bytes(
+        req.typed_ciphertexts
+            .iter()
+            .map(|ciphertext| ciphertext.external_handle.as_slice()),
+    )?;
+    let link = binding.compute_link(&req.enc_key, &pubkey);
+    let client_id = solana_user_decrypt_client_id(&pubkey);
+
+    UnifiedPublicEncKey::deserialize_and_validate(&req.enc_key).map_err(|error| {
+        anyhow::anyhow!(
+            "Error deserializing UnifiedPublicEncKey from Solana UserDecryptionRequest: {error}"
+        )
+    })?;
+    let response_domain = optional_protobuf_to_alloy_domain(req.domain.as_ref())?;
+
+    Ok(Some((link, client_id, response_domain)))
+}
+
+/// Derives the 20-byte signcryption client ID as `keccak256(pubkey)[12..]`, mirroring EVM
+/// address derivation. It is a deterministic response label, not an authorization input.
+fn solana_user_decrypt_client_id(pubkey: &[u8; 32]) -> Address {
+    Address::from_slice(&alloy_primitives::keccak256(pubkey)[12..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::solana_user_decrypt_client_id;
+
+    #[test]
+    fn client_id_is_keccak_derived_and_deterministic() {
+        let pubkey = [0x22u8; 32];
+        let id = solana_user_decrypt_client_id(&pubkey);
+        assert_eq!(id, solana_user_decrypt_client_id(&pubkey));
+        assert_eq!(id.as_slice(), &alloy_primitives::keccak256(pubkey)[12..]);
+
+        let mut other = pubkey;
+        other[0] ^= 0xff;
+        assert_ne!(id, solana_user_decrypt_client_id(&other));
+    }
+}


### PR DESCRIPTION
## Why

The Solana user-decryption validation and linker construction were embedded in the shared 2,494-line non-WASM validator. That made the EVM path harder to read and would force future Solana specification changes to reopen the shared validation block.

This is a PoC maintainability change. It intentionally does not generalize EVM and Solana behind a new host abstraction, and it does not implement the protocol decisions tracked in:

- https://github.com/zama-ai/fhevm-internal/issues/1632
- https://github.com/zama-ai/fhevm-internal/issues/1689
- https://github.com/zama-ai/fhevm-internal/issues/1690

## What changes

- moves the Solana-only user-decrypt validation into `engine/validation_solana.rs`;
- leaves common request-ID, key-ID, context, epoch, extra-data, and empty-ciphertext checks in the existing validator;
- replaces the embedded Solana block with one optional helper call before the unchanged EVM route;
- keeps the existing cross-route tests in the shared validator, where they verify dispatch and error downcasts.

The helper returns only the three Solana-specific values already consumed by the caller: request link, derived signcryption client ID, and response-signing domain. No shared request struct or host enum is introduced.

## EVM semantic comparison

The EVM path remains unchanged: absence of `solana_pubkey` continues through checksummed-address parsing, user EIP-712 verification, EVM link computation, and encryption-key validation.

The Solana sibling continues to:

- select the route only through the typed `solana_pubkey` field;
- require an exact 32-byte pubkey and an empty EVM `client_address`;
- validate exact 32-byte ciphertext handles, the high-bit Solana chain ID, and one common chain ID;
- bind the handles, encryption key, and pubkey through the Solana linker;
- validate the encryption key and response-signing domain;
- preserve typed `SolanaUserDecryptBindingError` values for callers and tests.

## Scope

- non-WASM KMS Core only;
- no protobuf or wire-format change;
- no EVM behavior or EVM type change;
- no backward-compatibility layer;
- 78 insertions / 76 deletions: this is isolation, not additional architecture.

## Validation

- `cargo test -p kms --no-default-features --features non-wasm engine::validation_solana`
- `cargo test -p kms --no-default-features --features non-wasm engine::validation_non_wasm::tests::test_validate_user_decrypt_req`
- `cargo clippy -p kms --no-default-features --features non-wasm --lib -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

An independent adversarial review found no actionable findings. It specifically checked EVM semantic drift, validation ordering, boxed-error/downcast preservation, feature gating, WASM impact, and whether the module boundary justified its indirection.
