### PR TITLE
fix: custodian-backup setup-failure handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,7 +3352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4399,7 +4399,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6185,7 +6185,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6701,9 +6701,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -6793,7 +6793,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6806,7 +6806,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6864,7 +6864,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7721,7 +7721,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9012,7 +9012,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9127,15 +9127,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -228,6 +228,16 @@ Custodian workflows are driven through the
 [kms-service.v1.proto](core/grpc/proto/kms-service.v1.proto).
 A separate `RestoreFromBackup` RPC completes restoration on the node for the non-custodian AWS-KMS path.
 
+`NewCustodianContext` points the keychain at the new context and re-encrypts the whole
+vault under it *before* persisting the recovery material, so it is rolled back if any later
+step fails: the keychain is restored to its pre-setup `(context_id, backup_enc_key)` and the
+vault entries written under the failed id are purged
+(`rollback_failed_custodian_setup` in
+[context_manager.rs](core/service/src/engine/context_manager.rs) and
+`Vault::purge_backup`). Without that, the node would keep encrypting backups under a key
+whose recovery material was never written, making them unrecoverable. Setups are serialized
+against each other for the same reason.
+
 Implementation code lives in [core/service/src/backup/](core/service/src/backup/);
 end-to-end tests live at
 [core/service/src/client/tests/centralized/custodian_backup_tests.rs](core/service/src/client/tests/centralized/custodian_backup_tests.rs)

--- a/core/service/src/engine/context_manager.rs
+++ b/core/service/src/engine/context_manager.rs
@@ -3,7 +3,9 @@ use crate::backup::custodian::InternalCustodianContext;
 use crate::backup::operator::{Operator, RecoveryValidationMaterial};
 use crate::conf::threshold::{ThresholdPartyConf, TlsConf};
 use crate::consts::{DEFAULT_MPC_CONTEXT, SAFE_SER_SIZE_LIMIT};
-use crate::cryptography::encryption::{Encryption, PkeScheme, PkeSchemeType, UnifiedPrivateEncKey};
+use crate::cryptography::encryption::{
+    Encryption, PkeScheme, PkeSchemeType, UnifiedPrivateEncKey, UnifiedPublicEncKey,
+};
 use crate::cryptography::signatures::{PrivateSigKey, PublicSigKey};
 use crate::engine::context::{ContextInfo, NodeInfo, SignerAddress, SoftwareVersion};
 use crate::engine::threshold::service::session::SessionMaker;
@@ -27,6 +29,7 @@ use crate::{
 };
 use aes_prng::AesRng;
 use itertools::Itertools;
+use kms_grpc::RequestId;
 use kms_grpc::identifiers::ContextId;
 use kms_grpc::kms::v1::Empty;
 use kms_grpc::kms::v1::{
@@ -42,7 +45,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use tfhe::safe_serialization::safe_serialize;
 use threshold_types::role::Role;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tonic::Response;
 
 const CENTRALIZED_MPC_IDENTITY: &str = "centralized-zama-kms";
@@ -57,6 +60,8 @@ struct SharedContextManager<
     base_kms: BaseKmsStruct,
     crypto_storage: CryptoMaterialStorage<PubS, PrivS>,
     custodian_meta_store: Arc<RwLock<CustodianMetaStore>>,
+    /// Serializes whole custodian-context setups; see `inner_new_custodian_context`.
+    custodian_setup_lock: Mutex<()>,
 }
 
 impl<PubS, PrivS> SharedContextManager<PubS, PrivS>
@@ -302,6 +307,13 @@ where
             Some(ref backup_vault) => backup_vault,
             None => return Err(anyhow::anyhow!("Backup vault is not configured")),
         };
+        // Serialize whole setups against each other. The meta-store permit below is keyed by
+        // context id, so two setups for *different* ids would otherwise interleave: the second
+        // one's pre-setup snapshot could capture the first one's half-applied keychain state and
+        // its rollback would then restore that over the first one's result. Held across
+        // `update_backup_vault`, which is the expensive part, but only custodian setups contend
+        // for it and they must not run concurrently anyway.
+        let _setup_guard = self.custodian_setup_lock.lock().await;
         let mut rng = self.base_kms.new_rng().await;
         // Generate asymmetric keys for the operator to use to encrypt the backup
         let mut enc = Encryption::new(PkeSchemeType::MlKem512, &mut rng);
@@ -329,6 +341,20 @@ where
                 inner_context.context_id
             )
         })?;
+
+        // Snapshot the keychain's current backup state before we mutate it, so a setup
+        // that fails before its recovery material is persisted can be rolled back
+        // (see `rollback_failed_custodian_setup`).
+        let previous_backup_state: Option<(RequestId, UnifiedPublicEncKey)> = {
+            let guarded_backup_vault = backup_vault.lock().await;
+            match guarded_backup_vault.keychain.as_ref() {
+                Some(KeychainProxy::SecretSharing(secret_share_keychain)) => secret_share_keychain
+                    .get_current_backup_id()
+                    .ok()
+                    .zip(secret_share_keychain.get_backup_enc_key().ok()),
+                _ => None,
+            }
+        };
 
         // Reencrypt everything
         // Basically we want to ensure the recovery request contains the decryption key and everything else is encrypted using the public encryption key
@@ -376,6 +402,12 @@ where
         }
         .await;
         if let Err(e) = prep {
+            self.rollback_failed_custodian_setup(
+                inner_context.context_id,
+                previous_backup_state,
+                RollbackScope::VaultAndKeychain,
+            )
+            .await;
             update_err_req_in_meta_store(
                 &self.custodian_meta_store,
                 meta_permit,
@@ -386,13 +418,27 @@ where
             return Err(e);
         }
         // Then store the results (consumes the permit, recording success or error).
-        self.crypto_storage
+        // `write_backup_keys` records the failure in the meta store and applies its own purge
+        // rule to the vault entries, so only the keychain is left to restore here — otherwise a
+        // failed setup would leave the vault encrypted under a context whose recovery material
+        // was never persisted.
+        if let Err(e) = self
+            .crypto_storage
             .write_backup_keys(
                 recovery_validation,
                 Arc::clone(&self.custodian_meta_store),
                 meta_permit,
             )
-            .await?;
+            .await
+        {
+            self.rollback_failed_custodian_setup(
+                inner_context.context_id,
+                previous_backup_state,
+                RollbackScope::KeychainOnly,
+            )
+            .await;
+            return Err(e.into());
+        }
         tracing::info!(
             "New custodian context created with context_id={}, threshold={} from {} custodians",
             inner_context.context_id,
@@ -401,6 +447,73 @@ where
         );
         Ok(())
     }
