### PR TITLE
chore: added support for pointer based conversion for epoch id

### DIFF
--- a/core/grpc/src/identifiers.rs
+++ b/core/grpc/src/identifiers.rs
@@ -474,10 +474,10 @@ macro_rules! impl_identifiers {
         }
 
         impl_identifier_conversion!($request_id, $key_id);
-        impl_identifier_conversion!($key_id, $request_id);
         impl_identifier_conversion!($request_id, $context_id);
-        impl_identifier_conversion!($context_id, $request_id);
         impl_identifier_conversion!($request_id, $epoch_id);
+        impl_identifier_conversion!($key_id, $request_id);
+        impl_identifier_conversion!($context_id, $request_id);
         impl_identifier_conversion!($epoch_id, $request_id);
     };
 }

--- a/core/grpc/src/identifiers.rs
+++ b/core/grpc/src/identifiers.rs
@@ -455,43 +455,30 @@ macro_rules! impl_identifiers {
         impl_identifier_common!($context_id);
         impl_identifier_common!($epoch_id);
 
-        // Implement conversions between request_id and the rest
-        // Both types have the same internal representation, so we can just copy the bytes
-        impl From<$request_id> for $key_id {
-            fn from(other: $request_id) -> Self {
-                Self(other.into_bytes())
-            }
+        // Implement conversions between request_id and the rest.
+        // Both types have the same internal representation, so we can just copy the bytes.
+        macro_rules! impl_identifier_conversion {
+            ($from:ident, $to:ident) => {
+                impl From<$from> for $to {
+                    fn from(other: $from) -> Self {
+                        Self(other.into_bytes())
+                    }
+                }
+
+                impl From<&$from> for $to {
+                    fn from(other: &$from) -> Self {
+                        Self(*other.as_bytes())
+                    }
+                }
+            };
         }
 
-        impl From<$key_id> for $request_id {
-            fn from(other: $key_id) -> Self {
-                Self(other.into_bytes())
-            }
-        }
-
-        impl From<$request_id> for $context_id {
-            fn from(other: $request_id) -> Self {
-                Self(other.into_bytes())
-            }
-        }
-
-        impl From<$context_id> for $request_id {
-            fn from(other: $context_id) -> Self {
-                Self(other.into_bytes())
-            }
-        }
-
-        impl From<$request_id> for $epoch_id {
-            fn from(other: $request_id) -> Self {
-                Self(other.into_bytes())
-            }
-        }
-
-        impl From<$epoch_id> for $request_id {
-            fn from(other: $epoch_id) -> Self {
-                Self(other.into_bytes())
-            }
-        }
+        impl_identifier_conversion!($request_id, $key_id);
+        impl_identifier_conversion!($key_id, $request_id);
+        impl_identifier_conversion!($request_id, $context_id);
+        impl_identifier_conversion!($context_id, $request_id);
+        impl_identifier_conversion!($request_id, $epoch_id);
+        impl_identifier_conversion!($epoch_id, $request_id);
     };
 }
 

