### PR TITLE
chore: remove minio-based s3_tests use mock instead

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -136,8 +136,6 @@ Two parallel entries on PRs:
 
 Schedule entry: `--release -F slow_tests nightly` — nightly-suffixed tests in release mode.
 
-(S3 storage tests now use in-process mocks — no MinIO sidecar — and run as part of the standard suite.)
-
 ### Test material
 
 Most test jobs depend on pre-generated FHE / signing material under `./test-material/`, produced by the `Generate Test Material` step in `common-testing.yml`. Jobs that don't need it pass `skip-test-material: true`. The `lfs:` input gates pulling Git-LFS-tracked `backward_compatibility_*.rs` fixtures — currently only `test-core-service` and `test-core-service-slow-threshold` set it. The btrfs CoW loopback (`/mnt/cow-scratch`) makes per-test material copies cheap (reflinks, not byte copies).

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -131,10 +131,12 @@ All Rust test jobs delegate to [`common-testing.yml`](common-testing.yml) for th
 ### `test-core-service` matrix
 
 Two parallel entries on PRs:
-1. `-F slow_tests -F s3_tests --lib -- --skip nightly` — workspace lib tests
-2. `-E kind(test) -F slow_tests -F s3_tests -- --skip threshold --skip nightly` — integration tests excluding threshold (those run in `test-core-service-slow-threshold`)
+1. `-F slow_tests --lib -- --skip nightly` — workspace lib tests
+2. `-E kind(test) -F slow_tests -- --skip threshold --skip nightly` — integration tests excluding threshold (those run in `test-core-service-slow-threshold`)
 
-Schedule entry: `--release -F slow_tests -F s3_tests nightly` — nightly-suffixed tests in release mode.
+Schedule entry: `--release -F slow_tests nightly` — nightly-suffixed tests in release mode.
+
+(S3 storage tests now use in-process mocks — no MinIO sidecar — and run as part of the standard suite.)
 
 ### Test material
 
@@ -154,7 +156,7 @@ Steps (subset):
 | GHCR + CGR registry login | OIDC + repo secrets |
 | Setup Rust + Protoc | Toolchain pinned via `rust-toolchain.toml` |
 | Swatinem rust-cache | Saves only on `main` |
-| Setup Redis / MinIO | Optional, gated by inputs |
+| Setup Redis | Optional, gated by inputs |
 | Generate Test Material | Unless `skip-test-material: true` |
 | Build `kms-custodian` binary | Required by integration tests |
 | Run Tests | `cargo nextest --profile <ci\|ci-nightly> run …` |
@@ -168,7 +170,7 @@ Inputs of note:
 - `nextest-profile` — `ci` (default) or `ci-nightly`
 - `lfs` — pull Git-LFS objects on checkout
 - `skip-test-material` — skip material generation + custodian build
-- `run-redis`, `run-minio` — start the relevant sidecar
+- `run-redis` — start the Redis sidecar
 - `runs-on`, `runner-volume` — runs-on slab selector
 
 Lint/format/security live in [`rust-lint.yml`](rust-lint.yml) and [`ci_lint.yml`](ci_lint.yml), not here.

--- a/.github/workflows/common-testing.yml
+++ b/.github/workflows/common-testing.yml
@@ -19,10 +19,6 @@ on:
         type: string
         required: false
         default: ''
-      run-minio:
-        type: boolean
-        required: false
-        default: false
       run-redis:
         type: boolean
         required: false
@@ -159,40 +155,6 @@ jobs:
           docker run -d -p 6379:6379 --name redis \
             redis/redis-stack:7.4.0-v8@sha256:5d5154123426693540ea6c1d9e638eae2bf2024879c839db6fcfdd7717e817c7
 
-      - name: Setup minio
-        if: ${{ inputs.run-minio }}
-        env:
-          MINIO_ACCESS_KEY: minioadmin
-          MINIO_SECRET_KEY: minioadmin
-        run: |
-          docker run -d -p 9000:9000 --name minio \
-                     -e "MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}" \
-                     -e "MINIO_SECRET_KEY=${MINIO_SECRET_KEY}" \
-                     -v /tmp/data:/data \
-                     -v /tmp/config:/root/.minio \
-                     minio/minio server /data
-
-      - name: Setup Minio bucket
-        if: ${{ inputs.run-minio }}
-        env:
-          MINIO_ALIAS: testminio
-          MINIO_BUCKET: ci-kms-key-test
-          MINIO_ACCESS_KEY: minioadmin
-          MINIO_SECRET_KEY: minioadmin
-          MINIO_REGION: eu-north-1
-        run: |
-          curl -fL --retry 3 --retry-delay 2 https://dl.min.io/client/mc/release/linux-amd64/mc \
-            --create-dirs \
-            -o "${HOME}/minio-binaries/mc"
-
-          chmod +x "${HOME}/minio-binaries/mc"
-          export PATH="${PATH}:${HOME}/minio-binaries/"
-          mc --version
-
-          mc alias set "${MINIO_ALIAS}" http://127.0.0.1:9000 "${MINIO_ACCESS_KEY}" "${MINIO_SECRET_KEY}"
-          mc mb "${MINIO_ALIAS}/${MINIO_BUCKET}"
-          mc anonymous set public "${MINIO_ALIAS}/${MINIO_BUCKET}"
-
       # Fallback when no EFS path is supplied (e.g. the nightly caller in
       # main.yml): the job still needs fixtures, so generate the full
       # insecure+secure set for parties 4,13 locally into ./test-material
@@ -228,10 +190,6 @@ jobs:
       - name: Run Tests
         id: tests
         env:
-          AWS_ACCESS_KEY_ID: 'minioadmin'
-          AWS_SECRET_ACCESS_KEY: 'minioadmin'
-          AWS_DEFAULT_REGION: 'eu-north-1'
-          AWS_ENDPOINT: 'http://127.0.0.1:9000'
           CRATE_NAMES: ${{ inputs.crate-names }}
           ARGS_TESTS: ${{inputs.args-tests}}
           NEXTEST_PROFILE: ${{ inputs.nextest-profile }}