+
+    /// Roll back a custodian-context setup that failed before its recovery material was
+    /// persisted, so the vault is not left in an unrecoverable state.
+    ///
+    /// `failed_context_id` is the id of the context whose setup failed.
+    /// `previous_backup_state` is the keychain's `(context_id, backup_enc_key)` snapshot taken
+    /// before the setup began; the keychain is restored to it (or reset to uninitialized when
+    /// `None`) so later backups are encrypted under a key whose recovery material still exists.
+    /// The previous context's backup material lives under its own id and is left untouched.
+    /// `scope` says whether the vault entries still need purging too; see [`RollbackScope`].
+    ///
+    /// This is a no-op when the vault has no secret-sharing keychain, or when the previous
+    /// context id already equals `failed_context_id` — the latter means the setup was rejected
+    /// before mutating any state (e.g. a duplicate context id), so the keychain needs no restore
+    /// and purging would destroy the live backup.
+    async fn rollback_failed_custodian_setup(
+        &self,
+        failed_context_id: RequestId,
+        previous_backup_state: Option<(RequestId, UnifiedPublicEncKey)>,
+        scope: RollbackScope,
+    ) {
+        let Some(backup_vault) = self.crypto_storage.backup_vault.as_ref() else {
+            return;
+        };
+        let mut guarded_backup_vault = backup_vault.lock().await;
+        // Only secret-sharing (custodian) vaults carry the state a custodian setup mutates.
+        if !matches!(
+            guarded_backup_vault.keychain.as_ref(),
+            Some(KeychainProxy::SecretSharing(_))
+        ) {
+            return;
+        }
+        // A setup rejected before any mutation leaves the current context id as the previous one;
+        // purging it would destroy the live backup, so there is nothing to roll back.
+        if previous_backup_state
+            .as_ref()
+            .is_some_and(|(prev_id, _)| *prev_id == failed_context_id)
+        {
+            return;
+        }
+        // Purge the backup material the failed setup re-encrypted under the new context id.
+        if scope == RollbackScope::VaultAndKeychain
+            && let Err(e) = guarded_backup_vault.purge_backup(&failed_context_id).await
+        {
+            tracing::error!(
+                "Failed to purge backup vault while rolling back custodian context {failed_context_id}: {e}"
+            );
+        }
+        // Restore the keychain to the pre-setup state.
+        if let Some(KeychainProxy::SecretSharing(secret_share_keychain)) =
+            guarded_backup_vault.keychain.as_mut()
+        {
+            secret_share_keychain.restore_backup_enc_key(previous_backup_state);
+        }
+    }
+}
+
+/// What a failed custodian setup still has to undo, i.e. which side of the
+/// `update_backup_vault` / `write_backup_keys` split has not cleaned up after itself.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RollbackScope {
+    /// The setup failed before `write_backup_keys` ran, so the entries the overwriting
+    /// `update_backup_vault` pass wrote under the new context id are still there.
+    VaultAndKeychain,
+    /// `write_backup_keys` failed and already applied its own purge rule to the vault —
+    /// notably keeping what is stored under a duplicate id — so only the keychain is left.
+    KeychainOnly,
 }
 
 pub async fn create_default_centralized_context_in_storage<
@@ -565,6 +678,7 @@ where
                 base_kms,
                 crypto_storage,
                 custodian_meta_store,
+                custodian_setup_lock: Mutex::new(()),
             },
             cache: Arc::new(RwLock::new(HashSet::new())),
         }
@@ -809,6 +923,7 @@ where
                 base_kms,
                 crypto_storage,
                 custodian_meta_store,
+                custodian_setup_lock: Mutex::new(()),
             },
             session_maker,
         }
@@ -2077,6 +2192,8 @@ mod tests {
         });
         let session_maker =
             SessionMaker::four_party_dummy_session(None, None, &epoch_id, base_kms.new_rng().await);
