### PR TITLE
chore: epoch/context lease in session maker

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -164,11 +164,14 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   the context's epoch IDs and erases their secret shares (cascading to the
   existing per-epoch deletion) before forgetting the context, so retiring a
   party set leaves no usable key shares behind; the kms-connector is the source
-  of truth for which epochs belong to a context. Destroying an epoch is refused
-  with `FailedPrecondition` while a `NewMpcEpoch` for that same epoch ID is still
-  in flight, because the creation task registers the epoch as soon as PRSS
-  completes but keeps writing private shares for the rest of the resharing;
-  callers retry once the creation has settled.
+  of truth for which epochs belong to a context. In-memory lifecycle leases
+  serialize creation against destruction: `NewMpcEpoch` holds shared leases for
+  its target context and epoch through all PRSS, resharing and persistence work,
+  while `DestroyMpcEpoch` and `DestroyMpcContext` require exclusive leases before
+  taking snapshots or deleting data. A conflicting destruction is refused with
+  `FailedPrecondition`, including while PRSS is still running and the new epoch
+  has not yet been registered in the session maker; callers retry once creation
+  has settled.
 - **Session management** — creation, result retrieval, and cleanup for
   long-running threshold sessions.
 

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -164,7 +164,11 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   the context's epoch IDs and erases their secret shares (cascading to the
   existing per-epoch deletion) before forgetting the context, so retiring a
   party set leaves no usable key shares behind; the kms-connector is the source
-  of truth for which epochs belong to a context.
+  of truth for which epochs belong to a context. Destroying an epoch is refused
+  with `FailedPrecondition` while a `NewMpcEpoch` for that same epoch ID is still
+  in flight, because the creation task registers the epoch as soon as PRSS
+  completes but keeps writing private shares for the rest of the resharing;
+  callers retry once the creation has settled.
 - **Session management** — creation, result retrieval, and cleanup for
   long-running threshold sessions.
 