--- a/.github/workflows/parallel-testing.yml
+++ b/.github/workflows/parallel-testing.yml
@@ -128,7 +128,6 @@ jobs:
           - job_name: core-client-threshold
             crate_names: '-p kms-core-client'
             args_tests: '--features slow_tests -- threshold --skip full_gen_tests --skip nightly --skip k8s_ --skip isolated_test_example --skip test_threshold_mpc_context_switch_6_docker'
-            run_minio: false
             run_redis: false
             skip_test_material: false
             lfs: false
@@ -140,7 +139,6 @@ jobs:
           - job_name: core-client-centralized-p1
             crate_names: '-p kms-core-client'
             args_tests: '--features testing --partition count:1/3 -- centralized --skip full_gen_tests --skip nightly --skip k8s_ --skip threshold --skip isolated_test_example'
-            run_minio: false
             run_redis: false
             skip_test_material: false
             lfs: false
@@ -151,7 +149,6 @@ jobs:
           - job_name: core-client-centralized-p2
             crate_names: '-p kms-core-client'
             args_tests: '--features testing --partition count:2/3 -- centralized --skip full_gen_tests --skip nightly --skip k8s_ --skip threshold --skip isolated_test_example'
-            run_minio: false
             run_redis: false
             skip_test_material: false
             lfs: false
@@ -162,7 +159,6 @@ jobs:
           - job_name: core-client-centralized-p3
             crate_names: '-p kms-core-client'
             args_tests: '--features testing --partition count:3/3 -- centralized --skip full_gen_tests --skip nightly --skip k8s_ --skip threshold --skip isolated_test_example'
-            run_minio: false
             run_redis: false
             skip_test_material: false
             lfs: false
@@ -174,7 +170,6 @@ jobs:
           - job_name: core-client-unit-p1
             crate_names: '-p kms-core-client'
             args_tests: '--features testing --partition count:1/3 -- --skip centralized --skip threshold --skip full_gen_tests --skip nightly --skip k8s_ --skip isolated_test_example'
-            run_minio: false
             run_redis: false
             skip_test_material: true
             lfs: false
@@ -185,7 +180,6 @@ jobs:
           - job_name: core-client-unit-p2
             crate_names: '-p kms-core-client'
             args_tests: '--features testing --partition count:2/3 -- --skip centralized --skip threshold --skip full_gen_tests --skip nightly --skip k8s_ --skip isolated_test_example'
-            run_minio: false
             run_redis: false
             skip_test_material: true
             lfs: false
@@ -196,7 +190,6 @@ jobs:
           - job_name: core-client-unit-p3
             crate_names: '-p kms-core-client'
             args_tests: '--features testing --partition count:3/3 -- --skip centralized --skip threshold --skip full_gen_tests --skip nightly --skip k8s_ --skip isolated_test_example'
-            run_minio: false
             run_redis: false
             skip_test_material: true
             lfs: false
@@ -208,8 +201,7 @@ jobs:
           # Core service - aggressively sharded by family and partition.
           - job_name: core-service-lib-p1
             crate_names: '-p kms'
-            args_tests: '-F slow_tests -F s3_tests -F insecure --partition count:1/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
-            run_minio: true
+            args_tests: '-F slow_tests -F insecure --partition count:1/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -219,8 +211,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-lib-p2
             crate_names: '-p kms'
-            args_tests: '-F slow_tests -F s3_tests -F insecure --partition count:2/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
-            run_minio: true
+            args_tests: '-F slow_tests -F insecure --partition count:2/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -230,8 +221,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-lib-p3
             crate_names: '-p kms'
-            args_tests: '-F slow_tests -F s3_tests -F insecure --partition count:3/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
-            run_minio: true
+            args_tests: '-F slow_tests -F insecure --partition count:3/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -241,8 +231,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-lib-p4
             crate_names: '-p kms'
-            args_tests: '-F slow_tests -F s3_tests -F insecure --partition count:4/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
-            run_minio: true
+            args_tests: '-F slow_tests -F insecure --partition count:4/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -252,8 +241,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-lib-p5
             crate_names: '-p kms'
-            args_tests: '-F slow_tests -F s3_tests -F insecure --partition count:5/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
-            run_minio: true
+            args_tests: '-F slow_tests -F insecure --partition count:5/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -263,8 +251,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-lib-p6
             crate_names: '-p kms'
-            args_tests: '-F slow_tests -F s3_tests -F insecure --partition count:6/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
-            run_minio: true
+            args_tests: '-F slow_tests -F insecure --partition count:6/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -274,8 +261,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-lib-p7
             crate_names: '-p kms'
-            args_tests: '-F slow_tests -F s3_tests -F insecure --partition count:7/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
-            run_minio: true
+            args_tests: '-F slow_tests -F insecure --partition count:7/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -285,8 +271,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-lib-p8
             crate_names: '-p kms'
-            args_tests: '-F slow_tests -F s3_tests -F insecure --partition count:8/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
-            run_minio: true
+            args_tests: '-F slow_tests -F insecure --partition count:8/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -296,8 +281,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-lib-p9
             crate_names: '-p kms'
-            args_tests: '-F slow_tests -F s3_tests -F insecure --partition count:9/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
-            run_minio: true
+            args_tests: '-F slow_tests -F insecure --partition count:9/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -307,8 +291,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-lib-p10
             crate_names: '-p kms'
-            args_tests: '-F slow_tests -F s3_tests -F insecure --partition count:10/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
-            run_minio: true
+            args_tests: '-F slow_tests -F insecure --partition count:10/10 --lib -- --skip nightly --skip test_new_epoch_with_reshare'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -319,8 +302,7 @@ jobs:
           #======================================================================
           - job_name: core-service-lib-epoch-reshare
             crate_names: '-p kms'
-            args_tests: '-F slow_tests -F s3_tests -F insecure --partition count:1/1 --lib -- test_new_epoch_with_reshare'
-            run_minio: true
+            args_tests: '-F slow_tests -F insecure --partition count:1/1 --lib -- test_new_epoch_with_reshare'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -331,8 +313,7 @@ jobs:
           #======================================================================
           - job_name: core-service-test-p1
             crate_names: '-p kms'