+        // Keep a handle on the backup vault so we can inspect the rollback after the failure.
+        let backup_vault = crypto_storage.get_backup_vault().unwrap();
         let context_manager = ThresholdContextManager::new(
             base_kms,
             crypto_storage,
@@ -2089,6 +2206,146 @@ mod tests {
         assert!(
             response.is_err(),
             "Expected custodian context creation to fail when backup update fails"
+        );
+
+        // The failed setup must be rolled back: the in-memory keychain must not be left
+        // pointing at the failed context (it started uninitialized here), and no backup
+        // material may be left re-encrypted under the failed context id — otherwise later
+        // backups would be encrypted under a key whose recovery material never persisted.
+        {
+            use crate::vault::VaultDataType;
+            use crate::vault::storage::StorageReader;
+            use strum::IntoEnumIterator;
+
+            let guarded_backup_vault = backup_vault.lock().await;
+            match guarded_backup_vault.keychain.as_ref() {
+                Some(KeychainProxy::SecretSharing(secret_share_keychain)) => {
+                    assert!(
+                        secret_share_keychain.get_current_backup_id().is_err(),
+                        "keychain backup id must be reset after a failed setup"
+                    );
+                    assert!(
+                        secret_share_keychain.get_backup_enc_key().is_err(),
+                        "keychain backup enc key must be reset after a failed setup"
+                    );
+                }
+                _ => panic!("expected a secret-sharing keychain in the backup vault"),
+            }
+            for cur_type in PrivDataType::iter() {
+                let vault_data_type =
+                    VaultDataType::CustodianBackupData(context_id, cur_type).to_string();
+                assert!(
+                    guarded_backup_vault
+                        .storage
+                        .all_data_ids(&vault_data_type)
+                        .await
+                        .unwrap()
+                        .is_empty(),
+                    "no leaked backup data may remain under the failed context id for {cur_type}"
+                );
+            }
+        }
+    }
+
+    /// The other rollback call site: `update_backup_vault` succeeds but `write_backup_keys`
+    /// fails. Triggered with a pre-existing `RecoveryMaterial` object under the context id, so
+    /// the write is rejected as a duplicate. `write_backup_keys` owns the vault cleanup and
+    /// deliberately keeps what is stored under a duplicate id, so the caller must restore the
+    /// keychain *without* purging — purging here would destroy backup material whose recovery
+    /// material is still on disk.
+    #[tokio::test]
+    async fn test_custodian_context_rollback_keeps_duplicate_backup() {
+        use crate::vault::VaultDataType;
+        use crate::vault::storage::{Storage, StorageReader};
+
+        let (_verification_key, sig_key, crypto_storage) = setup_crypto_storage(true).await;
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key).unwrap();
+        let context_id = RequestId::from_bytes([7u8; 32]);
+
+        // Make `write_all` inside `write_backup_keys` report a duplicate.
+        {
+            let mut pub_storage = crypto_storage.public_storage.lock().await;
+            pub_storage
+                .store_bytes(
+                    b"pre-existing recovery material",
+                    &context_id,
+                    &PubDataType::RecoveryMaterial.to_string(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let threshold = 1;
+        let amount_custodians = 2 * threshold + 1;
+        let mut setup_msgs = Vec::new();
+        let mut rng = AesRng::seed_from_u64(77);
+        let epoch_id = *DEFAULT_EPOCH_ID;
+        for custodian_index in 1..=amount_custodians {
+            let mut enc = Encryption::new(PkeSchemeType::MlKem512, &mut rng);
+            let (_sk_dec_key, pk_enc_key) = enc.keygen().unwrap();
+            let (verf_key, _sig_key) = gen_sig_keys(&mut rng);
+            setup_msgs.push(
+                InternalCustodianSetupMessage {
+                    header: HEADER.to_string(),
+                    custodian_role: Role::indexed_from_one(custodian_index),
+                    name: format!("Custodian-{custodian_index}"),
+                    random_value: [3u8; 32],
+                    timestamp: SystemTime::now(),
+                    public_enc_key: pk_enc_key,
+                    public_verf_key: verf_key,
+                }
+                .try_into()
+                .unwrap(),
+            );
+        }
+        let request = Request::new(NewCustodianContextRequest {
+            new_custodian_context: Some(CustodianContext {
+                custodian_nodes: setup_msgs,
+                custodian_context_id: Some(context_id.into()),
+                threshold: threshold as u32,
+            }),
+            mpc_context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
+        });
+        let session_maker =
+            SessionMaker::four_party_dummy_session(None, None, &epoch_id, base_kms.new_rng().await);
+        let backup_vault = crypto_storage.get_backup_vault().unwrap();
+        let context_manager = ThresholdContextManager::new(
+            base_kms,
+            crypto_storage,
+            MetaStore::new(100, 10),
+            session_maker,
+        );
+
+        assert!(
+            context_manager
+                .new_custodian_context(request)
+                .await
+                .is_err(),
+            "a duplicate recovery material must fail the setup"
+        );
+
+        let guarded_backup_vault = backup_vault.lock().await;
+        match guarded_backup_vault.keychain.as_ref() {
+            Some(KeychainProxy::SecretSharing(secret_share_keychain)) => {
+                assert!(
+                    secret_share_keychain.get_current_backup_id().is_err(),
+                    "keychain backup id must be restored to the pre-setup state"
+                );
+            }
+            _ => panic!("expected a secret-sharing keychain in the backup vault"),
+        }
+        // `update_backup_vault` re-encrypted the signing key under the new context id before
+        // the failure; the duplicate rule says it stays.
+        let vault_data_type =
+            VaultDataType::CustodianBackupData(context_id, PrivDataType::SigningKey).to_string();
+        assert!(
+            !guarded_backup_vault
+                .storage
+                .all_data_ids(&vault_data_type)
+                .await
+                .unwrap()
+                .is_empty(),
+            "backup material under a duplicate context id must be kept, not purged"
         );
     }
 

--- a/core/service/src/vault/keychain/secretsharing.rs
+++ b/core/service/src/vault/keychain/secretsharing.rs
@@ -119,8 +119,24 @@ impl<R: Rng + CryptoRng> SecretShareKeychain<R> {
         custodian_context_id: RequestId,
         backup_enc_key: UnifiedPublicEncKey,
     ) {
-        self.backup_enc_key = Some(backup_enc_key);
-        self.custodian_context_id = Some(custodian_context_id);
+        self.restore_backup_enc_key(Some((custodian_context_id, backup_enc_key)));
+    }
+
+    /// Restore the backup encryption key and custodian context id to a previously
+    /// captured `(context_id, backup_enc_key)` snapshot. Passing `None` resets the
+    /// keychain to the uninitialized state (no backup key set).
+    ///
+    /// This is used to roll back a custodian-context setup that fails before its
+    /// recovery material is persisted, so the keychain is never left pointing at a
+    /// context whose recovery material does not exist — which would otherwise make
+    /// any later backup encrypted under that key unrecoverable.
+    pub fn restore_backup_enc_key(&mut self, state: Option<(RequestId, UnifiedPublicEncKey)>) {
+        let (custodian_context_id, backup_enc_key) = match state {
+            Some((id, key)) => (Some(id), Some(key)),
+            None => (None, None),
+        };
+        self.custodian_context_id = custodian_context_id;
+        self.backup_enc_key = backup_enc_key;
     }
 
     /// After recovery of the private decryption key has been carried out with the help of the custodians
@@ -302,6 +318,34 @@ mod tests {
         keychain.set_backup_enc_key(req_id, enc_key.clone());
         assert_eq!(keychain.get_backup_enc_key().unwrap(), enc_key);
         assert_eq!(keychain.get_current_backup_id().unwrap(), req_id);
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_enc_key_restores_and_resets() {
+        let mut rng = AesRng::seed_from_u64(42);
+        let mut enc = Encryption::new(PkeSchemeType::MlKem512, &mut rng);
+        let (_dec_key, enc_key) = enc.keygen().unwrap();
+        let mut keychain = SecretShareKeychain::<AesRng>::new::<RamStorage>(rng, None)
+            .await
+            .unwrap();
+        let req_id = RequestId::zeros();
+
+        // Restoring to a captured snapshot initializes the keychain.
+        keychain.restore_backup_enc_key(Some((req_id, enc_key.clone())));
+        assert_eq!(keychain.get_backup_enc_key().unwrap(), enc_key);
+        assert_eq!(keychain.get_current_backup_id().unwrap(), req_id);
+
+        // Restoring `None` resets the keychain to the uninitialized state, so a failed
+        // custodian setup never leaves it pointing at a context with no recovery material.
+        keychain.restore_backup_enc_key(None);
+        assert!(
+            keychain.get_backup_enc_key().is_err(),
+            "backup enc key must be cleared on reset"
+        );
+        assert!(
+            keychain.get_current_backup_id().is_err(),
+            "current backup id must be cleared on reset"
+        );
     }
 
     #[tokio::test]

--- a/core/service/src/vault/mod.rs
+++ b/core/service/src/vault/mod.rs
@@ -102,37 +102,12 @@ impl Vault {
             }
         }
 
-        // We address the storage directly with the fully-qualified
+        // The helper addresses the storage directly with the fully-qualified
         // `CustodianBackupData(backup_id, ..)` data type rather than going through the
         // Vault's `StorageReaderExt`/`StorageExt` methods: those resolve the data type
         // against the *current* backup id and would therefore target the wrong namespace
         // when erasing a retired context.
-        for cur_type in PrivDataType::iter() {
-            let vault_data_type =
-                VaultDataType::CustodianBackupData(*backup_id, cur_type).to_string();
-
-            // Non-epoch objects.
-            for cur_id in self.storage.all_data_ids(&vault_data_type).await? {
-                self.storage.delete_data(&cur_id, &vault_data_type).await?;
-            }
-
-            // Epoch-scoped objects.
-            for epoch_id in self
-                .storage
-                .all_epoch_ids_for_data(&vault_data_type)
-                .await?
-            {
-                for cur_id in self
-                    .storage
-                    .all_data_ids_at_epoch(&epoch_id, &vault_data_type)
-                    .await?
-                {
-                    self.storage
-                        .delete_data_at_epoch(&cur_id, &epoch_id, &vault_data_type)
-                        .await?;
-                }
-            }
-        }
+        self.delete_custodian_backup_data(backup_id).await?;
 
         // confirm nothing survived before the caller is allowed to delete the
         // recovery material and drop lifecycle state.
@@ -174,6 +149,71 @@ impl Vault {
         }
 
         Ok(())
+    }
+
+    /// Delete all custodian backup data stored under `backup_id`, i.e. every
+    /// `<backup_id>/<data_type>/<data_id>` entry in the inner storage as well as every
+    /// epoched `<backup_id>/<data_type>/<epoch_id>/<data_id>` entry.
+    /// An error will be returned if existing data could not be deleted.
+    /// A single info log lists the data types that held nothing under this backup id.
+    async fn delete_custodian_backup_data(&mut self, backup_id: &RequestId) -> anyhow::Result<()> {
+        let mut empty_types = Vec::new();
+        for cur_type in PrivDataType::iter() {
+            let vault_data_type = VaultDataType::CustodianBackupData(*backup_id, cur_type);
+            let ids = self
+                .storage
+                .all_data_ids(&vault_data_type.to_string())
+                .await?;
+            // Epoched types (e.g. FheKeyInfo) are backed up under
+            // <backup_id>/<data_type>/<epoch_id>/<data_id> and are not visible to
+            // `all_data_ids`, so they must be enumerated per epoch.
+            let epoch_ids = self
+                .storage
+                .all_epoch_ids_for_data(&vault_data_type.to_string())
+                .await?;
+            if ids.is_empty() && epoch_ids.is_empty() {
+                empty_types.push(cur_type.to_string());
+            }
+            for cur_id in ids {
+                self.storage
+                    .delete_data(&cur_id, &vault_data_type.to_string())
+                    .await?;
+            }
+            for cur_epoch_id in epoch_ids {
+                let epoched_ids = self
+                    .storage
+                    .all_data_ids_at_epoch(&cur_epoch_id, &vault_data_type.to_string())
+                    .await?;
+                for cur_id in epoched_ids {
+                    self.storage
+                        .delete_data_at_epoch(&cur_id, &cur_epoch_id, &vault_data_type.to_string())
+                        .await?;
+                }
+            }
+        }
+        if !empty_types.is_empty() {
+            tracing::info!(
+                "No data found for backup id {backup_id} and data types {}",
+                empty_types.join(", ")
+            );
+        }
+        Ok(())
+    }
+
+    /// Purge everything the vault holds under `backup_id`.
+    ///
+    /// On a custodian (secret-sharing keychain) vault this removes the per-context entries
+    /// `<backup_id>/<data_type>/<data_id>` and their epoched counterparts; unlike
+    /// [`Self::remove_old_backup`] it may also be called on the _current_ backup id,
+    /// e.g. to clean up after a failed backup setup.
+    /// On other vaults it falls back to deleting the data stored directly under `backup_id`.
+    pub(crate) async fn purge_backup(&mut self, backup_id: &RequestId) -> anyhow::Result<()> {
+        match self.keychain.as_ref() {
+            Some(KeychainProxy::SecretSharing(_)) => {
+                self.delete_custodian_backup_data(backup_id).await
+            }
+            _ => storage::delete_all_at_request_id(self, backup_id).await,
+        }
     }
 }
 
@@ -559,12 +599,25 @@ pub mod tests {
     use crate::vault::keychain::KeychainProxy;
     use crate::vault::keychain::secretsharing::SecretShareKeychain;
     use crate::vault::storage::file::FileStorage;
+    use crate::vault::storage::ram::RamStorage;
     use crate::vault::storage::{
-        Storage, StorageExt, StorageReader, StorageReaderExt, StorageType,
+        Storage, StorageExt, StorageProxy, StorageReader, StorageReaderExt, StorageType,
     };
     use aes_prng::AesRng;
     use kms_grpc::{EpochId, RequestId, rpc_types::PrivDataType};
     use rand::SeedableRng;
+
+    /// Build a secret-sharing keychain whose current backup id is `current_backup_id`.
+    pub(crate) async fn make_secret_share_keychain(current_backup_id: RequestId) -> KeychainProxy {
+        let mut rng = AesRng::seed_from_u64(42);
+        let mut enc = Encryption::new(PkeSchemeType::MlKem512, &mut rng);
+        let (_dec_key, enc_key) = enc.keygen().unwrap();
+        let mut keychain = SecretShareKeychain::<AesRng>::new::<FileStorage>(rng, None)
+            .await
+            .unwrap();
+        keychain.set_backup_enc_key(current_backup_id, enc_key);
+        KeychainProxy::SecretSharing(keychain)
+    }
 
     #[test]
     fn regression_test_vault_data_type_serialization() {
@@ -598,18 +651,10 @@ pub mod tests {
         let backup_root = backup_storage.root_dir().to_path_buf();
 
         // Create a secret sharing keychain with a known custodian context ID
-        let mut rng = AesRng::seed_from_u64(42);
-        let mut enc = Encryption::new(PkeSchemeType::MlKem512, &mut rng);
-        let (_dec_key, enc_key) = enc.keygen().unwrap();
-        let mut keychain = SecretShareKeychain::<AesRng>::new::<FileStorage>(rng, None)
-            .await
-            .unwrap();
         let custodian_context_id = derive_request_id("test_custodian_context").unwrap();
-        keychain.set_backup_enc_key(custodian_context_id, enc_key);
-
         let mut vault = Vault {
-            storage: crate::vault::storage::StorageProxy::from(backup_storage),
-            keychain: Some(KeychainProxy::SecretSharing(keychain)),
+            storage: StorageProxy::from(backup_storage),
+            keychain: Some(make_secret_share_keychain(custodian_context_id).await),
         };
 
         // Store some data through the vault
@@ -636,6 +681,251 @@ pub mod tests {
             "Backup data file should be at <backup_root>/<custodian_context_id>/<data_type>/<request_id>, \
              expected: {expected_file:?}"
         );
+    }
+
+    /// `purge_backup` on a custodian vault must delete exactly the entries stored
+    /// under the given backup id — including the _current_ one, which
+    /// `remove_old_backup` refuses to touch (this is the cleanup path for a failed
+    /// backup setup) — and leave other backups intact.
+    #[tokio::test]
+    async fn test_purge_backup_custodian_vault_scoped_to_backup_id() {
+        let current_id = derive_request_id("purge_backup_current").unwrap();
+        let old_id = derive_request_id("purge_backup_old").unwrap();
+        let mut vault = Vault {
+            storage: StorageProxy::from(RamStorage::new()),
+            keychain: Some(make_secret_share_keychain(current_id).await),
+        };
+
+        let data_id = derive_request_id("purge_backup_data").unwrap();
+        let data_type = PrivDataType::SigningKey;
+        // Entry under the current backup id, written through the vault
+        vault
+            .store_bytes(b"current", &data_id, &data_type.to_string())
+            .await
+            .unwrap();
+        // Epoched entry under the current backup id
+        let mut rng = AesRng::seed_from_u64(44);
+        let epoch_id = EpochId::new_random(&mut rng);
+        vault
+            .store_bytes_at_epoch(
+                b"current_epoched",
+                &data_id,
+                &epoch_id,
+                &data_type.to_string(),
+            )
+            .await
+            .unwrap();
+        // Entry under an old backup id, written directly at its per-context path
+        let old_path = VaultDataType::CustodianBackupData(old_id, data_type).to_string();
+        vault
+            .storage
+            .store_bytes(b"old", &data_id, &old_path)
+            .await
+            .unwrap();
+
+        // Purging the old backup must not touch the current one
+        vault.purge_backup(&old_id).await.unwrap();
+        assert!(
+            !vault
+                .storage
+                .data_exists(&data_id, &old_path)
+                .await
+                .unwrap()
+        );
+        let current_path = VaultDataType::CustodianBackupData(current_id, data_type).to_string();
+        assert!(
+            vault
+                .storage
+                .data_exists(&data_id, &current_path)
+                .await
+                .unwrap()
+        );
+
+        // remove_old_backup refuses the current backup id, but purge_backup handles it
+        assert!(vault.remove_old_backup(&current_id).await.is_err());
+        vault.purge_backup(&current_id).await.unwrap();
+        assert!(
+            !vault
+                .storage
+                .data_exists(&data_id, &current_path)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !vault
+                .storage
+                .data_exists_at_epoch(&data_id, &epoch_id, &current_path)
+                .await
+                .unwrap()
+        );
+
+        // Purging an id with no data is not an error
+        vault.purge_backup(&current_id).await.unwrap();
+    }
+
+    /// On a vault without a custodian keychain, `purge_backup` falls back to
+    /// deleting the data stored directly under the given id, leaving other ids intact.
+    #[tokio::test]
+    async fn test_purge_backup_unencrypted_vault() {
+        let backup_id = derive_request_id("purge_backup_unencrypted").unwrap();
+        let other_id = derive_request_id("purge_backup_unencrypted_other").unwrap();
+        let mut vault = Vault {
+            storage: StorageProxy::from(RamStorage::new()),
+            keychain: None,
+        };
+        let data_type = PrivDataType::SigningKey.to_string();
+        vault
+            .store_bytes(b"mine", &backup_id, &data_type)
+            .await
+            .unwrap();
+        vault
+            .store_bytes(b"other", &other_id, &data_type)
+            .await
+            .unwrap();
+
+        vault.purge_backup(&backup_id).await.unwrap();
+        assert!(
+            !vault
+                .storage
+                .data_exists(&backup_id, &data_type)
+                .await
+                .unwrap()
+        );
+        assert!(
+            vault
+                .storage
+                .data_exists(&other_id, &data_type)
+                .await
+                .unwrap()
+        );
+    }
+
+    /// Shared scenario: `remove_old_backup` must delete both non-epoched and epoched
+    /// entries under the old backup id, leave the current backup untouched and refuse
+    /// to delete the current backup id.
+    async fn remove_old_backup_scenario(storage: StorageProxy) {
+        let mut rng = AesRng::seed_from_u64(43);
+        let epoch_id = EpochId::new_random(&mut rng);
+        let old_backup_id = derive_request_id("old_custodian_context").unwrap();
+        let mut vault = Vault {
+            storage,
+            keychain: Some(make_secret_share_keychain(old_backup_id).await),
+        };
+
+        // Store a non-epoched and an epoched entry under the old backup id.
+        // Use store_bytes since it doesn't require encryption (just wraps the path)
+        let data_id = derive_request_id("test_backup_data").unwrap();
+        let non_epoched_type = PrivDataType::SigningKey.to_string();
+        let epoched_type = PrivDataType::FheKeyInfo.to_string();
+        vault
+            .store_bytes(b"old_non_epoched", &data_id, &non_epoched_type)
+            .await
+            .unwrap();
+        vault
+            .store_bytes_at_epoch(b"old_epoched", &data_id, &epoch_id, &epoched_type)
+            .await
+            .unwrap();
+
+        // Switch the keychain to a new custodian context and store the same entries under it
+        let current_backup_id = derive_request_id("current_custodian_context").unwrap();
+        if let Some(KeychainProxy::SecretSharing(keychain)) = vault.keychain.as_mut() {
+            let enc_key = keychain.get_backup_enc_key().unwrap();
+            keychain.set_backup_enc_key(current_backup_id, enc_key);
+        }
+        vault
+            .store_bytes(b"cur_non_epoched", &data_id, &non_epoched_type)
+            .await
+            .unwrap();
+        vault
+            .store_bytes_at_epoch(b"cur_epoched", &data_id, &epoch_id, &epoched_type)
+            .await
+            .unwrap();
+
+        // Removing the current backup id must fail
+        assert!(vault.remove_old_backup(&current_backup_id).await.is_err());
+
+        vault.remove_old_backup(&old_backup_id).await.unwrap();
+
+        // Everything under the old backup id must be gone
+        for cur_type in [PrivDataType::SigningKey, PrivDataType::FheKeyInfo] {
+            let old_prefix =
+                VaultDataType::CustodianBackupData(old_backup_id, cur_type).to_string();
+            assert!(
+                vault
+                    .storage
+                    .all_data_ids(&old_prefix)
+                    .await
+                    .unwrap()
+                    .is_empty(),
+                "non-epoched data for {cur_type} should be deleted"
+            );
+            assert!(
+                vault
+                    .storage
+                    .all_data_ids_from_all_epochs(&old_prefix)
+                    .await
+                    .unwrap()
+                    .is_empty(),
+                "epoched data for {cur_type} should be deleted"
+            );
+        }
+
+        // The current backup must be untouched
+        let cur_non_epoched =
+            VaultDataType::CustodianBackupData(current_backup_id, PrivDataType::SigningKey)
+                .to_string();
+        let cur_epoched =
+            VaultDataType::CustodianBackupData(current_backup_id, PrivDataType::FheKeyInfo)
+                .to_string();
+        assert!(
+            vault
+                .storage
+                .data_exists(&data_id, &cur_non_epoched)
+                .await
+                .unwrap()
+        );
+        assert!(
+            vault
+                .storage
+                .data_exists_at_epoch(&data_id, &epoch_id, &cur_epoched)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_old_backup_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let storage = FileStorage::new(Some(temp_dir.path()), StorageType::BACKUP, None).unwrap();
+        remove_old_backup_scenario(StorageProxy::from(storage)).await;
+    }
+
+    #[tokio::test]
+    async fn test_remove_old_backup_ram() {
+        remove_old_backup_scenario(StorageProxy::from(RamStorage::new())).await;
+    }
+
+    // Runs against the in-process S3 mock (see `storage::s3::mock_s3`), so it needs the
+    // features that gate `create_s3_storage` rather than the removed `s3_tests` feature.
+    #[cfg(all(feature = "non-wasm", feature = "testing"))]
+    #[tokio::test]
+    async fn test_remove_old_backup_s3() {
+        let storage = crate::vault::storage::s3::create_s3_storage(
+            StorageType::BACKUP,
+            std::stringify!(test_remove_old_backup_s3),
+        )
+        .await;
+        remove_old_backup_scenario(StorageProxy::from(storage)).await;
+    }
+
+    #[tokio::test]
+    async fn test_remove_old_backup_requires_custodian_vault() {
+        let mut vault = Vault {
+            storage: StorageProxy::from(RamStorage::new()),
+            keychain: None,
+        };
+        let backup_id = derive_request_id("some_backup").unwrap();
+        assert!(vault.remove_old_backup(&backup_id).await.is_err());
     }
 
     /// Regression test for the epoch-namespace gap in custodian context destruction.
@@ -725,8 +1015,8 @@ pub mod tests {
         );
 
         // The retirement guarantee: no backup object for the retired context may remain.
-        // BUG: the epoch-scoped object survives because `remove_old_backup` only looks at the
-        // non-epoch namespace, so this assertion currently fails.
+        // The epoch namespace is enumerated separately from the non-epoch one, so this is
+        // what catches a regression back to deleting only what `all_data_ids` reports.
         let leftover = vault
             .storage
             .all_data_ids_from_all_epochs(&old_data_type)

--- a/core/service/src/vault/storage/crypto_material/base.rs
+++ b/core/service/src/vault/storage/crypto_material/base.rs
@@ -27,8 +27,8 @@ use crate::{
             crypto_material::{
                 log_storage_success_optional_variant, traits::PrivateCryptoMaterialReader,
             },
-            delete_all_at_request_id, delete_at_request_and_epoch_id, delete_at_request_id,
-            read_all_data_versioned, read_context_at_id, store_versioned_at_request_id,
+            delete_at_request_and_epoch_id, delete_at_request_id, read_all_data_versioned,
+            read_context_at_id, store_versioned_at_request_id,
         },
     },
 };
@@ -61,14 +61,23 @@ pub enum StorageError {
     Reading,
     #[error("Purging error")]
     Purging,
-    #[error("Backup vault purging error")]
-    BackupVaultPurging,
     #[error("MetaStore error: {0}")]
     MetaStore(String),
     #[error("Error when backing up material")]
     Backup,
     #[error("Other error: {0}")]
     Other(String),
+}
+
+/// How a caller of [`update_meta_store`] wants a failed backup to be recorded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::vault::storage::crypto_material) enum BackupPolicy {
+    /// The primary material is the deliverable and is already persisted, so a failed
+    /// backup is recorded as a success and can be redone later.
+    BackupIsBestEffort,
+    /// The backup itself is the deliverable (see `write_backup_keys`), so a failed
+    /// backup must be recorded as a failed request.
+    BackupIsRequired,
 }
 
 /// Marker trait for private FHE materials.
@@ -320,7 +329,15 @@ where
         let res = self
             .write_all(req_id, epoch_id, pub_data, priv_data, true, op_metric_tag)
             .await;
-        update_meta_store(res, meta_data, &meta_store, permit, op_metric_tag).await
+        update_meta_store(
+            res,
+            meta_data,
+            &meta_store,
+            permit,
+            BackupPolicy::BackupIsBestEffort,
+            op_metric_tag,
+        )
+        .await
     }
 
     /// General method for handling the storage of both public and private material along with the backup.
