### PR TITLE
fix: locally failing tests

### DIFF
--- a/core/experiments/src/conf/party.rs
+++ b/core/experiments/src/conf/party.rs
@@ -338,32 +338,36 @@ mod tests {
         assert!(r.is_err());
     }
 
-    // Sets process-wide env vars; safe under nextest because each test runs
-    // in its own process, so the mutations are not visible to siblings.
+    // Sets process-wide env vars. These mutations are visible to any sibling
+    // test running in the same process, and `init_conf` layers env vars on top
+    // of file config, so they would override the values the file-based tests
+    // (e.g. `test_party_conf_no_peers`) load. To keep this test isolated
+    // regardless of the test runner's process model, it uses a dedicated
+    // `DDECENV` prefix that no other test reads from.
     #[test]
     fn test_party_conf_with_env() {
         unsafe {
-            env::set_var("DDEC__PROTOCOL__HOST__ADDRESS", "p3");
-            env::set_var("DDEC__PROTOCOL__HOST__PORT", "50000");
-            env::set_var("DDEC__PROTOCOL__HOST__ID", "3");
-            env::set_var("DDEC__PROTOCOL__HOST__CHOREOPORT", "60000");
-            env::set_var("DDEC__CERTPATHS__CERT", "/path/to/cert");
-            env::set_var("DDEC__CERTPATHS__KEY", "/path/to/key");
-            env::set_var("DDEC__CERTPATHS__CALIST", "/path/one,/path/two");
-            env::set_var("DDEC__TELEMETRY__TRACING_SERVICE_NAME", "moby-p3");
-            env::set_var("DDEC__TELEMETRY__TRACING_ENDPOINT", "moby-p3-endpoint");
+            env::set_var("DDECENV__PROTOCOL__HOST__ADDRESS", "p3");
+            env::set_var("DDECENV__PROTOCOL__HOST__PORT", "50000");
+            env::set_var("DDECENV__PROTOCOL__HOST__ID", "3");
+            env::set_var("DDECENV__PROTOCOL__HOST__CHOREOPORT", "60000");
+            env::set_var("DDECENV__CERTPATHS__CERT", "/path/to/cert");
+            env::set_var("DDECENV__CERTPATHS__KEY", "/path/to/key");
+            env::set_var("DDECENV__CERTPATHS__CALIST", "/path/one,/path/two");
+            env::set_var("DDECENV__TELEMETRY__TRACING_SERVICE_NAME", "moby-p3");
+            env::set_var("DDECENV__TELEMETRY__TRACING_ENDPOINT", "moby-p3-endpoint");
 
-            env::set_var("DDEC__NET_CONF__MESSAGE_LIMIT", "60");
-            env::set_var("DDEC__NET_CONF__MULTIPLIER", "2.2");
-            env::set_var("DDEC__NET_CONF__MAX_INTERVAL", "4");
-            env::set_var("DDEC__NET_CONF__MAX_ELAPSED_TIME", "200");
-            env::set_var("DDEC__NET_CONF__NETWORK_TIMEOUT", "20");
-            env::set_var("DDEC__NET_CONF__NETWORK_TIMEOUT_BK", "200");
-            env::set_var("DDEC__NET_CONF__NETWORK_TIMEOUT_BK_SNS", "2300");
-            env::set_var("DDEC__NET_CONF__MAX_EN_DECODE_MESSAGE_SIZE", "3258");
+            env::set_var("DDECENV__NET_CONF__MESSAGE_LIMIT", "60");
+            env::set_var("DDECENV__NET_CONF__MULTIPLIER", "2.2");
+            env::set_var("DDECENV__NET_CONF__MAX_INTERVAL", "4");
+            env::set_var("DDECENV__NET_CONF__MAX_ELAPSED_TIME", "200");
+            env::set_var("DDECENV__NET_CONF__NETWORK_TIMEOUT", "20");
+            env::set_var("DDECENV__NET_CONF__NETWORK_TIMEOUT_BK", "200");
+            env::set_var("DDECENV__NET_CONF__NETWORK_TIMEOUT_BK_SNS", "2300");
+            env::set_var("DDECENV__NET_CONF__MAX_EN_DECODE_MESSAGE_SIZE", "3258");
         }
         let party_conf: PartyConf = Settings::builder()
-            .env_prefix("DDEC")
+            .env_prefix("DDECENV")
             .build()
             .init_conf()
             .unwrap();
@@ -390,24 +394,24 @@ mod tests {
         );
 
         unsafe {
-            env::remove_var("DDEC__PROTOCOL__HOST__ADDRESS");
-            env::remove_var("DDEC__PROTOCOL__HOST__PORT");
-            env::remove_var("DDEC__PROTOCOL__HOST__ID");
-            env::remove_var("DDEC__PROTOCOL__HOST__CHOREOPORT");
-            env::remove_var("DDEC__CERTPATHS__CERT");
-            env::remove_var("DDEC__CERTPATHS__KEY");
-            env::remove_var("DDEC__CERTPATHS__CALIST");
-            env::remove_var("DDEC__TELEMETRY__TRACING_SERVICE_NAME");
-            env::remove_var("DDEC__TELEMETRY__TRACING_ENDPOINT");
+            env::remove_var("DDECENV__PROTOCOL__HOST__ADDRESS");
+            env::remove_var("DDECENV__PROTOCOL__HOST__PORT");
+            env::remove_var("DDECENV__PROTOCOL__HOST__ID");
+            env::remove_var("DDECENV__PROTOCOL__HOST__CHOREOPORT");
+            env::remove_var("DDECENV__CERTPATHS__CERT");
+            env::remove_var("DDECENV__CERTPATHS__KEY");
+            env::remove_var("DDECENV__CERTPATHS__CALIST");
+            env::remove_var("DDECENV__TELEMETRY__TRACING_SERVICE_NAME");
+            env::remove_var("DDECENV__TELEMETRY__TRACING_ENDPOINT");
 
-            env::remove_var("DDEC__NET_CONF__MESSAGE_LIMIT");
-            env::remove_var("DDEC__NET_CONF__MULTIPLIER");
-            env::remove_var("DDEC__NET_CONF__MAX_INTERVAL");
-            env::remove_var("DDEC__NET_CONF__MAX_ELAPSED_TIME");
-            env::remove_var("DDEC__NET_CONF__NETWORK_TIMEOUT");
-            env::remove_var("DDEC__NET_CONF__NETWORK_TIMEOUT_BK");
-            env::remove_var("DDEC__NET_CONF__NETWORK_TIMEOUT_BK_SNS");
-            env::remove_var("DDEC__NET_CONF__MAX_EN_DECODE_MESSAGE_SIZE");
+            env::remove_var("DDECENV__NET_CONF__MESSAGE_LIMIT");
+            env::remove_var("DDECENV__NET_CONF__MULTIPLIER");
+            env::remove_var("DDECENV__NET_CONF__MAX_INTERVAL");
+            env::remove_var("DDECENV__NET_CONF__MAX_ELAPSED_TIME");
+            env::remove_var("DDECENV__NET_CONF__NETWORK_TIMEOUT");
+            env::remove_var("DDECENV__NET_CONF__NETWORK_TIMEOUT_BK");
+            env::remove_var("DDECENV__NET_CONF__NETWORK_TIMEOUT_BK_SNS");
+            env::remove_var("DDECENV__NET_CONF__MAX_EN_DECODE_MESSAGE_SIZE");
         }
     }
 }


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->
A couple of tests fail locally due them changing env variables used in other tests, that might be run in parallel. 

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
