### PR TITLE
chore: fix context deletion

### DIFF
--- a/core/service/src/engine/context_manager.rs
+++ b/core/service/src/engine/context_manager.rs
@@ -263,8 +263,11 @@ where
             })?;
         let mut guarded_backup_storage = guarded_backup_storage_ref.lock().await;
 
-        // There is nothing we can do if deletion fails here.
-        // Note that it cannot fail if the context does not exist.
+        // Fail closed: `delete_custodian_context_at_id` only removes the recovery material
+        // once every backed-up object for the context has been confirmed erased. If it
+        // returns an error we propagate it and, crucially, do NOT drop the context from the
+        // meta store below, so the operator retains a retryable degraded state instead of a
+        // context that reports successful destruction while backups linger in storage.
         delete_custodian_context_at_id(
             &mut *guarded_pub_storage,
             &mut guarded_backup_storage,

--- a/core/service/src/engine/context_manager.rs
+++ b/core/service/src/engine/context_manager.rs
@@ -263,7 +263,7 @@ where
             })?;
         let mut guarded_backup_storage = guarded_backup_storage_ref.lock().await;
 
-        // Fail closed: `delete_custodian_context_at_id` only removes the recovery material
+        // `delete_custodian_context_at_id` only removes the recovery material
         // once every backed-up object for the context has been confirmed erased. If it
         // returns an error we propagate it and, crucially, do NOT drop the context from the
         // meta store below, so the operator retains a retryable degraded state instead of a