@@ -776,7 +793,15 @@ where
                 OP_DECOMPRESSION_KEYGEN,
             )
             .await;
-        update_meta_store(res, meta_data, &meta_store, permit, OP_DECOMPRESSION_KEYGEN).await
+        update_meta_store(
+            res,
+            meta_data,
+            &meta_store,
+            permit,
+            BackupPolicy::BackupIsBestEffort,
+            OP_DECOMPRESSION_KEYGEN,
+        )
+        .await
     }
 
     /// Write the backup keys to the storage and update the meta store.
@@ -789,7 +814,11 @@ where
     /// The private key for decrypting backups is written to the private storage.
     ///
     /// NOTE: Unlike most other storage methods, this one WILL fail if there is no backup vault or if backup fails,
-    /// since the goal of this method is exactly to setup a backup.
+    /// since the goal of this method is exactly to setup a backup. On failure the material of the
+    /// failed setup — both the backup-vault entries and the public recovery material — is purged,
+    /// except on a duplicate, where nothing was written and what is stored under `req_id`
+    /// pre-existed this call. Callers that also need the keychain rolled back must do that
+    /// themselves; see `rollback_failed_custodian_setup`.
     ///
     /// Precondition: when the backup vault is configured with a `SecretSharing`
     /// keychain, the caller is expected to have set the backup encryption key