--- a/core/service/src/engine/threshold/endpoint.rs
+++ b/core/service/src/engine/threshold/endpoint.rs
@@ -246,6 +246,19 @@ impl_endpoint! {
                 .ok_or_else(|| Status::invalid_argument("context_id is required"))?;
             let context_id = parse_grpc_request_id::<ContextId>(proto_context_id, RequestIdParsingErr::Context)?;
 
+            // Hold the exclusive context lease across both phases. This makes the epoch snapshot
+            // stable with respect to `NewMpcEpoch`, including creations that are still running PRSS
+            // and therefore have not registered their epoch in the session maker yet.
+            let _destruction_lease = self
+                .session_maker
+                .try_start_context_destruction(&context_id)
+                .await
+                .map_err(|e| {
+                    Status::failed_precondition(format!(
+                        "Cannot destroy MPC context {context_id}: {e}. Retry once epoch creation has settled."
+                    ))
+                })?;
+
             // Destroy the associated epochs first: their secret key shares and PRSS randomness are security-sensitive
             // material. Erase them before touching anything else so that if there is a problem, the worst transient
             // state is "shares gone, context metadata lingers" rather than "context gone, shares still on disk".

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -90,7 +90,7 @@ use crate::{
     },
     util::{
         meta_store::{
-            MetaStore, add_req_to_meta_store, retrieve_from_meta_store,
+            EntryState, MetaStore, add_req_to_meta_store, retrieve_from_meta_store,
             update_err_req_in_meta_store, update_req_in_meta_store,
         },
         rate_limiter::RateLimiter,
@@ -1088,6 +1088,12 @@ impl<
     ///
     /// In case of any error during the deletion of private data, the epoch will not be removed from the session maker,
     /// and an error will be returned. This allows the caller to retry the operation until it succeeds.
+    ///
+    /// NOTE: this only guards against the preconditions it can see in storage and in the session
+    /// maker. The guard against a *concurrent* [`EpochManager::new_mpc_epoch`] still writing
+    /// private shares for this epoch lives in the caller,
+    /// [`Self::destroy_epoch_and_purge_cache`]; do not call this function directly from a
+    /// destruction path that bypasses it.
     async fn destroy_epoch(
         epoch_id: &EpochId,
         priv_storage: &tokio::sync::Mutex<PrivS>,
@@ -1217,10 +1223,47 @@ impl<
     ///
     /// [`Self::destroy_epoch`] only touches storage, so the cache must be cleared here as well or the decompressed keys
     /// stay resident until restart. The cache is purged regardless of the deletion outcome.
+    ///
+    /// Refuses with `FailedPrecondition` while an [`EpochManager::new_mpc_epoch`] for this epoch is
+    /// still in flight. [`Self::internal_init_epoch`] registers the epoch in the session maker as
+    /// soon as PRSS completes, but the resharing that follows keeps writing private shares for the
+    /// whole (potentially minutes-long) MPC protocol. Destroying in that window would delete every
+    /// visible piece of material, report success, and then let the resharing task persist a fresh
+    /// private share that no API can reach any more — the epoch is gone from the session maker and
+    /// its epoch data, from which a restart would rediscover it, has been deleted.
     async fn destroy_epoch_and_purge_cache(
         &self,
         epoch_id: &EpochId,
     ) -> Result<Response<Empty>, MetricedError> {
+        // `reshare_pubinfo_meta_store` is written only by `new_mpc_epoch`, so a `Pending` entry
+        // under this epoch id means exactly "an epoch creation for this epoch is running". The
+        // entry is claimed before the task is spawned and only resolved once the resharing future
+        // has fully returned, so it spans every write the task performs — private storage, the
+        // in-memory key cache, and the backup vault alike.
+        //
+        // A dead or cancelled task cannot wedge this check: its dropped permit is reaped into
+        // `Done(Err)`, and the store is in-memory only, so a restart clears the entry along with
+        // the task. A reshare that hangs forever does block destruction until the node restarts,
+        // which is the safe direction to fail — proceeding would leave unreachable shares on disk.
+        if matches!(
+            self.reshare_pubinfo_meta_store
+                .read()
+                .await
+                .retrieve(&(*epoch_id).into()),
+            Some(EntryState::Pending)
+        ) {
+            return Err(MetricedError::new(
+                OP_DESTROY_EPOCH,
+                Some((*epoch_id).into()),
+                anyhow::anyhow!(
+                    "Epoch ID {epoch_id} is still being created (PRSS setup and/or resharing in \
+                     progress); refusing to destroy it because the in-flight task would persist \
+                     private shares after the deletion. Retry once the epoch creation has settled."
+                ),
+                tonic::Code::FailedPrecondition,
+            ));
+        }
+
         let priv_storage = Arc::clone(&self.crypto_storage.inner.private_storage);
 
         // NOTE: destroy_epoch will also destroy PRSS data
@@ -2752,6 +2795,141 @@ pub(crate) mod tests {
         assert_eq!(err.code(), tonic::Code::NotFound);
     }
 
+    /// Destroying an epoch whose creation is still in flight must be refused. `internal_init_epoch`
+    /// registers the epoch as soon as PRSS completes, but the resharing that follows keeps writing
+    /// private shares; destroying in that window would report success and then let the task persist
+    /// a share that no API can reach any more.
+    #[tokio::test]
+    async fn test_destroy_epoch_rejected_while_creation_in_flight() {
+        let mut rng = AesRng::seed_from_u64(44);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+
+        let epoch_id = *DEFAULT_EPOCH_ID;
+        // A "keeper" epoch so the target is not the last remaining one, which `destroy_epoch`
+        // refuses to remove for an unrelated reason.
+        let keeper_epoch_id = EpochId::new_random(&mut rng);
+        seed_epoch(&epoch_manager, epoch_id, *DEFAULT_MPC_CONTEXT).await;
+        seed_epoch(&epoch_manager, keeper_epoch_id, *DEFAULT_MPC_CONTEXT).await;
+        let data_id = seed_epoched_key_data(&epoch_manager, &epoch_id, "in_flight_share").await;
+
+        // Claim the meta store entry the way `new_mpc_epoch` does and keep the permit, mirroring a
+        // resharing task that has finished PRSS but not yet written its shares.
+        let permit = add_req_to_meta_store(
+            &epoch_manager.reshare_pubinfo_meta_store,
+            &epoch_id.into(),
+            OP_NEW_EPOCH,
+        )
+        .await
+        .unwrap();
+
+        let err = epoch_manager
+            .destroy_epoch_and_purge_cache(&epoch_id)
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+
+        // The refusal must leave everything intact so a retry still has something to delete.
+        assert!(epoch_manager.session_maker.epoch_exists(&epoch_id).await);
+        {
+            let private_storage = epoch_manager.crypto_storage.get_private_storage();
+            let priv_storage = private_storage.lock().await;
+            assert!(
+                priv_storage
+                    .all_data_ids_at_epoch(&epoch_id, &PrivDataType::FheKeyInfo.to_string())
+                    .await
+                    .unwrap()
+                    .contains(&data_id),
+                "a refused destruction must not delete private key material"
+            );
+            assert!(
+                priv_storage
+                    .data_exists(&epoch_id.into(), &PrivDataType::EpochData.to_string())
+                    .await
+                    .unwrap(),
+                "a refused destruction must not delete the epoch data holding the PRSS setup"
+            );
+        }
+
+        // Once the creation settles the epoch must become destroyable again, so the guard cannot
+        // turn into a permanent block. Resolve the entry explicitly instead of dropping the permit,
+        // since the reaper that fails an abandoned entry runs asynchronously.
+        assert!(
+            update_req_in_meta_store::<_, String>(
+                &epoch_manager.reshare_pubinfo_meta_store,
+                permit,
+                Ok(EpochOutput::PRSSInitOnly),
+                OP_NEW_EPOCH,
+            )
+            .await
+        );
+
+        epoch_manager
+            .destroy_epoch_and_purge_cache(&epoch_id)
+            .await
+            .unwrap();
+
+        assert!(!epoch_manager.session_maker.epoch_exists(&epoch_id).await);
+        {
+            let private_storage = epoch_manager.crypto_storage.get_private_storage();
+            let priv_storage = private_storage.lock().await;
+            assert!(
+                priv_storage
+                    .all_data_ids_at_epoch(&epoch_id, &PrivDataType::FheKeyInfo.to_string())
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+        }
+    }
+
+    /// An epoch whose creation *failed* must remain destroyable: the guard only holds while a
+    /// creation is genuinely in flight, never for an entry that already carries an outcome.
+    #[tokio::test]
+    async fn test_destroy_epoch_allowed_after_failed_creation() {
+        let mut rng = AesRng::seed_from_u64(45);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+
+        let epoch_id = *DEFAULT_EPOCH_ID;
+        let keeper_epoch_id = EpochId::new_random(&mut rng);
+        seed_epoch(&epoch_manager, epoch_id, *DEFAULT_MPC_CONTEXT).await;
+        seed_epoch(&epoch_manager, keeper_epoch_id, *DEFAULT_MPC_CONTEXT).await;
+        let data_id =
+            seed_epoched_key_data(&epoch_manager, &epoch_id, "failed_creation_share").await;
+
+        let permit = add_req_to_meta_store(
+            &epoch_manager.reshare_pubinfo_meta_store,
+            &epoch_id.into(),
+            OP_NEW_EPOCH,
+        )
+        .await
+        .unwrap();
+        assert!(
+            update_err_req_in_meta_store(
+                &epoch_manager.reshare_pubinfo_meta_store,
+                permit,
+                "resharing failed".to_string(),
+                OP_NEW_EPOCH,
+            )
+            .await
+        );
+
+        epoch_manager
+            .destroy_epoch_and_purge_cache(&epoch_id)
+            .await
+            .unwrap();
+
+        assert!(!epoch_manager.session_maker.epoch_exists(&epoch_id).await);
+        let private_storage = epoch_manager.crypto_storage.get_private_storage();
+        let priv_storage = private_storage.lock().await;
+        assert!(
+            !priv_storage
+                .all_data_ids_at_epoch(&epoch_id, &PrivDataType::FheKeyInfo.to_string())
+                .await
+                .unwrap()
+                .contains(&data_id)
+        );
+    }
+
     /// Validates partial-failure in destroying MPC epoch:
     /// If deleting the private data fails, retrying should be possible until success,
     /// at which point all epoch Ids associated to the destroyed context should be returned.
@@ -3041,6 +3219,33 @@ pub(crate) mod tests {
         )
         .await
         .unwrap();
+    }
+
+    /// Store a dummy `FheKeyInfo` entry under `epoch_id`, standing in for the private share material
+    /// a keygen or a resharing would persist there, and return its data ID.
+    async fn seed_epoched_key_data(
+        epoch_manager: &RealThresholdEpochManager<
+            ram::RamStorage,
+            ram::RamStorage,
+            EmptyPrss,
+            SecureReshareSecretKeys,
+        >,
+        epoch_id: &EpochId,
+        label: &str,
+    ) -> RequestId {
+        let data_id = derive_request_id(label).unwrap();
+        let private_storage = epoch_manager.crypto_storage.get_private_storage();
+        let mut priv_storage = private_storage.lock().await;
+        store_versioned_at_request_and_epoch_id(
+            &mut (*priv_storage),
+            &data_id,
+            epoch_id,
+            &TestType { i: 42 },
+            &PrivDataType::FheKeyInfo.to_string(),
+        )
+        .await
+        .unwrap();
+        data_id
     }
 
     #[tokio::test]

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -2817,14 +2817,15 @@ pub(crate) mod tests {
         // Destruction must return before touching the registered epoch or its persisted PRSS data.
         assert!(epoch_manager.session_maker.epoch_exists(&epoch_id).await);
         let private_storage = epoch_manager.crypto_storage.get_private_storage();
-        let priv_storage = private_storage.lock().await;
-        assert!(
-            priv_storage
-                .data_exists(&epoch_id.into(), &PrivDataType::EpochData.to_string())
-                .await
-                .unwrap()
-        );
-        drop(priv_storage);
+        {
+            let priv_storage = private_storage.lock().await;
+            assert!(
+                priv_storage
+                    .data_exists(&epoch_id.into(), &PrivDataType::EpochData.to_string())
+                    .await
+                    .unwrap()
+            );
+        }
 
         // Success, failure, panic and task cancellation all drop this owned lease, allowing cleanup.
         drop(creation_lease);

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -90,7 +90,7 @@ use crate::{
     },
     util::{
         meta_store::{
-            EntryState, MetaStore, add_req_to_meta_store, retrieve_from_meta_store,
+            MetaStore, add_req_to_meta_store, retrieve_from_meta_store,
             update_err_req_in_meta_store, update_req_in_meta_store,
         },
         rate_limiter::RateLimiter,
@@ -1088,12 +1088,6 @@ impl<
     ///
     /// In case of any error during the deletion of private data, the epoch will not be removed from the session maker,
     /// and an error will be returned. This allows the caller to retry the operation until it succeeds.
-    ///
-    /// NOTE: this only guards against the preconditions it can see in storage and in the session
-    /// maker. The guard against a *concurrent* [`EpochManager::new_mpc_epoch`] still writing
-    /// private shares for this epoch lives in the caller,
-    /// [`Self::destroy_epoch_and_purge_cache`]; do not call this function directly from a
-    /// destruction path that bypasses it.
     async fn destroy_epoch(
         epoch_id: &EpochId,
         priv_storage: &tokio::sync::Mutex<PrivS>,
@@ -1224,45 +1218,27 @@ impl<
     /// [`Self::destroy_epoch`] only touches storage, so the cache must be cleared here as well or the decompressed keys
     /// stay resident until restart. The cache is purged regardless of the deletion outcome.
     ///
-    /// Refuses with `FailedPrecondition` while an [`EpochManager::new_mpc_epoch`] for this epoch is
-    /// still in flight. [`Self::internal_init_epoch`] registers the epoch in the session maker as
-    /// soon as PRSS completes, but the resharing that follows keeps writing private shares for the
-    /// whole (potentially minutes-long) MPC protocol. Destroying in that window would delete every
-    /// visible piece of material, report success, and then let the resharing task persist a fresh
-    /// private share that no API can reach any more — the epoch is gone from the session maker and
-    /// its epoch data, from which a restart would rediscover it, has been deleted.
+    /// An exclusive lifecycle lease prevents creation of the same epoch from starting or completing
+    /// concurrently with deletion.
     async fn destroy_epoch_and_purge_cache(
         &self,
         epoch_id: &EpochId,
     ) -> Result<Response<Empty>, MetricedError> {
-        // `reshare_pubinfo_meta_store` is written only by `new_mpc_epoch`, so a `Pending` entry
-        // under this epoch id means exactly "an epoch creation for this epoch is running". The
-        // entry is claimed before the task is spawned and only resolved once the resharing future
-        // has fully returned, so it spans every write the task performs — private storage, the
-        // in-memory key cache, and the backup vault alike.
-        //
-        // A dead or cancelled task cannot wedge this check: its dropped permit is reaped into
-        // `Done(Err)`, and the store is in-memory only, so a restart clears the entry along with
-        // the task. A reshare that hangs forever does block destruction until the node restarts,
-        // which is the safe direction to fail — proceeding would leave unreachable shares on disk.
-        if matches!(
-            self.reshare_pubinfo_meta_store
-                .read()
-                .await
-                .retrieve(&(*epoch_id).into()),
-            Some(EntryState::Pending)
-        ) {
-            return Err(MetricedError::new(
-                OP_DESTROY_EPOCH,
-                Some((*epoch_id).into()),
-                anyhow::anyhow!(
-                    "Epoch ID {epoch_id} is still being created (PRSS setup and/or resharing in \
-                     progress); refusing to destroy it because the in-flight task would persist \
-                     private shares after the deletion. Retry once the epoch creation has settled."
-                ),
-                tonic::Code::FailedPrecondition,
-            ));
-        }
+        let _destruction_lease = self
+            .session_maker
+            .try_start_epoch_destruction(epoch_id)
+            .await
+            .map_err(|e| {
+                MetricedError::new(
+                    OP_DESTROY_EPOCH,
+                    Some((*epoch_id).into()),
+                    anyhow::anyhow!(
+                        "Cannot destroy epoch ID {epoch_id}: {e}. Retry once epoch creation has \
+                         settled."
+                    ),
+                    tonic::Code::FailedPrecondition,
+                )
+            })?;
 
         let priv_storage = Arc::clone(&self.crypto_storage.inner.private_storage);
 
@@ -1491,6 +1467,21 @@ impl<
             resharing: resharing_params,
         } = validate_new_mpc_epoch_request(inner)?;
 
+        // Retain both shared leases until the background task has completed every write. Context
+        // and epoch destruction acquire the corresponding exclusive lease before mutating state.
+        let creation_lease = self
+            .session_maker
+            .try_start_epoch_creation(&context_id, &epoch_id)
+            .await
+            .map_err(|e| {
+                MetricedError::new(
+                    OP_NEW_EPOCH,
+                    Some(epoch_id.into()),
+                    anyhow::anyhow!("Cannot create epoch ID {epoch_id}: {e}"),
+                    tonic::Code::FailedPrecondition,
+                )
+            })?;
+
         if self.session_maker.epoch_exists(&epoch_id).await {
             return Err(MetricedError::new(
                 OP_NEW_EPOCH,
@@ -1544,6 +1535,7 @@ impl<
         let session_maker = self.session_maker.clone();
         let crypto_storage = self.crypto_storage.clone();
         self.tracker.spawn(async move {
+            let _creation_lease = creation_lease;
             let _rate_limiter_permit = rate_limiter_permit;
             let crypto_storage = crypto_storage;
             let context_id = context_id;
@@ -2795,10 +2787,8 @@ pub(crate) mod tests {
         assert_eq!(err.code(), tonic::Code::NotFound);
     }
 
-    /// Destroying an epoch whose creation is still in flight must be refused. `internal_init_epoch`
-    /// registers the epoch as soon as PRSS completes, but the resharing that follows keeps writing
-    /// private shares; destroying in that window would report success and then let the task persist
-    /// a share that no API can reach any more.
+    /// The creation lease remains live after PRSS registers the epoch, preventing destruction while
+    /// resharing can still write private shares. Releasing the lease makes destruction retryable.
     #[tokio::test]
     async fn test_destroy_epoch_rejected_while_creation_in_flight() {
         let mut rng = AesRng::seed_from_u64(44);
@@ -2810,17 +2800,13 @@ pub(crate) mod tests {
         let keeper_epoch_id = EpochId::new_random(&mut rng);
         seed_epoch(&epoch_manager, epoch_id, *DEFAULT_MPC_CONTEXT).await;
         seed_epoch(&epoch_manager, keeper_epoch_id, *DEFAULT_MPC_CONTEXT).await;
-        let data_id = seed_epoched_key_data(&epoch_manager, &epoch_id, "in_flight_share").await;
 
-        // Claim the meta store entry the way `new_mpc_epoch` does and keep the permit, mirroring a
-        // resharing task that has finished PRSS but not yet written its shares.
-        let permit = add_req_to_meta_store(
-            &epoch_manager.reshare_pubinfo_meta_store,
-            &epoch_id.into(),
-            OP_NEW_EPOCH,
-        )
-        .await
-        .unwrap();
+        // Mirror a creation task that has registered its epoch after PRSS but is still resharing.
+        let creation_lease = epoch_manager
+            .session_maker
+            .try_start_epoch_creation(&DEFAULT_MPC_CONTEXT, &epoch_id)
+            .await
+            .unwrap();
 
         let err = epoch_manager
             .destroy_epoch_and_purge_cache(&epoch_id)
@@ -2828,105 +2814,32 @@ pub(crate) mod tests {
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
 
-        // The refusal must leave everything intact so a retry still has something to delete.
+        // Destruction must return before touching the registered epoch or its persisted PRSS data.
         assert!(epoch_manager.session_maker.epoch_exists(&epoch_id).await);
-        {
-            let private_storage = epoch_manager.crypto_storage.get_private_storage();
-            let priv_storage = private_storage.lock().await;
-            assert!(
-                priv_storage
-                    .all_data_ids_at_epoch(&epoch_id, &PrivDataType::FheKeyInfo.to_string())
-                    .await
-                    .unwrap()
-                    .contains(&data_id),
-                "a refused destruction must not delete private key material"
-            );
-            assert!(
-                priv_storage
-                    .data_exists(&epoch_id.into(), &PrivDataType::EpochData.to_string())
-                    .await
-                    .unwrap(),
-                "a refused destruction must not delete the epoch data holding the PRSS setup"
-            );
-        }
-
-        // Once the creation settles the epoch must become destroyable again, so the guard cannot
-        // turn into a permanent block. Resolve the entry explicitly instead of dropping the permit,
-        // since the reaper that fails an abandoned entry runs asynchronously.
-        assert!(
-            update_req_in_meta_store::<_, String>(
-                &epoch_manager.reshare_pubinfo_meta_store,
-                permit,
-                Ok(EpochOutput::PRSSInitOnly),
-                OP_NEW_EPOCH,
-            )
-            .await
-        );
-
-        epoch_manager
-            .destroy_epoch_and_purge_cache(&epoch_id)
-            .await
-            .unwrap();
-
-        assert!(!epoch_manager.session_maker.epoch_exists(&epoch_id).await);
-        {
-            let private_storage = epoch_manager.crypto_storage.get_private_storage();
-            let priv_storage = private_storage.lock().await;
-            assert!(
-                priv_storage
-                    .all_data_ids_at_epoch(&epoch_id, &PrivDataType::FheKeyInfo.to_string())
-                    .await
-                    .unwrap()
-                    .is_empty()
-            );
-        }
-    }
-
-    /// An epoch whose creation *failed* must remain destroyable: the guard only holds while a
-    /// creation is genuinely in flight, never for an entry that already carries an outcome.
-    #[tokio::test]
-    async fn test_destroy_epoch_allowed_after_failed_creation() {
-        let mut rng = AesRng::seed_from_u64(45);
-        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
-
-        let epoch_id = *DEFAULT_EPOCH_ID;
-        let keeper_epoch_id = EpochId::new_random(&mut rng);
-        seed_epoch(&epoch_manager, epoch_id, *DEFAULT_MPC_CONTEXT).await;
-        seed_epoch(&epoch_manager, keeper_epoch_id, *DEFAULT_MPC_CONTEXT).await;
-        let data_id =
-            seed_epoched_key_data(&epoch_manager, &epoch_id, "failed_creation_share").await;
-
-        let permit = add_req_to_meta_store(
-            &epoch_manager.reshare_pubinfo_meta_store,
-            &epoch_id.into(),
-            OP_NEW_EPOCH,
-        )
-        .await
-        .unwrap();
-        assert!(
-            update_err_req_in_meta_store(
-                &epoch_manager.reshare_pubinfo_meta_store,
-                permit,
-                "resharing failed".to_string(),
-                OP_NEW_EPOCH,
-            )
-            .await
-        );
-
-        epoch_manager
-            .destroy_epoch_and_purge_cache(&epoch_id)
-            .await
-            .unwrap();
-
-        assert!(!epoch_manager.session_maker.epoch_exists(&epoch_id).await);
         let private_storage = epoch_manager.crypto_storage.get_private_storage();
         let priv_storage = private_storage.lock().await;
         assert!(
-            !priv_storage
-                .all_data_ids_at_epoch(&epoch_id, &PrivDataType::FheKeyInfo.to_string())
+            priv_storage
+                .data_exists(&epoch_id.into(), &PrivDataType::EpochData.to_string())
                 .await
                 .unwrap()
-                .contains(&data_id)
+        );
+        drop(priv_storage);
+
+        // Success, failure, panic and task cancellation all drop this owned lease, allowing cleanup.
+        drop(creation_lease);
+        epoch_manager
+            .destroy_epoch_and_purge_cache(&epoch_id)
+            .await
+            .unwrap();
+
+        assert!(!epoch_manager.session_maker.epoch_exists(&epoch_id).await);
+        let priv_storage = private_storage.lock().await;
+        assert!(
+            !priv_storage
+                .data_exists(&epoch_id.into(), &PrivDataType::EpochData.to_string())
+                .await
+                .unwrap()
         );
     }
 
@@ -3219,33 +3132,6 @@ pub(crate) mod tests {
         )
         .await
         .unwrap();
-    }
-
-    /// Store a dummy `FheKeyInfo` entry under `epoch_id`, standing in for the private share material
-    /// a keygen or a resharing would persist there, and return its data ID.
-    async fn seed_epoched_key_data(
-        epoch_manager: &RealThresholdEpochManager<
-            ram::RamStorage,
-            ram::RamStorage,
-            EmptyPrss,
-            SecureReshareSecretKeys,
-        >,
-        epoch_id: &EpochId,
-        label: &str,
-    ) -> RequestId {
-        let data_id = derive_request_id(label).unwrap();
-        let private_storage = epoch_manager.crypto_storage.get_private_storage();
-        let mut priv_storage = private_storage.lock().await;
-        store_versioned_at_request_and_epoch_id(
-            &mut (*priv_storage),
-            &data_id,
-            epoch_id,
-            &TestType { i: 42 },
-            &PrivDataType::FheKeyInfo.to_string(),
-        )
-        .await
-        .unwrap();
-        data_id
     }
 
     #[tokio::test]

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1226,7 +1226,7 @@ impl<
     ) -> Result<Response<Empty>, MetricedError> {
         let _destruction_lease = self
             .session_maker
-            .try_start_epoch_destruction(epoch_id)
+            .try_get_epoch_destruction_lease(epoch_id)
             .await
             .map_err(|e| {
                 MetricedError::new(
@@ -1471,7 +1471,7 @@ impl<
         // and epoch destruction acquire the corresponding exclusive lease before mutating state.
         let creation_lease = self
             .session_maker
-            .try_start_epoch_creation(&context_id, &epoch_id)
+            .try_get_epoch_creation_lease(&context_id, &epoch_id)
             .await
             .map_err(|e| {
                 MetricedError::new(
@@ -2804,7 +2804,7 @@ pub(crate) mod tests {
         // Mirror a creation task that has registered its epoch after PRSS but is still resharing.
         let creation_lease = epoch_manager
             .session_maker
-            .try_start_epoch_creation(&DEFAULT_MPC_CONTEXT, &epoch_id)
+            .try_get_epoch_creation_lease(&DEFAULT_MPC_CONTEXT, &epoch_id)
             .await
             .unwrap();
 

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -1,7 +1,7 @@
 // === Standard Library ===
 use std::{
     collections::{HashMap, hash_map::Entry},
-    sync::Arc,
+    sync::{Arc, Weak},
 };
 
 use crate::{
@@ -34,12 +34,13 @@ use rand::{RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
 use tfhe::Versionize;
 use tfhe_versionable::VersionsDispatch;
+use thiserror::Error;
 use threshold_types::session_id::SessionId;
 use threshold_types::{
     network::NetworkMode,
     party::{Identity, MpcIdentity, RoleAssignment},
 };
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 use tonic::Code;
 
 struct Context {
@@ -75,11 +76,76 @@ impl tfhe::named::Named for PRSSSetupCombined {
 
 type ContextMap = HashMap<ContextId, Context>;
 
+#[derive(Clone, Default)]
+struct LifecycleCoordinator {
+    // Weak entries ensure rejected requests for random IDs do not grow these registries forever.
+    // The owned lock guards keep their lock alive for exactly the lifecycle operation.
+    context_locks: Arc<Mutex<HashMap<ContextId, Weak<RwLock<()>>>>>,
+    epoch_locks: Arc<Mutex<HashMap<EpochId, Weak<RwLock<()>>>>>,
+}
+
+impl LifecycleCoordinator {
+    async fn context_lock(&self, context_id: &ContextId) -> Arc<RwLock<()>> {
+        let mut locks = self.context_locks.lock().await;
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(context_id).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        let lock = Arc::new(RwLock::new(()));
+        locks.insert(*context_id, Arc::downgrade(&lock));
+        lock
+    }
+
+    async fn epoch_lock(&self, epoch_id: &EpochId) -> Arc<RwLock<()>> {
+        let mut locks = self.epoch_locks.lock().await;
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(epoch_id).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        let lock = Arc::new(RwLock::new(()));
+        locks.insert(*epoch_id, Arc::downgrade(&lock));
+        lock
+    }
+}
+
+/// Identifies the lifecycle resource that is already held by a conflicting operation.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub(crate) enum LifecycleConflict {
+    /// A context is being destroyed while an epoch creation wants to use it, or vice versa.
+    #[error("MPC context {0} has a conflicting lifecycle operation in progress")]
+    Context(ContextId),
+    /// An epoch is being created while it is being destroyed, or vice versa.
+    #[error("epoch {0} has a conflicting lifecycle operation in progress")]
+    Epoch(EpochId),
+}
+
+/// Keeps an epoch creation mutually exclusive with destruction of its epoch and context.
+#[derive(Debug)]
+pub(crate) struct EpochCreationLease {
+    _context: OwnedRwLockReadGuard<()>,
+    _epoch: OwnedRwLockReadGuard<()>,
+}
+
+/// Prevents epoch creation for a context while that context and its epochs are destroyed.
+#[derive(Debug)]
+pub(crate) struct ContextDestructionLease {
+    _context: OwnedRwLockWriteGuard<()>,
+}
+
+/// Prevents creation of an epoch while that epoch is destroyed.
+#[derive(Debug)]
+pub(crate) struct EpochDestructionLease {
+    _epoch: OwnedRwLockWriteGuard<()>,
+}
+
 #[derive(Clone)]
 pub(crate) struct SessionMaker {
     networking_manager: Arc<RwLock<GrpcNetworkingManager>>,
     context_map: Arc<RwLock<ContextMap>>,
     epoch_map: Arc<RwLock<HashMap<EpochId, EpochData>>>,
+    lifecycle: LifecycleCoordinator,
     verifier: Option<Arc<AttestedVerifier>>, // optional as it's not used when there's no TLS
     rng: Arc<Mutex<AesRng>>,
 }
@@ -135,9 +201,67 @@ impl SessionMaker {
             networking_manager,
             context_map: Arc::new(RwLock::new(HashMap::new())),
             epoch_map: Arc::new(RwLock::new(HashMap::new())),
+            lifecycle: LifecycleCoordinator::default(),
             verifier,
             rng: Arc::new(Mutex::new(rng)),
         }
+    }
+
+    /// Reserve `context_id` and `epoch_id` for an epoch creation.
+    ///
+    /// The returned lease must live until the creation task has finished every persistent write.
+    /// Destruction uses exclusive leases for the same IDs and therefore fails while this lease is
+    /// alive.
+    pub(crate) async fn try_start_epoch_creation(
+        &self,
+        context_id: &ContextId,
+        epoch_id: &EpochId,
+    ) -> Result<EpochCreationLease, LifecycleConflict> {
+        let context = self.lifecycle.context_lock(context_id).await;
+        let context = context
+            .try_read_owned()
+            .map_err(|_| LifecycleConflict::Context(*context_id))?;
+
+        let epoch = self.lifecycle.epoch_lock(epoch_id).await;
+        let epoch = epoch
+            .try_read_owned()
+            .map_err(|_| LifecycleConflict::Epoch(*epoch_id))?;
+
+        Ok(EpochCreationLease {
+            _context: context,
+            _epoch: epoch,
+        })
+    }
+
+    /// Exclusively reserve a context for destruction.
+    ///
+    /// The caller must retain the lease while taking the epoch snapshot, deleting every associated
+    /// epoch, and deleting the context itself. Acquiring it fails while an epoch creation for this
+    /// context is in flight.
+    pub(crate) async fn try_start_context_destruction(
+        &self,
+        context_id: &ContextId,
+    ) -> Result<ContextDestructionLease, LifecycleConflict> {
+        let context = self.lifecycle.context_lock(context_id).await;
+        let context = context
+            .try_write_owned()
+            .map_err(|_| LifecycleConflict::Context(*context_id))?;
+        Ok(ContextDestructionLease { _context: context })
+    }
+
+    /// Exclusively reserve an epoch for destruction.
+    ///
+    /// Acquiring this lease fails while creation of the same epoch is in flight. The caller must
+    /// retain it through all storage and cache deletion.
+    pub(crate) async fn try_start_epoch_destruction(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<EpochDestructionLease, LifecycleConflict> {
+        let epoch = self.lifecycle.epoch_lock(epoch_id).await;
+        let epoch = epoch
+            .try_write_owned()
+            .map_err(|_| LifecycleConflict::Epoch(*epoch_id))?;
+        Ok(EpochDestructionLease { _epoch: epoch })
     }
 
     /// Returns the number of active sessions.
@@ -179,6 +303,7 @@ impl SessionMaker {
             networking_manager,
             context_map: Arc::new(RwLock::new(HashMap::new())),
             epoch_map: Arc::new(RwLock::new(HashMap::new())),
+            lifecycle: LifecycleCoordinator::default(),
             verifier: None,
             rng: Arc::new(Mutex::new(rng)),
         }
@@ -232,6 +357,7 @@ impl SessionMaker {
                 Some(epoch) => HashMap::from_iter([(*epoch_id, epoch)]),
                 None => HashMap::new(),
             })),
+            lifecycle: LifecycleCoordinator::default(),
             verifier: None,
             rng: Arc::new(Mutex::new(rng)),
         }
@@ -782,6 +908,14 @@ pub(crate) struct ImmutableSessionMaker {
 }
 
 impl ImmutableSessionMaker {
+    /// Exclusively reserve a context while its epochs and context metadata are destroyed.
+    pub(crate) async fn try_start_context_destruction(
+        &self,
+        context_id: &ContextId,
+    ) -> Result<ContextDestructionLease, LifecycleConflict> {
+        self.inner.try_start_context_destruction(context_id).await
+    }
+
     #[allow(dead_code)]
     pub(crate) async fn context_exists(&self, context_id: &ContextId) -> bool {
         self.inner.context_exists(context_id).await
@@ -1009,5 +1143,99 @@ mod tests {
                 .await
                 .is_empty()
         );
+    }
+
+    /// An epoch creation is visible to lifecycle coordination before it is registered in
+    /// `epoch_map`, so neither its context nor its epoch can be destroyed in that window.
+    #[tokio::test]
+    async fn epoch_creation_lease_blocks_matching_destruction_only() {
+        let mut rng = AesRng::seed_from_u64(6);
+        let session_maker = SessionMaker::empty_dummy_session(AesRng::seed_from_u64(7));
+        let context_id = ContextId::new_random(&mut rng);
+        let epoch_id = EpochId::new_random(&mut rng);
+        let endpoint_session_maker = session_maker.make_immutable();
+
+        let creation = session_maker
+            .try_start_epoch_creation(&context_id, &epoch_id)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            endpoint_session_maker
+                .try_start_context_destruction(&context_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Context(context_id)
+        );
+        assert_eq!(
+            session_maker
+                .try_start_epoch_destruction(&epoch_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Epoch(epoch_id)
+        );
+
+        // Unrelated lifecycle operations remain independent.
+        let other_context_id = ContextId::new_random(&mut rng);
+        let other_epoch_id = EpochId::new_random(&mut rng);
+        endpoint_session_maker
+            .try_start_context_destruction(&other_context_id)
+            .await
+            .unwrap();
+        session_maker
+            .try_start_epoch_destruction(&other_epoch_id)
+            .await
+            .unwrap();
+
+        drop(creation);
+        endpoint_session_maker
+            .try_start_context_destruction(&context_id)
+            .await
+            .unwrap();
+        session_maker
+            .try_start_epoch_destruction(&epoch_id)
+            .await
+            .unwrap();
+    }
+
+    /// Whichever destructive operation acquires its exclusive lease first prevents a conflicting
+    /// epoch creation from beginning until that lease is released.
+    #[tokio::test]
+    async fn destruction_leases_block_epoch_creation_until_drop() {
+        let mut rng = AesRng::seed_from_u64(8);
+        let session_maker = SessionMaker::empty_dummy_session(AesRng::seed_from_u64(9));
+        let context_id = ContextId::new_random(&mut rng);
+        let epoch_id = EpochId::new_random(&mut rng);
+
+        let context_destruction = session_maker
+            .try_start_context_destruction(&context_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            session_maker
+                .try_start_epoch_creation(&context_id, &epoch_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Context(context_id)
+        );
+        drop(context_destruction);
+
+        let epoch_destruction = session_maker
+            .try_start_epoch_destruction(&epoch_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            session_maker
+                .try_start_epoch_creation(&context_id, &epoch_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Epoch(epoch_id)
+        );
+        drop(epoch_destruction);
+
+        session_maker
+            .try_start_epoch_creation(&context_id, &epoch_id)
+            .await
+            .unwrap();
     }
 }

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -1,6 +1,7 @@
 // === Standard Library ===
 use std::{
     collections::{HashMap, hash_map::Entry},
+    hash::Hash,
     sync::{Arc, Weak},
 };
 
@@ -76,38 +77,43 @@ impl tfhe::named::Named for PRSSSetupCombined {
 
 type ContextMap = HashMap<ContextId, Context>;
 
-#[derive(Clone, Default)]
-struct LifecycleCoordinator {
-    // Weak entries ensure rejected requests for random IDs do not grow these registries forever.
-    // The owned lock guards keep their lock alive for exactly the lifecycle operation.
-    context_locks: Arc<Mutex<HashMap<ContextId, Weak<RwLock<()>>>>>,
-    epoch_locks: Arc<Mutex<HashMap<EpochId, Weak<RwLock<()>>>>>,
+/// Hands out one lock per ID, keyed by the identifier type of the guarded resource.
+///
+/// Weak entries ensure rejected requests for random IDs do not grow the registry forever.
+/// The owned lock guards taken by the callers keep their lock alive for exactly the lifecycle
+/// operation.
+#[derive(Clone)]
+struct LockRegistry<Id> {
+    locks: Arc<Mutex<HashMap<Id, Weak<RwLock<()>>>>>,
 }
 
-impl LifecycleCoordinator {
-    async fn context_lock(&self, context_id: &ContextId) -> Arc<RwLock<()>> {
-        let mut locks = self.context_locks.lock().await;
+// Hand-written because `#[derive(Default)]` would add a spurious `Id: Default` bound.
+impl<Id> Default for LockRegistry<Id> {
+    fn default() -> Self {
+        Self {
+            locks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl<Id: Copy + Eq + Hash> LockRegistry<Id> {
+    async fn lock(&self, id: &Id) -> Arc<RwLock<()>> {
+        let mut locks = self.locks.lock().await;
         locks.retain(|_, lock| lock.strong_count() > 0);
-        if let Some(lock) = locks.get(context_id).and_then(Weak::upgrade) {
+        if let Some(lock) = locks.get(id).and_then(Weak::upgrade) {
             return lock;
         }
 
         let lock = Arc::new(RwLock::new(()));
-        locks.insert(*context_id, Arc::downgrade(&lock));
+        locks.insert(*id, Arc::downgrade(&lock));
         lock
     }
+}
 
-    async fn epoch_lock(&self, epoch_id: &EpochId) -> Arc<RwLock<()>> {
-        let mut locks = self.epoch_locks.lock().await;
-        locks.retain(|_, lock| lock.strong_count() > 0);
-        if let Some(lock) = locks.get(epoch_id).and_then(Weak::upgrade) {
-            return lock;
-        }
-
-        let lock = Arc::new(RwLock::new(()));
-        locks.insert(*epoch_id, Arc::downgrade(&lock));
-        lock
-    }
+#[derive(Clone, Default)]
+struct LifecycleCoordinator {
+    context_locks: LockRegistry<ContextId>,
+    epoch_locks: LockRegistry<EpochId>,
 }
 
 /// Identifies the lifecycle resource that is already held by a conflicting operation.
@@ -217,12 +223,12 @@ impl SessionMaker {
         context_id: &ContextId,
         epoch_id: &EpochId,
     ) -> Result<EpochCreationLease, LifecycleConflict> {
-        let context = self.lifecycle.context_lock(context_id).await;
+        let context = self.lifecycle.context_locks.lock(context_id).await;
         let context = context
             .try_read_owned()
             .map_err(|_| LifecycleConflict::Context(*context_id))?;
 
-        let epoch = self.lifecycle.epoch_lock(epoch_id).await;
+        let epoch = self.lifecycle.epoch_locks.lock(epoch_id).await;
         let epoch = epoch
             .try_read_owned()
             .map_err(|_| LifecycleConflict::Epoch(*epoch_id))?;
@@ -242,7 +248,7 @@ impl SessionMaker {
         &self,
         context_id: &ContextId,
     ) -> Result<ContextDestructionLease, LifecycleConflict> {
-        let context = self.lifecycle.context_lock(context_id).await;
+        let context = self.lifecycle.context_locks.lock(context_id).await;
         let context = context
             .try_write_owned()
             .map_err(|_| LifecycleConflict::Context(*context_id))?;
@@ -257,7 +263,7 @@ impl SessionMaker {
         &self,
         epoch_id: &EpochId,
     ) -> Result<EpochDestructionLease, LifecycleConflict> {
-        let epoch = self.lifecycle.epoch_lock(epoch_id).await;
+        let epoch = self.lifecycle.epoch_locks.lock(epoch_id).await;
         let epoch = epoch
             .try_write_owned()
             .map_err(|_| LifecycleConflict::Epoch(*epoch_id))?;

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -218,7 +218,7 @@ impl SessionMaker {
     /// The returned lease must live until the creation task has finished every persistent write.
     /// Destruction uses exclusive leases for the same IDs and therefore fails while this lease is
     /// alive.
-    pub(crate) async fn try_start_epoch_creation(
+    pub(crate) async fn try_get_epoch_creation_lease(
         &self,
         context_id: &ContextId,
         epoch_id: &EpochId,
@@ -244,7 +244,7 @@ impl SessionMaker {
     /// The caller must retain the lease while taking the epoch snapshot, deleting every associated
     /// epoch, and deleting the context itself. Acquiring it fails while an epoch creation for this
     /// context is in flight.
-    pub(crate) async fn try_start_context_destruction(
+    pub(crate) async fn try_get_context_destruction_lease(
         &self,
         context_id: &ContextId,
     ) -> Result<ContextDestructionLease, LifecycleConflict> {
@@ -259,7 +259,7 @@ impl SessionMaker {
     ///
     /// Acquiring this lease fails while creation of the same epoch is in flight. The caller must
     /// retain it through all storage and cache deletion.
-    pub(crate) async fn try_start_epoch_destruction(
+    pub(crate) async fn try_get_epoch_destruction_lease(
         &self,
         epoch_id: &EpochId,
     ) -> Result<EpochDestructionLease, LifecycleConflict> {
@@ -919,7 +919,9 @@ impl ImmutableSessionMaker {
         &self,
         context_id: &ContextId,
     ) -> Result<ContextDestructionLease, LifecycleConflict> {
-        self.inner.try_start_context_destruction(context_id).await
+        self.inner
+            .try_get_context_destruction_lease(context_id)
+            .await
     }
 
     #[allow(dead_code)]
@@ -1162,7 +1164,7 @@ mod tests {
         let endpoint_session_maker = session_maker.make_immutable();
 
         let creation = session_maker
-            .try_start_epoch_creation(&context_id, &epoch_id)
+            .try_get_epoch_creation_lease(&context_id, &epoch_id)
             .await
             .unwrap();
 
@@ -1175,7 +1177,7 @@ mod tests {
         );
         assert_eq!(
             session_maker
-                .try_start_epoch_destruction(&epoch_id)
+                .try_get_epoch_destruction_lease(&epoch_id)
                 .await
                 .unwrap_err(),
             LifecycleConflict::Epoch(epoch_id)
@@ -1189,7 +1191,7 @@ mod tests {
             .await
             .unwrap();
         session_maker
-            .try_start_epoch_destruction(&other_epoch_id)
+            .try_get_epoch_destruction_lease(&other_epoch_id)
             .await
             .unwrap();
 
@@ -1199,7 +1201,7 @@ mod tests {
             .await
             .unwrap();
         session_maker
-            .try_start_epoch_destruction(&epoch_id)
+            .try_get_epoch_destruction_lease(&epoch_id)
             .await
             .unwrap();
     }
@@ -1214,12 +1216,12 @@ mod tests {
         let epoch_id = EpochId::new_random(&mut rng);
 
         let context_destruction = session_maker
-            .try_start_context_destruction(&context_id)
+            .try_get_context_destruction_lease(&context_id)
             .await
             .unwrap();
         assert_eq!(
             session_maker
-                .try_start_epoch_creation(&context_id, &epoch_id)
+                .try_get_epoch_creation_lease(&context_id, &epoch_id)
                 .await
                 .unwrap_err(),
             LifecycleConflict::Context(context_id)
@@ -1227,12 +1229,12 @@ mod tests {
         drop(context_destruction);
 
         let epoch_destruction = session_maker
-            .try_start_epoch_destruction(&epoch_id)
+            .try_get_epoch_destruction_lease(&epoch_id)
             .await
             .unwrap();
         assert_eq!(
             session_maker
-                .try_start_epoch_creation(&context_id, &epoch_id)
+                .try_get_epoch_creation_lease(&context_id, &epoch_id)
                 .await
                 .unwrap_err(),
             LifecycleConflict::Epoch(epoch_id)
@@ -1240,7 +1242,7 @@ mod tests {
         drop(epoch_destruction);
 
         session_maker
-            .try_start_epoch_creation(&context_id, &epoch_id)
+            .try_get_epoch_creation_lease(&context_id, &epoch_id)
             .await
             .unwrap();
     }


### PR DESCRIPTION
## Description
Implement lease in session maker so that creation and destruction of epoch/context cannot happen concurrently.

### Related issue(s)
Closes zama-ai/kms-internal#3108

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