--- a/core/service/src/engine/backup_operator.rs
+++ b/core/service/src/engine/backup_operator.rs
@@ -516,7 +516,7 @@ where
     let public_storage_guard = public_storage.lock().await;
     let recovery_material: RecoveryValidationMaterial = public_storage_guard
         .read_data(
-            &(*custodian_context_id).into(),
+            &custodian_context_id.into(),
             &PubDataType::RecoveryMaterial.to_string(),
         )
         .await?;

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -2431,7 +2431,7 @@ mod tests {
     ) {
         store_versioned_at_request_id(
             storage,
-            &(*epoch_id).into(),
+            &(epoch_id.into()),
             &make_test_prss_combined(num_parties, threshold),
             #[expect(deprecated)]
             &PrivDataType::PrssSetupCombined.to_string(),

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -2431,7 +2431,7 @@ mod tests {
     ) {
         store_versioned_at_request_id(
             storage,
-            &(epoch_id.into()),
+            &epoch_id.into(),
             &make_test_prss_combined(num_parties, threshold),
             #[expect(deprecated)]
             &PrivDataType::PrssSetupCombined.to_string(),

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1136,7 +1136,7 @@ impl<
         // sees the epoch and can finish the deletion.
         if let Err(e) = delete_at_request_id(
             &mut (*priv_storage_guard),
-            &(*epoch_id).into(),
+            &epoch_id.into(),
             &PrivDataType::EpochData.to_string(),
         )
         .await
@@ -1149,7 +1149,7 @@ impl<
         // Also delete legacy data to avoid it coming back on migration at restart.
         if let Err(e) = delete_at_request_id(
             &mut (*priv_storage_guard),
-            &(*epoch_id).into(),
+            &epoch_id.into(),
             #[expect(deprecated)]
             &PrivDataType::PrssSetupCombined.to_string(),
         )
@@ -1224,7 +1224,7 @@ impl<
             new_epoch_id
         );
 
-        let verified_previous_epoch = verify_epoch_info(&(*new_epoch_id).into(), previous_epoch)?;
+        let verified_previous_epoch = verify_epoch_info(&(new_epoch_id.into()), previous_epoch)?;
 
         // Fetch CRS (also parties from set 1 even if they don't actually need it, but they should fetch it from their storage anyway so no big deal)
         let new_epoch_id_as_request_id = (*new_epoch_id).into();
@@ -1799,7 +1799,7 @@ pub(crate) mod tests {
 
             store_versioned_at_request_id(
                 &mut (*guarded_private_storage),
-                &(*epoch_id).into(),
+                &(epoch_id.into()),
                 &epoch,
                 &PrivDataType::EpochData.to_string(),
             )
@@ -2586,7 +2586,7 @@ pub(crate) mod tests {
             }
             store_versioned_at_request_id(
                 &mut (*priv_storage),
-                &(*epoch_id).into(),
+                &(epoch_id.into()),
                 &epoch,
                 &PrivDataType::EpochData.to_string(),
             )
@@ -2632,7 +2632,7 @@ pub(crate) mod tests {
             }
             assert!(
                 !priv_storage
-                    .data_exists(&(*epoch_id).into(), &PrivDataType::EpochData.to_string())
+                    .data_exists(&(epoch_id.into()), &PrivDataType::EpochData.to_string())
                     .await
                     .unwrap(),
                 "PRSS setup should be gone for {epoch_id}"

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1224,7 +1224,7 @@ impl<
             new_epoch_id
         );
 
-        let verified_previous_epoch = verify_epoch_info(&(new_epoch_id.into()), previous_epoch)?;
+        let verified_previous_epoch = verify_epoch_info(&new_epoch_id.into(), previous_epoch)?;
 
         // Fetch CRS (also parties from set 1 even if they don't actually need it, but they should fetch it from their storage anyway so no big deal)
         let new_epoch_id_as_request_id = (*new_epoch_id).into();
@@ -1799,7 +1799,7 @@ pub(crate) mod tests {
 
             store_versioned_at_request_id(
                 &mut (*guarded_private_storage),
-                &(epoch_id.into()),
+                &epoch_id.into(),
                 &epoch,
                 &PrivDataType::EpochData.to_string(),
             )
@@ -2586,7 +2586,7 @@ pub(crate) mod tests {
             }
             store_versioned_at_request_id(
                 &mut (*priv_storage),
-                &(epoch_id.into()),
+                &epoch_id.into(),
                 &epoch,
                 &PrivDataType::EpochData.to_string(),
             )
@@ -2632,7 +2632,7 @@ pub(crate) mod tests {
             }
             assert!(
                 !priv_storage
-                    .data_exists(&(epoch_id.into()), &PrivDataType::EpochData.to_string())
+                    .data_exists(&epoch_id.into(), &PrivDataType::EpochData.to_string())
                     .await
                     .unwrap(),
                 "PRSS setup should be gone for {epoch_id}"

--- a/core/service/src/vault/storage/crypto_material/readers/context.rs
+++ b/core/service/src/vault/storage/crypto_material/readers/context.rs
@@ -11,7 +11,7 @@ impl CryptoMaterialReader for ContextInfo {
     where
         S: StorageReader + Send + Sync + 'static,
     {
-        read_context_at_id(storage, &(request_id.into()))
+        read_context_at_id(storage, &request_id.into())
             .await
             .map_err(|e| {
                 anyhow_error_and_warn_log(format!(

--- a/core/service/src/vault/storage/crypto_material/readers/context.rs
+++ b/core/service/src/vault/storage/crypto_material/readers/context.rs
@@ -11,7 +11,7 @@ impl CryptoMaterialReader for ContextInfo {
     where
         S: StorageReader + Send + Sync + 'static,
     {
-        read_context_at_id(storage, &(*request_id).into())
+        read_context_at_id(storage, &(request_id.into()))
             .await
             .map_err(|e| {
                 anyhow_error_and_warn_log(format!(

--- a/core/service/src/vault/storage/crypto_material/threshold.rs
+++ b/core/service/src/vault/storage/crypto_material/threshold.rs
@@ -83,7 +83,7 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
     ) -> anyhow::Result<()> {
         self.inner
             .write_all::<EpochData, EpochData>(
-                &(*epoch_id).into(), // using epoch_id as req_id since epoch data is stored under this directly
+                &(epoch_id.into()), // using epoch_id as req_id since epoch data is stored under this directly
                 None,
                 None, // no public data for epoch info
                 Some((epoch_data, PrivDataType::EpochData)),

--- a/core/service/src/vault/storage/crypto_material/threshold.rs
+++ b/core/service/src/vault/storage/crypto_material/threshold.rs
@@ -83,7 +83,7 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
     ) -> anyhow::Result<()> {
         self.inner
             .write_all::<EpochData, EpochData>(
-                &(epoch_id.into()), // using epoch_id as req_id since epoch data is stored under this directly
+                &epoch_id.into(), // using epoch_id as req_id since epoch data is stored under this directly
                 None,
                 None, // no public data for epoch info
                 Some((epoch_data, PrivDataType::EpochData)),

--- a/core/service/src/vault/storage/mod.rs
+++ b/core/service/src/vault/storage/mod.rs
@@ -497,11 +497,11 @@ pub async fn read_context_at_id<S: StorageReader>(
 
 pub async fn delete_context_at_id<S: Storage>(
     storage: &mut S,
-    request_id: &ContextId,
+    context_id: &ContextId,
 ) -> anyhow::Result<()> {
     delete_at_request_id(
         storage,
-        &request_id.into(),
+        &context_id.into(),
         &PrivDataType::ContextInfo.to_string(),
     )
     .await

--- a/core/service/src/vault/storage/mod.rs
+++ b/core/service/src/vault/storage/mod.rs
@@ -474,7 +474,7 @@ pub async fn store_context_at_id<S: Storage>(
 ) -> anyhow::Result<()> {
     store_versioned_at_request_id(
         storage,
-        &(*context_id).into(),
+        &(context_id.into()),
         context_info,
         &PrivDataType::ContextInfo.to_string(),
     )
@@ -489,7 +489,7 @@ pub async fn read_context_at_id<S: StorageReader>(
 ) -> anyhow::Result<context::ContextInfo> {
     read_versioned_at_request_id(
         storage,
-        &(*context_id).into(),
+        &(context_id.into()),
         &PrivDataType::ContextInfo.to_string(),
     )
     .await
@@ -501,7 +501,7 @@ pub async fn delete_context_at_id<S: Storage>(
 ) -> anyhow::Result<()> {
     delete_at_request_id(
         storage,
-        &(*request_id).into(),
+        &(request_id.into()),
         &PrivDataType::ContextInfo.to_string(),
     )
     .await

--- a/core/service/src/vault/storage/mod.rs
+++ b/core/service/src/vault/storage/mod.rs
@@ -474,7 +474,7 @@ pub async fn store_context_at_id<S: Storage>(
 ) -> anyhow::Result<()> {
     store_versioned_at_request_id(
         storage,
-        &(context_id.into()),
+        &context_id.into(),
         context_info,
         &PrivDataType::ContextInfo.to_string(),
     )
@@ -489,7 +489,7 @@ pub async fn read_context_at_id<S: StorageReader>(
 ) -> anyhow::Result<context::ContextInfo> {
     read_versioned_at_request_id(
         storage,
-        &(context_id.into()),
+        &context_id.into(),
         &PrivDataType::ContextInfo.to_string(),
     )
     .await
@@ -501,7 +501,7 @@ pub async fn delete_context_at_id<S: Storage>(
 ) -> anyhow::Result<()> {
     delete_at_request_id(
         storage,
-        &(request_id.into()),
+        &request_id.into(),
         &PrivDataType::ContextInfo.to_string(),
     )
     .await


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->
Small PR allowing to convert `&EpochId` into `ReqeustId` along with changes to ensure it is used instead of  the `&(*epoch_id.into())` pattern

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