@@ -813,7 +842,7 @@ where
                 return Err(StorageError::Backup);
             }
         };
-        let mut res = self
+        let res = self
             .write_all::<RecoveryValidationMaterial, RecoveryValidationMaterial>(
                 &req_id,
                 None,
@@ -823,23 +852,45 @@ where
                 OP_NEW_CUSTODIAN_CONTEXT,
             )
             .await;
-        if res.is_err() {
-            // Note that we also care about a BackupError here, since we are actually setting up the initial backup
-            // Something went wrong so we will also purge the backup
-            res = delete_all_at_request_id(&mut *vault.lock().await, &req_id)
-                .await
-                .map_err(|e| {
-                    tracing::error!(
-                        "Failed to purge backup vault after failed backup setup for request {req_id}: {e}"
-                    );
-                    StorageError::BackupVaultPurging
-                });
+        if let Err(write_err) = &res {
+            // Note that we also care about a BackupError here, since we are actually setting up the initial backup.
+            // Purge what this setup wrote to the backup vault — the caller re-encrypts the current
+            // material into the vault under `req_id` before this method, so on failure those entries
+            // must be rolled back. The one exception is a duplicate: then this call wrote nothing and
+            // the material under `req_id` pre-existed (possibly a live backup), so it must be kept.
+            // The write error is kept in all cases: neither a successful purge nor a purge failure
+            // (which is only logged) may mask the root cause recorded in the meta store.
+            if !matches!(write_err, StorageError::Duplicate)
+                && let Err(e) = vault.lock().await.purge_backup(&req_id).await
+            {
+                tracing::error!(
+                    "Failed to purge backup vault after failed backup setup for request {req_id}: {e}"
+                );
+            }
+            // These are the two outcomes that can leave the recovery material in public storage:
+            // `Backup` means the write itself succeeded, and `Purging` means `write_all`'s own
+            // compensating purge failed. On a plain `Writing` error that purge succeeded, on a
+            // duplicate the material pre-existed and must be kept, and on the remaining variants
+            // nothing was written at all. A leftover would be picked as the active custodian
+            // context on restart (the latest RecoveryMaterial id wins) and would block retrying
+            // the same context id via the duplicate check, so purge it here. Like the vault purge
+            // above, a failure is only logged and never masks the write error.
+            if matches!(write_err, StorageError::Backup | StorageError::Purging)
+                && !self
+                    .purge_material(&req_id, None, &[PubDataType::RecoveryMaterial], &[])
+                    .await
+            {
+                tracing::error!(
+                    "Failed to purge recovery material for {req_id} after failed backup setup"
+                );
+            }
         }
         update_meta_store(
             res,
             recovery_material,
             &meta_store,
             permit,
+            BackupPolicy::BackupIsRequired,
             OP_NEW_CUSTODIAN_CONTEXT,
         )
         .await
@@ -1075,17 +1126,25 @@ where
 }
 
 /// Update the meta store based on the result of a storage operation, and log and update the metrics in case of an error.