--- a/core/service/src/vault/mod.rs
+++ b/core/service/src/vault/mod.rs
@@ -489,9 +489,9 @@ pub mod tests {
     use crate::vault::keychain::KeychainProxy;
     use crate::vault::keychain::secretsharing::SecretShareKeychain;
     use crate::vault::storage::file::FileStorage;
-    use crate::vault::storage::{Storage, StorageType};
+    use crate::vault::storage::{Storage, StorageExt, StorageReader, StorageReaderExt, StorageType};
     use aes_prng::AesRng;
-    use kms_grpc::{RequestId, rpc_types::PrivDataType};
+    use kms_grpc::{EpochId, RequestId, rpc_types::PrivDataType};
     use rand::SeedableRng;
 
     #[test]
@@ -564,5 +564,119 @@ pub mod tests {
             "Backup data file should be at <backup_root>/<custodian_context_id>/<data_type>/<request_id>, \
              expected: {expected_file:?}"
         );
+    }
+
+    /// Regression test for the epoch-namespace gap in custodian context destruction.
+    ///
+    /// `remove_old_backup` (the first thing `delete_custodian_context_at_id` does when a
+    /// custodian context is retired) enumerates and deletes backups with the non-epoch-aware
+    /// [`StorageReader::all_data_ids`] / `delete_data` APIs. Epoch-scoped backup material
+    /// (`FheKeyInfo`, `FhePrivateKey`, `CrsInfo`) is written under
+    /// `<backup_id>/<type>/<epoch_id>/<data_id>`, which those APIs never see. So retiring a
+    /// context reports success while leaving epoch-scoped ciphertexts recoverable in storage.
+    ///
+    /// This test fails on the current (buggy) code and should pass once `remove_old_backup`
+    /// enumerates and deletes epoch-scoped objects too.
+    #[tokio::test]
+    async fn test_remove_old_backup_deletes_epoch_scoped_data() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let backup_storage =
+            FileStorage::new(Some(temp_dir.path()), StorageType::BACKUP, None).unwrap();
+
+        // Build a secret-sharing backup vault.
+        let mut rng = AesRng::seed_from_u64(42);
+        let mut enc = Encryption::new(PkeSchemeType::MlKem512, &mut rng);
+        let (_dec_key, enc_key) = enc.keygen().unwrap();
+        let keychain = SecretShareKeychain::<AesRng>::new::<FileStorage>(rng, None)
+            .await
+            .unwrap();
+        let mut vault = Vault {
+            storage: crate::vault::storage::StorageProxy::from(backup_storage),
+            keychain: Some(KeychainProxy::SecretSharing(keychain)),
+        };
+
+        // The custodian context we will retire, and the one that becomes current after rotation.
+        let old_backup_id = derive_request_id("old_custodian_context").unwrap();
+        let current_backup_id = derive_request_id("current_custodian_context").unwrap();
+
+        // `FheKeyInfo` is one of the epoch-scoped private data types.
+        let data_type = PrivDataType::FheKeyInfo;
+        let epoch_id = EpochId::from_bytes([7u8; 32]);
+
+        // While `old_backup_id` is the current context, back up two objects: one epoch-scoped
+        // (as the real backup-sync path does via `store_data_at_epoch`) and one non-epoch object
+        // (a positive control proving `remove_old_backup` actually runs and deletes what it sees).
+        set_current_backup_id(&mut vault, old_backup_id, enc_key.clone());
+        let epoch_id_item = derive_request_id("epoch_backup_item").unwrap();
+        vault
+            .store_bytes_at_epoch(
+                b"epoch_secret",
+                &epoch_id_item,
+                &epoch_id,
+                &data_type.to_string(),
+            )
+            .await
+            .unwrap();
+        let non_epoch_item = derive_request_id("non_epoch_backup_item").unwrap();
+        vault
+            .store_bytes(b"non_epoch_secret", &non_epoch_item, &data_type.to_string())
+            .await
+            .unwrap();
+
+        // Sanity: both objects are present under the old context before retirement.
+        let old_data_type =
+            VaultDataType::CustodianBackupData(old_backup_id, data_type).to_string();
+        assert!(
+            vault
+                .storage
+                .data_exists_at_epoch(&epoch_id_item, &epoch_id, &old_data_type)
+                .await
+                .unwrap(),
+            "epoch-scoped backup should exist before destruction"
+        );
+
+        // Rotate: a new custodian context becomes current so the old one is allowed to be retired.
+        set_current_backup_id(&mut vault, current_backup_id, enc_key);
+
+        // Retire the old context. This is exactly what `delete_custodian_context_at_id` calls
+        // before deleting the recovery material and reporting a successful destruction.
+        vault.remove_old_backup(&old_backup_id).await.unwrap();
+
+        // Positive control: the non-epoch object was deleted, so `remove_old_backup` did run.
+        assert!(
+            vault
+                .storage
+                .all_data_ids(&old_data_type)
+                .await
+                .unwrap()
+                .is_empty(),
+            "non-epoch backup should have been deleted by remove_old_backup"
+        );
+
+        // The retirement guarantee: no backup object for the retired context may remain.
+        // BUG: the epoch-scoped object survives because `remove_old_backup` only looks at the
+        // non-epoch namespace, so this assertion currently fails.
+        let leftover = vault
+            .storage
+            .all_data_ids_from_all_epochs(&old_data_type)
+            .await
+            .unwrap();
+        assert!(
+            leftover.is_empty(),
+            "destroying a custodian context must erase epoch-scoped backups, \
+             but these survived: {leftover:?}"
+        );
+    }
+
+    /// Point the vault's secret-sharing keychain at `backup_id` as the current custodian context.
+    fn set_current_backup_id(
+        vault: &mut Vault,
+        backup_id: RequestId,
+        enc_key: crate::cryptography::encryption::UnifiedPublicEncKey,
+    ) {
+        match vault.keychain.as_mut() {
+            Some(KeychainProxy::SecretSharing(kc)) => kc.set_backup_enc_key(backup_id, enc_key),
+            _ => panic!("expected a secret sharing keychain"),
+        }
     }
 }

--- a/core/service/src/vault/mod.rs
+++ b/core/service/src/vault/mod.rs
@@ -70,10 +70,23 @@ impl Vault {
     }
 
     /// Method for removing an old custodian backup identified by `backup_id`.