-            args_tests: '-E kind(test) -F slow_tests -F s3_tests -F insecure --partition count:1/4 -- --skip threshold --skip nightly'
-            run_minio: true
+            args_tests: '-E kind(test) -F slow_tests -F insecure --partition count:1/4 -- --skip threshold --skip nightly'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -342,8 +323,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-test-p2
             crate_names: '-p kms'
-            args_tests: '-E kind(test) -F slow_tests -F s3_tests -F insecure --partition count:2/4 -- --skip threshold --skip nightly'
-            run_minio: true
+            args_tests: '-E kind(test) -F slow_tests -F insecure --partition count:2/4 -- --skip threshold --skip nightly'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -353,8 +333,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-test-p3
             crate_names: '-p kms'
-            args_tests: '-E kind(test) -F slow_tests -F s3_tests -F insecure --partition count:3/4 -- --skip threshold --skip nightly'
-            run_minio: true
+            args_tests: '-E kind(test) -F slow_tests -F insecure --partition count:3/4 -- --skip threshold --skip nightly'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -364,8 +343,7 @@ jobs:
             nextest_threads: '4'
           - job_name: core-service-test-p4
             crate_names: '-p kms'
-            args_tests: '-E kind(test) -F slow_tests -F s3_tests -F insecure --partition count:4/4 -- --skip threshold --skip nightly'
-            run_minio: true
+            args_tests: '-E kind(test) -F slow_tests -F insecure --partition count:4/4 -- --skip threshold --skip nightly'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -376,8 +354,7 @@ jobs:
           #======================================================================
           - job_name: core-service-threshold-p1
             crate_names: '-p kms'
-            args_tests: '-E kind(test) -F slow_tests -F s3_tests -F insecure --partition count:1/3 threshold -- --skip default_user_decryption_threshold --skip nightly'
-            run_minio: true
+            args_tests: '-E kind(test) -F slow_tests -F insecure --partition count:1/3 threshold -- --skip default_user_decryption_threshold --skip nightly'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -387,8 +364,7 @@ jobs:
             nextest_threads: '6'
           - job_name: core-service-threshold-p2
             crate_names: '-p kms'
-            args_tests: '-E kind(test) -F slow_tests -F s3_tests -F insecure --partition count:2/3 threshold -- --skip default_user_decryption_threshold --skip nightly'
-            run_minio: true
+            args_tests: '-E kind(test) -F slow_tests -F insecure --partition count:2/3 threshold -- --skip default_user_decryption_threshold --skip nightly'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -398,8 +374,7 @@ jobs:
             nextest_threads: '6'
           - job_name: core-service-threshold-p3
             crate_names: '-p kms'
-            args_tests: '-E kind(test) -F slow_tests -F s3_tests -F insecure --partition count:3/3 threshold -- --skip default_user_decryption_threshold --skip nightly'
-            run_minio: true
+            args_tests: '-E kind(test) -F slow_tests -F insecure --partition count:3/3 threshold -- --skip default_user_decryption_threshold --skip nightly'
             run_redis: false
             skip_test_material: false
             lfs: true
@@ -412,7 +387,6 @@ jobs:
           - job_name: core-threshold-lib-p1
             crate_names: '-p experiments'
             args_tests: '--partition count:1/3 --lib'
-            run_minio: false
             run_redis: false
             skip_test_material: true
             lfs: false
@@ -423,7 +397,6 @@ jobs:
           - job_name: core-threshold-lib-p2
             crate_names: '-p experiments'
             args_tests: '--partition count:2/3 --lib'
-            run_minio: false
             run_redis: false
             skip_test_material: true
             lfs: false
@@ -434,7 +407,6 @@ jobs:
           - job_name: core-threshold-lib-p3
             crate_names: '-p experiments'
             args_tests: '--partition count:3/3 --lib'
-            run_minio: false
             run_redis: false
             skip_test_material: true
             lfs: false
@@ -445,7 +417,6 @@ jobs:
           - job_name: core-threshold-redis
             crate_names: '-p experiments'
             args_tests: '--partition count:1/1 --test integration_redis'
-            run_minio: false
             run_redis: true
             skip_test_material: true
             lfs: false
@@ -458,7 +429,6 @@ jobs:
           - job_name: core-grpc-p1
             crate_names: '-p kms-grpc'
             args_tests: '--partition count:1/3 --all-features'
-            run_minio: false
             run_redis: false
             skip_test_material: true
             lfs: false
@@ -469,7 +439,6 @@ jobs:
           - job_name: core-grpc-p2
             crate_names: '-p kms-grpc'
             args_tests: '--partition count:2/3 --all-features'
-            run_minio: false
             run_redis: false
             skip_test_material: true
             lfs: false
@@ -480,7 +449,6 @@ jobs:
           - job_name: core-grpc-p3
             crate_names: '-p kms-grpc'
             args_tests: '--partition count:3/3 --all-features'
-            run_minio: false
             run_redis: false
             skip_test_material: true
             lfs: false
@@ -493,7 +461,6 @@ jobs:
     with:
       crate-names: ${{ matrix.crate_names }}
       args-tests: ${{ matrix.args_tests }}