-/// If the meta store is updated successfully, then the orginal storage result is returned.
+/// If the meta store is updated successfully, then the original storage result is returned.
 /// If the meta store update fails, then a MetaStoreError is returned, which includes the original StorageError.
+///
+/// `backup_policy` decides how an `Err(StorageError::Backup)` outcome is recorded; the error is
+/// returned to the caller either way. See [`BackupPolicy`].
 pub(in crate::vault::storage::crypto_material) async fn update_meta_store<MetaT: Clone>(
     storage_res: Result<(), StorageError>,
     meta_data: MetaT,
     meta_store: &RwLock<MetaStore<MetaT>>,
     permit: MetaStorePermit<MetaT>,
+    backup_policy: BackupPolicy,
     op_metric_tag: &'static str,
 ) -> Result<(), StorageError> {
     let req_id = *permit.req_id();
-    let is_storage_err = matches!(&storage_res, Err(e) if e != &StorageError::Backup);
+    let is_storage_err = match &storage_res {
+        Ok(()) => false,
+        Err(StorageError::Backup) => backup_policy == BackupPolicy::BackupIsRequired,
+        Err(_) => true,
+    };
     let meta_store_ok = if is_storage_err {
         update_err_req_in_meta_store(
             meta_store,

--- a/core/service/src/vault/storage/crypto_material/centralized.rs
+++ b/core/service/src/vault/storage/crypto_material/centralized.rs
@@ -21,7 +21,7 @@ use crate::{
             Storage, StorageExt,
             crypto_material::{
                 PublicKeySet,
-                base::{StorageError, update_meta_store},
+                base::{BackupPolicy, StorageError, update_meta_store},
             },
         },
     },
@@ -94,7 +94,15 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
                 op_metric_tag,
             )
             .await;
-        update_meta_store(res, meta_res, &meta_store, permit, op_metric_tag).await
+        update_meta_store(
+            res,
+            meta_res,
+            &meta_store,
+            permit,
+            BackupPolicy::BackupIsBestEffort,
+            op_metric_tag,
+        )
+        .await
     }
 
     /// Purge centralized FHE key material from disk **and** from the in-memory

--- a/core/service/src/vault/storage/crypto_material/tests.rs
+++ b/core/service/src/vault/storage/crypto_material/tests.rs
@@ -13,7 +13,7 @@ use crate::{
     engine::base::{CrsGenMetadata, KeyGenMetadata, derive_request_id},
     util::meta_store::{EntryState, add_req_to_meta_store, retrieve_from_meta_store},
     vault::{
-        Vault,
+        Vault, VaultDataType,
         storage::{Storage, StorageProxy, crypto_material::PublicKeySet},
     },
 };
