### PR TITLE
chore: check preprocessing ID during reshare

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -145,9 +145,16 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
 - **CRS** — `CrsGen` for ZK-proof common reference strings.
 - **Resharing** — `NewMpcEpoch` with `previous_epoch` set rotates parties /
   refreshes secret shares as part of epoch creation; the outcome is fetched
-  via `GetEpochResult`. When resharing legacy key material that has no
-  dedicated OPRF secret-key share, the OPRF sub-protocol is skipped and the
-  reshared private keyset keeps that field absent. `DestroyMpcContext` carries
+  via `GetEpochResult`. The `preproc_id` supplied per key in `previous_epoch` is
+  caller-controlled but ends up in the EIP-712 struct signed for the new epoch,
+  so before any resharing protocol runs each party checks it against the
+  preprocessing ID stored in that key's `KeyGenMetadata` and rejects a mismatch.
+  What a missing keyset means depends on the party's `TwoSetsRole`: set 1 and
+  both sets must hold the key material, so failing to read it rejects the
+  request, whereas a pure set 2 party (a node joining the new context) never held
+  the key and logs a warning instead. When resharing legacy key material that
+  has no dedicated OPRF secret-key share, the OPRF sub-protocol is skipped and
+  the reshared private keyset keeps that field absent. `DestroyMpcContext` carries
   the context's epoch IDs and erases their secret shares (cascading to the
   existing per-epoch deletion) before forgetting the context, so retiring a
   party set leaves no usable key shares behind; the kms-connector is the source

--- a/core/grpc/proto/kms.v1.proto
+++ b/core/grpc/proto/kms.v1.proto
@@ -778,7 +778,10 @@ message KeyInfo {
   // keyID of the key to be reshared.
   RequestId key_id = 1;
   // Preprocessing ID that was used to generate the key initially
-  // required for the EIP struct
+  // required for the EIP struct.
+  // This must be the preprocessing ID the key was actually generated with: each KMS core
+  // compares it against the preprocessing ID it has stored for the key and rejects the
+  // request with InvalidArgument on a mismatch.
   RequestId preproc_id = 2;
   // Parameters of the key to be reshard
   FheParameter key_parameters = 3;

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -1037,6 +1037,17 @@ impl KeyGenMetadata {
         }
     }
 