-      run-minio: ${{ matrix.run_minio }}
       run-redis: ${{ matrix.run_redis }}
       skip-test-material: ${{ matrix.skip_test_material }}
       lfs: ${{ matrix.lfs }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,17 +1653,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-protocol-test",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2",
+ "bytes",
+ "h2 0.3.27",
+ "h2 0.4.15",
+ "http 0.2.12",
  "http 1.3.1",
- "hyper",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "hyper 0.14.32",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-rustls",
  "tower",
@@ -1672,12 +1692,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-mocks"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9a9490933f8faa0aeb1eb9fbb8bf4f1c214b3149c61b3a4074b68030b21bd5"
+dependencies = [
+ "aws-smithy-http-client",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.3.1",
+]
+
+[[package]]
 name = "aws-smithy-observability"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-protocol-test"
+version = "0.63.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b227aa94af99a8e5ee52551cc7e3ee30a217019ef99207b6f0b7a1527685941"
+dependencies = [
+ "assert-json-diff",
+ "aws-smithy-runtime-api",
+ "base64-simd",
+ "cbor-diag",
+ "ciborium",
+ "http 0.2.12",
+ "pretty_assertions",
+ "regex-lite",
+ "roxmltree",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1714,6 +1765,7 @@ dependencies = [
  "pin-utils",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1819,7 +1871,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -2274,6 +2326,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbor-diag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half 2.7.1",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2981,6 +3052,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3667,6 +3744,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
@@ -3908,6 +4004,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
@@ -3916,7 +4036,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -3935,7 +4055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -3951,7 +4071,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3970,7 +4090,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -4409,6 +4529,7 @@ dependencies = [
  "aws-nitro-enclaves-nsm-api 0.5.1",
  "aws-sdk-kms",
  "aws-sdk-s3",
+ "aws-smithy-mocks",
  "aws-smithy-types",
  "backward-compatibility",
  "bc2wrap",
@@ -5631,6 +5752,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6325,7 +6456,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -6409,6 +6540,15 @@ dependencies = [
  "serde_derive",
  "typeid",
  "unicode-ident",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
 ]
 
 [[package]]
@@ -6847,6 +6987,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6925,6 +7071,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -8109,11 +8256,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -8189,7 +8336,7 @@ checksum = "c1ace145c667504b488f44f08fd4966da7feefd430621a4ce1eae5ca79e6c867"
 dependencies = [
  "async-stream",
  "futures",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "socket2 0.6.4",
  "tokio",
@@ -9083,6 +9230,12 @@ dependencies = [
  "encoding_rs",
  "hashlink",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,10 @@ aws-lc-rs = { version = "=1.17.0" } # AWS-LC cryptographic library - LOW RISK: O
 aws-nitro-enclaves-nsm-api = { version = "=0.5.1" }  # AWS Nitro Enclaves NSM API - LOW RISK: Official AWS SDK
 aws-sdk-kms = { version = "=1.111.0", default-features = false, features = ["default-https-client", "rt-tokio"] }  # AWS KMS client - LOW RISK: Official AWS SDK for key management
 aws-sdk-s3 = { version = "=1.137.0", default-features = false, features = ["default-https-client", "rt-tokio", "sigv4a"] }  # AWS S3 client - LOW RISK: Official AWS SDK for object storage
+# Official AWS SDK mocking crate (same org/repo as aws-sdk-s3); test-only, replaces the MinIO
+# integration test setup with in-process HTTP mocks. 0.2.6 is the newest release compatible with
+# our pinned smithy stack (aws-smithy-runtime-api 1.12.x / aws-smithy-types 1.5.0). - LOW RISK: Official AWS SDK
+aws-smithy-mocks = { version = "=0.2.6" }
 aws-smithy-types = { version = "=1.5.0" }  # AWS Smithy types (used for low risk base64 implementation) - LOW RISK: Official AWS type definitions
 axum = { version = "=0.8.9", features = ["tokio"] }  # Web framework - LOW RISK: tokio-rs team, 168M+ downloads, actively maintained
 backoff = "=0.4.0"  # Retry with exponential backoff - HIGH RISK: Individual maintainer (ihrwein), despite 50M+ downloads

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -132,6 +132,8 @@ zeroize.workspace = true
 # Use .workspace = true to reference workspace dependencies
 # Maintain alphabetical order
 assert_cmd.workspace = true
+# In-process S3 mocking for the vault storage tests (replaces the MinIO integration setup).
+aws-smithy-mocks = { workspace = true }
 backward-compatibility = { workspace = true, features = ["load", "tests"] }
 cargo_metadata = { workspace = true }
 threshold-execution = { workspace = true, features = ["testing", "malicious_strategies"] }
@@ -149,7 +151,10 @@ walkdir = { workspace = true }
 
 [features]
 default = ["non-wasm"]
-testing = ["dep:tempfile", "threshold-execution/testing"]
+# `aws-sdk-s3?/test-util` is required by aws-smithy-mocks' `mock_client!`. The weak-dependency
+# (`?`) syntax only enables it when aws-sdk-s3 is already pulled in (i.e. via `non-wasm`), so
+# wasm / `--no-default-features` builds are unaffected and production never gets test-util.
+testing = ["dep:tempfile", "threshold-execution/testing", "aws-sdk-s3?/test-util"]
 non-wasm = [
     "kms-grpc/non-wasm",
     "threshold-execution/non-wasm",
@@ -180,7 +185,6 @@ non-wasm = [
 ]
 slow_tests = ["testing"]
 wasm_tests = ["testing"]
-s3_tests = ["testing"]
 insecure = [
     "kms-grpc/insecure",
     "threshold-networking/testing",

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -2961,8 +2961,8 @@ mod tests {
             .unwrap();
     }
 
-    // S3 storage tests
-    #[cfg(feature = "s3_tests")]
+    // S3 storage tests, run against an in-process mock S3 (no MinIO) via `create_s3_storage`.
+    #[cfg(all(feature = "non-wasm", feature = "testing"))]
     mod s3_tests {
         use super::*;
         use crate::vault::storage::s3::create_s3_storage;

--- a/core/service/src/vault/storage/s3.rs
+++ b/core/service/src/vault/storage/s3.rs
@@ -690,21 +690,11 @@ pub(crate) const MOCK_BUCKET: &str = "test-bucket";
 /// Build an [`S3Storage`] backed by a fresh in-memory mock S3 client, so the storage tests
 /// exercise the real `S3Storage` + `aws_sdk_s3` code paths with no network / MinIO.
 ///
+/// Lives outside [`tests`] because other modules' test suites (e.g. `engine::migration`) use it.
 /// Kept `async` to match the call sites (the previous MinIO-backed helper was async).
 #[cfg(all(test, feature = "non-wasm", feature = "testing"))]
 pub async fn create_s3_storage(storage_type: StorageType, prefix: &str) -> S3Storage {
-    create_s3_storage_with_store(mock_s3::new_store(), storage_type, prefix)
-}
-
-/// Like [`create_s3_storage`] but reuses an existing in-memory store, so several storage handles
-/// can share one logical bucket (used to read data back through a second client).
-#[cfg(all(test, feature = "non-wasm", feature = "testing"))]
-pub(crate) fn create_s3_storage_with_store(
-    store: mock_s3::SharedStore,
-    storage_type: StorageType,
-    prefix: &str,
-) -> S3Storage {
-    let s3_client = mock_s3::build_mock_s3_client(store);
+    let s3_client = mock_s3::build_mock_s3_client(mock_s3::new_store());
     S3Storage::new(
         s3_client,
         MOCK_BUCKET.to_string(),
@@ -844,6 +834,14 @@ pub(crate) mod mock_s3 {
 #[cfg(all(test, feature = "non-wasm", feature = "testing"))]
 mod tests {
     use super::*;
+    use aws_sdk_s3::error::ErrorMetadata;
+    use aws_sdk_s3::operation::{
+        head_object::{HeadObjectError, HeadObjectOutput},
+        list_objects_v2::ListObjectsV2Output,
+    };
+    use aws_sdk_s3::types::{Object, error::NotFound};
+    use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
+
     use crate::vault::storage::tests::{
         test_batch_helper_methods, test_epoch_methods, test_storage_read_store_methods,
         test_store_bytes_does_not_overwrite_existing_bytes,
@@ -948,39 +946,11 @@ mod tests {
         .await;
     }
 
-    /// `data_exists` maps a `head_object` "not found" service error to `Ok(false)` (rather than
-    /// propagating it), matching the "absent object" semantics callers rely on.
-    #[tokio::test]
-    async fn data_exists_maps_head_not_found_to_false() {
-        use aws_sdk_s3::operation::head_object::HeadObjectError;
-        use aws_sdk_s3::types::error::NotFound;
-        use aws_smithy_mocks::{RuleMode, mock, mock_client};
-
-        let head = mock!(aws_sdk_s3::Client::head_object)
-            .then_error(|| HeadObjectError::NotFound(NotFound::builder().build()));
-        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, [&head], |c| c
-            .force_path_style(true));
-        let storage =
-            S3Storage::new(client, MOCK_BUCKET.to_string(), StorageType::PUB, None).unwrap();
-
-        assert!(
-            !storage
-                .data_exists(&RequestId::default(), "PublicKey")
-                .await
-                .unwrap()
-        );
-    }
-
     /// `data_exists_at_key` distinguishes three `head_object` outcomes: success ⇒ `true`, a genuine
     /// "not found" service error ⇒ `false`, and any other service error (403/500/503/…) ⇒ propagated
     /// as `Err`, so a transient failure is never silently mistaken for an absent object.
     #[tokio::test]
     async fn data_exists_at_key_maps_head_errors() {
-        use aws_sdk_s3::error::ErrorMetadata;
-        use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
-        use aws_sdk_s3::types::error::NotFound;
-        use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
-
         const KEY: &str = "PUB/PublicKey/some-object";
 
         // An `S3Storage` whose only mocked operation is `head_object`, served by `rule`.
@@ -1035,10 +1005,6 @@ mod tests {
     /// mock returns a single page, so this uses explicit multi-page rules).
     #[tokio::test]
     async fn list_all_follows_continuation_tokens() {
-        use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output;
-        use aws_sdk_s3::types::Object;
-        use aws_smithy_mocks::{RuleMode, mock, mock_client};
-
         let mut rng = rand::thread_rng();
         let id_a = RequestId::new_random(&mut rng);
         let id_b = RequestId::new_random(&mut rng);

--- a/core/service/src/vault/storage/s3.rs
+++ b/core/service/src/vault/storage/s3.rs
@@ -683,73 +683,165 @@ pub fn find_region_from_s3_url(s3_bucket_url: &str) -> anyhow::Result<String> {
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "s3_tests")]{
-        pub const BUCKET_NAME: &str = "ci-kms-key-test";
-        pub const AWS_REGION: &str = "eu-north-1";
-        // this points to a locally running Minio
-        pub const AWS_S3_ENDPOINT: &str = "http://127.0.0.1:9000";
-    }
+/// Bucket name expected by the in-memory mock S3 backend in tests.
+#[cfg(all(test, feature = "non-wasm", feature = "testing"))]
+pub(crate) const MOCK_BUCKET: &str = "test-bucket";
+
+/// Build an [`S3Storage`] backed by a fresh in-memory mock S3 client, so the storage tests
+/// exercise the real `S3Storage` + `aws_sdk_s3` code paths with no network / MinIO.
+///
+/// Kept `async` to match the call sites (the previous MinIO-backed helper was async).
+#[cfg(all(test, feature = "non-wasm", feature = "testing"))]
+pub async fn create_s3_storage(storage_type: StorageType, prefix: &str) -> S3Storage {
+    create_s3_storage_with_store(mock_s3::new_store(), storage_type, prefix)
 }
 
-#[cfg(all(feature = "s3_tests", any(test, feature = "testing")))]
-pub async fn create_s3_storage(storage_type: StorageType, prefix: &str) -> S3Storage {
-    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
-    let s3_client = build_s3_client(&config, Some(Url::parse(AWS_S3_ENDPOINT).unwrap()))
-        .await
-        .unwrap();
+/// Like [`create_s3_storage`] but reuses an existing in-memory store, so several storage handles
+/// can share one logical bucket (used to read data back through a second client).
+#[cfg(all(test, feature = "non-wasm", feature = "testing"))]
+pub(crate) fn create_s3_storage_with_store(
+    store: mock_s3::SharedStore,
+    storage_type: StorageType,
+    prefix: &str,
+) -> S3Storage {
+    let s3_client = mock_s3::build_mock_s3_client(store);
     S3Storage::new(
         s3_client,
-        BUCKET_NAME.to_string(),
+        MOCK_BUCKET.to_string(),
         storage_type,
         Some(prefix),
     )
     .unwrap()
 }
 
-// Observe that certain tests require an S3 instance setup.
-// There are run with the extra argument `-F s3_tests`.
-// Note that we pay for each of these tests, in the order of single digit cents per tests.
-//
-// To setup the testing environment locally with Minio, proceed as follows:
-// 1. Install and run Minio in Docker
-//    a. Simplest way is to just run `docker compose -vvv -f docker-compose-core-base.yml -f docker-compose-core-threshold.yml up` as this ensure Minio is configured and started correctly.
-// 2. Setup the bucket. Within the `dev-s3-mock-1` container in Docker execute the following commands:
-//   a. First open Docker desktop and navigate to `Volumes` and find `zama-core-threshold_minio_secrets` and copy the content of `access_key` and the content of `secret_key`.
-//   b. Run `mc alias set testminio http://127.0.0.1:9000 <access_key> <secret_key>` (and replace `<access_key>` respectively `<secret_key>` with the values copied above and assuming no change to [`AWS_S3_ENDPOINT`])
-//   c. Run `mc mb testminio/ci-kms-key-test` (Assuming no change to [`BUCKET_NAME`])
-//   d. Run `mc anonymous set public testminio/ci-kms-key-test`
-// 3. Update the environment variables in the shell where you run the tests:
-//   a. Execute the following:
-//   ```bash
-//      AWS_ACCESS_KEY_ID=<access_key> &&
-//      export AWS_ACCESS_KEY_ID &&
-//      AWS_SECRET_ACCESS_KEY=<secret_key> &&
-//      export AWS_SECRET_ACCESS_KEY
-//   ```
-//   where `<access_key>` and `<secret_key>` are the values copied above.
-// 4. Now you can execute the tests: `cargo test --lib -F s3_tests s3_`
-//
-// To instead setup a test environment for a real S3 proceed as follows:
-//
-// 1. Creating access keys:
-//    a. Log into aws.amazon.com
-//    b. In the top right corner of the page there will be your AWS account name. Click on it, and in the drop-down menu go to "security credentials".
-//    c. Select “Create access keys”
-//    d. Make sure to locally store the AWS access key ID and secret access key.
-// 2. Create S3 bucket
-//    a. Search for “S3 console” in the search bar after logging into aws.amazon.com
-//    b. Click “Create a bucket”
-//    c. Make a “general bucket” and remember the name you gave it
-//    d. Download the AWS CLI tool
-//    e. Run `aws configure` to set it up with the correct information for your bucket
-//    f. Validate it works with `aws s3 ls`
-// 3. Test S3 storage
-//    a. Update the const's BUCKET_NAME and AWS_REGION below to reflect what you created.
-//    b. Now you can run the tests :)
-//    cargo test --lib -F s3_tests s3_
-#[cfg(feature = "s3_tests")]
-#[cfg(test)]
+/// In-memory mock of the S3 operations used by [`S3Storage`], built on `aws-smithy-mocks`.
+///
+/// A bucket is modelled as a shared `key -> bytes` map. One `mock!` rule per operation
+/// (`put`/`get`/`head`/`delete`/`list_objects_v2`) reads and writes that map, so stored data can
+/// be read back exactly like a real bucket. `list_objects_v2` reproduces S3's `delimiter="/"`
+/// behaviour (direct objects in `contents`, sub-"directories" in `common_prefixes`) because the
+/// epoch-enumeration helpers ([`StorageReaderExt::all_epoch_ids_for_data`] etc.) depend on it.
+#[cfg(all(test, feature = "non-wasm", feature = "testing"))]
+pub(crate) mod mock_s3 {
+    use super::*;
+    use aws_sdk_s3::operation::{
+        delete_object::DeleteObjectOutput,
+        get_object::{GetObjectError, GetObjectOutput},
+        head_object::{HeadObjectError, HeadObjectOutput},
+        list_objects_v2::ListObjectsV2Output,
+        put_object::PutObjectOutput,
+    };
+    use aws_sdk_s3::types::{
+        CommonPrefix, Object,
+        error::{NoSuchKey, NotFound},
+    };
+    use aws_smithy_mocks::{MockResponse, RuleMode, mock, mock_client};
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::{Arc, Mutex};
+
+    /// In-memory object store shared by every rule of a single mock client, keyed by full object
+    /// key. Tests use a single logical bucket, so the mock ignores the request's bucket name.
+    pub(crate) type SharedStore = Arc<Mutex<BTreeMap<String, Vec<u8>>>>;
+
+    /// Create a fresh, empty [`SharedStore`].
+    pub(crate) fn new_store() -> SharedStore {
+        Arc::new(Mutex::new(BTreeMap::new()))
+    }
+
+    /// Build a mocked [`S3Client`] whose operations are served from `store`.
+    pub(crate) fn build_mock_s3_client(store: SharedStore) -> S3Client {
+        let put_store = Arc::clone(&store);
+        let put = mock!(aws_sdk_s3::Client::put_object).then_compute_output(move |input| {
+            let key = input.key().expect("put_object requires a key").to_string();
+            // `s3_put_blob` builds the body from an in-memory `Vec`, so `bytes()` is always `Some`.
+            let bytes = input
+                .body()
+                .bytes()
+                .expect("mock put_object expects an in-memory body")
+                .to_vec();
+            put_store.lock().unwrap().insert(key, bytes);
+            PutObjectOutput::builder().build()
+        });
+
+        let get_store = Arc::clone(&store);
+        let get = mock!(aws_sdk_s3::Client::get_object).then_compute_response(move |input| {
+            let key = input.key().expect("get_object requires a key");
+            match get_store.lock().unwrap().get(key) {
+                Some(bytes) => MockResponse::Output(
+                    GetObjectOutput::builder()
+                        .body(ByteStream::from(bytes.clone()))
+                        .build(),
+                ),
+                None => {
+                    MockResponse::Error(GetObjectError::NoSuchKey(NoSuchKey::builder().build()))
+                }
+            }
+        });
+
+        let head_store = Arc::clone(&store);
+        let head = mock!(aws_sdk_s3::Client::head_object).then_compute_response(move |input| {
+            let key = input.key().expect("head_object requires a key");
+            if head_store.lock().unwrap().contains_key(key) {
+                MockResponse::Output(HeadObjectOutput::builder().build())
+            } else {
+                MockResponse::Error(HeadObjectError::NotFound(NotFound::builder().build()))
+            }
+        });
+
+        let delete_store = Arc::clone(&store);
+        let delete = mock!(aws_sdk_s3::Client::delete_object).then_compute_output(move |input| {
+            let key = input.key().expect("delete_object requires a key");
+            delete_store.lock().unwrap().remove(key);
+            DeleteObjectOutput::builder().build()
+        });
+
+        let list_store = Arc::clone(&store);
+        let list = mock!(aws_sdk_s3::Client::list_objects_v2).then_compute_output(move |input| {
+            let prefix = input.prefix().unwrap_or("");
+            let delimiter = input.delimiter();
+            let guard = list_store.lock().unwrap();
+            let mut contents = Vec::new();
+            let mut common_prefixes = BTreeSet::new();
+            for key in guard.keys() {
+                let Some(rest) = key.strip_prefix(prefix) else {
+                    continue;
+                };
+                match delimiter.and_then(|d| rest.find(d).map(|i| i + d.len())) {
+                    // `rest` contains the delimiter: collapse into a common prefix that includes
+                    // everything up to and including the first delimiter (S3 semantics).
+                    Some(end) => {
+                        common_prefixes.insert(format!("{prefix}{}", &rest[..end]));
+                    }
+                    // No delimiter after the prefix: a direct object.
+                    None => {
+                        contents.push(Object::builder().key(key.clone()).build());
+                    }
+                }
+            }
+            let common_prefixes: Vec<_> = common_prefixes
+                .into_iter()
+                .map(|p| CommonPrefix::builder().prefix(p).build())
+                .collect();
+            ListObjectsV2Output::builder()
+                .is_truncated(false)
+                .set_contents((!contents.is_empty()).then_some(contents))
+                .set_common_prefixes((!common_prefixes.is_empty()).then_some(common_prefixes))
+                .build()
+        });
+
+        mock_client!(
+            aws_sdk_s3,
+            RuleMode::MatchAny,
+            [&put, &get, &head, &delete, &list],
+            |c| c.force_path_style(true)
+        )
+    }
+}
+
+// These tests exercise the real `S3Storage` + `aws_sdk_s3` code paths against an in-process
+// mock S3 (see [`mock_s3`]) — no MinIO, no network, no credentials. They run as part of the
+// normal `cargo test -F testing` suite.
+#[cfg(all(test, feature = "non-wasm", feature = "testing"))]
 mod tests {
     use super::*;
     use crate::vault::storage::tests::{
@@ -757,20 +849,6 @@ mod tests {
         test_store_bytes_does_not_overwrite_existing_bytes,
         test_store_data_does_not_overwrite_existing_data, test_store_data_records_payload_size,
     };
-
-    async fn create_s3_storage(storage_type: StorageType, prefix: &str) -> S3Storage {
-        let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
-        let s3_client = build_s3_client(&config, Some(Url::parse(AWS_S3_ENDPOINT).unwrap()))
-            .await
-            .unwrap();
-        S3Storage::new(
-            s3_client,
-            BUCKET_NAME.to_string(),
-            storage_type,
-            Some(prefix),
-        )
-        .unwrap()
-    }
 
     #[tokio::test]
     async fn s3_storage_helper_methods() {
@@ -870,30 +948,131 @@ mod tests {
         .await;
     }
 
+    /// `data_exists` maps a `head_object` "not found" service error to `Ok(false)` (rather than
+    /// propagating it), matching the "absent object" semantics callers rely on.
     #[tokio::test]
-    async fn test_s3_anon() {
-        let prefix = std::stringify!(test_s3_anon);
-        let mut storage = create_s3_storage(StorageType::PUB, prefix).await;
-        storage
-            .store_bytes(b"fake-pk", &RequestId::default(), "PublicKey")
-            .await
-            .unwrap();
+    async fn data_exists_maps_head_not_found_to_false() {
+        use aws_sdk_s3::operation::head_object::HeadObjectError;
+        use aws_sdk_s3::types::error::NotFound;
+        use aws_smithy_mocks::{RuleMode, mock, mock_client};
 
-        // Build an anonymous client pointing at local MinIO
-        let s3_client = build_anonymous_s3_client(AWS_S3_ENDPOINT, AWS_REGION.to_string())
-            .await
-            .unwrap();
+        let head = mock!(aws_sdk_s3::Client::head_object)
+            .then_error(|| HeadObjectError::NotFound(NotFound::builder().build()));
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, [&head], |c| c
+            .force_path_style(true));
+        let storage =
+            S3Storage::new(client, MOCK_BUCKET.to_string(), StorageType::PUB, None).unwrap();
 
-        let pub_storage = ReadOnlyS3Storage::new(
-            s3_client,
-            BUCKET_NAME.to_string(),
-            StorageType::PUB,
-            Some(prefix),
-        )
-        .unwrap();
+        assert!(
+            !storage
+                .data_exists(&RequestId::default(), "PublicKey")
+                .await
+                .unwrap()
+        );
+    }
 
-        let public_key_ids = pub_storage.all_data_ids("PublicKey").await.unwrap();
-        assert!(!public_key_ids.is_empty());
+    /// `data_exists_at_key` distinguishes three `head_object` outcomes: success ⇒ `true`, a genuine
+    /// "not found" service error ⇒ `false`, and any other service error (403/500/503/…) ⇒ propagated
+    /// as `Err`, so a transient failure is never silently mistaken for an absent object.
+    #[tokio::test]
+    async fn data_exists_at_key_maps_head_errors() {
+        use aws_sdk_s3::error::ErrorMetadata;
+        use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
+        use aws_sdk_s3::types::error::NotFound;
+        use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
+
+        const KEY: &str = "PUB/PublicKey/some-object";
+
+        // An `S3Storage` whose only mocked operation is `head_object`, served by `rule`.
+        fn storage_for(rule: &Rule) -> S3Storage {
+            let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, [rule], |c| c
+                .force_path_style(true));
+            S3Storage::new(client, MOCK_BUCKET.to_string(), StorageType::PUB, None).unwrap()
+        }
+
+        // Object present: `head_object` succeeds ⇒ `true`.
+        let ok = mock!(aws_sdk_s3::Client::head_object)
+            .then_output(|| HeadObjectOutput::builder().build());
+        assert!(storage_for(&ok).data_exists_at_key(KEY).await.unwrap());
+
+        // Genuine "not found" ⇒ `false`.
+        let not_found = mock!(aws_sdk_s3::Client::head_object)
+            .then_error(|| HeadObjectError::NotFound(NotFound::builder().build()));
+        assert!(
+            !storage_for(&not_found)
+                .data_exists_at_key(KEY)
+                .await
+                .unwrap()
+        );
+
+        // Any other service error must propagate rather than read as "absent". Cover a 403-style
+        // access error and a 503-style throttling error, both non-`NotFound` variants.
+        for code in ["AccessDenied", "SlowDown"] {
+            let err = mock!(aws_sdk_s3::Client::head_object).then_error(move || {
+                HeadObjectError::generic(ErrorMetadata::builder().code(code).build())
+            });
+            assert!(
+                storage_for(&err).data_exists_at_key(KEY).await.is_err(),
+                "head_object {code} error should propagate, not map to Ok(false)"
+            );
+        }
+    }
+
+    /// Reading a key that does not exist surfaces the `get_object` error as an `Err` rather than
+    /// silently succeeding.
+    #[tokio::test]
+    async fn read_missing_data_errors() {
+        let storage = create_s3_storage(StorageType::PUB, "read_missing").await;
+        assert!(
+            storage
+                .load_bytes(&RequestId::default(), "PublicKey")
+                .await
+                .is_err()
+        );
+    }
+
+    /// `list_all` follows `ListObjectsV2` continuation tokens and merges every page (the stateful
+    /// mock returns a single page, so this uses explicit multi-page rules).
+    #[tokio::test]
+    async fn list_all_follows_continuation_tokens() {
+        use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output;
+        use aws_sdk_s3::types::Object;
+        use aws_smithy_mocks::{RuleMode, mock, mock_client};
+
+        let mut rng = rand::thread_rng();
+        let id_a = RequestId::new_random(&mut rng);
+        let id_b = RequestId::new_random(&mut rng);
+        let key_a = format!("PUB/PublicKey/{id_a}");
+        let key_b = format!("PUB/PublicKey/{id_b}");
+
+        // First page: truncated, hands back a continuation token.
+        let page1 = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .match_requests(|i| i.continuation_token().is_none())
+            .then_output(move || {
+                ListObjectsV2Output::builder()
+                    .contents(Object::builder().key(key_a.clone()).build())
+                    .is_truncated(true)
+                    .next_continuation_token("page-2")
+                    .build()
+            });
+        // Second page: final page for that token.
+        let page2 = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .match_requests(|i| i.continuation_token() == Some("page-2"))
+            .then_output(move || {
+                ListObjectsV2Output::builder()
+                    .contents(Object::builder().key(key_b.clone()).build())
+                    .is_truncated(false)
+                    .build()
+            });
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, [&page1, &page2], |c| c
+            .force_path_style(true));
+        let storage =
+            S3Storage::new(client, MOCK_BUCKET.to_string(), StorageType::PUB, None).unwrap();
+
+        let ids = storage.all_data_ids("PublicKey").await.unwrap();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&id_a));
+        assert!(ids.contains(&id_b));
     }
 }
 

--- a/core/service/tests/integration_test.rs
+++ b/core/service/tests/integration_test.rs
@@ -301,49 +301,26 @@ tls_subject = "kms-party"
         );
     }
 
-    #[cfg(feature = "s3_tests")]
+    /// Deterministic centralized key generation persists both the public and private signing keys
+    /// under the expected fixed handle.
+    ///
+    /// Formerly `central_s3`, which wrote the public vault to a live MinIO endpoint. The S3
+    /// storage layer is now covered by in-process mock unit tests
+    /// (`vault::storage::s3::tests`), so this exercises only the binary + config wiring against
+    /// the file backend.
     #[test]
     #[integration_test]
-    fn central_s3() {
-        use kms_lib::vault::storage::s3::{AWS_REGION, AWS_S3_ENDPOINT, BUCKET_NAME};
-
-        // Unique S3 prefix per run so concurrent CI invocations of this test
-        // don't fight each other on the shared bucket.
-        let s3_prefix = format!(
-            "central_s3_{}_{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        );
+    fn central_deterministic_signing_keys() {
         let temp_dir_priv = tempdir().unwrap();
-
+        let temp_dir_pub = tempdir().unwrap();
         let config_dir = tempdir().unwrap();
-        let config_path = config_dir.path().join("kms-gen-keys.toml");
-        fs::write(
-            &config_path,
-            format!(
-                r#"
-[keygen]
-deterministic = true
-overwrite = true
-
-[aws]
-region = "{AWS_REGION}"
-s3_endpoint = "{AWS_S3_ENDPOINT}"
-
-[public_vault.storage.s3]
-bucket = "{BUCKET_NAME}"
-prefix = "{s3_prefix}"
-
-[private_vault.storage.file]
-path = "{private_path}"
-"#,
-                private_path = temp_dir_priv.path().display(),
-            ),
-        )
-        .unwrap();
+        let config_path = write_file_storage_config(
+            &config_dir,
+            temp_dir_priv.path(),
+            temp_dir_pub.path(),
+            "deterministic = true\noverwrite = true",
+            None,
+        );
         let output = kms_gen_keys_command()
             .arg("--config-file")
             .arg(config_path)
@@ -356,11 +333,11 @@ path = "{private_path}"
                 status = %output.status,
                 stdout = %log,
                 stderr = %err_log,
-                "kms-gen-keys centralized S3 integration command failed"
+                "kms-gen-keys centralized deterministic command failed"
             );
         }
         assert!(output.status.success());
-        assert!(log.contains("Successfully stored public centralized server signing key under the handle 60b7070add74be3827160aa635fb255eeeeb88586c4debf7ab1134ddceb4beee in storage \"S3 storage with"));
+        assert!(log.contains("Successfully stored public centralized server signing key under the handle 60b7070add74be3827160aa635fb255eeeeb88586c4debf7ab1134ddceb4beee in storage \"file storage with"));
         assert!(log.contains("Successfully stored private centralized server signing key under the handle 60b7070add74be3827160aa635fb255eeeeb88586c4debf7ab1134ddceb4beee in storage \"file storage with"));
     }
 }


### PR DESCRIPTION
## Description

Use s3 mock for s3 based tests instead of relying on minio running inside docker.

### Related issue(s)

Closes https://github.com/zama-ai/kms-internal/issues/3141

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