@@ -40,7 +40,7 @@ use threshold_execution::tfhe_internals::{
 use threshold_types::role::Role;
 use tokio::sync::{Mutex, RwLock};
 
-use super::base::{StorageError, update_meta_store};
+use super::base::{BackupPolicy, StorageError, update_meta_store};
 use crate::{
     consts::TEST_PARAM,
     engine::{
@@ -1436,14 +1436,312 @@ async fn write_backup_keys_no_vault() {
 }
 
 #[tokio::test]
+async fn write_backup_keys_write_failure() {
+    // Public storage rejects every write while the backup-vault purge succeeds; the
+    // purge must not mask the write failure, so the meta store has to record the
+    // request as failed.
+    let storage = CryptoMaterialStorage::from(
+        FailingRamStorage::new(0),
+        RamStorage::new(),
+        Some(make_unencrypted_backup_vault()),
+    );
+    let recovery = dummy_recovery_material("write_backup_keys_write_failure");
+    let req_id = recovery.custodian_context().context_id;
+    let meta_store = MetaStore::new_unlimited();
+
+    let permit = add_req_to_meta_store(&meta_store, &req_id, TEST_METRIC)
+        .await
+        .unwrap();
+    assert_eq!(
+        storage
+            .write_backup_keys(recovery, Arc::clone(&meta_store), permit)
+            .await,
+        Err(StorageError::Writing),
+    );
+    assert!(matches!(
+        meta_store
+            .read()
+            .await
+            .retrieve(&req_id)
+            .expect("request should remain tracked in meta store"),
+        EntryState::Done(Err(_))
+    ));
+}
+
+#[tokio::test]
+async fn write_backup_keys_write_failure_custodian_vault() {
+    // Like write_backup_keys_write_failure, but against a custodian (secret-sharing
+    // keychain) vault, where entries live under `<context_id>/<data_type>/<data_id>`:
+    // the purge after the failed setup must delete exactly the entries of the failed
+    // context and the meta store must record the root-cause write error. The purge
+    // used to always fail on such vaults — masking the write error — because the
+    // generic per-request deletion cannot even parse public data types.
+    let recovery = dummy_recovery_material("write_backup_keys_write_failure_custodian");
+    let req_id = recovery.custodian_context().context_id;
+    let mut vault = Vault {
+        storage: StorageProxy::Ram(RamStorage::new()),
+        keychain: Some(crate::vault::tests::make_secret_share_keychain(req_id).await),
+    };
+    // Plant a backup entry for the new context (as the re-encryption preceding
+    // write_backup_keys does) and one for an older context that must survive.
+    let data_id = derive_request_id("write_backup_keys_write_failure_custodian_data").unwrap();
+    let planted_path =
+        VaultDataType::CustodianBackupData(req_id, PrivDataType::SigningKey).to_string();
+    let other_id = derive_request_id("write_backup_keys_write_failure_custodian_old").unwrap();
+    let other_path =
+        VaultDataType::CustodianBackupData(other_id, PrivDataType::SigningKey).to_string();
+    vault
+        .storage
+        .store_bytes(&[1, 2, 3], &data_id, &planted_path)
+        .await
+        .unwrap();
+    vault
+        .storage
+        .store_bytes(&[4, 5, 6], &data_id, &other_path)
+        .await
+        .unwrap();
+
+    let storage =
+        CryptoMaterialStorage::from(FailingRamStorage::new(0), RamStorage::new(), Some(vault));
+    let meta_store = MetaStore::new_unlimited();
+    let permit = add_req_to_meta_store(&meta_store, &req_id, TEST_METRIC)
+        .await
+        .unwrap();
+    assert_eq!(
+        storage
+            .write_backup_keys(recovery, Arc::clone(&meta_store), permit)
+            .await,
+        Err(StorageError::Writing),
+    );
+    assert!(matches!(
+        meta_store
+            .read()
+            .await
+            .retrieve(&req_id)
+            .expect("request should remain tracked in meta store"),
+        EntryState::Done(Err(_))
+    ));
+    // The failed context's entries are purged, other backups are untouched.
+    let vault = storage.get_backup_vault().unwrap();
+    let vault = vault.lock().await;
+    assert!(
+        !vault
+            .storage
+            .data_exists(&data_id, &planted_path)
+            .await
+            .unwrap()
+    );
+    assert!(
+        vault
+            .storage
+            .data_exists(&data_id, &other_path)
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn write_backup_keys_duplicate_keeps_existing_backup() {
+    // A duplicate means the recovery material already existed and this call wrote nothing,
+    // so write_backup_keys must NOT purge the backup vault under that context id — that data
+    // may be a live backup. Regression test: the purge previously ran unconditionally on every
+    // error, so it also deleted pre-existing data on a duplicate.
+    let recovery = dummy_recovery_material("write_backup_keys_duplicate");
+    let req_id = recovery.custodian_context().context_id;
+
+    let mut vault = Vault {
+        storage: StorageProxy::Ram(RamStorage::new()),
+        keychain: Some(crate::vault::tests::make_secret_share_keychain(req_id).await),
+    };
+    // Plant a pre-existing backup entry under the context id.
+    let data_id = derive_request_id("write_backup_keys_duplicate_data").unwrap();
+    let planted_path =
+        VaultDataType::CustodianBackupData(req_id, PrivDataType::SigningKey).to_string();
+    vault
+        .storage
+        .store_bytes(&[1, 2, 3], &data_id, &planted_path)
+        .await
+        .unwrap();
+
+    let storage = CryptoMaterialStorage::from(RamStorage::new(), RamStorage::new(), Some(vault));
+    // Make the recovery material already present so write_all reports a duplicate.
+    {
+        let mut pub_s = storage.public_storage.lock().await;
+        pub_s
+            .store_bytes(
+                b"existing",
+                &req_id,
+                &PubDataType::RecoveryMaterial.to_string(),
+            )
+            .await
+            .unwrap();
+    }
+
+    let meta_store = MetaStore::new_unlimited();
+    let permit = add_req_to_meta_store(&meta_store, &req_id, TEST_METRIC)
+        .await
+        .unwrap();
+    assert_eq!(
+        storage
+            .write_backup_keys(recovery, Arc::clone(&meta_store), permit)
+            .await,
+        Err(StorageError::Duplicate),
+    );
+
+    // The pre-existing backup data must survive the duplicate.
+    let vault = storage.get_backup_vault().unwrap();
+    let vault = vault.lock().await;
+    assert!(
+        vault
+            .storage
+            .data_exists(&data_id, &planted_path)
+            .await
+            .unwrap(),
+        "a duplicate must not purge pre-existing backup vault data"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn write_backup_keys_purge_failure_keeps_write_error() {
+    // Even when the backup-vault purge itself fails after a failed write, the meta
+    // store and the caller must still see the root-cause write error, not a purging one.
+    use crate::vault::storage::{StorageType, file::FileStorage};
+    use std::os::unix::fs::PermissionsExt;
+
+    let recovery = dummy_recovery_material("write_backup_keys_purge_failure");
+    let req_id = recovery.custodian_context().context_id;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let backup_storage =
+        FileStorage::new(Some(temp_dir.path()), StorageType::BACKUP, None).unwrap();
+    let backup_root = backup_storage.root_dir().to_path_buf();
+    let mut vault = Vault {
+        storage: StorageProxy::from(backup_storage),
+        keychain: Some(crate::vault::tests::make_secret_share_keychain(req_id).await),
+    };
+    let data_id = derive_request_id("write_backup_keys_purge_failure_data").unwrap();
+    vault
+        .store_bytes(&[1, 2, 3], &data_id, &PrivDataType::SigningKey.to_string())
+        .await
+        .unwrap();
+
+    // Make the entry's directory read-only so the purge cannot delete the entry.
+    let entry_dir = backup_root
+        .join(req_id.to_string())
+        .join(PrivDataType::SigningKey.to_string());
+    let saved = std::fs::metadata(&entry_dir).unwrap().permissions();
+    let mut read_only = saved.clone();
+    read_only.set_mode(0o555);
+    std::fs::set_permissions(&entry_dir, read_only).unwrap();
+    // Root ignores directory permissions; skip the assertions if the purge
+    // failure cannot be induced.
+    let probe = entry_dir.join(".probe");
+    let perms_enforced = std::fs::File::create(&probe).is_err();
+    let _ = std::fs::remove_file(&probe);
+
+    let outcome = if perms_enforced {
+        let storage =
+            CryptoMaterialStorage::from(FailingRamStorage::new(0), RamStorage::new(), Some(vault));
+        let meta_store = MetaStore::new_unlimited();
+        let permit = add_req_to_meta_store(&meta_store, &req_id, TEST_METRIC)
+            .await
+            .unwrap();
+        Some((
+            storage
+                .write_backup_keys(recovery, Arc::clone(&meta_store), permit)
+                .await,
+            meta_store,
+        ))
+    } else {
+        None
+    };
+
+    // Always restore permissions so the tempdir can be cleaned up.
+    std::fs::set_permissions(&entry_dir, saved).unwrap();
+
+    if let Some((res, meta_store)) = outcome {
+        assert_eq!(res, Err(StorageError::Writing));
+        assert!(matches!(
+            meta_store
+                .read()
+                .await
+                .retrieve(&req_id)
+                .expect("request should remain tracked in meta store"),
+            EntryState::Done(Err(_))
+        ));
+    }
+}
+
+#[tokio::test]
+async fn write_backup_keys_backup_failure() {
+    // Public storage is healthy but the backup pass fails: the planted signing-key
+    // entry cannot be deserialized when update_backup_vault copies it into the vault.
+    // Setting up the backup is the whole point of write_backup_keys, so the meta
+    // store must record the request as failed, not fall back to the best-effort
+    // backup handling used for ordinary key material, and the recovery material the
+    // public write already persisted must be purged rather than left behind.
+    let storage = CryptoMaterialStorage::from(
+        RamStorage::new(),
+        RamStorage::new(),
+        Some(make_unencrypted_backup_vault()),
+    );
+    {
+        let mut priv_s = storage.private_storage.lock().await;
+        priv_s
+            .store_bytes(
+                &[1, 2, 3],
+                &derive_request_id("write_backup_keys_backup_failure_bad").unwrap(),
+                &PrivDataType::SigningKey.to_string(),
+            )
+            .await
+            .unwrap();
+    }
+    let recovery = dummy_recovery_material("write_backup_keys_backup_failure");
+    let req_id = recovery.custodian_context().context_id;
+    let meta_store = MetaStore::new_unlimited();
+
+    let permit = add_req_to_meta_store(&meta_store, &req_id, TEST_METRIC)
+        .await
+        .unwrap();
+    assert_eq!(
+        storage
+            .write_backup_keys(recovery, Arc::clone(&meta_store), permit)
+            .await,
+        Err(StorageError::Backup),
+    );
+    // The recovery material written before the backup pass failed must not survive: on
+    // restart the latest RecoveryMaterial id decides the active custodian context, and a
+    // leftover also blocks retrying the same context id via the duplicate check.
+    assert!(
+        !storage
+            .public_storage
+            .lock()
+            .await
+            .data_exists(&req_id, &PubDataType::RecoveryMaterial.to_string())
+            .await
+            .unwrap()
+    );
+    assert!(matches!(
+        meta_store
+            .read()
+            .await
+            .retrieve(&req_id)
+            .expect("request should remain tracked in meta store"),
+        EntryState::Done(Err(_))
+    ));
+}
+
+#[tokio::test]
 async fn update_meta_store_storage_outcomes() {
-    // All three "happy" paths through update_meta_store, sharing one meta store with three req_ids:
-    //   - storage Ok                     -> meta cell becomes Ok and call returns Ok;
-    //   - storage Err(BackupError)       -> meta cell becomes Ok (we don't fail on backup errors)
-    //                                       but the original storage error is forwarded;
-    //   - storage Err(WritingError)      -> meta cell becomes Err and the same error is forwarded.
+    // The four paths through update_meta_store, sharing one meta store with four req_ids:
+    //   - storage Ok                             -> meta cell becomes Ok and call returns Ok;
+    //   - storage Err(BackupError), best-effort  -> meta cell becomes Ok (we don't fail on backup errors)
+    //                                               but the original storage error is forwarded;
+    //   - storage Err(BackupError), not best-effort -> meta cell becomes Err and the error is forwarded;
+    //   - storage Err(WritingError)              -> meta cell becomes Err and the same error is forwarded.
     let req_ok = derive_request_id("ums_ok").unwrap();
     let req_backup = derive_request_id("ums_backup").unwrap();
+    let req_backup_fatal = derive_request_id("ums_backup_fatal").unwrap();
     let req_writing = derive_request_id("ums_writing").unwrap();
     let meta_store = MetaStore::new_unlimited();
 
@@ -1453,13 +1751,23 @@ async fn update_meta_store_storage_outcomes() {
     let permit_backup = add_req_to_meta_store(&meta_store, &req_backup, TEST_METRIC)
         .await
         .unwrap();
+    let permit_backup_fatal = add_req_to_meta_store(&meta_store, &req_backup_fatal, TEST_METRIC)
+        .await
+        .unwrap();
     let permit_writing = add_req_to_meta_store(&meta_store, &req_writing, TEST_METRIC)
         .await
         .unwrap();
     assert!(
-        update_meta_store(Ok(()), 42_u32, &meta_store, permit_ok, TEST_METRIC)
-            .await
-            .is_ok()
+        update_meta_store(
+            Ok(()),
+            42_u32,
+            &meta_store,
+            permit_ok,
+            BackupPolicy::BackupIsBestEffort,
+            TEST_METRIC,
+        )
+        .await
+        .is_ok()
     );
     assert_eq!(
         update_meta_store(
@@ -1467,6 +1775,19 @@ async fn update_meta_store_storage_outcomes() {
             7_u32,
             &meta_store,
             permit_backup,
+            BackupPolicy::BackupIsBestEffort,
+            TEST_METRIC,
+        )
+        .await,
+        Err(StorageError::Backup),
+    );
+    assert_eq!(
+        update_meta_store(
+            Err(StorageError::Backup),
+            9_u32,
+            &meta_store,
+            permit_backup_fatal,
+            BackupPolicy::BackupIsRequired,
             TEST_METRIC,
         )
         .await,
@@ -1478,6 +1799,7 @@ async fn update_meta_store_storage_outcomes() {
             0_u32,
             &meta_store,
             permit_writing,
+            BackupPolicy::BackupIsBestEffort,
             TEST_METRIC,
         )
         .await,
@@ -1494,6 +1816,11 @@ async fn update_meta_store_storage_outcomes() {
             .await
             .unwrap(),
         7
+    );
+    assert!(
+        retrieve_from_meta_store::<u32>(&meta_store, &req_backup_fatal, TEST_METRIC)
+            .await
+            .is_err(),
     );
     assert!(
         retrieve_from_meta_store::<u32>(&meta_store, &req_writing, TEST_METRIC)

--- a/core/service/src/vault/storage/crypto_material/threshold.rs
+++ b/core/service/src/vault/storage/crypto_material/threshold.rs
@@ -22,7 +22,7 @@ use crate::{
             Storage, StorageExt,
             crypto_material::{
                 PublicKeySet,
-                base::{StorageError, update_meta_store},
+                base::{BackupPolicy, StorageError, update_meta_store},
             },
             delete_at_request_and_epoch_id, delete_at_request_id, read_all_data_versioned,
             read_versioned_at_request_and_epoch_id, read_versioned_at_request_id,
@@ -189,7 +189,15 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
                 op_metric_tag,
             )
             .await;
-        update_meta_store(res, meta_res, &meta_store, permit, op_metric_tag).await
+        update_meta_store(
+            res,
+            meta_res,
+            &meta_store,
+            permit,
+            BackupPolicy::BackupIsBestEffort,
+            op_metric_tag,
+        )
+        .await
     }
 
     /// Purge threshold FHE key material from disk **and** from the in-memory


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->

Makes a **failed** custodian-backup setup roll back cleanly
instead of leaving the vault in an unrecoverable or inconsistent state.

- `vault/mod.rs` — `purge_backup` + `delete_custodian_backup_data`. **Fixes a latent bug:** the old
  `remove_old_backup` deleted only `all_data_ids` entries and left **epoched** backup material
  (e.g. `FheKeyInfo`, stored under `<backup_id>/<type>/<epoch_id>/<id>`) orphaned; deletion now
  enumerates epochs too.
- `engine/context_manager.rs` — `rollback_failed_custodian_setup`: on a setup that fails before its
  recovery material is persisted, purges the material re-encrypted under the failed context and
  restores the keychain to its pre-setup state (with a guard that never destroys a live backup).
- `vault/keychain/secretsharing.rs` — `restore_backup_enc_key` (the rollback counterpart of
  `set_backup_enc_key`; `None` resets the keychain).
- `vault/storage/crypto_material/base.rs` — `write_backup_keys` purges leftover backup-vault and
  public recovery material on failure while always preserving the root-cause error; `update_meta_store`
  gains a `backup_is_best_effort` flag so a backup-setup failure (where the backup *is* the
  deliverable) is recorded as a failure rather than a success. The backup-vault purge is skipped on a
  `Duplicate` error (the material pre-existed and this call wrote nothing), so it can never delete a
  pre-existing backup; a regression test (`write_backup_keys_duplicate_keeps_existing_backup`) locks
  this in.

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
