### PR TITLE
chore: make s3 data_exists_at_key consistent with file backend

### DIFF
--- a/core/service/src/vault/storage/s3.rs
+++ b/core/service/src/vault/storage/s3.rs
@@ -118,10 +118,19 @@ impl S3Storage {
             .await;
         match result {
             Ok(_) => Ok(true),
-            Err(sdk_error) => match sdk_error.as_service_error().map(|e| e.is_not_found()) {
-                Some(_) => Ok(false),
-                None => Err(sdk_error.into()),
-            },
+            // Only a genuine "not found" error means the object is absent. Any
+            // other error (403 Access Denied, 500, 503 Slow Down, ...) must
+            // propagate so callers.
+            Err(sdk_error) => {
+                if sdk_error
+                    .as_service_error()
+                    .is_some_and(|e| e.is_not_found())
+                {
+                    Ok(false)
+                } else {
+                    Err(sdk_error.into())
+                }
+            }
         }
     }
 

--- a/core/service/src/vault/storage/s3.rs
+++ b/core/service/src/vault/storage/s3.rs
@@ -120,7 +120,7 @@ impl S3Storage {
             Ok(_) => Ok(true),
             // Only a genuine "not found" error means the object is absent. Any
             // other error (403 Access Denied, 500, 503 Slow Down, ...) must
-            // propagate so callers.
+            // propagate to callers.
             Err(sdk_error) => {
                 if sdk_error
                     .as_service_error()


### PR DESCRIPTION
## Description
Ensure the S3 `data_exists_at_key` returns an error for all errors except a not found error. No tests for this since we're using real minio for tests, which can't be mocked to simulate other types of errors easily.

### Related issue(s)
Closes zama-ai/kms-internal#3111

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