-    /// This is based on the id of the backup, and removes all the backed up information under `backup_id`.
-    /// An error will be returned if the backup exists but could not be deleted or if `backup_id` is the _current_ backup id.
-    /// An info log is produced for each data type that is not found in the backup.
+    ///
+    /// Removes *all* backed-up information stored under `backup_id`, covering both the
+    /// non-epoch namespace (`<backup_id>/<type>/<id>`) and the epoch namespace
+    /// (`<backup_id>/<type>/<epoch>/<id>`) used for epoch-scoped material such as
+    /// [`PrivDataType::FheKeyInfo`], [`PrivDataType::FhePrivateKey`] and
+    /// [`PrivDataType::CrsInfo`].
+    ///
+    /// The method fails closed: after deleting, it re-enumerates every namespace and
+    /// returns an error if any object still remains. Callers therefore only proceed to
+    /// delete recovery material / drop lifecycle state once erasure is confirmed complete,
+    /// so a partial deletion is retried rather than reported as a successful destruction.
+    ///
+    /// An error is also returned if `backup_id` is the _current_ backup id, or if this is
+    /// not a custodian (secret-sharing) backup vault.
     async fn remove_old_backup(&mut self, backup_id: &RequestId) -> anyhow::Result<()> {
+        // Only secret-sharing (custodian) backup vaults support per-backup-id removal, and
+        // we must never wipe the backup that is currently in use.
         match self.keychain.as_ref() {
             Some(KeychainProxy::SecretSharing(secret_share_keychain)) => {
                 if secret_share_keychain.get_current_backup_id()? == *backup_id {
@@ -81,29 +94,86 @@ impl Vault {
                         "remove_old_backup cannot be called on the current backup id"
                     ));
                 }
-                for cur_type in PrivDataType::iter() {
-                    let vault_data_type = VaultDataType::CustodianBackupData(*backup_id, cur_type);
-                    let ids = self
-                        .storage
-                        .all_data_ids(&vault_data_type.to_string())
-                        .await?;
-                    if ids.is_empty() {
-                        tracing::info!(
-                            "No data found for backup id {backup_id} and data type {cur_type}"
-                        );
-                    }
-                    for cur_id in ids {
-                        self.storage
-                            .delete_data(&cur_id, &vault_data_type.to_string())
-                            .await?;
-                    }
-                }
-                Ok(())
             }
-            _ => Err(anyhow!(
-                "remove_old_backup can only be called on custodian backup vaults"
-            )),
+            _ => {
+                return Err(anyhow!(
+                    "remove_old_backup can only be called on custodian backup vaults"
+                ));
+            }
         }