+    /// The preprocessing ID that was signed and stored when the key was generated.
+    ///
+    /// Returns `None` for [`KeyGenMetadata::LegacyV0`], which predates the field, so there is
+    /// nothing recorded to compare a request against.
+    pub fn preprocessing_id(&self) -> Option<&RequestId> {
+        match self {
+            KeyGenMetadata::Current(inner) => Some(&inner.preprocessing_id),
+            KeyGenMetadata::LegacyV0(_inner) => None,
+        }
+    }
+
     pub fn pub_data_types(&self) -> HashSet<PubDataType> {
         match self {
             KeyGenMetadata::Current(key_gen_metadata_inner) => key_gen_metadata_inner
@@ -1162,8 +1173,8 @@ pub type UserDecryptCallValues = (UserDecryptionResponsePayload, Vec<u8>, Vec<u8
 #[cfg(test)]
 pub(crate) mod tests {
     use super::{
-        CrsGenMetadataInner, CrsGenMetadataInnerV0, KeyGenMetadataInner, KeyGenMetadataInnerV0,
-        KeyGenMetadataInnerV1,
+        CrsGenMetadataInner, CrsGenMetadataInnerV0, KeyGenMetadata, KeyGenMetadataInner,
+        KeyGenMetadataInnerV0, KeyGenMetadataInnerV1,
     };
     use super::{TypedPlaintext, deserialize_to_low_level};
     use crate::cryptography::signatures::compute_eip712_signature;
@@ -2140,6 +2151,26 @@ pub(crate) mod tests {
                 .collect::<BTreeMap<_, _>>(),
         );
         assert_eq!(upgraded_v2.external_signature, q126.external_signature);
+    }
+
+    #[test]
+    fn keygen_metadata_preprocessing_id() {
+        let mut rng = AesRng::seed_from_u64(890);
+        let key_id = RequestId::new_random(&mut rng);
+        let preprocessing_id = RequestId::new_random(&mut rng);
+
+        let current = KeyGenMetadata::new(
+            key_id,
+            preprocessing_id,
+            BTreeMap::new(),
+            vec![],
+            Vec::new(),
+        );
+        assert_eq!(current.preprocessing_id(), Some(&preprocessing_id));
+
+        // Legacy metadata predates the field, so there is nothing to report.
+        let legacy = KeyGenMetadata::LegacyV0(HashMap::new());
+        assert_eq!(legacy.preprocessing_id(), None);
     }
 
     #[test]

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -261,8 +261,8 @@ fn verify_epoch_info(
 
 /// Rejects a supplied preprocessing ID that disagrees with the one stored for the key.
 ///
-/// `stored` is `None` when the previous epoch's metadata is legacy and records no preprocessing
-/// ID; there is nothing to match against, so the request is accepted with a warning.
+/// If stored is `None` then a warning is logged and nothing is checked (this is the
+/// case for legacy preprecessing).
 fn check_preproc_id_matches(
     supplied: &kms_grpc::RequestId,
     stored: Option<&kms_grpc::RequestId>,
@@ -1239,8 +1239,7 @@ impl<
     /// from.
     ///
     /// `preproc_id` is caller-supplied metadata that ends up inside the EIP-712 struct signed for
-    /// the new epoch, so an unchecked value would let the caller obtain KMS signatures binding a
-    /// key to a preprocessing ID it was never generated with.
+    /// the new epoch.
     ///
     /// `my_role` decides what a missing keyset means. A party in the previous context (set 1 or
     /// both sets) must hold the key material, so failing to read it is an error and the request is
@@ -1254,8 +1253,7 @@ impl<
     ) -> Result<(), MetricedError> {
         let previous_epoch_id = &verified_previous_epoch.epoch_id;
         for key_info in verified_previous_epoch.keys_info.iter() {
-            // The in-memory key cache, populated from private storage on a miss, is the single
-            // source of truth here — the same one the reshare paths themselves read from.
+            // This is the in-memory key cache which should be in sync with what's in storage.
             let keys = match self
                 .crypto_storage
                 .read_guarded_fhe_keys(&key_info.key_id, previous_epoch_id)
@@ -1287,7 +1285,7 @@ impl<
                 // Pure set 2: this party never held the key, so there is nothing local to compare
                 // the supplied ID against.
                 Err(e) => {
-                    tracing::warn!(
+                    tracing::info!(
                         "Cannot validate the supplied preprocessing ID {} for key {} at epoch \
                          {}: this party is only in the new context (role {my_role}) and holds no \
                          key material for it: {e}",
@@ -1341,21 +1339,6 @@ impl<
 
         let new_epoch_id_as_request_id = (*new_epoch_id).into();
 
-        // Fetch CRS (also parties from set 1 even if they don't actually need it, but they should fetch it from their storage anyway so no big deal)
-        let crs_info = join_all(verified_previous_epoch.crs_info.iter().map(|crs_info| {
-            get_verified_crs_material(
-                &self.crypto_storage,
-                &new_epoch_id_as_request_id,
-                &crs_info.crs_id,
-                &verified_previous_epoch.context_id,
-                &crs_info.crs_digest,
-                &RealReadOnlyS3StorageGetter {},
-            )
-        }))
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>, MetricedError>>()?;
-
         let session_maker_immutable = self.session_maker.make_immutable();
 
         let two_sets_session = async {
@@ -1381,10 +1364,25 @@ impl<
 
         let my_role = two_sets_session.my_role();
 
-        // Reject a request whose preprocessing IDs disagree with what we signed and stored for
-        // these keys before running any protocol: the supplied values end up inside the EIP-712
-        // struct signed for the new epoch. Checking here, before the role-specific paths are
-        // dispatched below, covers all three resharing roles with one call.
+        // Fetch CRS for parties that are in set2 or both
+        let crs_info = if matches!(my_role, TwoSetsRole::OnlySet1(_)) {
+            vec![]
+        } else {
+            join_all(verified_previous_epoch.crs_info.iter().map(|crs_info| {
+                get_verified_crs_material(
+                    &self.crypto_storage,
+                    &new_epoch_id_as_request_id,
+                    &crs_info.crs_id,
+                    &verified_previous_epoch.context_id,
+                    &crs_info.crs_digest,
+                    &RealReadOnlyS3StorageGetter {},
+                )
+            }))
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, MetricedError>>()?
+        };
+
         self.validate_supplied_preproc_ids(
             new_epoch_id_as_request_id,
             my_role,
@@ -1393,11 +1391,11 @@ impl<
         .await?;
 
         Ok(match my_role {
-            TwoSetsRole::Set1(_) => self
+            TwoSetsRole::OnlySet1(_) => self
                 .reshare_as_set_1(two_sets_session, *new_epoch_id, verified_previous_epoch)
                 .await?
                 .boxed(),
-            TwoSetsRole::Set2(_) => self
+            TwoSetsRole::OnlySet2(_) => self
                 .reshare_as_set_2(
                     two_sets_session,
                     *new_epoch_id,
@@ -2369,12 +2367,12 @@ pub(crate) mod tests {
 
     /// A party in the previous context, which must therefore hold the key material.
     fn set1_role() -> TwoSetsRole {
-        TwoSetsRole::Set1(Role::indexed_from_one(1))
+        TwoSetsRole::OnlySet1(Role::indexed_from_one(1))
     }
 
     /// A party only in the new context, which never held the key material.
     fn set2_role() -> TwoSetsRole {
-        TwoSetsRole::Set2(Role::indexed_from_one(1))
+        TwoSetsRole::OnlySet2(Role::indexed_from_one(1))
     }
 
     fn make_verified_previous_epoch(
@@ -2518,6 +2516,7 @@ pub(crate) mod tests {
                     epoch_id: Some(previous_epoch_id.into()),
                     keys_info: vec![KeyInfo {
                         key_id: Some(key_id.into()),
+                        // Observe the use of wrong preproc_id here
                         preproc_id: Some(wrong_preproc_id.into()),
                         key_parameters: FheParameter::Test as i32,
                         key_digests: vec![],

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -136,7 +136,9 @@ struct VerifiedKeyInfo {
     /// keyID of the key to be reshared.
     pub key_id: kms_grpc::RequestId,
     /// Preprocessing ID that was used to generate the key initially
-    /// required for the EIP struct
+    /// required for the EIP struct.
+    /// Caller-supplied, so it is checked against the preprocessing ID stored for the key
+    /// by [`RealThresholdEpochManager::validate_supplied_preproc_ids`] before it is used.
     pub preproc_id: kms_grpc::RequestId,
     /// Parameters of the key to be reshard
     pub key_parameters: DKGParams,
@@ -255,6 +257,34 @@ fn verify_epoch_info(
         keys_info,
         crs_info,
     })
+}
+
+/// Rejects a supplied preprocessing ID that disagrees with the one stored for the key.
+///
+/// `stored` is `None` when the previous epoch's metadata is legacy and records no preprocessing
+/// ID; there is nothing to match against, so the request is accepted with a warning.
+fn check_preproc_id_matches(
+    supplied: &kms_grpc::RequestId,
+    stored: Option<&kms_grpc::RequestId>,
+    key_id: &kms_grpc::RequestId,
+    previous_epoch_id: &EpochId,
+) -> anyhow::Result<()> {
+    match stored {
+        Some(stored) if stored == supplied => Ok(()),
+        Some(stored) => Err(anyhow::anyhow!(
+            "Refusing to reshare key {key_id} from epoch {previous_epoch_id}: the supplied \
+             preprocessing ID {supplied} does not match the preprocessing ID {stored} stored \
+             for that key"
+        )),
+        None => {
+            tracing::warn!(
+                "Cannot validate the supplied preprocessing ID {supplied} for key {key_id} at \
+                 epoch {previous_epoch_id}: the stored key metadata is legacy and records no \
+                 preprocessing ID"
+            );
+            Ok(())
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -1204,6 +1234,89 @@ impl<
         res
     }
 
+    /// Rejects the request unless every `preproc_id` supplied in [`PreviousEpochInfo`] matches the
+    /// preprocessing ID that was signed and stored alongside that key in the epoch we reshare
+    /// from.
+    ///
+    /// `preproc_id` is caller-supplied metadata that ends up inside the EIP-712 struct signed for
+    /// the new epoch, so an unchecked value would let the caller obtain KMS signatures binding a
+    /// key to a preprocessing ID it was never generated with.
+    ///
+    /// `my_role` decides what a missing keyset means. A party in the previous context (set 1 or
+    /// both sets) must hold the key material, so failing to read it is an error and the request is
+    /// rejected. A party only in the new context (pure set 2, i.e. a node joining) never held the
+    /// key, so there is nothing to compare against locally and that key is skipped with a warning.
+    async fn validate_supplied_preproc_ids(
+        &self,
+        new_epoch_id_as_request_id: kms_grpc::RequestId,
+        my_role: TwoSetsRole,
+        verified_previous_epoch: &VerifiedPreviousEpochInfo,
+    ) -> Result<(), MetricedError> {
+        let previous_epoch_id = &verified_previous_epoch.epoch_id;
+        for key_info in verified_previous_epoch.keys_info.iter() {
+            // The in-memory key cache, populated from private storage on a miss, is the single
+            // source of truth here — the same one the reshare paths themselves read from.
+            let keys = match self
+                .crypto_storage
+                .read_guarded_fhe_keys(&key_info.key_id, previous_epoch_id)
+                .await
+            {
+                Ok(keys) => keys,
+                // `is_set1` covers set 1 and both sets: every party in the previous context holds
+                // the key material, so a failed read means either the request names a key or
+                // epoch we do not have, or our own copy is unusable. Either way we cannot confirm
+                // the preprocessing ID and must not sign. `InvalidArgument` matches
+                // `fetch_existing_private_keysets`, which fails the same way on the very same
+                // read for these roles.
+                Err(e) if my_role.is_set1() => {
+                    return Err(MetricedError::new(
+                        OP_NEW_EPOCH,
+                        Some(new_epoch_id_as_request_id),
+                        anyhow::anyhow!(
+                            "Refusing to reshare key {} from epoch {}: this party is in the \
+                             previous context (role {my_role}) and so must hold the key material, \
+                             but reading it failed, leaving the supplied preprocessing ID {} \
+                             unvalidated: {e}",
+                            key_info.key_id,
+                            previous_epoch_id,
+                            key_info.preproc_id
+                        ),
+                        tonic::Code::InvalidArgument,
+                    ));
+                }
+                // Pure set 2: this party never held the key, so there is nothing local to compare
+                // the supplied ID against.
+                Err(e) => {
+                    tracing::warn!(
+                        "Cannot validate the supplied preprocessing ID {} for key {} at epoch \
+                         {}: this party is only in the new context (role {my_role}) and holds no \
+                         key material for it: {e}",
+                        key_info.preproc_id,
+                        key_info.key_id,
+                        previous_epoch_id
+                    );
+                    continue;
+                }
+            };
+
+            check_preproc_id_matches(
+                &key_info.preproc_id,
+                keys.meta_data.preprocessing_id(),
+                &key_info.key_id,
+                previous_epoch_id,
+            )
+            .map_err(|e| {
+                MetricedError::new(
+                    OP_NEW_EPOCH,
+                    Some(new_epoch_id_as_request_id),
+                    e,
+                    tonic::Code::InvalidArgument,
+                )
+            })?;
+        }
+        Ok(())
+    }
+
     async fn initiate_resharing_and_crs_resign(
         &self,
         new_context_id: &ContextId,
@@ -1226,8 +1339,9 @@ impl<
 
         let verified_previous_epoch = verify_epoch_info(&new_epoch_id.into(), previous_epoch)?;
 
-        // Fetch CRS (also parties from set 1 even if they don't actually need it, but they should fetch it from their storage anyway so no big deal)
         let new_epoch_id_as_request_id = (*new_epoch_id).into();
+
+        // Fetch CRS (also parties from set 1 even if they don't actually need it, but they should fetch it from their storage anyway so no big deal)
         let crs_info = join_all(verified_previous_epoch.crs_info.iter().map(|crs_info| {
             get_verified_crs_material(
                 &self.crypto_storage,
@@ -1265,7 +1379,20 @@ impl<
             )
         })?;
 
-        Ok(match two_sets_session.my_role() {
+        let my_role = two_sets_session.my_role();
+
+        // Reject a request whose preprocessing IDs disagree with what we signed and stored for
+        // these keys before running any protocol: the supplied values end up inside the EIP-712
+        // struct signed for the new epoch. Checking here, before the role-specific paths are
+        // dispatched below, covers all three resharing roles with one call.
+        self.validate_supplied_preproc_ids(
+            new_epoch_id_as_request_id,
+            my_role,
+            &verified_previous_epoch,
+        )
+        .await?;
+
+        Ok(match my_role {
             TwoSetsRole::Set1(_) => self
                 .reshare_as_set_1(two_sets_session, *new_epoch_id, verified_previous_epoch)
                 .await?
@@ -1590,6 +1717,7 @@ pub(crate) mod tests {
             PUBLIC_STORAGE_PREFIX_THRESHOLD_ALL, SIGNING_KEY_ID, default_extra_data,
         },
         cryptography::signatures::gen_sig_keys,
+        dummy_domain,
         engine::{
             base::{BaseKmsStruct, derive_request_id},
             threshold::service::session::PRSSSetupCombined,
@@ -1616,13 +1744,15 @@ pub(crate) mod tests {
     use kms_grpc::{
         RequestId,
         kms::v1::{CrsInfo, FheParameter, KeyInfo, NewMpcEpochRequest},
-        rpc_types::{KMSType, PrivDataType},
+        rpc_types::{KMSType, PrivDataType, alloy_to_protobuf_domain},
     };
     use rand::SeedableRng;
     use threshold_execution::{
         endpoints::reshare_sk::SecureReshareSecretKeys,
         malicious_execution::small_execution::malicious_prss::EmptyPrss,
+        tfhe_internals::test_feature::gen_key_set,
     };
+    use threshold_types::role::Role;
 
     impl<
         Init: PRSSInit<ResiduePolyF4Z64, OutputType = PRSSSetup<ResiduePolyF4Z64>>
@@ -2193,6 +2323,222 @@ pub(crate) mod tests {
             }],
         };
         verify_epoch_info(&new_epoch_id, missing_field_previous_epoch).unwrap_err();
+    }
+
+    /// Builds key material whose metadata records `preproc_id`. Cheap enough for a unit test
+    /// because it pairs the small `TEST_PARAM` keyset with a dummy private keyset.
+    fn make_threshold_keys_with_preproc_id(
+        key_id: &RequestId,
+        preproc_id: &RequestId,
+        rng: &mut AesRng,
+    ) -> ThresholdFheKeys {
+        let (_keyset, compressed_keyset) =
+            gen_key_set(crate::consts::TEST_PARAM, tfhe::Tag::default(), rng).unwrap();
+        ThresholdFheKeys::new(
+            Arc::new(PrivateKeySet::init_dummy(crate::consts::TEST_PARAM)),
+            PublicKeyMaterial::new(compressed_keyset),
+            KeyGenMetadata::new(
+                *key_id,
+                *preproc_id,
+                std::collections::BTreeMap::new(),
+                vec![],
+                vec![],
+            ),
+        )
+    }
+
+    /// Stores `keys` as the key material this party holds for `key_id` in `epoch_id`.
+    async fn store_previous_epoch_keys(
+        crypto_storage: &ThresholdCryptoMaterialStorage<RamStorage, RamStorage>,
+        key_id: &RequestId,
+        epoch_id: &EpochId,
+        keys: &ThresholdFheKeys,
+    ) {
+        let private_storage = crypto_storage.get_private_storage();
+        let mut guard = private_storage.lock().await;
+        store_versioned_at_request_and_epoch_id(
+            &mut (*guard),
+            key_id,
+            epoch_id,
+            keys,
+            &PrivDataType::FheKeyInfo.to_string(),
+        )
+        .await
+        .unwrap();
+    }
+
+    /// A party in the previous context, which must therefore hold the key material.
+    fn set1_role() -> TwoSetsRole {
+        TwoSetsRole::Set1(Role::indexed_from_one(1))
+    }
+
+    /// A party only in the new context, which never held the key material.
+    fn set2_role() -> TwoSetsRole {
+        TwoSetsRole::Set2(Role::indexed_from_one(1))
+    }
+
+    fn make_verified_previous_epoch(
+        previous_epoch_id: EpochId,
+        key_id: &RequestId,
+        preproc_id: &RequestId,
+    ) -> VerifiedPreviousEpochInfo {
+        VerifiedPreviousEpochInfo {
+            context_id: *DEFAULT_MPC_CONTEXT,
+            epoch_id: previous_epoch_id,
+            keys_info: vec![VerifiedKeyInfo {
+                key_id: *key_id,
+                preproc_id: *preproc_id,
+                key_parameters: crate::consts::TEST_PARAM,
+                key_digests: HashMap::new(),
+            }],
+            crs_info: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_supplied_preproc_ids_against_storage() {
+        let mut rng = AesRng::seed_from_u64(42);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+        let previous_epoch_id = *DEFAULT_EPOCH_ID;
+        let new_epoch_id = EpochId::new_random(&mut rng);
+        let key_id = derive_request_id("validate_preproc_key").unwrap();
+        let stored_preproc_id = derive_request_id("validate_preproc_stored").unwrap();
+        let wrong_preproc_id = derive_request_id("validate_preproc_wrong").unwrap();
+
+        let keys = make_threshold_keys_with_preproc_id(&key_id, &stored_preproc_id, &mut rng);
+        store_previous_epoch_keys(
+            &epoch_manager.crypto_storage,
+            &key_id,
+            &previous_epoch_id,
+            &keys,
+        )
+        .await;
+
+        // Sunshine: the supplied preprocessing ID is the one stored with the key.
+        epoch_manager
+            .validate_supplied_preproc_ids(
+                new_epoch_id.into(),
+                set1_role(),
+                &make_verified_previous_epoch(previous_epoch_id, &key_id, &stored_preproc_id),
+            )
+            .await
+            .unwrap();
+
+        // A different preprocessing ID is rejected as an invalid argument.
+        let err = epoch_manager
+            .validate_supplied_preproc_ids(
+                new_epoch_id.into(),
+                set1_role(),
+                &make_verified_previous_epoch(previous_epoch_id, &key_id, &wrong_preproc_id),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+        // Legacy metadata has no preprocessing ID to compare against, so validation accepts it.
+        let legacy_key_id = derive_request_id("validate_preproc_legacy_key").unwrap();
+        let mut legacy_keys = keys;
+        legacy_keys.meta_data = KeyGenMetadata::LegacyV0(HashMap::new());
+        store_previous_epoch_keys(
+            &epoch_manager.crypto_storage,
+            &legacy_key_id,
+            &previous_epoch_id,
+            &legacy_keys,
+        )
+        .await;
+        epoch_manager
+            .validate_supplied_preproc_ids(
+                new_epoch_id.into(),
+                set1_role(),
+                &make_verified_previous_epoch(previous_epoch_id, &legacy_key_id, &wrong_preproc_id),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn validate_supplied_preproc_ids_absent_key_material_depends_on_role() {
+        let mut rng = AesRng::seed_from_u64(42);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+        let previous_epoch_id = *DEFAULT_EPOCH_ID;
+        let new_epoch_id = EpochId::new_random(&mut rng);
+        let key_id = derive_request_id("absent_preproc_key").unwrap();
+        let preproc_id = derive_request_id("absent_preproc_preproc").unwrap();
+
+        // Nothing is stored for this key. A party in the previous context should have had it, so
+        // the request names a key or epoch it does not hold and must be refused.
+        let err = epoch_manager
+            .validate_supplied_preproc_ids(
+                new_epoch_id.into(),
+                set1_role(),
+                &make_verified_previous_epoch(previous_epoch_id, &key_id, &preproc_id),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+        // For a party joining the new context this is the expected state: it never held the key,
+        // so there is nothing to compare against and the request is accepted.
+        epoch_manager
+            .validate_supplied_preproc_ids(
+                new_epoch_id.into(),
+                set2_role(),
+                &make_verified_previous_epoch(previous_epoch_id, &key_id, &preproc_id),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn new_epoch_rejects_mismatched_preproc_id() {
+        let mut rng = AesRng::seed_from_u64(42);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+        let previous_epoch_id = *DEFAULT_EPOCH_ID;
+        let new_epoch_id = EpochId::new_random(&mut rng);
+        let key_id = derive_request_id("new_epoch_preproc_key").unwrap();
+        let stored_preproc_id = derive_request_id("new_epoch_preproc_stored").unwrap();
+        let wrong_preproc_id = derive_request_id("new_epoch_preproc_wrong").unwrap();
+
+        let keys = make_threshold_keys_with_preproc_id(&key_id, &stored_preproc_id, &mut rng);
+        store_previous_epoch_keys(
+            &epoch_manager.crypto_storage,
+            &key_id,
+            &previous_epoch_id,
+            &keys,
+        )
+        .await;
+
+        // The request must be refused up front, before any material is fetched or signed.
+        let err = epoch_manager
+            .new_mpc_epoch(tonic::Request::new(NewMpcEpochRequest {
+                epoch_id: Some(new_epoch_id.into()),
+                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
+                previous_epoch: Some(PreviousEpochInfo {
+                    context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
+                    epoch_id: Some(previous_epoch_id.into()),
+                    keys_info: vec![KeyInfo {
+                        key_id: Some(key_id.into()),
+                        preproc_id: Some(wrong_preproc_id.into()),
+                        key_parameters: FheParameter::Test as i32,
+                        key_digests: vec![],
+                    }],
+                    crs_info: vec![],
+                }),
+                domain: Some(alloy_to_protobuf_domain(&dummy_domain()).unwrap()),
+                extra_data: make_extra_data(2, Some(&DEFAULT_MPC_CONTEXT), Some(&new_epoch_id))
+                    .unwrap(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        // Session setup also reports InvalidArgument, so pin down that the preprocessing ID is
+        // what got us rejected.
+        let msg = err.internal_err().to_string();
+        assert!(
+            msg.contains(&wrong_preproc_id.to_string())
+                && msg.contains(&stored_preproc_id.to_string()),
+            "expected the preprocessing ID mismatch to be the reason, got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -674,8 +674,8 @@ impl SessionMaker {
                     context_id_set2
                 ));
             }
-            (None, Some(role)) => TwoSetsRole::Set2(role),
-            (Some(role), None) => TwoSetsRole::Set1(role),
+            (None, Some(role)) => TwoSetsRole::OnlySet2(role),
+            (Some(role), None) => TwoSetsRole::OnlySet1(role),
             (Some(role_set_1), Some(role_set_2)) => TwoSetsRole::Both(DualRole {
                 role_set_1,
                 role_set_2,
@@ -686,7 +686,7 @@ impl SessionMaker {
         // TwoSetsRole::Both, else TwoSetsRole::Set1 or TwoSetsRole::Set2
         let mut reversed_role_assignment_both_sets = role_assignment_s1
             .into_iter()
-            .map(|(role, id)| (id, TwoSetsRole::Set1(role)))
+            .map(|(role, id)| (id, TwoSetsRole::OnlySet1(role)))
             .collect::<HashMap<_, _>>();
 
         role_assignment_s2.into_iter().for_each(|(role, id)| {
@@ -694,7 +694,7 @@ impl SessionMaker {
                 Entry::Occupied(occupied_entry) => {
                     let role_set_1 = occupied_entry.into_mut();
                     match role_set_1 {
-                        TwoSetsRole::Set1(role1) => {
+                        TwoSetsRole::OnlySet1(role1) => {
                             *role_set_1 = TwoSetsRole::Both(DualRole {
                                 role_set_1: *role1,
                                 role_set_2: role,
@@ -706,7 +706,7 @@ impl SessionMaker {
                     }
                 }
                 Entry::Vacant(vacant_entry) => {
-                    let _ = vacant_entry.insert(TwoSetsRole::Set2(role));
+                    let _ = vacant_entry.insert(TwoSetsRole::OnlySet2(role));
                 }
             }
         });

--- a/core/threshold-execution/src/endpoints/reshare_sk.rs
+++ b/core/threshold-execution/src/endpoints/reshare_sk.rs
@@ -1137,7 +1137,7 @@ mod tests {
 
             let my_role = common_session.my_role();
             let out = match my_role {
-                TwoSetsRole::Set1(_) => {
+                TwoSetsRole::OnlySet1(_) => {
                     let mut party_keyshare = party_keyshare.unwrap();
                     SecureReshareSecretKeys::reshare_sk_two_sets_as_s1(
                         &mut common_session,
@@ -1149,7 +1149,7 @@ mod tests {
                     .unwrap();
                     party_keyshare
                 }
-                TwoSetsRole::Set2(_) => SecureReshareSecretKeys::reshare_sk_two_sets_as_s2(
+                TwoSetsRole::OnlySet2(_) => SecureReshareSecretKeys::reshare_sk_two_sets_as_s2(
                     &mut (common_session, session_set_2.unwrap()),
                     preproc_128.as_mut().unwrap(),
                     preproc_64.as_mut().unwrap(),
@@ -1201,8 +1201,8 @@ mod tests {
         let (results_set_1_only, mut results_set_2_and_both): (Vec<_>, Vec<_>) = results
             .into_iter()
             .partition_map(|(role, out, expected_sk)| match role {
-                TwoSetsRole::Set1(role) => itertools::Either::Left((role, out, expected_sk)),
-                TwoSetsRole::Set2(role) => itertools::Either::Right((role, out, expected_sk)),
+                TwoSetsRole::OnlySet1(role) => itertools::Either::Left((role, out, expected_sk)),
+                TwoSetsRole::OnlySet2(role) => itertools::Either::Right((role, out, expected_sk)),
                 TwoSetsRole::Both(dual_role) => {
                     itertools::Either::Right((dual_role.role_set_2, out, expected_sk))
                 }

--- a/core/threshold-execution/src/online/reshare.rs
+++ b/core/threshold-execution/src/online/reshare.rs
@@ -704,10 +704,10 @@ where
 
         let mut jobs = JoinSet::new();
         let transform_s1_to_role = |sender: &TwoSetsRole, _external_opening_info: ()| match sender {
-            TwoSetsRole::Set1(role) => *role,
+            TwoSetsRole::OnlySet1(role) => *role,
             TwoSetsRole::Both(dual_role) => dual_role.role_set_1,
             // Here it is OK to panic because this function is only called for parties in set 1
-            TwoSetsRole::Set2(role) => {
+            TwoSetsRole::OnlySet2(role) => {
                 panic!("Expected to receive from set 1 parties, got {:?}", role)
             }
         };
@@ -1226,7 +1226,7 @@ mod tests {
                 threshold_set_2: 1,
             },
             HashSet::from([
-                TwoSetsRole::Set1(Role::indexed_from_one(4)),
+                TwoSetsRole::OnlySet1(Role::indexed_from_one(4)),
                 TwoSetsRole::Both(DualRole {
                     role_set_1: Role::indexed_from_one(2),
                     role_set_2: Role::indexed_from_one(3),
@@ -1254,7 +1254,7 @@ mod tests {
                 threshold_set_2: 1,
             },
             HashSet::from([
-                TwoSetsRole::Set1(Role::indexed_from_one(4)),
+                TwoSetsRole::OnlySet1(Role::indexed_from_one(4)),
                 TwoSetsRole::Both(DualRole {
                     role_set_1: Role::indexed_from_one(2),
                     role_set_2: Role::indexed_from_one(3),
@@ -1269,7 +1269,7 @@ mod tests {
                 threshold_set_2: 2,
             },
             HashSet::from([
-                TwoSetsRole::Set2(Role::indexed_from_one(6)),
+                TwoSetsRole::OnlySet2(Role::indexed_from_one(6)),
                 TwoSetsRole::Both(DualRole {
                     role_set_1: Role::indexed_from_one(3),
                     role_set_2: Role::indexed_from_one(4),
@@ -1493,7 +1493,7 @@ mod tests {
         };
 
         let (reshare_result, set_2_session) = match two_sets_session.my_role() {
-            TwoSetsRole::Set1(_) => (
+            TwoSetsRole::OnlySet1(_) => (
                 malicious_reshare_set_1
                     .execute(
                         &mut two_sets_session,
@@ -1505,7 +1505,7 @@ mod tests {
                     .map(|res| res.into()),
                 None,
             ),
-            TwoSetsRole::Set2(_) => {
+            TwoSetsRole::OnlySet2(_) => {
                 let mut sessions = (two_sets_session, set_2_session.unwrap());
                 (
                     malicious_reshare_set_2

--- a/core/threshold-execution/src/runtime/test_runtime.rs
+++ b/core/threshold-execution/src/runtime/test_runtime.rs
@@ -59,11 +59,11 @@ pub fn generate_fixed_roles_two_sets_with_intersection(
 
     let mut roles = (1..=parties_set_1)
         .map(Role::indexed_from_one)
-        .map(TwoSetsRole::Set1)
+        .map(TwoSetsRole::OnlySet1)
         .chain(
             (1..=parties_set_2)
                 .map(Role::indexed_from_one)
-                .map(TwoSetsRole::Set2),
+                .map(TwoSetsRole::OnlySet2),
         )
         .collect::<HashSet<_>>();
 
@@ -71,8 +71,8 @@ pub fn generate_fixed_roles_two_sets_with_intersection(
     // and add the corresponding dual role
     for i in 0..intersection_size {
         // index_role_2 is i+1 with wrap around back to 1
-        let role_set1 = TwoSetsRole::Set1(Role::indexed_from_zero(i));
-        let role_set2 = TwoSetsRole::Set2(Role::indexed_from_zero((i + 1) % parties_set_2));
+        let role_set1 = TwoSetsRole::OnlySet1(Role::indexed_from_zero(i));
+        let role_set2 = TwoSetsRole::OnlySet2(Role::indexed_from_zero((i + 1) % parties_set_2));
         assert!(
             roles.remove(&role_set1),
             "role {role_set1:?} not found in roles set"

--- a/core/threshold-execution/src/sharing/open.rs
+++ b/core/threshold-execution/src/sharing/open.rs
@@ -346,8 +346,8 @@ impl RobustOpen for SecureRobustOpen {
                 ) {
                     // Note that we only receive from the opposite set
                     // but it doesnt hurt to map the Roles this way
-                    (TwoSetsRole::Set1(role), ExternalOpeningInfo::FromSet1(_)) => *role,
-                    (TwoSetsRole::Set2(role), ExternalOpeningInfo::FromSet2(_)) => *role,
+                    (TwoSetsRole::OnlySet1(role), ExternalOpeningInfo::FromSet1(_)) => *role,
+                    (TwoSetsRole::OnlySet2(role), ExternalOpeningInfo::FromSet2(_)) => *role,
                     (TwoSetsRole::Both(role), ExternalOpeningInfo::FromSet1(_)) => role.role_set_1,
                     (TwoSetsRole::Both(role), ExternalOpeningInfo::FromSet2(_)) => role.role_set_2,
                     _ => panic!("Mismatched role and external opening info"),
@@ -897,7 +897,7 @@ pub(crate) mod test {
         let mut external_opening_info = None;
         if session.my_role().is_set1() {
             let my_role = match session.my_role() {
-                TwoSetsRole::Set1(r) => r,
+                TwoSetsRole::OnlySet1(r) => r,
                 TwoSetsRole::Both(r) => r.role_set_1,
                 _ => panic!("Expected role in set 1"),
             };
@@ -911,7 +911,7 @@ pub(crate) mod test {
 
             let mut inner_input_map = HashMap::new();
             for outer_output_role in session.roles().iter() {
-                if let TwoSetsRole::Set2(inner_output_role) = outer_output_role {
+                if let TwoSetsRole::OnlySet2(inner_output_role) = outer_output_role {
                     inner_input_map.insert(*outer_output_role, vec![shares[inner_output_role]]);
                 } else if let TwoSetsRole::Both(inner_output_role_both) = outer_output_role {
                     println!("Inserting share for both role {:?}", inner_output_role_both);
@@ -1010,10 +1010,10 @@ pub(crate) mod test {
         let mut result_set_2 = Vec::new();
         for (role, (_, secrets, openings)) in results_honests.into_iter() {
             match role {
-                TwoSetsRole::Set1(role) => {
+                TwoSetsRole::OnlySet1(role) => {
                     result_set_1.push((role, secrets, openings));
                 }
-                TwoSetsRole::Set2(role) => {
+                TwoSetsRole::OnlySet2(role) => {
                     result_set_2.push((role, secrets, openings));
                 }
                 TwoSetsRole::Both(role_both_sets) => {
@@ -1143,7 +1143,7 @@ pub(crate) mod test {
 
     #[tokio::test]
     async fn test_sync_robust_open_external_drop() {
-        let malicious_roles = HashSet::from([TwoSetsRole::Set1(Role::indexed_from_one(2))]);
+        let malicious_roles = HashSet::from([TwoSetsRole::OnlySet1(Role::indexed_from_one(2))]);
         test_robust_open_external::<ResiduePolyF4Z128, { ResiduePolyF4Z128::EXTENSION_DEGREE }, _>(
             4,
             4,
@@ -1162,9 +1162,9 @@ pub(crate) mod test {
     #[tokio::test]
     async fn test_sync_robust_open_external_lie() {
         let malicious_roles = HashSet::from([
-            TwoSetsRole::Set1(Role::indexed_from_one(5)),
-            TwoSetsRole::Set1(Role::indexed_from_one(7)),
-            TwoSetsRole::Set1(Role::indexed_from_one(10)),
+            TwoSetsRole::OnlySet1(Role::indexed_from_one(5)),
+            TwoSetsRole::OnlySet1(Role::indexed_from_one(7)),
+            TwoSetsRole::OnlySet1(Role::indexed_from_one(10)),
         ]);
         test_robust_open_external::<ResiduePolyF4Z128, { ResiduePolyF4Z128::EXTENSION_DEGREE }, _>(
             13,
@@ -1185,8 +1185,8 @@ pub(crate) mod test {
     #[tokio::test]
     async fn test_sync_robust_open_external_lie_too_many() {
         let malicious_roles = HashSet::from([
-            TwoSetsRole::Set1(Role::indexed_from_one(3)),
-            TwoSetsRole::Set1(Role::indexed_from_one(2)),
+            TwoSetsRole::OnlySet1(Role::indexed_from_one(3)),
+            TwoSetsRole::OnlySet1(Role::indexed_from_one(2)),
         ]);
         test_robust_open_external::<ResiduePolyF4Z128, { ResiduePolyF4Z128::EXTENSION_DEGREE }, _>(
             4,

--- a/core/threshold-execution/src/tests/helper.rs
+++ b/core/threshold-execution/src/tests/helper.rs
@@ -28,8 +28,8 @@ pub mod tests_and_benches {
 
     pub fn get_seed_for_two_sets_role(role: &TwoSetsRole) -> u64 {
         match role {
-            TwoSetsRole::Set1(r) => r.one_based() as u64 | (1 << 60),
-            TwoSetsRole::Set2(r) => r.one_based() as u64 | (2 << 60),
+            TwoSetsRole::OnlySet1(r) => r.one_based() as u64 | (1 << 60),
+            TwoSetsRole::OnlySet2(r) => r.one_based() as u64 | (2 << 60),
             TwoSetsRole::Both(r) => {
                 r.role_set_1.one_based() as u64
                     | ((r.role_set_2.one_based() as u64) << 32)
@@ -95,7 +95,7 @@ pub mod tests_and_benches {
 
             let set_1_session = if party.is_set1() {
                 let role = match party {
-                    TwoSetsRole::Set1(r) => r,
+                    TwoSetsRole::OnlySet1(r) => r,
                     TwoSetsRole::Both(r) => r.role_set_1,
                     _ => unreachable!(),
                 };
@@ -110,7 +110,7 @@ pub mod tests_and_benches {
 
             let set_2_session = if party.is_set2() {
                 let role = match party {
-                    TwoSetsRole::Set2(r) => r,
+                    TwoSetsRole::OnlySet2(r) => r,
                     TwoSetsRole::Both(r) => r.role_set_2,
                     _ => unreachable!(),
                 };
@@ -901,7 +901,7 @@ pub mod tests {
             );
 
             let (set_1_session, set_2_session) = match party {
-                TwoSetsRole::Set1(role) => (
+                TwoSetsRole::OnlySet1(role) => (
                     Some(test_runtime_set_1.base_session_for_party(
                         sid_set_1,
                         role,
@@ -909,7 +909,7 @@ pub mod tests {
                     )),
                     None,
                 ),
-                TwoSetsRole::Set2(role) => (
+                TwoSetsRole::OnlySet2(role) => (
                     None,
                     Some(test_runtime_set_2.base_session_for_party(
                         sid_set_2,

--- a/core/threshold-networking/src/local.rs
+++ b/core/threshold-networking/src/local.rs
@@ -324,8 +324,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_networking_two_sets() {
-        let role_1_set_1 = TwoSetsRole::Set1(Role::indexed_from_one(1));
-        let role_1_set_2 = TwoSetsRole::Set2(Role::indexed_from_one(1));
+        let role_1_set_1 = TwoSetsRole::OnlySet1(Role::indexed_from_one(1));
+        let role_1_set_2 = TwoSetsRole::OnlySet2(Role::indexed_from_one(1));
 
         let roles = HashSet::from([role_1_set_1, role_1_set_2]);
         let net_producer = LocalNetworkingProducer::from_roles(&roles);

--- a/core/threshold-networking/src/sending_service.rs
+++ b/core/threshold-networking/src/sending_service.rs
@@ -1049,15 +1049,15 @@ mod tests {
         let sid = SessionId::from(0);
         let mut role_assignment = RoleAssignment::default();
         // Create the roles from Set 1
-        let role_1_set_1 = TwoSetsRole::Set1(Role::indexed_from_one(1));
+        let role_1_set_1 = TwoSetsRole::OnlySet1(Role::indexed_from_one(1));
         let id_1_set_1 = Identity::new(format!("{ip_addr}"), ports[0], None);
-        let role_2_set_1 = TwoSetsRole::Set1(Role::indexed_from_one(2));
+        let role_2_set_1 = TwoSetsRole::OnlySet1(Role::indexed_from_one(2));
         let id_2_set_1 = Identity::new(format!("{ip_addr}"), ports[1], None);
 
         // Create the roles from Set 2
-        let role_1_set_2 = TwoSetsRole::Set2(Role::indexed_from_one(1));
+        let role_1_set_2 = TwoSetsRole::OnlySet2(Role::indexed_from_one(1));
         let id_1_set_2 = Identity::new(format!("{ip_addr}"), ports[2], None);
-        let role_2_set_2 = TwoSetsRole::Set2(Role::indexed_from_one(2));
+        let role_2_set_2 = TwoSetsRole::OnlySet2(Role::indexed_from_one(2));
         let id_2_set_2 = Identity::new(format!("{ip_addr}"), ports[3], None);
 
         role_assignment.insert(role_1_set_1, id_1_set_1.clone());

--- a/core/threshold-types/src/role.rs
+++ b/core/threshold-types/src/role.rs
@@ -58,18 +58,18 @@ impl Display for DualRole {
 
 #[derive(Debug, /*Display,*/ Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TwoSetsRole {
-    Set1(Role),
-    Set2(Role),
+    OnlySet1(Role),
+    OnlySet2(Role),
     Both(DualRole),
 }
 
 impl TwoSetsRole {
     pub fn is_set1(&self) -> bool {
-        matches!(self, TwoSetsRole::Set1(_) | TwoSetsRole::Both(_))
+        matches!(self, TwoSetsRole::OnlySet1(_) | TwoSetsRole::Both(_))
     }
 
     pub fn is_set2(&self) -> bool {
-        matches!(self, TwoSetsRole::Set2(_) | TwoSetsRole::Both(_))
+        matches!(self, TwoSetsRole::OnlySet2(_) | TwoSetsRole::Both(_))
     }
 }
 
@@ -125,15 +125,15 @@ impl RoleTrait for Role {
 
 impl Default for TwoSetsRole {
     fn default() -> Self {
-        TwoSetsRole::Set1(Role::default())
+        TwoSetsRole::OnlySet1(Role::default())
     }
 }
 
 impl Display for TwoSetsRole {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TwoSetsRole::Set1(role) => write!(f, "Set1({})", role),
-            TwoSetsRole::Set2(role) => write!(f, "Set2({})", role),
+            TwoSetsRole::OnlySet1(role) => write!(f, "Set1({})", role),
+            TwoSetsRole::OnlySet2(role) => write!(f, "Set2({})", role),
             TwoSetsRole::Both(dual_role) => write!(f, "{}", dual_role),
         }
     }
@@ -305,13 +305,13 @@ pub mod tests {
         };
 
         let parties = HashSet::from([
-            TwoSetsRole::Set1(Role::indexed_from_one(1)),
-            TwoSetsRole::Set1(Role::indexed_from_one(2)),
+            TwoSetsRole::OnlySet1(Role::indexed_from_one(1)),
+            TwoSetsRole::OnlySet1(Role::indexed_from_one(2)),
             TwoSetsRole::Both(DualRole {
                 role_set_1: Role::indexed_from_one(3),
                 role_set_2: Role::indexed_from_one(1),
             }),
-            TwoSetsRole::Set2(Role::indexed_from_one(2)),
+            TwoSetsRole::OnlySet2(Role::indexed_from_one(2)),
         ]);
         assert!(TwoSetsRole::is_threshold_smaller_than_num_parties(
             threshold, &parties
@@ -324,13 +324,13 @@ pub mod tests {
         };
 
         let parties = HashSet::from([
-            TwoSetsRole::Set1(Role::indexed_from_one(1)),
-            TwoSetsRole::Set1(Role::indexed_from_one(2)),
+            TwoSetsRole::OnlySet1(Role::indexed_from_one(1)),
+            TwoSetsRole::OnlySet1(Role::indexed_from_one(2)),
             TwoSetsRole::Both(DualRole {
                 role_set_1: Role::indexed_from_one(3),
                 role_set_2: Role::indexed_from_one(1),
             }),
-            TwoSetsRole::Set2(Role::indexed_from_one(2)),
+            TwoSetsRole::OnlySet2(Role::indexed_from_one(2)),
         ]);
         assert!(!TwoSetsRole::is_threshold_smaller_than_num_parties(
             threshold, &parties
@@ -342,13 +342,13 @@ pub mod tests {
             threshold_set_2: 2,
         };
         let parties = HashSet::from([
-            TwoSetsRole::Set1(Role::indexed_from_one(1)),
-            TwoSetsRole::Set1(Role::indexed_from_one(2)),
+            TwoSetsRole::OnlySet1(Role::indexed_from_one(1)),
+            TwoSetsRole::OnlySet1(Role::indexed_from_one(2)),
             TwoSetsRole::Both(DualRole {
                 role_set_1: Role::indexed_from_one(3),
                 role_set_2: Role::indexed_from_one(1),
             }),
-            TwoSetsRole::Set2(Role::indexed_from_one(2)),
+            TwoSetsRole::OnlySet2(Role::indexed_from_one(2)),
         ]);
         assert!(!TwoSetsRole::is_threshold_smaller_than_num_parties(
             threshold, &parties


### PR DESCRIPTION
## Description

During epoch change, MPC parties are given a previous preprocessing ID, this PR adds some verification around the previous preprocessing ID. There are two scenarios where it cannot be verified: (1) if the party is only in set 2, so it has no knowledge about previous epochs and (2) the keygen metadata stored in private storage uses the legacy format which contains no preprocessing ID. We skip verification in these scenario and give a warning instead.

### Related issue(s)
Closes zama-ai/kms-internal#3143

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