+
+        // We address the storage directly with the fully-qualified
+        // `CustodianBackupData(backup_id, ..)` data type rather than going through the
+        // Vault's `StorageReaderExt`/`StorageExt` methods: those resolve the data type
+        // against the *current* backup id and would therefore target the wrong namespace
+        // when erasing a retired context.
+        for cur_type in PrivDataType::iter() {
+            let vault_data_type =
+                VaultDataType::CustodianBackupData(*backup_id, cur_type).to_string();
+
+            // Non-epoch objects.
+            for cur_id in self.storage.all_data_ids(&vault_data_type).await? {
+                self.storage.delete_data(&cur_id, &vault_data_type).await?;
+            }
+
+            // Epoch-scoped objects.
+            for epoch_id in self
+                .storage
+                .all_epoch_ids_for_data(&vault_data_type)
+                .await?
+            {
+                for cur_id in self
+                    .storage
+                    .all_data_ids_at_epoch(&epoch_id, &vault_data_type)
+                    .await?
+                {
+                    self.storage
+                        .delete_data_at_epoch(&cur_id, &epoch_id, &vault_data_type)
+                        .await?;
+                }
+            }
+        }
+
+        // Fail closed: confirm nothing survived before the caller is allowed to delete the
+        // recovery material and drop lifecycle state.
+        let mut residual = Vec::new();
+        for cur_type in PrivDataType::iter() {
+            let vault_data_type =
+                VaultDataType::CustodianBackupData(*backup_id, cur_type).to_string();
+
+            let remaining_non_epoch = self.storage.all_data_ids(&vault_data_type).await?;
+            if !remaining_non_epoch.is_empty() {
+                residual.push(format!(
+                    "{} non-epoch object(s) for data type {cur_type}",
+                    remaining_non_epoch.len()
+                ));
+            }
+
+            for epoch_id in self
+                .storage
+                .all_epoch_ids_for_data(&vault_data_type)
+                .await?
+            {
+                let remaining_epoch = self
+                    .storage
+                    .all_data_ids_at_epoch(&epoch_id, &vault_data_type)
+                    .await?;
+                if !remaining_epoch.is_empty() {
+                    residual.push(format!(
+                        "{} object(s) for data type {cur_type} at epoch {epoch_id}",
+                        remaining_epoch.len()
+                    ));
+                }
+            }
+        }
+        if !residual.is_empty() {
+            return Err(anyhow!(
+                "remove_old_backup did not fully erase backup id {backup_id}; residual data remains: {}",
+                residual.join(", ")
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -489,7 +559,9 @@ pub mod tests {
     use crate::vault::keychain::KeychainProxy;
     use crate::vault::keychain::secretsharing::SecretShareKeychain;
     use crate::vault::storage::file::FileStorage;
-    use crate::vault::storage::{Storage, StorageExt, StorageReader, StorageReaderExt, StorageType};
+    use crate::vault::storage::{
+        Storage, StorageExt, StorageReader, StorageReaderExt, StorageType,
+    };
     use aes_prng::AesRng;
     use kms_grpc::{EpochId, RequestId, rpc_types::PrivDataType};
     use rand::SeedableRng;

--- a/core/service/src/vault/mod.rs
+++ b/core/service/src/vault/mod.rs
@@ -134,7 +134,7 @@ impl Vault {
             }
         }
 
-        // Fail closed: confirm nothing survived before the caller is allowed to delete the
+        // confirm nothing survived before the caller is allowed to delete the
         // recovery material and drop lifecycle state.
         let mut residual = Vec::new();
         for cur_type in PrivDataType::iter() {
@@ -639,16 +639,7 @@ pub mod tests {
     }
 
     /// Regression test for the epoch-namespace gap in custodian context destruction.
-    ///
-    /// `remove_old_backup` (the first thing `delete_custodian_context_at_id` does when a
-    /// custodian context is retired) enumerates and deletes backups with the non-epoch-aware
-    /// [`StorageReader::all_data_ids`] / `delete_data` APIs. Epoch-scoped backup material
-    /// (`FheKeyInfo`, `FhePrivateKey`, `CrsInfo`) is written under
-    /// `<backup_id>/<type>/<epoch_id>/<data_id>`, which those APIs never see. So retiring a
-    /// context reports success while leaving epoch-scoped ciphertexts recoverable in storage.
-    ///
-    /// This test fails on the current (buggy) code and should pass once `remove_old_backup`
-    /// enumerates and deletes epoch-scoped objects too.
+    /// Details can be found in https://github.com/zama-ai/kms-internal/issues/3110.
     #[tokio::test]
     async fn test_remove_old_backup_deletes_epoch_scoped_data() {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -698,6 +689,14 @@ pub mod tests {
         // Sanity: both objects are present under the old context before retirement.
         let old_data_type =
             VaultDataType::CustodianBackupData(old_backup_id, data_type).to_string();
+        assert!(
+            vault
+                .storage
+                .data_exists(&non_epoch_item, &old_data_type)
+                .await
+                .unwrap(),
+            "non-epoch backup should exist before destruction"
+        );
         assert!(
             vault
                 .storage

--- a/core/service/src/vault/storage/s3.rs
+++ b/core/service/src/vault/storage/s3.rs
@@ -147,7 +147,10 @@ impl S3Storage {
         Ok(())
     }
 
-    /// Deletes the object at the given key, if it exists. Does not fail if the object does not exist or if the deletion fails.
+    /// Deletes the object at the given key. `DeleteObject` is idempotent on S3, so this
+    /// succeeds when the object does not exist, but a genuine deletion failure is now
+    /// propagated to the caller instead of being logged and swallowed. Callers that must
+    /// guarantee erasure (e.g. custodian-context destruction) rely on this to fail closed.
     async fn delete_data_at_key(&mut self, key: &str) -> anyhow::Result<()> {
         tracing::info!(
             "Deleting object from bucket {} under key {}",
@@ -155,19 +158,51 @@ impl S3Storage {
             key
         );
 
-        // Attempt S3 deletion but don't fail on errors
-        if let Err(e) = self
-            .s3_client
+        self.s3_client
             .delete_object()
             .bucket(&self.bucket)
             .key(key)
             .send()
             .await
-        {
-            tracing::warn!("S3 delete failed: {:?}", e);
-        }
+            .map_err(|e| anyhow::anyhow!("S3 delete failed for key {key}: {e}"))?;
 
         Ok(())
+    }
+
+    /// List every object key (from `contents`) and common prefix (from `common_prefixes`)
+    /// under `prefix`, following `ListObjectsV2` continuation tokens so the result is the
+    /// full listing rather than a single (≤1000-entry) page. Keys and prefixes are trimmed.
+    async fn list_all(&self, prefix: &str) -> anyhow::Result<(Vec<String>, Vec<String>)> {
+        let mut keys = Vec::new();
+        let mut common_prefixes = Vec::new();
+        let mut continuation_token = None;
+        loop {
+            let result = self
+                .s3_client
+                .list_objects_v2()
+                .bucket(&self.bucket)
+                .delimiter("/")
+                .prefix(prefix)
+                .set_continuation_token(continuation_token)
+                .send()
+                .await?;
+            for cur_res in result.contents() {
+                if let Some(key) = &cur_res.key {
+                    keys.push(key.trim().to_string());
+                }
+            }
+            for cur_res in result.common_prefixes() {
+                if let Some(p) = &cur_res.prefix {
+                    common_prefixes.push(p.trim().to_string());
+                }
+            }
+            if result.is_truncated().unwrap_or(false) {
+                continuation_token = result.next_continuation_token().map(str::to_string);
+            } else {
+                break;
+            }
+        }
+        Ok((keys, common_prefixes))
     }
 }
 
@@ -208,23 +243,14 @@ impl StorageReader for S3Storage {
     }
 
     async fn all_data_ids(&self, data_type: &str) -> anyhow::Result<HashSet<RequestId>> {
-        let mut ids = HashSet::new();
-        let result = self
-            .s3_client
-            .list_objects_v2()
-            .bucket(&self.bucket)
-            .delimiter("/")
-            .prefix(format!("{}/{}/", self.prefix, data_type))
-            .send()
+        let (keys, _) = self
+            .list_all(&format!("{}/{}/", self.prefix, data_type))
             .await?;
-        for cur_res in result.contents() {
-            if let Some(key) = &cur_res.key {
-                let trimmed_key = key.trim();
-                // Find the elements with the right prefix
-                // Find the id of file which is always the last segment when splitting on "/"
-                if let Some(cur_id) = trimmed_key.split('/').next_back() {
-                    ids.insert(RequestId::from_str(cur_id)?);
-                }
+        let mut ids = HashSet::new();
+        for key in keys {
+            // The id is always the last segment when splitting the key on "/".
+            if let Some(cur_id) = key.split('/').next_back() {
+                ids.insert(RequestId::from_str(cur_id)?);
             }
         }
         Ok(ids)
@@ -270,49 +296,32 @@ impl StorageReaderExt for S3Storage {
         epoch_id: &EpochId,
         data_type: &str,
     ) -> anyhow::Result<HashSet<RequestId>> {
-        let mut ids = HashSet::new();
-        let result = self
-            .s3_client
-            .list_objects_v2()
-            .bucket(&self.bucket)
-            .delimiter("/")
-            .prefix(format!("{}/{}/{}/", self.prefix, data_type, epoch_id))
-            .send()
+        let (keys, _) = self
+            .list_all(&format!("{}/{}/{}/", self.prefix, data_type, epoch_id))
             .await?;
-        for cur_res in result.contents() {
-            if let Some(key) = &cur_res.key {
-                let trimmed_key = key.trim();
-                // Find the elements with the right prefix
-                // Find the id of file which is always the last segment when splitting on "/"
-                if let Some(cur_id) = trimmed_key.split('/').next_back() {
-                    ids.insert(RequestId::from_str(cur_id)?);
-                }
+        let mut ids = HashSet::new();
+        for key in keys {
+            // The id is always the last segment when splitting the key on "/".
+            if let Some(cur_id) = key.split('/').next_back() {
+                ids.insert(RequestId::from_str(cur_id)?);
             }
         }
         Ok(ids)
     }
 
     async fn all_epoch_ids_for_data(&self, data_type: &str) -> anyhow::Result<HashSet<EpochId>> {
-        let mut ids = HashSet::new();
-        let result = self
-            .s3_client
-            .list_objects_v2()
-            .bucket(&self.bucket)
-            .delimiter("/")
-            .prefix(format!("{}/{}/", self.prefix, data_type))
-            .send()
+        let (_, common_prefixes) = self
+            .list_all(&format!("{}/{}/", self.prefix, data_type))
             .await?;
+        let mut ids = HashSet::new();
         // With delimiter="/", epoch_ids appear as "directories" in common_prefixes,
         // not as objects in contents()
-        for cur_res in result.common_prefixes() {
-            if let Some(key) = &cur_res.prefix {
-                let trimmed_key = key.trim();
-                // Ensure we only count "directories" by checking for the trailing "/"
-                if trimmed_key.ends_with('/') {
-                    // Remove the '/' at the end and take the last segment after splitting on "/" to get epoch_id
-                    if let Some(cur_id) = trimmed_key.trim_end_matches('/').split('/').next_back() {
-                        ids.insert(EpochId::from_str(cur_id)?);
-                    }
+        for key in common_prefixes {
+            // Ensure we only count "directories" by checking for the trailing "/"
+            if key.ends_with('/') {
+                // Remove the '/' at the end and take the last segment after splitting on "/" to get epoch_id
+                if let Some(cur_id) = key.trim_end_matches('/').split('/').next_back() {
+                    ids.insert(EpochId::from_str(cur_id)?);
                 }
             }
         }

--- a/core/service/src/vault/storage/s3.rs
+++ b/core/service/src/vault/storage/s3.rs
@@ -147,10 +147,10 @@ impl S3Storage {
         Ok(())
     }
 
-    /// Deletes the object at the given key. `DeleteObject` is idempotent on S3, so this
-    /// succeeds when the object does not exist, but a genuine deletion failure is now
-    /// propagated to the caller instead of being logged and swallowed. Callers that must
-    /// guarantee erasure (e.g. custodian-context destruction) rely on this to fail closed.
+    /// Deletes the object at the given key.
+    ///
+    /// This operation is idempotent on S3, so this succeeds when the object
+    /// does not exist.
     async fn delete_data_at_key(&mut self, key: &str) -> anyhow::Result<()> {
         tracing::info!(
             "Deleting object from bucket {} under key {}",


### PR DESCRIPTION
## Description
`remove_old_backup` does not delete epoch-data, it only deletes non-epoch data. This PR adds a regression test and a fix. Also added `list_all` because `list_objects_v2` uses pagination (lists no more than 1000 items).

### Related issue(s)
Closes zama-ai/kms-internal#3110

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
