### PR TITLE
feat: sync user decrypt endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,7 +3352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4399,7 +4399,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6195,7 +6195,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6711,9 +6711,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -6803,7 +6803,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6816,7 +6816,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6874,7 +6874,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7752,7 +7752,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9043,7 +9043,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9158,15 +9158,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -147,7 +147,10 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   and persists a fresh OPRF share for such legacy material before regenerating
   public keys.
 - **Decryption** — `PublicDecrypt` (returns plaintext) and `UserDecrypt`
-  (user-initiated, EIP-712 authenticated).
+  (user-initiated, EIP-712 authenticated). `UserDecryptSync` starts a user
+  decryption and waits for its result in the same call, so the caller does not
+  need `GetUserDecryptionResult`; a known `request_id` attaches to the running or
+  succeeded attempt, and redoes a failed one, just like `UserDecrypt`.
 - **CRS** — `CrsGen` for ZK-proof common reference strings.
 - **Resharing** — `NewMpcEpoch` with `previous_epoch` set rotates parties /
   refreshes secret shares as part of epoch creation; the outcome is fetched

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -4,7 +4,7 @@ use kms_grpc::{
     ContextId, EpochId, KeyId, RequestId,
     kms::v1::{
         PublicDecryptionRequest, PublicDecryptionResponse, TypedCiphertext, TypedPlaintext,
-        UserDecryptionRequest,
+        UserDecryptionRequest, UserDecryptionResponse,
     },
     kms_service::v1::core_service_endpoint_client::CoreServiceEndpointClient,
     rpc_types::protobuf_to_alloy_domain,
@@ -1005,23 +1005,53 @@ fn decrypt_rate_metrics<T>(
     }
 }
 
-#[expect(clippy::too_many_arguments)]
-async fn send_and_collect_user_decrypt(
-    rate: u64,
-    req_id: RequestId,
-    user_decrypt_req: UserDecryptionRequest,
-    enc_pk: UnifiedPublicEncKey,
-    enc_sk: UnifiedPrivateEncKey,
-    core_endpoints_req: CoreEndpointClients,
-    core_endpoints_resp: CoreEndpointClients,
-    num_parties: usize,
+/// Fan out the request to the sync endpoint, which returns the decryption result directly.
+fn spawn_user_decrypt_sync(
+    user_decrypt_req: &UserDecryptionRequest,
+    core_endpoints: &CoreEndpointClients,
     max_iter: usize,
-    num_expected_responses: usize,
-) -> anyhow::Result<CollectedUserDecrypt> {
-    let request_start = Instant::now();
+) -> JoinSet<anyhow::Result<UserDecryptionResponse>> {
+    let mut resp_tasks = JoinSet::new();
+    for ce in core_endpoints.iter() {
+        let req_cloned = user_decrypt_req.clone();
+        let mut cur_client = ce.clone();
+        resp_tasks.spawn(async move {
+            let mut response = cur_client
+                .user_decrypt_sync(tonic::Request::new(req_cloned.clone()))
+                .await;
+            let mut ctr = 0_usize;
+            while response.is_err()
+                && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
+            {
+                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                if ctr >= max_iter {
+                    anyhow::bail!(
+                        "timeout while waiting for sync user decryption after {max_iter} retries."
+                    );
+                }
+                ctr += 1;
+                // Re-sending the same request attaches to the in-flight
+                // decryption instead of starting a new one.
+                response = cur_client
+                    .user_decrypt_sync(tonic::Request::new(req_cloned.clone()))
+                    .await;
+            }
+            let resp = response.map_err(|e| anyhow::anyhow!("sync user decryption failed: {e}"))?;
+            Ok(resp.into_inner())
+        });
+    }
+    resp_tasks
+}
 
+/// Fan out the request to the async endpoint and check that enough cores accepted it.
+async fn send_user_decrypt_requests(
+    user_decrypt_req: &UserDecryptionRequest,
+    core_endpoints: &CoreEndpointClients,
+    num_parties: usize,
+    num_expected_responses: usize,
+) -> anyhow::Result<()> {
     let mut req_tasks = JoinSet::new();
-    for ce in core_endpoints_req.iter() {
+    for ce in core_endpoints.iter() {
         let req_cloned = user_decrypt_req.clone();
         let mut cur_client = ce.clone();
         req_tasks.spawn(async move {
@@ -1031,10 +1061,10 @@ async fn send_and_collect_user_decrypt(
         });
     }
 
-    let mut req_response_vec = Vec::with_capacity(core_endpoints_req.len());
+    let mut succeeded = 0_usize;
     while let Some(inner) = req_tasks.join_next().await {
         match inner {
-            Ok(Ok(resp)) => req_response_vec.push(resp.into_inner()),
+            Ok(Ok(_resp)) => succeeded += 1,
             Ok(Err(e)) => {
                 tracing::debug!("User decrypt request to a core failed: {e}");
             }
@@ -1043,23 +1073,29 @@ async fn send_and_collect_user_decrypt(
             }
         }
     }
-    if req_response_vec.len() < num_expected_responses {
+    if succeeded < num_expected_responses {
         anyhow::bail!(
-            "Only {}/{} user decrypt requests succeeded, need at least {}",
-            req_response_vec.len(),
-            num_parties,
-            num_expected_responses
+            "Only {succeeded}/{num_parties} user decrypt requests succeeded, need at least {num_expected_responses}"
         );
     }
+    Ok(())
+}
+
+/// Poll the async endpoint until every core has a decryption result available.
+fn spawn_get_user_decrypt_result(
+    user_decrypt_req: &UserDecryptionRequest,
+    core_endpoints: &CoreEndpointClients,
+    max_iter: usize,
+) -> anyhow::Result<JoinSet<anyhow::Result<UserDecryptionResponse>>> {
+    let req_id = user_decrypt_req
+        .request_id
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("request_id not set in user decrypt request"))?;
 
     let mut resp_tasks = JoinSet::new();
-    for ce in core_endpoints_resp.iter() {
+    for ce in core_endpoints.iter() {
         let mut cur_client = ce.clone();
-        let req_id_clone = user_decrypt_req
-            .request_id
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("request_id not set in user decrypt request"))?
-            .clone();
+        let req_id_clone = req_id.clone();
 
         resp_tasks.spawn(async move {
             let mut response = cur_client
@@ -1085,9 +1121,43 @@ async fn send_and_collect_user_decrypt(
             Ok(resp.into_inner())
         });
     }
+    Ok(resp_tasks)
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn send_and_collect_user_decrypt(
+    rate: u64,
+    req_id: RequestId,
+    user_decrypt_req: UserDecryptionRequest,
+    enc_pk: UnifiedPublicEncKey,
+    enc_sk: UnifiedPrivateEncKey,
+    core_endpoints_req: CoreEndpointClients,
+    core_endpoints_resp: CoreEndpointClients,
+    num_parties: usize,
+    max_iter: usize,
+    num_expected_responses: usize,
+    use_sync_endpoint: bool,
+) -> anyhow::Result<CollectedUserDecrypt> {
+    let request_start = Instant::now();
+
+    let (label, resp_tasks) = if use_sync_endpoint {
+        let tasks = spawn_user_decrypt_sync(&user_decrypt_req, &core_endpoints_req, max_iter);
+        ("sync user decrypt", tasks)
+    } else {
+        send_user_decrypt_requests(
+            &user_decrypt_req,
+            &core_endpoints_req,
+            num_parties,
+            num_expected_responses,
+        )
+        .await?;
+        let tasks =
+            spawn_get_user_decrypt_result(&user_decrypt_req, &core_endpoints_resp, max_iter)?;
+        ("user decrypt", tasks)
+    };
 
     let (resp_response_vec, collect_duration) = collect_decrypt_responses(
-        "user decrypt",
+        label,
         rate,
         request_start,
         resp_tasks,
@@ -1176,6 +1246,7 @@ pub(crate) async fn do_user_decrypt_once<R: Rng + CryptoRng>(
     max_iter: usize,
     num_expected_responses: usize,
     domain: Eip712Domain,
+    use_sync_endpoint: bool,
 ) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
     let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
     let expected = TestingPlaintext::try_from(ptxt)?;
@@ -1205,6 +1276,7 @@ pub(crate) async fn do_user_decrypt_once<R: Rng + CryptoRng>(
         num_parties,
         max_iter,
         num_expected_responses,
+        use_sync_endpoint,
     )
     .await?;
     let collect_duration = collected.collect_duration;
@@ -1244,6 +1316,7 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
     max_iter: usize,
     num_expected_responses: usize,
     domain: Eip712Domain,
+    use_sync_endpoint: bool,
 ) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
     let total_requests = (rate * duration_secs) as usize;
     let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
@@ -1295,6 +1368,7 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
                 num_parties,
                 max_iter,
                 num_expected_responses,
+                use_sync_endpoint,
             )
         },
     )

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -1006,6 +1006,15 @@ fn decrypt_rate_metrics<T>(
 }
 
 /// Fan out the request to the sync endpoint, which returns the decryption result directly.
+///
+/// Unlike the async path, which submits on `core_endpoints_req` and waits on
+/// `core_endpoints_resp`, a sync call is both the submission and the wait, so it only uses one
+/// channel per core. In rate mode every in-flight call therefore holds a stream on that single
+/// connection for up to the server's waiting window, which is worth keeping in mind when
+/// comparing `--sync` throughput against the two-channel async path.
+///
+/// Re-sending the same request after `Unavailable` is cheap on the server: it recognises the
+/// request ID and waits on the running decryption instead of re-validating and restarting it.
 fn spawn_user_decrypt_sync(
     user_decrypt_req: &UserDecryptionRequest,
     core_endpoints: &CoreEndpointClients,

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -1006,15 +1006,6 @@ fn decrypt_rate_metrics<T>(
 }
 
 /// Fan out the request to the sync endpoint, which returns the decryption result directly.
-///
-/// Unlike the async path, which submits on `core_endpoints_req` and waits on
-/// `core_endpoints_resp`, a sync call is both the submission and the wait, so it only uses one
-/// channel per core. In rate mode every in-flight call therefore holds a stream on that single
-/// connection for up to the server's waiting window, which is worth keeping in mind when
-/// comparing `--sync` throughput against the two-channel async path.
-///
-/// Re-sending the same request after `Unavailable` is cheap on the server: it recognises the
-/// request ID and waits on the running decryption instead of re-validating and restarting it.
 fn spawn_user_decrypt_sync(
     user_decrypt_req: &UserDecryptionRequest,
     core_endpoints: &CoreEndpointClients,

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -636,8 +636,8 @@ impl DecryptRateArgs for DecryptArguments {
 
     fn get_sync(&self) -> bool {
         match self {
-            DecryptArguments::FromFile(cipher_file) => cipher_file.rate_options.sync,
-            DecryptArguments::FromArgs(cipher_parameters) => cipher_parameters.rate_options.sync,
+            DecryptArguments::FromFile(cipher_file) => cipher_file.sync,
+            DecryptArguments::FromArgs(cipher_parameters) => cipher_parameters.sync,
         }
     }
 }
@@ -741,6 +741,9 @@ pub struct DecryptParameters {
     /// Optionally dump the ciphertext to a file.
     #[clap(long)]
     pub ciphertext_output_path: Option<PathBuf>,
+    /// Whether to use the synchronous endpoint. Currently only supported for `user-decrypt`.
+    #[clap(long, default_value_t = false)]
+    pub sync: bool,
     #[clap(flatten)]
     pub rate_options: DecryptRateOptions,
 }
@@ -772,9 +775,6 @@ pub struct DecryptRateOptions {
     /// Maximum number of in-flight requests allowed during a rate-mode run.
     #[clap(long)]
     pub max_in_flight: Option<usize>,
-    /// Whether to use the synchronous endpoint. Currently only supported for `user-decrypt`.
-    #[clap(long, default_value_t = false)]
-    pub sync: bool,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -785,6 +785,9 @@ pub struct DecryptFile {
     /// Number of copies of the ciphertext to process in a single request.
     #[clap(long, short = 'b', default_value_t = 1)]
     pub batch_size: usize,
+    /// Whether to use the synchronous endpoint. Currently only supported for `user-decrypt`.
+    #[clap(long, default_value_t = false)]
+    pub sync: bool,
     #[clap(flatten)]
     pub rate_options: DecryptRateOptions,
 }
@@ -3048,11 +3051,11 @@ mod tests {
             epoch_id: None,
             batch_size: 1,
             ciphertext_output_path: None,
+            sync: false,
             rate_options: DecryptRateOptions {
                 rate: Some(10),
                 duration: Some(10),
                 max_in_flight: None,
-                sync: false,
             },
         }
     }

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -337,6 +337,7 @@ trait DecryptRateArgs {
     fn get_rate(&self) -> Option<u64>;
     fn get_duration(&self) -> Option<u64>;
     fn get_max_in_flight(&self) -> Option<usize>;
+    fn get_sync(&self) -> bool;
 }
 
 fn validate_decrypt_rate_args(cf: &impl DecryptRateArgs) -> anyhow::Result<()> {
@@ -632,6 +633,13 @@ impl DecryptRateArgs for DecryptArguments {
             }
         }
     }
+
+    fn get_sync(&self) -> bool {
+        match self {
+            DecryptArguments::FromFile(cipher_file) => cipher_file.rate_options.sync,
+            DecryptArguments::FromArgs(cipher_parameters) => cipher_parameters.rate_options.sync,
+        }
+    }
 }
 
 impl DecryptArguments {
@@ -649,6 +657,10 @@ impl DecryptArguments {
 
     pub fn get_max_in_flight(&self) -> Option<usize> {
         DecryptRateArgs::get_max_in_flight(self)
+    }
+
+    pub fn get_sync(&self) -> bool {
+        DecryptRateArgs::get_sync(self)
     }
 }
 
@@ -760,6 +772,9 @@ pub struct DecryptRateOptions {
     /// Maximum number of in-flight requests allowed during a rate-mode run.
     #[clap(long)]
     pub max_in_flight: Option<usize>,
+    /// Whether to use the synchronous endpoint. Currently only supported for `user-decrypt`.
+    #[clap(long, default_value_t = false)]
+    pub sync: bool,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -1965,6 +1980,11 @@ pub async fn execute_cmd(
     let res = match command {
         CCCommand::PublicDecrypt(cipher_args) => {
             validate_decrypt_rate_args(cipher_args)?;
+            if cipher_args.get_sync() {
+                return Err(
+                    anyhow::anyhow!("--sync is not yet supported for public-decrypt").into(),
+                );
+            }
             let internal_client = Arc::new(RwLock::new(internal_client.unwrap()));
             let num_expected_responses = if expect_all_responses {
                 num_parties
@@ -2153,6 +2173,7 @@ pub async fn execute_cmd(
                         max_iter,
                         num_expected_responses,
                         cc_conf.default_domain()?,
+                        cipher_args.get_sync(),
                     )
                     .await?
                 }
@@ -2171,6 +2192,7 @@ pub async fn execute_cmd(
                         max_iter,
                         num_expected_responses,
                         cc_conf.default_domain()?,
+                        cipher_args.get_sync(),
                     )
                     .await?
                 }
@@ -2976,6 +2998,45 @@ mod tests {
         assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
+    #[test]
+    fn test_user_decrypt_sync_flag() {
+        // `--sync` is off by default and enabled by the flag
+        let conf = CmdConfig::try_parse_from([
+            "core-client",
+            "user-decrypt",
+            "from-args",
+            "--to-encrypt",
+            "0x1",
+            "--data-type",
+            "ebool",
+            "--key-id",
+            "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+        ])
+        .unwrap();
+        let CCCommand::UserDecrypt(args) = conf.command else {
+            panic!("expected a user-decrypt command");
+        };
+        assert!(!args.get_sync());
+
+        let conf = CmdConfig::try_parse_from([
+            "core-client",
+            "user-decrypt",
+            "from-args",
+            "--to-encrypt",
+            "0x1",
+            "--data-type",
+            "ebool",
+            "--key-id",
+            "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+            "--sync",
+        ])
+        .unwrap();
+        let CCCommand::UserDecrypt(args) = conf.command else {
+            panic!("expected a user-decrypt command");
+        };
+        assert!(args.get_sync());
+    }
+
     fn test_decrypt_parameters() -> DecryptParameters {
         DecryptParameters {
             to_encrypt: "0x1".to_string(),
@@ -2991,6 +3052,7 @@ mod tests {
                 rate: Some(10),
                 duration: Some(10),
                 max_in_flight: None,
+                sync: false,
             },
         }
     }

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1025,6 +1025,7 @@ fn public_decrypt_params(
         epoch_id: None,
         batch_size,
         ciphertext_output_path,
+        sync: false,
         rate_options: DecryptRateOptions::default(),
     }
 }
@@ -1048,6 +1049,7 @@ fn user_decrypt_params(
         epoch_id: None,
         batch_size,
         ciphertext_output_path: None,
+        sync: false,
         rate_options: DecryptRateOptions::default(),
     }
 }
@@ -1056,6 +1058,7 @@ fn user_decrypt_file(input_path: PathBuf, batch_size: usize) -> DecryptFile {
     DecryptFile {
         input_path,
         batch_size,
+        sync: false,
         rate_options: DecryptRateOptions::default(),
     }
 }
@@ -1180,10 +1183,7 @@ async fn integration_test_commands(
         ))),
         // Same user decryption through the synchronous endpoint (single round trip)
         CCCommand::UserDecrypt(DecryptArguments::FromArgs(DecryptParameters {
-            rate_options: DecryptRateOptions {
-                sync: true,
-                ..Default::default()
-            },
+            sync: true,
             ..ucp("0x1", FheType::Ebool, 1, false, true)
         })),
         CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
@@ -1233,6 +1233,7 @@ async fn integration_test_commands(
         CCCommand::PublicDecrypt(DecryptArguments::FromFile(DecryptFile {
             input_path: ctxt_path.clone(),
             batch_size: 2,
+            sync: false,
             rate_options: DecryptRateOptions::default(),
         })),
         CCCommand::UserDecrypt(DecryptArguments::FromFile(user_decrypt_file(
@@ -1307,6 +1308,7 @@ async fn integration_test_commands(
         CCCommand::PublicDecrypt(DecryptArguments::FromFile(DecryptFile {
             input_path: ctxt_with_sns_path.clone(),
             batch_size: 2,
+            sync: false,
             rate_options: DecryptRateOptions::default(),
         })),
         CCCommand::UserDecrypt(DecryptArguments::FromFile(user_decrypt_file(
@@ -1327,6 +1329,7 @@ async fn integration_test_commands(
         CCCommand::PublicDecrypt(DecryptArguments::FromFile(DecryptFile {
             input_path: compressed_ctxt_with_sns_path.clone(),
             batch_size: 2,
+            sync: false,
             rate_options: DecryptRateOptions::default(),
         })),
         CCCommand::UserDecrypt(DecryptArguments::FromFile(user_decrypt_file(
@@ -3121,6 +3124,7 @@ async fn test_threshold_reshare() -> Result<()> {
             epoch_id: Some(new_epoch_id),
             batch_size: 1,
             ciphertext_output_path: None,
+            sync: false,
             rate_options: DecryptRateOptions::default(),
         })),
         200,

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1178,6 +1178,14 @@ async fn integration_test_commands(
             false,
             true,
         ))),
+        // Same user decryption through the synchronous endpoint (single round trip)
+        CCCommand::UserDecrypt(DecryptArguments::FromArgs(DecryptParameters {
+            rate_options: DecryptRateOptions {
+                sync: true,
+                ..Default::default()
+            },
+            ..ucp("0x1", FheType::Ebool, 1, false, true)
+        })),
         CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0x6F",
             FheType::Euint8,

--- a/core-client/tests/kind-testing/kubernetes_test_threshold.rs
+++ b/core-client/tests/kind-testing/kubernetes_test_threshold.rs
@@ -245,6 +245,7 @@ impl K8sTestContext {
                 DecryptFile {
                     input_path: enc.cipher_path.clone(),
                     batch_size: 1,
+                    sync: false,
                     rate_options: DecryptRateOptions::default(),
                 },
             )))

--- a/core/grpc/proto/kms-service-insecure.v1.proto
+++ b/core/grpc/proto/kms-service-insecure.v1.proto
@@ -52,6 +52,8 @@ service CoreServiceEndpoint {
 
   rpc GetUserDecryptionResult(kms.v1.RequestId) returns (kms.v1.UserDecryptionResponse);
 
+  rpc UserDecryptSync(kms.v1.UserDecryptionRequest) returns (kms.v1.UserDecryptionResponse);
+
   rpc CrsGen(kms.v1.CrsGenRequest) returns (kms.v1.Empty);
 
   rpc GetCrsGenResult(kms.v1.RequestId) returns (kms.v1.CrsGenResult);

--- a/core/grpc/proto/kms-service.v1.proto
+++ b/core/grpc/proto/kms-service.v1.proto
@@ -263,12 +263,16 @@ service CoreServiceEndpoint {
   // # Conditions
   // ## Pre-condition:
   // * Same pre-conditions as `UserDecrypt`, except that `request_id` in `request` does not need
-  //   to be fresh: if it was already used to start a user decryption, no new decryption is
-  //   started; instead this call waits on the existing one and returns its result (idempotent
-  //   retry). Note that in this case the remaining content of `request` is ignored.
+  //   to be fresh. A `request_id` that is already known is handled exactly as re-sending it to
+  //   `UserDecrypt`, with the difference that this method then waits for the outcome instead of
+  //   rejecting the call:
+  //   * if a decryption for it is still running, or has already succeeded, no new decryption is
+  //     started: this call attaches to that attempt and returns its result. The remaining
+  //     content of `request` is ignored in this case.
+  //   * if the previous attempt for it failed, a new decryption is started from the content of
+  //     this `request`, and this call returns the outcome of that new attempt.
   // ## Post-condition:
-  // * `request_id` in `request` has been consumed; the ciphertexts are decrypted at most once per
-  //   `request_id` and the result can be retrieved again with `GetUserDecryptionResult`.
+  // * The result can be retrieved again with `GetUserDecryptionResult`.
   rpc UserDecryptSync(kms.v1.UserDecryptionRequest) returns (kms.v1.UserDecryptionResponse);
 
   // Start CRS generation.
@@ -347,9 +351,9 @@ service CoreServiceEndpoint {
   // context is active and which is not. It does however ensure that at least 1 context will remain after the destruction call.
   //
   // The call returns the set of epoch IDs that belong to the context in `epoch_ids` which has also been destroyed as part of the call.
-  // If something goes wrong, an error is returned, and the call should be retried as some epochs might have been removed from disk. 
-  // Once a call is successful, *all* epoch ids that were associated to a context is returned. 
-  // However, after a successful call, any further calls will produce a NotFound error. 
+  // If something goes wrong, an error is returned, and the call should be retried as some epochs might have been removed from disk.
+  // Once a call is successful, *all* epoch ids that were associated to a context is returned.
+  // However, after a successful call, any further calls will produce a NotFound error.
   //
   // # Parameters
   // * `context_id` - Context ID of the MPC context to destroy.
@@ -362,7 +366,7 @@ service CoreServiceEndpoint {
   // ## Pre-condition:
   // * `context_id` in `request` must be present, valid, and unique [`RequestId`] of an MPC context that has been constructed with `NewMpcContext`.
   // ## Post-condition:
-  // * The `context_id` in `request` and any `epoch_id` in the list returned in the response can no longer be used. 
+  // * The `context_id` in `request` and any `epoch_id` in the list returned in the response can no longer be used.
   //   All MPC context data and epoch data associated with these ids, that may have existed, has been purged from both memory and disk.
   //   Concretely each epoch in `epoch_ids` that existed has had its private key shares and PRSS data purged from both memory and disk.
   //   Epochs NOT listed in the `epoch_ids` response are left untouched, even if they belong to the destroyed context.

--- a/core/grpc/proto/kms-service.v1.proto
+++ b/core/grpc/proto/kms-service.v1.proto
@@ -242,6 +242,35 @@ service CoreServiceEndpoint {
   // * The `request_id` in `request` can be used to retrieve the result of the user decryption again in the future. However there is no guarantee on how long the result will be stored.
   rpc GetUserDecryptionResult(kms.v1.RequestId) returns (kms.v1.UserDecryptionResponse);
 
+  // Synchronous variant of user decryption.
+  //
+  // That is, it starts the user decryption exactly as `UserDecrypt` does and then waits for the
+  // result within the same call, returning this KMS' `UserDecryptionResponse` directly.
+  // This saves the caller the second round trip through `GetUserDecryptionResult`.
+  //
+  // The request is still recorded in the meta-store, so the result of a user decryption started
+  // through this method can also be retrieved (again) with `GetUserDecryptionResult`.
+  // If the result is not ready before the server's waiting window expires, the call returns
+  // `Unavailable`; the decryption keeps running in the background and the result can be fetched
+  // with `GetUserDecryptionResult`, or by calling this method again with the same request.
+  //
+  // # Parameters
+  // * `request` - Struct containing all the data of the request.
+  //
+  // # Returns
+  // * `Response<UserDecryptionResponse>` - Identical to what `GetUserDecryptionResult` returns.
+  //
+  // # Conditions
+  // ## Pre-condition:
+  // * Same pre-conditions as `UserDecrypt`, except that `request_id` in `request` does not need
+  //   to be fresh: if it was already used to start a user decryption, no new decryption is
+  //   started; instead this call waits on the existing one and returns its result (idempotent
+  //   retry). Note that in this case the remaining content of `request` is ignored.
+  // ## Post-condition:
+  // * `request_id` in `request` has been consumed; the ciphertexts are decrypted at most once per
+  //   `request_id` and the result can be retrieved again with `GetUserDecryptionResult`.
+  rpc UserDecryptSync(kms.v1.UserDecryptionRequest) returns (kms.v1.UserDecryptionResponse);
+
   // Start CRS generation.
   //
   // That is, it generates a common reference string (CRS) for the KMS.

--- a/core/grpc/proto/kms-service.v1.proto
+++ b/core/grpc/proto/kms-service.v1.proto
@@ -263,14 +263,14 @@ service CoreServiceEndpoint {
   // # Conditions
   // ## Pre-condition:
   // * Same pre-conditions as `UserDecrypt`, except that `request_id` in `request` does not need
-  //   to be fresh. A `request_id` that is already known is handled exactly as re-sending it to
-  //   `UserDecrypt`, with the difference that this method then waits for the outcome instead of
-  //   rejecting the call:
+  //   to be fresh: unlike `UserDecrypt`, this method never rejects a known `request_id` with
+  //   `AlreadyExists`. Instead:
   //   * if a decryption for it is still running, or has already succeeded, no new decryption is
   //     started: this call attaches to that attempt and returns its result. The remaining
   //     content of `request` is ignored in this case.
   //   * if the previous attempt for it failed, a new decryption is started from the content of
-  //     this `request`, and this call returns the outcome of that new attempt.
+  //     this `request` (the same redo-on-failure rule as `UserDecrypt`), and this call returns
+  //     the outcome of that new attempt.
   // ## Post-condition:
   // * The result can be retrieved again with `GetUserDecryptionResult`.
   rpc UserDecryptSync(kms.v1.UserDecryptionRequest) returns (kms.v1.UserDecryptionResponse);

--- a/core/grpc/proto/kms.v1.proto
+++ b/core/grpc/proto/kms.v1.proto
@@ -97,12 +97,12 @@ message KeyGenPreprocRequest {
   Eip712DomainMsg domain = 4;
 
   // MPC context ID which is used to identify the context to use for this request.
-  //
-  // NOTE: at the moment this can be None since we do not fully support multiple contexts.
-  // See https://github.com/zama-ai/kms-internal/issues/2530
+  // If unset, the server's default context is used.
   RequestId context_id = 5;
 
-  // The epoch number placeholder (zama-ai/kms-internal#2743).
+  // The epoch ID for the key generation preprocessing, i.e., the shares
+  // produced under this preprocessing will be stored and registered under
+  // this epoch.
   RequestId epoch_id = 6;
 
   // Extra data used in the EIP712 signature - external_signature
@@ -193,9 +193,7 @@ message KeyGenRequest {
   KeySetAddedInfo keyset_added_info = 6;
 
   // MPC context ID which is used to identify the context to use for this request.
-  //
-  // NOTE: at the moment this can be None since we do not fully support multiple contexts.
-  // See https://github.com/zama-ai/kms-internal/issues/2530
+  // If unset, the server's default context is used.
   RequestId context_id = 7;
 
   // The epoch ID for the key generation, i.e., the shares produced
@@ -277,9 +275,7 @@ message CrsGenRequest {
   Eip712DomainMsg domain = 4;
 
   // MPC context ID which is used to identify the context to use for this request.
-  //
-  // NOTE: at the moment this can be None since we do not fully support multiple contexts.
-  // See https://github.com/zama-ai/kms-internal/issues/2530
+  // If unset, the server's default context is used.
   RequestId context_id = 5;
 
   // MPC Epoch ID because we tie all key material to epochs
@@ -363,12 +359,11 @@ message PublicDecryptionRequest {
   bytes extra_data = 5;
 
   // MPC context ID which is used to identify the context to use for this request.
-  //
-  // NOTE: at the moment this can be None since we do not fully support multiple contexts.
-  // See https://github.com/zama-ai/kms-internal/issues/2530
+  // If unset, the server's default context is used.
   RequestId context_id = 6;
 
-  // The epoch number placeholder (zama-ai/kms-internal#2743).
+  // The MPC epoch ID identifying which epoch's key material and session to
+  // use for this request.
   RequestId epoch_id = 7;
 }
 
@@ -443,12 +438,11 @@ message UserDecryptionRequest {
   bytes extra_data = 7;
 
   // MPC context ID which is used to identify the context to use for this request.
-  //
-  // NOTE: at the moment this can be None since we do not fully support multiple contexts.
-  // See https://github.com/zama-ai/kms-internal/issues/2530
+  // If unset, the server's default context is used.
   RequestId context_id = 8;
 
-  // The epoch number placeholder (zama-ai/kms-internal#2743).
+  // The MPC epoch ID identifying which epoch's key material and session to
+  // use for this request.
   RequestId epoch_id = 9;
 }
 
@@ -825,9 +819,7 @@ message NewMpcEpochRequest {
   // The KMS context of the parties that will receive
   // the shares of the private key at the end of the reshare execution
   RequestId context_id = 1;
-  // The epoch number placeholder (zama-ai/kms-internal#2743).
-  // This is the epochId we reshare the shares from.
-  // Note: currently unused but reserved for future use.
+  // The ID of the new epoch being created by this request.
   RequestId epoch_id = 2;
   // Information about the previous epoch, used to perform resharing.
   // If not set, no keys will exist for the new epoch. (e.g. during init)

--- a/core/service/src/engine/centralized/endpoint.rs
+++ b/core/service/src/engine/centralized/endpoint.rs
@@ -25,7 +25,7 @@ use crate::engine::centralized::service::{crs_gen_impl, get_crs_gen_result_impl}
 use crate::engine::centralized::service::{get_key_gen_result_impl, key_gen_impl};
 use crate::engine::centralized::service::{
     get_public_decryption_result_impl, get_user_decryption_result_impl, public_decrypt_impl,
-    user_decrypt_impl,
+    user_decrypt_impl, user_decrypt_sync_impl,
 };
 #[cfg(feature = "insecure")]
 use crate::engine::utils::MetricedError;
@@ -184,6 +184,17 @@ impl<
     ) -> Result<Response<kms_grpc::kms::v1::UserDecryptionResponse>, Status> {
         METRICS.increment_request_counter(OP_USER_DECRYPT_RESULT);
         get_user_decryption_result_impl(self, request)
+            .await
+            .map_err(|e| e.into())
+    }
+
+    #[tracing::instrument(skip(self, request))]
+    async fn user_decrypt_sync(
+        &self,
+        request: Request<kms_grpc::kms::v1::UserDecryptionRequest>,
+    ) -> Result<Response<kms_grpc::kms::v1::UserDecryptionResponse>, Status> {
+        METRICS.increment_request_counter(OP_USER_DECRYPT_SYNC);
+        user_decrypt_sync_impl(self, request)
             .await
             .map_err(|e| e.into())
     }

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -22,7 +22,7 @@ use kms_grpc::kms::v1::{
 use observability::metrics::METRICS;
 use observability::metrics_names::{
     CENTRAL_TAG, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT, OP_USER_DECRYPT_REQUEST,
-    OP_USER_DECRYPT_RESULT, TAG_PARTY_ID,
+    OP_USER_DECRYPT_RESULT, OP_USER_DECRYPT_SYNC, TAG_PARTY_ID,
 };
 use std::sync::Arc;
 use tonic::{Request, Response};
@@ -146,6 +146,33 @@ pub async fn user_decrypt_impl<
     );
 
     Ok(Response::new(Empty {}))
+}
+
+/// Implementation of the user_decrypt_sync endpoint
+pub async fn user_decrypt_sync_impl<
+    PubS: Storage + Sync + Send + 'static,
+    PrivS: StorageExt + Sync + Send + 'static,
+    CM: ContextManager + Sync + Send + 'static,
+    BO: BackupOperator + Sync + Send + 'static,
+>(
+    service: &CentralizedKms<PubS, PrivS, CM, BO>,
+    request: Request<UserDecryptionRequest>,
+) -> Result<Response<UserDecryptionResponse>, MetricedError> {
+    let request_id = request.get_ref().request_id.clone().ok_or_else(|| {
+        MetricedError::new(
+            OP_USER_DECRYPT_SYNC,
+            None,
+            anyhow::anyhow!("Missing request ID in UserDecryptionRequest (sync)"),
+            tonic::Code::InvalidArgument,
+        )
+    })?;
+    match user_decrypt_impl(service, request).await {
+        Ok(_empty) => (),
+        // Idempotent retry: attach to the existing entry and return its result instead of failing
+        Err(e) if e.code() == tonic::Code::AlreadyExists => (),
+        Err(e) => return Err(e),
+    }
+    get_user_decryption_result_impl(service, Request::new(request_id)).await
 }
 
 /// Implementation of the get_user_decryption_result endpoint
@@ -744,6 +771,7 @@ mod tests_public_decryption {
 mod test_user_decryption {
     use aes_prng::AesRng;
     use kms_grpc::rpc_types::alloy_to_protobuf_domain;
+    use kms_grpc::{RequestId, kms::v1::TypedCiphertext};
     use rand::SeedableRng;
 
     use crate::{
@@ -774,6 +802,49 @@ mod test_user_decryption {
         (enc_key_buf, enc_sk)
     }
 
+    fn make_valid_request(
+        request_id: RequestId,
+        key_id: RequestId,
+        ciphertexts: Vec<TypedCiphertext>,
+        enc_key: Vec<u8>,
+        domain: &kms_grpc::kms::v1::Eip712DomainMsg,
+    ) -> UserDecryptionRequest {
+        let client_address = alloy_primitives::address!("dadB0d80178819F2319190D340ce9A924f783711");
+        UserDecryptionRequest {
+            request_id: Some(request_id.into()),
+            typed_ciphertexts: ciphertexts,
+            key_id: Some(key_id.into()),
+            client_address: client_address.to_checksum(None),
+            enc_key,
+            domain: Some(domain.clone()),
+            extra_data: vec![],
+            context_id: None,
+            epoch_id: None,
+        }
+    }
+
+    /// Decrypts the signcrypted payload with `enc_sk` and checks it holds `expected`.
+    fn assert_payload_decrypts_to(
+        payload: &kms_grpc::kms::v1::UserDecryptionResponsePayload,
+        enc_sk: &UnifiedPrivateEncKey,
+        expected: TestingPlaintext,
+    ) {
+        // LEGACY should have been using safe_deserialize
+        let signcrypted_msg: HybridKemCt =
+            bc2wrap::deserialize_slice(&payload.signcrypted_ciphertexts[0].signcrypted_ciphertext)
+                .unwrap();
+        // Extract the DecapsulationKey<MlKem512Params> from UnifiedPrivateDecKey
+        let decap_key = match enc_sk {
+            UnifiedPrivateEncKey::MlKem512(sk) => sk,
+            _ => panic!("Expected UnifiedPrivateDecKey::MlKem512"),
+        };
+        let res = hybrid_ml_kem::dec::<ml_kem::MlKem512>(signcrypted_msg, &decap_key.0).unwrap();
+        assert_eq!(
+            TestingPlaintext::from((res, tfhe::FheTypes::Bool)),
+            expected
+        );
+    }
+
     #[tokio::test]
     async fn sunshine() {
         let mut rng = AesRng::seed_from_u64(1234);
@@ -782,20 +853,9 @@ mod test_user_decryption {
         let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
         let request_id = derive_request_id("req_id_decryption_sunshine").unwrap();
         let (msg, ciphertexts) = make_test_msg_ct(&pk, true);
-        let client_address = alloy_primitives::address!("dadB0d80178819F2319190D340ce9A924f783711");
         let (enc_key_buf, enc_sk) = make_test_pk(&mut rng);
 
-        let request = UserDecryptionRequest {
-            request_id: Some(request_id.into()),
-            typed_ciphertexts: ciphertexts,
-            key_id: Some(key_id.into()),
-            client_address: client_address.to_checksum(None),
-            enc_key: enc_key_buf,
-            domain: Some(domain.clone()),
-            extra_data: vec![],
-            context_id: None,
-            epoch_id: None,
-        };
+        let request = make_valid_request(request_id, key_id, ciphertexts, enc_key_buf, &domain);
 
         let _ = user_decrypt_impl(&kms, tonic::Request::new(request))
             .await
@@ -805,24 +865,9 @@ mod test_user_decryption {
             get_user_decryption_result_impl(&kms, tonic::Request::new(request_id.into()))
         })
         .await
-        .unwrap();
-        // LEGACY should have been using safe_deserialize
-        let signcrypted_msg: HybridKemCt = bc2wrap::deserialize_slice(
-            &response
-                .into_inner()
-                .payload
-                .unwrap()
-                .signcrypted_ciphertexts[0]
-                .signcrypted_ciphertext,
-        )
-        .unwrap();
-        // Extract the DecapsulationKey<MlKem512Params> from UnifiedPrivateDecKey
-        let decap_key = match &enc_sk {
-            UnifiedPrivateEncKey::MlKem512(sk) => sk,
-            _ => panic!("Expected UnifiedPrivateDecKey::MlKem512"),
-        };
-        let res = hybrid_ml_kem::dec::<ml_kem::MlKem512>(signcrypted_msg, &decap_key.0).unwrap();
-        assert_eq!(TestingPlaintext::from((res, tfhe::FheTypes::Bool)), msg);
+        .unwrap()
+        .into_inner();
+        assert_payload_decrypts_to(&response.payload.unwrap(), &enc_sk, msg);
     }
 
     #[tokio::test]
@@ -833,24 +878,20 @@ mod test_user_decryption {
         let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
         let request_id = derive_request_id("req_id_decryption_sunshine").unwrap();
         let (_msg, ciphertexts) = make_test_msg_ct(&pk, true);
-        let client_address = alloy_primitives::address!("dadB0d80178819F2319190D340ce9A924f783711");
         let (enc_key_buf, _enc_sk) = make_test_pk(&mut rng);
+        let valid_request =
+            make_valid_request(request_id, key_id, ciphertexts, enc_key_buf, &domain);
 
         // missing request ID
         {
-            let request = UserDecryptionRequest {
-                request_id: None,
-                typed_ciphertexts: ciphertexts.clone(),
-                key_id: Some(key_id.into()),
-                client_address: client_address.to_checksum(None),
-                enc_key: enc_key_buf.clone(),
-                domain: Some(domain.clone()),
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
+            let mut request = valid_request.clone();
+            request.request_id = None;
+            let err = user_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
 
-            let err = user_decrypt_impl(&kms, tonic::Request::new(request))
+            let err = user_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::InvalidArgument);
@@ -858,21 +899,16 @@ mod test_user_decryption {
 
         // wrongly formatted request ID
         {
-            let wrong_request_id = kms_grpc::kms::v1::RequestId {
+            let mut request = valid_request.clone();
+            request.request_id = Some(kms_grpc::kms::v1::RequestId {
                 request_id: "wrong_id".to_string(),
-            };
-            let request = UserDecryptionRequest {
-                request_id: Some(wrong_request_id),
-                typed_ciphertexts: ciphertexts.clone(),
-                key_id: Some(key_id.into()),
-                client_address: client_address.to_checksum(None),
-                enc_key: enc_key_buf.clone(),
-                domain: Some(domain.clone()),
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
-            let err = user_decrypt_impl(&kms, tonic::Request::new(request))
+            });
+            let err = user_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = user_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::InvalidArgument);
@@ -880,18 +916,14 @@ mod test_user_decryption {
 
         // missing domain
         {
-            let request = UserDecryptionRequest {
-                request_id: Some(request_id.into()),
-                typed_ciphertexts: ciphertexts.clone(),
-                key_id: Some(key_id.into()),
-                client_address: client_address.to_checksum(None),
-                enc_key: enc_key_buf.clone(),
-                domain: None,
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
-            let err = user_decrypt_impl(&kms, tonic::Request::new(request))
+            let mut request = valid_request.clone();
+            request.domain = None;
+            let err = user_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = user_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::InvalidArgument);
@@ -899,18 +931,14 @@ mod test_user_decryption {
 
         // wrongly formatted client address
         {
-            let request = UserDecryptionRequest {
-                request_id: Some(request_id.into()),
-                typed_ciphertexts: ciphertexts.clone(),
-                key_id: Some(key_id.into()),
-                client_address: "wrong_address".to_string(),
-                enc_key: enc_key_buf.clone(),
-                domain: Some(domain.clone()),
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
-            let err = user_decrypt_impl(&kms, tonic::Request::new(request))
+            let mut request = valid_request.clone();
+            request.client_address = "wrong_address".to_string();
+            let err = user_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = user_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::InvalidArgument);
@@ -925,25 +953,20 @@ mod test_user_decryption {
         let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
         let request_id = derive_request_id("req_id_decryption_sunshine").unwrap();
         let (_msg, ciphertexts) = make_test_msg_ct(&pk, true);
-        let client_address = alloy_primitives::address!("dadB0d80178819F2319190D340ce9A924f783711");
         let (enc_key_buf, _enc_sk) = make_test_pk(&mut rng);
 
         // not found when using a wrong key
         {
             let wrong_key_id = derive_request_id("wrong_keyid_decryption_not_found").unwrap();
-            let request = UserDecryptionRequest {
-                request_id: Some(request_id.into()),
-                typed_ciphertexts: ciphertexts.clone(),
-                key_id: Some(wrong_key_id.into()), // wrong
-                client_address: client_address.to_checksum(None),
-                enc_key: enc_key_buf.clone(),
-                domain: Some(domain.clone()),
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
+            let request =
+                make_valid_request(request_id, wrong_key_id, ciphertexts, enc_key_buf, &domain);
 
-            let err = user_decrypt_impl(&kms, tonic::Request::new(request))
+            let err = user_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
+
+            let err = user_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::NotFound);
@@ -966,7 +989,6 @@ mod test_user_decryption {
         let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
         let request_id = derive_request_id("req_id_decryption_resource_exhausted").unwrap();
         let (_msg, ciphertexts) = make_test_msg_ct(&pk, true);
-        let client_address = alloy_primitives::address!("dadB0d80178819F2319190D340ce9A924f783711");
         let (enc_key_buf, _enc_sk) = make_test_pk(&mut rng);
 
         // set the rate limiter bucket size to 0
@@ -975,18 +997,13 @@ mod test_user_decryption {
 
         // make a normal request then it should fail
         {
-            let request = UserDecryptionRequest {
-                request_id: Some(request_id.into()),
-                typed_ciphertexts: ciphertexts.clone(),
-                key_id: Some(key_id.into()),
-                client_address: client_address.to_checksum(None),
-                enc_key: enc_key_buf.clone(),
-                domain: Some(domain.clone()),
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
-            let err = user_decrypt_impl(&kms, tonic::Request::new(request))
+            let request = make_valid_request(request_id, key_id, ciphertexts, enc_key_buf, &domain);
+            let err = user_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+
+            let err = user_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::ResourceExhausted);
@@ -1001,20 +1018,9 @@ mod test_user_decryption {
         let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
         let request_id = derive_request_id("req_id_decryption_already_exists").unwrap();
         let (_msg, ciphertexts) = make_test_msg_ct(&pk, true);
-        let client_address = alloy_primitives::address!("dadB0d80178819F2319190D340ce9A924f783711");
         let (enc_key_buf, _enc_sk) = make_test_pk(&mut rng);
 
-        let request = UserDecryptionRequest {
-            request_id: Some(request_id.into()),
-            typed_ciphertexts: ciphertexts.clone(),
-            key_id: Some(key_id.into()),
-            client_address: client_address.to_checksum(None),
-            enc_key: enc_key_buf.clone(),
-            domain: Some(domain.clone()),
-            extra_data: vec![],
-            context_id: None,
-            epoch_id: None,
-        };
+        let request = make_valid_request(request_id, key_id, ciphertexts, enc_key_buf, &domain);
 
         // first request should succeed
         let _ = user_decrypt_impl(&kms, tonic::Request::new(request.clone()))
@@ -1022,9 +1028,54 @@ mod test_user_decryption {
             .unwrap();
 
         // second one should fail
-        let err = user_decrypt_impl(&kms, tonic::Request::new(request))
+        let err = user_decrypt_impl(&kms, tonic::Request::new(request.clone()))
             .await
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::AlreadyExists);
+
+        // the sync endpoint instead attaches to the existing entry and
+        // returns its result
+        let response = user_decrypt_sync_impl(&kms, tonic::Request::new(request))
+            .await
+            .unwrap();
+        assert!(response.into_inner().payload.is_some());
+    }
+
+    #[tokio::test]
+    async fn sunshine_sync() {
+        let mut rng = AesRng::seed_from_u64(1234);
+        let key_id = derive_request_id("keyid_decryption_sunshine_sync").unwrap();
+        let (kms, pk, _verf_key) = setup_test_kms_with_key(&mut rng, &key_id).await;
+        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
+        let request_id = derive_request_id("req_id_decryption_sunshine_sync").unwrap();
+        let (msg, ciphertexts) = make_test_msg_ct(&pk, true);
+        let (enc_key_buf, enc_sk) = make_test_pk(&mut rng);
+
+        let request = make_valid_request(request_id, key_id, ciphertexts, enc_key_buf, &domain);
+
+        // The sync endpoint returns the response directly, no polling needed.
+        let payload = user_decrypt_sync_impl(&kms, tonic::Request::new(request.clone()))
+            .await
+            .unwrap()
+            .into_inner()
+            .payload
+            .unwrap();
+        assert_payload_decrypts_to(&payload, &enc_sk, msg);
+
+        // The request went through the meta-store, so the result stays
+        // retrievable through the async result endpoint...
+        let again = get_user_decryption_result_impl(&kms, tonic::Request::new(request_id.into()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(Some(&payload), again.payload.as_ref());
+
+        // ...and re-sending the same sync request attaches to the existing
+        // entry and returns the result instead of failing with `AlreadyExists`.
+        let retry = user_decrypt_sync_impl(&kms, tonic::Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(Some(&payload), retry.payload.as_ref());
     }
 }

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -8,7 +8,7 @@ use crate::engine::traits::{BackupOperator, BaseKms, ContextManager};
 use crate::engine::utils::MetricedError;
 use crate::engine::validation::{
     DSEP_PUBLIC_DECRYPTION, DSEP_USER_DECRYPTION, RequestIdParsingErr, parse_grpc_request_id,
-    validate_public_decrypt_req, validate_user_decrypt_req,
+    parse_optional_grpc_request_id, validate_public_decrypt_req, validate_user_decrypt_req,
 };
 use crate::util::meta_store::{
     EntryState, add_or_redo_failed_in_meta_store, retrieve_from_meta_store_with_timeout,
@@ -164,19 +164,11 @@ pub async fn user_decrypt_sync_impl<
         .tag(TAG_PARTY_ID, CENTRAL_TAG.to_string())
         .start();
 
-    let request_id = {
-        let proto_req_id = request.get_ref().request_id.as_ref().ok_or_else(|| {
-            MetricedError::new(
-                OP_USER_DECRYPT_SYNC,
-                None,
-                anyhow::anyhow!("Missing request ID in UserDecryptionRequest (sync)"),
-                tonic::Code::InvalidArgument,
-            )
-        })?;
-        parse_grpc_request_id(proto_req_id, RequestIdParsingErr::UserDecRequest).map_err(|e| {
-            MetricedError::new(OP_USER_DECRYPT_SYNC, None, e, tonic::Code::InvalidArgument)
-        })?
-    };
+    let request_id = parse_optional_grpc_request_id(
+        &request.get_ref().request_id,
+        RequestIdParsingErr::UserDecRequest,
+    )
+    .map_err(|e| MetricedError::new(OP_USER_DECRYPT_SYNC, None, e, tonic::Code::InvalidArgument))?;
 
     let should_start = match service
         .user_dec_meta_store

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -11,7 +11,7 @@ use crate::engine::validation::{
     validate_public_decrypt_req, validate_user_decrypt_req,
 };
 use crate::util::meta_store::{
-    add_or_redo_failed_in_meta_store, retrieve_from_meta_store_with_timeout,
+    EntryState, add_or_redo_failed_in_meta_store, retrieve_from_meta_store_with_timeout,
     update_req_in_meta_store,
 };
 use crate::vault::storage::{Storage, StorageExt};
@@ -158,21 +158,50 @@ pub async fn user_decrypt_sync_impl<
     service: &CentralizedKms<PubS, PrivS, CM, BO>,
     request: Request<UserDecryptionRequest>,
 ) -> Result<Response<UserDecryptionResponse>, MetricedError> {
-    let request_id = request.get_ref().request_id.clone().ok_or_else(|| {
-        MetricedError::new(
-            OP_USER_DECRYPT_SYNC,
-            None,
-            anyhow::anyhow!("Missing request ID in UserDecryptionRequest (sync)"),
-            tonic::Code::InvalidArgument,
-        )
-    })?;
-    match user_decrypt_impl(service, request).await {
-        Ok(_empty) => (),
-        // Idempotent retry: attach to the existing entry and return its result instead of failing
-        Err(e) if e.code() == tonic::Code::AlreadyExists => (),
-        Err(e) => return Err(e),
+    // Time the whole call, wait included: this is the latency the sync endpoint exists to cut.
+    let _timer = METRICS
+        .time_operation(OP_USER_DECRYPT_SYNC)
+        .tag(TAG_PARTY_ID, CENTRAL_TAG.to_string())
+        .start();
+
+    let request_id = {
+        let proto_req_id = request.get_ref().request_id.as_ref().ok_or_else(|| {
+            MetricedError::new(
+                OP_USER_DECRYPT_SYNC,
+                None,
+                anyhow::anyhow!("Missing request ID in UserDecryptionRequest (sync)"),
+                tonic::Code::InvalidArgument,
+            )
+        })?;
+        parse_grpc_request_id(proto_req_id, RequestIdParsingErr::UserDecRequest).map_err(|e| {
+            MetricedError::new(OP_USER_DECRYPT_SYNC, None, e, tonic::Code::InvalidArgument)
+        })?
+    };
+
+    let should_start = match service
+        .user_dec_meta_store
+        .read()
+        .await
+        .retrieve(&request_id)
+    {
+        None => true,                           // fresh request ID
+        Some(EntryState::Done(Err(_))) => true, // previously failed, redo it under the same ID
+        Some(EntryState::Done(Ok(_))) => false, // already succeeded, return the stored result
+        Some(EntryState::Pending) => false,     // in flight, attach to it
+        Some(EntryState::Deleted) => false,     // tombstoned, let the wait report `NotFound`
+    };
+    if should_start {
+        match user_decrypt_impl(service, request).await {
+            Ok(_empty) => (),
+            // Another call won the race to start or redo this request: attach to that attempt
+            Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
+            Err(e) => return Err(e.retag(OP_USER_DECRYPT_SYNC)),
+        }
     }
-    get_user_decryption_result_impl(service, Request::new(request_id)).await
+
+    get_user_decryption_result_impl(service, Request::new(request_id.into()))
+        .await
+        .map_err(|e| e.retag(OP_USER_DECRYPT_SYNC))
 }
 
 /// Implementation of the get_user_decryption_result endpoint
@@ -1017,8 +1046,8 @@ mod test_user_decryption {
         let (kms, pk, _verf_key) = setup_test_kms_with_key(&mut rng, &key_id).await;
         let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
         let request_id = derive_request_id("req_id_decryption_already_exists").unwrap();
-        let (_msg, ciphertexts) = make_test_msg_ct(&pk, true);
-        let (enc_key_buf, _enc_sk) = make_test_pk(&mut rng);
+        let (msg, ciphertexts) = make_test_msg_ct(&pk, true);
+        let (enc_key_buf, enc_sk) = make_test_pk(&mut rng);
 
         let request = make_valid_request(request_id, key_id, ciphertexts, enc_key_buf, &domain);
 
@@ -1033,12 +1062,20 @@ mod test_user_decryption {
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::AlreadyExists);
 
-        // the sync endpoint instead attaches to the existing entry and
-        // returns its result
+        // The sync endpoint instead attaches to the existing entry and returns its result.
+        // Attaching is a success path, so it must not record an error: the `AlreadyExists`
+        // signal is defused rather than dropped.
+        let recorded_errors_before = crate::engine::utils::handle_error_call_count();
         let response = user_decrypt_sync_impl(&kms, tonic::Request::new(request))
             .await
-            .unwrap();
-        assert!(response.into_inner().payload.is_some());
+            .unwrap()
+            .into_inner();
+        assert_payload_decrypts_to(&response.payload.unwrap(), &enc_sk, msg);
+        assert_eq!(
+            crate::engine::utils::handle_error_call_count(),
+            recorded_errors_before,
+            "attaching to an already-known request ID must not report a failure"
+        );
     }
 
     #[tokio::test]
@@ -1077,5 +1114,45 @@ mod test_user_decryption {
             .unwrap()
             .into_inner();
         assert_eq!(Some(&payload), retry.payload.as_ref());
+    }
+
+    /// A `request_id` whose previous attempt failed is redone, exactly as re-sending it to the
+    /// async endpoint would be, and the sync call returns the new attempt's outcome.
+    #[tokio::test]
+    async fn sync_redoes_failed_request() {
+        let mut rng = AesRng::seed_from_u64(1234);
+        let key_id = derive_request_id("keyid_decryption_sync_redo").unwrap();
+        let (kms, pk, _verf_key) = setup_test_kms_with_key(&mut rng, &key_id).await;
+        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
+        let request_id = derive_request_id("req_id_decryption_sync_redo").unwrap();
+        let (msg, ciphertexts) = make_test_msg_ct(&pk, true);
+        let (enc_key_buf, enc_sk) = make_test_pk(&mut rng);
+
+        let request = make_valid_request(request_id, key_id, ciphertexts, enc_key_buf, &domain);
+
+        // Leave the request ID in the state a failed attempt would leave it in.
+        let permit = kms
+            .user_dec_meta_store
+            .write()
+            .await
+            .insert(&request_id)
+            .unwrap();
+        crate::util::meta_store::update_err_req_in_meta_store(
+            &kms.user_dec_meta_store,
+            permit,
+            "forced failure".to_string(),
+            OP_USER_DECRYPT_REQUEST,
+        )
+        .await;
+
+        // The sync call redoes the decryption instead of returning the stored failure, and the
+        // plaintext it produces is the one this request asked for.
+        let payload = user_decrypt_sync_impl(&kms, tonic::Request::new(request))
+            .await
+            .unwrap()
+            .into_inner()
+            .payload
+            .unwrap();
+        assert_payload_decrypts_to(&payload, &enc_sk, msg);
     }
 }

--- a/core/service/src/engine/threshold/endpoint.rs
+++ b/core/service/src/engine/threshold/endpoint.rs
@@ -145,6 +145,15 @@ impl_endpoint! {
         }
 
         #[tracing::instrument(skip(self, request))]
+        async fn user_decrypt_sync(
+            &self,
+            request: Request<UserDecryptionRequest>,
+        ) -> Result<Response<UserDecryptionResponse>, Status> {
+            METRICS.increment_request_counter(OP_USER_DECRYPT_SYNC);
+            self.user_decryptor.user_decrypt_sync(request).await.map_err(|e| e.into())
+        }
+
+        #[tracing::instrument(skip(self, request))]
         async fn public_decrypt(
             &self,
             request: Request<PublicDecryptionRequest>,

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -27,8 +27,8 @@ use kms_grpc::{
 use observability::{
     metrics,
     metrics_names::{
-        OP_USER_DECRYPT_INNER, OP_USER_DECRYPT_REQUEST, OP_USER_DECRYPT_RESULT, TAG_PARTY_ID,
-        TAG_TFHE_TYPE, TAG_USER_DECRYPTION_KIND,
+        OP_USER_DECRYPT_INNER, OP_USER_DECRYPT_REQUEST, OP_USER_DECRYPT_RESULT,
+        OP_USER_DECRYPT_SYNC, TAG_PARTY_ID, TAG_TFHE_TYPE, TAG_USER_DECRYPTION_KIND,
     },
 };
 use rand::{CryptoRng, RngCore};
@@ -566,6 +566,27 @@ impl<
         Ok(Response::new(Empty {}))
     }
 
+    async fn user_decrypt_sync(
+        &self,
+        request: Request<UserDecryptionRequest>,
+    ) -> Result<Response<UserDecryptionResponse>, MetricedError> {
+        let req_id = request.get_ref().request_id.clone().ok_or_else(|| {
+            MetricedError::new(
+                OP_USER_DECRYPT_SYNC,
+                None,
+                anyhow!("Missing request ID in UserDecryptionRequest"),
+                tonic::Code::InvalidArgument,
+            )
+        })?;
+        match self.user_decrypt(request).await {
+            Ok(_empty) => (),
+            // Idempotent retry: attach to the existing entry and return its result instead of failing
+            Err(e) if e.code() == tonic::Code::AlreadyExists => (),
+            Err(e) => return Err(e),
+        }
+        self.get_result(Request::new(req_id)).await
+    }
+
     async fn get_result(
         &self,
         request: Request<v1::RequestId>,
@@ -711,6 +732,34 @@ mod tests {
         enc_key_buf
     }
 
+    fn make_valid_request(
+        rng: &mut AesRng,
+        req_id: RequestId,
+        key_id: RequestId,
+        epoch_id: EpochId,
+        ct_buf: Vec<u8>,
+    ) -> UserDecryptionRequest {
+        let client_address = alloy_primitives::address!("d8da6bf26964af9d7eed9e03e53415d37aa96045");
+        UserDecryptionRequest {
+            enc_key: make_dummy_enc_pk(rng),
+            typed_ciphertexts: vec![TypedCiphertext {
+                ciphertext: ct_buf,
+                fhe_type: FheTypes::Uint8 as i32,
+                external_handle: vec![],
+                // NOTE: because the way [setup_user_decryptor] is implemented,
+                // the ciphertext format must be SmallExpanded for the dummy decryptor to work
+                ciphertext_format: CiphertextFormat::SmallExpanded as i32,
+            }],
+            key_id: Some(key_id.into()),
+            domain: Some(alloy_to_protobuf_domain(&dummy_domain()).unwrap()),
+            request_id: Some(req_id.into()),
+            client_address: client_address.to_checksum(None),
+            extra_data: vec![],
+            context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
+            epoch_id: Some(epoch_id.into()),
+        }
+    }
+
     async fn setup_user_decryptor(
         rng: &mut AesRng,
     ) -> (
@@ -790,160 +839,118 @@ mod tests {
         let mut rng = AesRng::seed_from_u64(1123);
         let (key_id, epoch_id, ct_buf, user_decryptor) = setup_user_decryptor(&mut rng).await;
 
-        let client_address = alloy_primitives::address!("d8da6bf26964af9d7eed9e03e53415d37aa96045");
-        let domain = dummy_domain();
-
+        let req_id = RequestId::new_random(&mut rng);
+        let valid_request = make_valid_request(&mut rng, req_id, key_id, epoch_id, ct_buf);
         {
-            let bad_req_id = kms_grpc::kms::v1::RequestId {
+            // missing request ID
+            let mut request = valid_request.clone();
+            request.request_id = None;
+            let err = user_decryptor
+                .user_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = user_decryptor
+                .user_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        }
+        {
+            // wrongly formatted request ID
+            let mut request = valid_request.clone();
+            request.request_id = Some(kms_grpc::kms::v1::RequestId {
                 request_id: "invalid_id".to_string(),
-            };
-            let request = Request::new(UserDecryptionRequest {
-                enc_key: make_dummy_enc_pk(&mut rng),
-                typed_ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf.clone(),
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::BigExpanded as i32,
-                }],
-                key_id: Some(key_id.into()),
-                domain: Some(alloy_to_protobuf_domain(&domain).unwrap()),
-                request_id: Some(bad_req_id),
-                client_address: client_address.to_checksum(None),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
             });
-            assert_eq!(
-                user_decryptor
-                    .user_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            let err = user_decryptor
+                .user_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = user_decryptor
+                .user_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
         {
             // empty typed ciphertexts
-            let req_id = RequestId::new_random(&mut rng);
-            let request = Request::new(UserDecryptionRequest {
-                enc_key: make_dummy_enc_pk(&mut rng),
-                typed_ciphertexts: vec![],
-                key_id: Some(key_id.into()),
-                domain: Some(alloy_to_protobuf_domain(&domain).unwrap()),
-                request_id: Some(req_id.into()),
-                client_address: client_address.to_checksum(None),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
-            });
-            assert_eq!(
-                user_decryptor
-                    .user_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            let mut request = valid_request.clone();
+            request.typed_ciphertexts.clear();
+            let err = user_decryptor
+                .user_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = user_decryptor
+                .user_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
         {
             // missing domain
-            let req_id = RequestId::new_random(&mut rng);
-            let request = Request::new(UserDecryptionRequest {
-                enc_key: make_dummy_enc_pk(&mut rng),
-                typed_ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf.clone(),
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::BigExpanded as i32,
-                }],
-                key_id: Some(key_id.into()),
-                domain: None,
-                request_id: Some(req_id.into()),
-                client_address: client_address.to_checksum(None),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
-            });
-            assert_eq!(
-                user_decryptor
-                    .user_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            let mut request = valid_request.clone();
+            request.domain = None;
+            let err = user_decryptor
+                .user_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = user_decryptor
+                .user_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
         {
             // bad client address
-            let req_id = RequestId::new_random(&mut rng);
-            let request = Request::new(UserDecryptionRequest {
-                enc_key: make_dummy_enc_pk(&mut rng),
-                typed_ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf.clone(),
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::BigExpanded as i32,
-                }],
-                key_id: Some(key_id.into()),
-                domain: Some(alloy_to_protobuf_domain(&domain).unwrap()),
-                request_id: Some(req_id.into()),
-                client_address: "bad client address".to_string(),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
-            });
-            assert_eq!(
-                user_decryptor
-                    .user_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            let mut request = valid_request.clone();
+            request.client_address = "bad client address".to_string();
+            let err = user_decryptor
+                .user_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = user_decryptor
+                .user_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
         {
+            // wrongly formatted request ID on the result endpoint
             let bad_req_id = kms_grpc::kms::v1::RequestId {
                 request_id: "invalid_id".to_string(),
             };
-            assert_eq!(
-                user_decryptor
-                    .get_result(Request::new(bad_req_id))
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            let err = user_decryptor
+                .get_result(Request::new(bad_req_id))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
-        // Invalid decryption key id
         {
-            let req_id = RequestId::new_random(&mut rng);
-            let bad_key_id = kms_grpc::kms::v1::RequestId {
+            // wrongly formatted key ID
+            let mut request = valid_request.clone();
+            request.key_id = Some(kms_grpc::kms::v1::RequestId {
                 request_id: "invalid_key_id".to_string(),
-            };
-            let request = Request::new(UserDecryptionRequest {
-                enc_key: make_dummy_enc_pk(&mut rng),
-                typed_ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf.clone(),
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::BigExpanded as i32,
-                }],
-                key_id: Some(bad_key_id),
-                domain: Some(alloy_to_protobuf_domain(&domain).unwrap()),
-                request_id: Some(req_id.into()),
-                client_address: client_address.to_checksum(None),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
             });
-            assert_eq!(
-                user_decryptor
-                    .user_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            let err = user_decryptor
+                .user_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = user_decryptor
+                .user_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
     }
 
@@ -951,37 +958,24 @@ mod tests {
     async fn resource_exhausted() {
         let mut rng = AesRng::seed_from_u64(123);
         let (key_id, epoch_id, ct_buf, mut user_decryptor) = setup_user_decryptor(&mut rng).await;
-        let client_address = alloy_primitives::address!("d8da6bf26964af9d7eed9e03e53415d37aa96045");
-        let domain = dummy_domain();
         // `ResourceExhausted` - If the KMS is currently busy with too many requests.
         // Set bucket size to zero, so no operations are allowed
         user_decryptor.set_bucket_size(0);
 
         let req_id = RequestId::new_random(&mut rng);
-        let request = Request::new(UserDecryptionRequest {
-            enc_key: make_dummy_enc_pk(&mut rng),
-            typed_ciphertexts: vec![TypedCiphertext {
-                ciphertext: ct_buf.clone(),
-                fhe_type: FheTypes::Uint8 as i32,
-                external_handle: vec![],
-                ciphertext_format: CiphertextFormat::BigExpanded as i32,
-            }],
-            key_id: Some(key_id.into()),
-            domain: Some(alloy_to_protobuf_domain(&domain).unwrap()),
-            request_id: Some(req_id.into()),
-            client_address: client_address.to_checksum(None),
-            extra_data: vec![],
-            context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-            epoch_id: Some(epoch_id.into()),
-        });
-        assert_eq!(
-            user_decryptor
-                .user_decrypt(request)
-                .await
-                .unwrap_err()
-                .code(),
-            tonic::Code::ResourceExhausted
-        );
+        let request = make_valid_request(&mut rng, req_id, key_id, epoch_id, ct_buf);
+        let err = user_decryptor
+            .user_decrypt(Request::new(request.clone()))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+
+        // the sync endpoint is rate-limited the same way
+        let err = user_decryptor
+            .user_decrypt_sync(Request::new(request))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::ResourceExhausted);
 
         // finally reset the bucket size to a non-zero value
         user_decryptor.set_bucket_size(100);
@@ -991,152 +985,150 @@ mod tests {
     async fn not_found() {
         let mut rng = AesRng::seed_from_u64(123);
         let (key_id, epoch_id, ct_buf, user_decryptor) = setup_user_decryptor(&mut rng).await;
-        let client_address = alloy_primitives::address!("d8da6bf26964af9d7eed9e03e53415d37aa96045");
-        let domain = dummy_domain();
+
+        let req_id = RequestId::new_random(&mut rng);
+        let valid_request = make_valid_request(&mut rng, req_id, key_id, epoch_id, ct_buf);
 
         {
-            // bad key ID
-            let req_id = RequestId::new_random(&mut rng);
-            let bad_key_id = RequestId::new_random(&mut rng);
-            let request = Request::new(UserDecryptionRequest {
-                enc_key: make_dummy_enc_pk(&mut rng),
-                typed_ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf.clone(),
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::BigExpanded as i32,
-                }],
-                key_id: Some(bad_key_id.into()),
-                domain: Some(alloy_to_protobuf_domain(&domain).unwrap()),
-                request_id: Some(req_id.into()),
-                client_address: client_address.to_checksum(None),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
-            });
-            assert_eq!(
-                user_decryptor
-                    .user_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::NotFound
-            );
+            // unknown key ID
+            let mut request = valid_request.clone();
+            request.key_id = Some(RequestId::new_random(&mut rng).into());
+            let err = user_decryptor
+                .user_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
+
+            let err = user_decryptor
+                .user_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
         }
 
         {
-            // bad epoch ID
-            let req_id = RequestId::new_random(&mut rng);
-            let bad_epoch_id = EpochId::new_random(&mut rng);
-            let request = Request::new(UserDecryptionRequest {
-                enc_key: make_dummy_enc_pk(&mut rng),
-                typed_ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf.clone(),
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::BigExpanded as i32,
-                }],
-                key_id: Some(key_id.into()),
-                domain: Some(alloy_to_protobuf_domain(&domain).unwrap()),
-                request_id: Some(req_id.into()),
-                client_address: client_address.to_checksum(None),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(bad_epoch_id.into()),
-            });
-            assert_eq!(
-                user_decryptor
-                    .user_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::NotFound
-            );
+            // unknown epoch ID
+            let mut request = valid_request.clone();
+            request.epoch_id = Some(EpochId::new_random(&mut rng).into());
+            let err = user_decryptor
+                .user_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
+
+            let err = user_decryptor
+                .user_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
         }
 
-        let another_req_id = RequestId::new_random(&mut rng);
-        assert_eq!(
-            user_decryptor
+        {
+            // unknown request ID on the result endpoint
+            let another_req_id = RequestId::new_random(&mut rng);
+            let err = user_decryptor
                 .get_result(Request::new(another_req_id.into()))
                 .await
-                .unwrap_err()
-                .code(),
-            tonic::Code::NotFound
-        );
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
+        }
     }
 
     #[tokio::test]
     async fn already_exists() {
         let mut rng = AesRng::seed_from_u64(123);
         let (key_id, epoch_id, ct_buf, user_decryptor) = setup_user_decryptor(&mut rng).await;
-        let client_address = alloy_primitives::address!("d8da6bf26964af9d7eed9e03e53415d37aa96045");
-        let domain = dummy_domain();
 
         let req_id = RequestId::new_random(&mut rng);
-        let request = UserDecryptionRequest {
-            enc_key: make_dummy_enc_pk(&mut rng),
-            typed_ciphertexts: vec![TypedCiphertext {
-                ciphertext: ct_buf.clone(),
-                fhe_type: FheTypes::Uint8 as i32,
-                external_handle: vec![],
-                ciphertext_format: CiphertextFormat::BigExpanded as i32,
-            }],
-            key_id: Some(key_id.into()),
-            domain: Some(alloy_to_protobuf_domain(&domain).unwrap()),
-            request_id: Some(req_id.into()),
-            client_address: client_address.to_checksum(None),
-            extra_data: vec![],
-            context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-            epoch_id: Some(epoch_id.into()),
-        };
+        let request = make_valid_request(&mut rng, req_id, key_id, epoch_id, ct_buf);
         user_decryptor
             .user_decrypt(Request::new(request.clone()))
             .await
             .unwrap();
 
         // try sending the same request again
-        assert_eq!(
-            user_decryptor
-                .user_decrypt(Request::new(request))
-                .await
-                .unwrap_err()
-                .code(),
-            tonic::Code::AlreadyExists
-        );
+        let err = user_decryptor
+            .user_decrypt(Request::new(request))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::AlreadyExists);
     }
 
     #[tokio::test]
     async fn sunshine() {
         let mut rng = AesRng::seed_from_u64(123);
         let (key_id, epoch_id, ct_buf, user_decryptor) = setup_user_decryptor(&mut rng).await;
-        let client_address = alloy_primitives::address!("d8da6bf26964af9d7eed9e03e53415d37aa96045");
-        let domain = dummy_domain();
 
         // finally everything is ok
         let req_id = RequestId::new_random(&mut rng);
-        let request = Request::new(UserDecryptionRequest {
-            enc_key: make_dummy_enc_pk(&mut rng),
-            typed_ciphertexts: vec![TypedCiphertext {
-                ciphertext: ct_buf.clone(),
-                fhe_type: FheTypes::Uint8 as i32,
-                external_handle: vec![],
-                // NOTE: because the way [setup_user_decryptor] is implemented,
-                // the ciphertext format must be SmallExpanded for the dummy decryptor to work
-                ciphertext_format: CiphertextFormat::SmallExpanded as i32,
-            }],
-            key_id: Some(key_id.into()),
-            domain: Some(alloy_to_protobuf_domain(&domain).unwrap()),
-            request_id: Some(req_id.into()),
-            client_address: client_address.to_checksum(None),
-            extra_data: vec![],
-            context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-            epoch_id: Some(epoch_id.into()),
-        });
-        user_decryptor.user_decrypt(request).await.unwrap();
+        let request = make_valid_request(&mut rng, req_id, key_id, epoch_id, ct_buf);
+        user_decryptor
+            .user_decrypt(Request::new(request))
+            .await
+            .unwrap();
         crate::testing::utils::poll_result_until_ready(|| {
             user_decryptor.get_result(Request::new(req_id.into()))
         })
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn sunshine_sync() {
+        let mut rng = AesRng::seed_from_u64(123);
+        let (key_id, epoch_id, ct_buf, user_decryptor) = setup_user_decryptor(&mut rng).await;
+
+        let req_id = RequestId::new_random(&mut rng);
+        let request = make_valid_request(&mut rng, req_id, key_id, epoch_id, ct_buf);
+
+        // The sync endpoint returns the response directly, no polling needed.
+        let response = user_decryptor
+            .user_decrypt_sync(Request::new(request.clone()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(response.payload.is_some());
+
+        // The request went through the meta-store, so the result stays retrievable through the
+        // async result endpoint...
+        let again = user_decryptor
+            .get_result(Request::new(req_id.into()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.payload, again.payload);
+
+        // ...and re-sending the same sync request attaches to the existing entry and returns the
+        // result instead of failing with `AlreadyExists`.
+        let retry = user_decryptor
+            .user_decrypt_sync(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.payload, retry.payload);
+    }
+
+    #[tokio::test]
+    async fn sync_attaches_to_async_request() {
+        let mut rng = AesRng::seed_from_u64(123);
+        let (key_id, epoch_id, ct_buf, user_decryptor) = setup_user_decryptor(&mut rng).await;
+
+        let req_id = RequestId::new_random(&mut rng);
+        let request = make_valid_request(&mut rng, req_id, key_id, epoch_id, ct_buf);
+
+        // Start the decryption through the async endpoint...
+        user_decryptor
+            .user_decrypt(Request::new(request.clone()))
+            .await
+            .unwrap();
+
+        // ...then a sync request with the same request ID attaches to the
+        // in-flight entry and returns its result.
+        let response = user_decryptor
+            .user_decrypt_sync(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(response.payload.is_some());
     }
 }

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -72,8 +72,8 @@ use crate::{
     },
     util::{
         meta_store::{
-            MetaStore, add_or_redo_failed_in_meta_store, retrieve_from_meta_store_with_timeout,
-            update_req_in_meta_store,
+            EntryState, MetaStore, add_or_redo_failed_in_meta_store,
+            retrieve_from_meta_store_with_timeout, update_req_in_meta_store,
         },
         rate_limiter::RateLimiter,
     },
@@ -570,21 +570,43 @@ impl<
         &self,
         request: Request<UserDecryptionRequest>,
     ) -> Result<Response<UserDecryptionResponse>, MetricedError> {
-        let req_id = request.get_ref().request_id.clone().ok_or_else(|| {
-            MetricedError::new(
-                OP_USER_DECRYPT_SYNC,
-                None,
-                anyhow!("Missing request ID in UserDecryptionRequest"),
-                tonic::Code::InvalidArgument,
-            )
-        })?;
-        match self.user_decrypt(request).await {
-            Ok(_empty) => (),
-            // Idempotent retry: attach to the existing entry and return its result instead of failing
-            Err(e) if e.code() == tonic::Code::AlreadyExists => (),
-            Err(e) => return Err(e),
+        let _timer = metrics::METRICS
+            .time_operation(OP_USER_DECRYPT_SYNC)
+            .start();
+
+        let req_id = {
+            let proto_req_id = request.get_ref().request_id.as_ref().ok_or_else(|| {
+                MetricedError::new(
+                    OP_USER_DECRYPT_SYNC,
+                    None,
+                    anyhow!("Missing request ID in UserDecryptionRequest"),
+                    tonic::Code::InvalidArgument,
+                )
+            })?;
+            parse_grpc_request_id(proto_req_id, RequestIdParsingErr::UserDecRequest).map_err(
+                |e| MetricedError::new(OP_USER_DECRYPT_SYNC, None, e, tonic::Code::InvalidArgument),
+            )?
+        };
+
+        let should_start = match self.user_decrypt_meta_store.read().await.retrieve(&req_id) {
+            None => true,                           // fresh request ID
+            Some(EntryState::Done(Err(_))) => true, // previously failed, redo it under the same ID
+            Some(EntryState::Done(Ok(_))) => false, // already succeeded, return the stored result
+            Some(EntryState::Pending) => false,     // in flight, attach to it
+            Some(EntryState::Deleted) => false,     // tombstoned, let the wait report `NotFound`
+        };
+        if should_start {
+            match self.user_decrypt(request).await {
+                Ok(_empty) => (),
+                // Another call won the race to start or redo this request: attach to that attempt
+                Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
+                Err(e) => return Err(e.retag(OP_USER_DECRYPT_SYNC)),
+            }
         }
-        self.get_result(Request::new(req_id)).await
+
+        self.get_result(Request::new(req_id.into()))
+            .await
+            .map_err(|e| e.retag(OP_USER_DECRYPT_SYNC))
     }
 
     async fn get_result(
@@ -1087,7 +1109,12 @@ mod tests {
             .await
             .unwrap()
             .into_inner();
-        assert!(response.payload.is_some());
+        let payload = response
+            .payload
+            .clone()
+            .expect("sync response carries a payload");
+        assert_eq!(payload.signcrypted_ciphertexts.len(), 1);
+        assert!(!response.signature.is_empty());
 
         // The request went through the meta-store, so the result stays retrievable through the
         // async result endpoint...
@@ -1098,14 +1125,21 @@ mod tests {
             .into_inner();
         assert_eq!(response.payload, again.payload);
 
-        // ...and re-sending the same sync request attaches to the existing entry and returns the
-        // result instead of failing with `AlreadyExists`.
+        // ...and re-sending the same sync request returns that stored result instead of failing
+        // with `AlreadyExists`. Attaching is a success path, so nothing may be recorded as a
+        // failure along the way.
+        let recorded_errors_before = crate::engine::utils::handle_error_call_count();
         let retry = user_decryptor
             .user_decrypt_sync(Request::new(request))
             .await
             .unwrap()
             .into_inner();
         assert_eq!(response.payload, retry.payload);
+        assert_eq!(
+            crate::engine::utils::handle_error_call_count(),
+            recorded_errors_before,
+            "attaching to an already-known request ID must not report a failure"
+        );
     }
 
     #[tokio::test]
@@ -1122,13 +1156,138 @@ mod tests {
             .await
             .unwrap();
 
-        // ...then a sync request with the same request ID attaches to the
-        // in-flight entry and returns its result.
+        // ...then a sync request with the same request ID attaches to that entry rather than
+        // starting a second decryption, without reporting a failure along the way.
+        let recorded_errors_before = crate::engine::utils::handle_error_call_count();
         let response = user_decryptor
             .user_decrypt_sync(Request::new(request))
             .await
             .unwrap()
             .into_inner();
-        assert!(response.payload.is_some());
+        assert_eq!(
+            response
+                .payload
+                .clone()
+                .expect("sync response carries a payload")
+                .signcrypted_ciphertexts
+                .len(),
+            1
+        );
+        assert_eq!(
+            crate::engine::utils::handle_error_call_count(),
+            recorded_errors_before,
+            "attaching to an in-flight request must not report a failure"
+        );
+
+        // The entry the sync call waited on is the one the async request created.
+        let stored = user_decryptor
+            .get_result(Request::new(req_id.into()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.payload, stored.payload);
+    }
+
+    /// A `request_id` whose previous attempt failed is redone, exactly as re-sending it to the
+    /// async endpoint would be, and the sync call returns the new attempt's outcome.
+    #[tokio::test]
+    async fn sync_redoes_failed_request() {
+        let mut rng = AesRng::seed_from_u64(123);
+        let (key_id, epoch_id, ct_buf, user_decryptor) = setup_user_decryptor(&mut rng).await;
+
+        let req_id = RequestId::new_random(&mut rng);
+        let request = make_valid_request(&mut rng, req_id, key_id, epoch_id, ct_buf);
+
+        // Leave the request ID in the state a failed attempt would leave it in.
+        let permit = user_decryptor
+            .user_decrypt_meta_store
+            .write()
+            .await
+            .insert(&req_id)
+            .unwrap();
+        crate::util::meta_store::update_err_req_in_meta_store(
+            &user_decryptor.user_decrypt_meta_store,
+            permit,
+            "forced failure".to_string(),
+            OP_USER_DECRYPT_REQUEST,
+        )
+        .await;
+        assert!(matches!(
+            user_decryptor
+                .user_decrypt_meta_store
+                .read()
+                .await
+                .retrieve(&req_id),
+            Some(EntryState::Done(Err(_)))
+        ));
+
+        // The sync call redoes the decryption instead of returning the stored failure.
+        let response = user_decryptor
+            .user_decrypt_sync(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            response
+                .payload
+                .expect("redone decryption carries a payload")
+                .signcrypted_ciphertexts
+                .len(),
+            1
+        );
+    }
+
+    /// A failed entry that is still permit-held cannot be redone, so `user_decrypt` answers
+    /// `AlreadyExists`, which the sync endpoint reads as "attach to the existing entry". That
+    /// internal signal must be defused rather than dropped: dropping a `MetricedError` records
+    /// an error and logs a failure for what is only a control-flow decision.
+    #[tokio::test]
+    async fn sync_attach_signal_is_not_recorded_as_error() {
+        let mut rng = AesRng::seed_from_u64(123);
+        let (key_id, epoch_id, ct_buf, user_decryptor) = setup_user_decryptor(&mut rng).await;
+
+        let req_id = RequestId::new_random(&mut rng);
+        let request = make_valid_request(&mut rng, req_id, key_id, epoch_id, ct_buf);
+
+        // Fail the entry, then hold a permit on it so that `redo_failed` reports `Locked`.
+        let permit = user_decryptor
+            .user_decrypt_meta_store
+            .write()
+            .await
+            .insert(&req_id)
+            .unwrap();
+        crate::util::meta_store::update_err_req_in_meta_store(
+            &user_decryptor.user_decrypt_meta_store,
+            permit,
+            "forced failure".to_string(),
+            OP_USER_DECRYPT_REQUEST,
+        )
+        .await;
+        let _held_permit = user_decryptor
+            .user_decrypt_meta_store
+            .write()
+            .await
+            .lock_entry(&req_id)
+            .unwrap();
+
+        let recorded_errors_before = crate::engine::utils::handle_error_call_count();
+        let err = user_decryptor
+            .user_decrypt_sync(Request::new(request))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Internal);
+        // `err` has not been returned to a caller yet, so nothing should have been recorded so
+        // far: an `AlreadyExists` dropped instead of defused would already show up here.
+        assert_eq!(
+            crate::engine::utils::handle_error_call_count(),
+            recorded_errors_before,
+            "the internal attach signal must not be recorded as a failure"
+        );
+        // Handing the error back to the caller records it exactly once.
+        drop(err);
+        assert_eq!(
+            crate::engine::utils::handle_error_call_count(),
+            recorded_errors_before + 1
+        );
     }
 }

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -67,7 +67,7 @@ use crate::{
         utils::MetricedError,
         validation::{
             DSEP_USER_DECRYPTION, RequestIdParsingErr, parse_grpc_request_id,
-            validate_user_decrypt_req,
+            parse_optional_grpc_request_id, validate_user_decrypt_req,
         },
     },
     util::{
@@ -574,19 +574,13 @@ impl<
             .time_operation(OP_USER_DECRYPT_SYNC)
             .start();
 
-        let req_id = {
-            let proto_req_id = request.get_ref().request_id.as_ref().ok_or_else(|| {
-                MetricedError::new(
-                    OP_USER_DECRYPT_SYNC,
-                    None,
-                    anyhow!("Missing request ID in UserDecryptionRequest"),
-                    tonic::Code::InvalidArgument,
-                )
-            })?;
-            parse_grpc_request_id(proto_req_id, RequestIdParsingErr::UserDecRequest).map_err(
-                |e| MetricedError::new(OP_USER_DECRYPT_SYNC, None, e, tonic::Code::InvalidArgument),
-            )?
-        };
+        let req_id = parse_optional_grpc_request_id(
+            &request.get_ref().request_id,
+            RequestIdParsingErr::UserDecRequest,
+        )
+        .map_err(|e| {
+            MetricedError::new(OP_USER_DECRYPT_SYNC, None, e, tonic::Code::InvalidArgument)
+        })?;
 
         let should_start = match self.user_decrypt_meta_store.read().await.retrieve(&req_id) {
             None => true,                           // fresh request ID

--- a/core/service/src/engine/threshold/traits.rs
+++ b/core/service/src/engine/threshold/traits.rs
@@ -12,6 +12,10 @@ pub trait UserDecryptor {
         &self,
         request: Request<RequestId>,
     ) -> Result<Response<UserDecryptionResponse>, MetricedError>;
+    async fn user_decrypt_sync(
+        &self,
+        request: Request<UserDecryptionRequest>,
+    ) -> Result<Response<UserDecryptionResponse>, MetricedError>;
 }
 
 #[tonic::async_trait]

--- a/core/service/src/engine/utils.rs
+++ b/core/service/src/engine/utils.rs
@@ -546,6 +546,18 @@ impl MetricedError {
         self.error_code
     }
 
+    /// Re-attribute this error to another operation metric.
+    pub(crate) fn retag(mut self, op_metric: &'static str) -> Self {
+        self.op_metric = op_metric;
+        self
+    }
+
+    /// Consume an error that the caller expected and has already accounted for, without recording
+    /// it.
+    pub(crate) fn defuse(mut self) {
+        self.returned = true;
+    }
+
     pub fn internal_err(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
         &*self.internal_error
     }
@@ -645,6 +657,16 @@ impl From<MetricedError> for Status {
 #[cfg(test)]
 thread_local! {
     static HANDLE_ERROR_CALL_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// How many errors have been recorded on the current thread so far.
+///
+/// Test-only hook for asserting that a code path does *not* report a failure, which
+/// is the regression guard for control-flow errors that must be defused rather than
+/// dropped (see [`MetricedError::defuse`]).
+#[cfg(test)]
+pub(crate) fn handle_error_call_count() -> usize {
+    HANDLE_ERROR_CALL_COUNT.with(|c| c.get())
 }
 
 /// Serialize an element to a base64 string using safe serialization.

--- a/docs/developer/metrics.md
+++ b/docs/developer/metrics.md
@@ -39,6 +39,7 @@ pub const OP_PUBLIC_DECRYPT_REQUEST: &str = "public_decrypt_request";
 pub const OP_PUBLIC_DECRYPT_RESULT: &str = "public_decrypt_result";
 pub const OP_USER_DECRYPT_REQUEST: &str = "user_decrypt_request";
 pub const OP_USER_DECRYPT_RESULT: &str = "user_decrypt_result";
+pub const OP_USER_DECRYPT_SYNC: &str = "user_decrypt_sync";
 // Inner variants of the OP
 // Corresponds to a single ciphertext
 pub const OP_PUBLIC_DECRYPT_INNER: &str = "public_decrypt_inner";

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -655,7 +655,7 @@ Public/user-decrypt rate-mode options are:
  - `--max-in-flight <NUM>`: optional rate-mode cap for in-flight requests before the client starts shedding requests.
  - `--sync`: use the synchronous endpoint (request and result in a single call). Currently only supported for `user-decrypt`.
 
- __NOTE__: For public and user decrypt from file, only `-b`/`--batch-size <BATCH_SIZE>`, `--rate <REQUESTS_PER_SECOND>`, `--duration <SECONDS>`, `--max-in-flight <NUM>`, and `--sync` are supported.
+ __NOTE__: For public and user decrypt from file, only `-b`/`--batch-size <BATCH_SIZE>`, `--rate <REQUESTS_PER_SECOND>`, `--duration <SECONDS>`, and `--max-in-flight <NUM>` are supported, plus `--sync` for user decrypt only.
 
 ### Custodian context
 

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -633,6 +633,8 @@ $ cargo run --bin kms-core-client -- -f <path-to-toml-config-file> user-decrypt 
 
 Upon success, the above commands print the decrypted plaintext. To run a fixed-rate load test, provide both `--rate` and `--duration`.
 
+User decryption also supports `--sync`, which uses the synchronous `UserDecryptSync` endpoint: each request returns the decryption result directly in a single call instead of polling `GetUserDecryptionResult`. The request still goes through the meta-store on the server, so the result remains retrievable via `GetUserDecryptionResult` afterwards.
+
 #### Arguments
 Arguments required for public and user decryption from args are:
  - `--to-encrypt <TO_ENCRYPT>` - The hex value to encrypt and decrypt. The value will be converted from a little endian hex string to a `Vec<u8>`. Can optionally have a "0x" prefix.
@@ -651,8 +653,9 @@ Public/user-decrypt rate-mode options are:
  - `--rate <REQUESTS_PER_SECOND>`: request launch rate. Must be used together with `--duration`.
  - `--duration <SECONDS>`: load-test duration. Must be used together with `--rate`.
  - `--max-in-flight <NUM>`: optional rate-mode cap for in-flight requests before the client starts shedding requests.
+ - `--sync`: use the synchronous endpoint (request and result in a single call). Currently only supported for `user-decrypt`.
 
- __NOTE__: For public and user decrypt from file, only `-b`/`--batch-size <BATCH_SIZE>`, `--rate <REQUESTS_PER_SECOND>`, `--duration <SECONDS>`, and `--max-in-flight <NUM>` are supported.
+ __NOTE__: For public and user decrypt from file, only `-b`/`--batch-size <BATCH_SIZE>`, `--rate <REQUESTS_PER_SECOND>`, `--duration <SECONDS>`, `--max-in-flight <NUM>`, and `--sync` are supported.
 
 ### Custodian context
 

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -648,12 +648,12 @@ Options shared by public and user decryption are:
  - `--context-id <CONTEXT_ID>`: optionally specify the context ID to use for the decryption. Defaults to the default context if not specified.
  - `--epoch-id <EPOCH_ID>`: optionally specify the epoch ID to use for the decryption. Defaults to the default epoch if not specified.
  - `--ciphertext-output-path <FILENAME>`: optionally write the ciphertext (the encryption of `to-encrypt`) to file
+ - `--sync`: use the synchronous endpoint (request and result in a single call). Currently only supported for `user-decrypt`.
 
 Public/user-decrypt rate-mode options are:
  - `--rate <REQUESTS_PER_SECOND>`: request launch rate. Must be used together with `--duration`.
  - `--duration <SECONDS>`: load-test duration. Must be used together with `--rate`.
  - `--max-in-flight <NUM>`: optional rate-mode cap for in-flight requests before the client starts shedding requests.
- - `--sync`: use the synchronous endpoint (request and result in a single call). Currently only supported for `user-decrypt`.
 
  __NOTE__: For public and user decrypt from file, only `-b`/`--batch-size <BATCH_SIZE>`, `--rate <REQUESTS_PER_SECOND>`, `--duration <SECONDS>`, and `--max-in-flight <NUM>` are supported, plus `--sync` for user decrypt only.
 

--- a/docs/operations/advanced/metrics.md
+++ b/docs/operations/advanced/metrics.md
@@ -52,8 +52,9 @@ KMS exposes metrics via Prometheus format on the configured metrics endpoint (de
 - `decompression_keygen` - Decompression key generation
 
 *Decryption Operations*:
-- `user_decrypt_request` - User decryption requests
-- `user_decrypt_result` - User decryption result retrievals
+- `user_decrypt_request` - Asynchronous user decryption requests
+- `user_decrypt_result` - User decryption result retrievals through `GetUserDecryptionResult`
+- `user_decrypt_sync` - Synchronous user decryption requests
 - `user_decrypt_inner` - Individual user decryption operations *(duration only)*
 - `public_decrypt_request` - Public decryption requests
 - `public_decrypt_result` - Public decryption result retrievals

--- a/docs/references/api/core_grpc.md
+++ b/docs/references/api/core_grpc.md
@@ -920,17 +920,15 @@ The endpoint performs real-time connectivity checks to peers and returns current
 
 ```proto
 message UserDecryptionRequest {
-  UserDecryptionRequestPayload payload = 1;
-  Eip712DomainMsg domain = 2;
-  RequestId request_id = 3;
-}
-
-
-message UserDecryptionRequestPayload {
-  string client_address = 1;
-  bytes enc_key = 2;
+  RequestId request_id = 1;
+  repeated TypedCiphertext typed_ciphertexts = 2;
   RequestId key_id = 3;
-  repeated TypedCiphertext typed_ciphertexts = 4;
+  string client_address = 4;
+  bytes enc_key = 5;
+  Eip712DomainMsg domain = 6;
+  bytes extra_data = 7;
+  RequestId context_id = 8;
+  RequestId epoch_id = 9;
 }
 ```
 
@@ -948,16 +946,15 @@ The process ensures that no-one (even the MPC parties) learn the decrypted value
 
 It expects:
 
-- `payload`: the `UserDecryptionRequestPayload` described below.
-- `domain`: EIP712 domain information which will be used when signing the decrypted plaintext.
 - `request_id`: A unique uint256 RequestId for the decryption request.
-
-The `UserDecryptionRequestPayload` contains all the information necessary to perform the user decryption:
-
+- `typed_ciphertexts`: The ciphertexts to decrypt and their meta information.
+- `key_id`: The `RequestId` of the TFHE key the ciphertext is encrypted under.
 - `client_address`: An EIP-55 encoded address (including the `0x` prefix) of the end-user who is supposed to learn the user decryption response.
 - `enc_key`: The `bincode::serialize` of `PublicEncKey`, which is a wrapper around a `crypto_box::PublicKey` to be used for encrypting the result.
-- `key_id`: The `RequestId` of the TFHE key the ciphertext is encrypted under.
-- `typed_ciphertext`: The ciphertexts to decrypt and their meta information.
+- `domain`: EIP712 domain information which will be used when signing the decrypted plaintext.
+- `extra_data`: Extra data used in the EIP712 signature - `external_signature`.
+- `context_id`: The MPC context ID used to identify the context to use for this request. If unset, the server's default context is used.
+- `epoch_id`: The MPC epoch ID identifying which epoch's key material and session to use for this request.
 
 The response will be EIP712-signed using the KMS core's private key and the provided `domain` as `Eip712Domain`. The `EIP712` signature is referred to as the `external_signature`.
 </details>
@@ -976,7 +973,9 @@ message RequestId { string request_id = 1; }
 ```proto
 message UserDecryptionResponse {
   bytes signature = 1;
-  UserDecryptionResponsePayload payload = 2;
+  bytes external_signature = 2;
+  UserDecryptionResponsePayload payload = 3;
+  bytes extra_data = 4;
 }
 
 message UserDecryptionResponsePayload {
@@ -985,7 +984,6 @@ message UserDecryptionResponsePayload {
   repeated TypedSigncryptedCiphertext signcrypted_ciphertexts = 3;
   uint32 party_id = 4;
   uint32 degree = 5;
-  bytes external_signature = 6;
 }
 ```
 
@@ -995,13 +993,17 @@ This RPC allows to retrieve the user decrypted plaintext if the `request_id` is 
 
 The signature is a `secp256k1` signature on the `bincode::serialize` of the `payload` using the core's private key.
 
+- `signature`: the `secp256k1` signature described above.
+- `external_signature`: a `EIP-712` signature on the _solidity-compatible_  256 bits `SHAKE-256` hash of the `tfhe::safe_serialization` of the underlying struct.
+- `extra_data`: Extra data used in the EIP712 signature - `external_signature`.
+
 #### The `payload` is composed of
 
 - `verification_key`: the `bincode::serialize` `ECDSA/secp256k1` verification key of the core.
 - `digest`: The concatenation of two digests `(eip712_signing_hash(pk, domain) || ciphertext digest)`
+- `signcrypted_ciphertexts`: The resulting signcrypted ciphertexts, each of which must be decrypted and then reconstructed with the other shares to produce the final plaintext.
 - `party_id`: The MPC ID of the KMS core party doing the user decryption. Necessary for doing the share reconstruction.
 - `degree`: The degree of the sharing scheme used. Necessary for doing the share reconstruction.
-- `external_signature`: a `EIP-712` signature on the _solidity-compatible_  256 bits `SHAKE-256` hash of the `tfhe::safe_serialization` of the underlying struct.
 
 </details>
 
@@ -1012,9 +1014,15 @@ The signature is a `secp256k1` signature on the `bincode::serialize` of the `pay
 
 ```proto
 message UserDecryptionRequest {
-  UserDecryptionRequestPayload payload = 1;
-  Eip712DomainMsg domain = 2;
-  RequestId request_id = 3;
+  RequestId request_id = 1;
+  repeated TypedCiphertext typed_ciphertexts = 2;
+  RequestId key_id = 3;
+  string client_address = 4;
+  bytes enc_key = 5;
+  Eip712DomainMsg domain = 6;
+  bytes extra_data = 7;
+  RequestId context_id = 8;
+  RequestId epoch_id = 9;
 }
 ```
 
@@ -1023,11 +1031,15 @@ message UserDecryptionRequest {
 ```proto
 message UserDecryptionResponse {
   bytes signature = 1;
-  UserDecryptionResponsePayload payload = 2;
+  bytes external_signature = 2;
+  UserDecryptionResponsePayload payload = 3;
+  bytes extra_data = 4;
 }
 ```
 
 ### Description
+
+This is the same request and response as `UserDecrypt`/`GetUserDecryptionResult` above, see the `UserDecryption` and `UserDecryptionResponse` sections for a description of each field.
 
 `UserDecryptSync` is the __synchronous__ variant of `UserDecrypt`: it starts the user decryption exactly as `UserDecrypt` does and then waits for the result within the same call, returning the same `UserDecryptionResponse` that `GetUserDecryptionResult` would return. This saves the caller the second round trip.
 

--- a/docs/references/api/core_grpc.md
+++ b/docs/references/api/core_grpc.md
@@ -1004,3 +1004,33 @@ The signature is a `secp256k1` signature on the `bincode::serialize` of the `pay
 - `external_signature`: a `EIP-712` signature on the _solidity-compatible_  256 bits `SHAKE-256` hash of the `tfhe::safe_serialization` of the underlying struct.
 
 </details>
+
+<details>
+    <summary> UserDecryptionSync </summary>
+
+### Input
+
+```proto
+message UserDecryptionRequest {
+  UserDecryptionRequestPayload payload = 1;
+  Eip712DomainMsg domain = 2;
+  RequestId request_id = 3;
+}
+```
+
+### Output
+
+```proto
+message UserDecryptionResponse {
+  bytes signature = 1;
+  UserDecryptionResponsePayload payload = 2;
+}
+```
+
+### Description
+
+`UserDecryptSync` is the __synchronous__ variant of `UserDecrypt`: it starts the user decryption exactly as `UserDecrypt` does and then waits for the result within the same call, returning the same `UserDecryptionResponse` that `GetUserDecryptionResult` would return. This saves the caller the second round trip.
+
+The request is still recorded internally, so the result also remains retrievable through `GetUserDecryptionResult`. If the result is not ready before the server's waiting window expires, the call returns `UNAVAILABLE` while the decryption keeps running in the background; the result can then be fetched with `GetUserDecryptionResult` or by re-sending the same request to `UserDecryptSync`. Re-sending a request whose `request_id` was already used does not start a new decryption; the call attaches to the existing request and returns its result.
+
+</details>

--- a/docs/references/api/core_grpc.md
+++ b/docs/references/api/core_grpc.md
@@ -1045,6 +1045,6 @@ This is the same request and response as `UserDecrypt`/`GetUserDecryptionResult`
 
 The request is still recorded internally, so the result also remains retrievable through `GetUserDecryptionResult`. If the result is not ready before the server's waiting window expires, the call returns `UNAVAILABLE` while the decryption keeps running in the background; the result can then be fetched with `GetUserDecryptionResult` or by re-sending the same request to `UserDecryptSync`.
 
-A `request_id` that is already known is handled exactly as re-sending it to `UserDecrypt` would be, except that this method waits for the outcome instead of rejecting the call. If a decryption for that `request_id` is still running or has already succeeded, no new decryption is started: the call attaches to that attempt and returns its result, ignoring the rest of the request. If the previous attempt failed, a new decryption is started from the content of the new request, and the call returns the outcome of that new attempt.
+Unlike `UserDecrypt`, this method never rejects a `request_id` that is already known with `ALREADY_EXISTS`. If a decryption for that `request_id` is still running or has already succeeded, no new decryption is started: the call attaches to that attempt and returns its result, ignoring the rest of the request. If the previous attempt failed, a new decryption is started from the content of the new request (the same redo-on-failure rule as `UserDecrypt`), and the call returns the outcome of that new attempt.
 
 </details>

--- a/docs/references/api/core_grpc.md
+++ b/docs/references/api/core_grpc.md
@@ -1006,7 +1006,7 @@ The signature is a `secp256k1` signature on the `bincode::serialize` of the `pay
 </details>
 
 <details>
-    <summary> UserDecryptionSync </summary>
+    <summary> UserDecryptSync </summary>
 
 ### Input
 
@@ -1031,6 +1031,8 @@ message UserDecryptionResponse {
 
 `UserDecryptSync` is the __synchronous__ variant of `UserDecrypt`: it starts the user decryption exactly as `UserDecrypt` does and then waits for the result within the same call, returning the same `UserDecryptionResponse` that `GetUserDecryptionResult` would return. This saves the caller the second round trip.
 
-The request is still recorded internally, so the result also remains retrievable through `GetUserDecryptionResult`. If the result is not ready before the server's waiting window expires, the call returns `UNAVAILABLE` while the decryption keeps running in the background; the result can then be fetched with `GetUserDecryptionResult` or by re-sending the same request to `UserDecryptSync`. Re-sending a request whose `request_id` was already used does not start a new decryption; the call attaches to the existing request and returns its result.
+The request is still recorded internally, so the result also remains retrievable through `GetUserDecryptionResult`. If the result is not ready before the server's waiting window expires, the call returns `UNAVAILABLE` while the decryption keeps running in the background; the result can then be fetched with `GetUserDecryptionResult` or by re-sending the same request to `UserDecryptSync`.
+
+A `request_id` that is already known is handled exactly as re-sending it to `UserDecrypt` would be, except that this method waits for the outcome instead of rejecting the call. If a decryption for that `request_id` is still running or has already succeeded, no new decryption is started: the call attaches to that attempt and returns its result, ignoring the rest of the request. If the previous attempt failed, a new decryption is started from the content of the new request, and the call returns the outcome of that new attempt.
 
 </details>

--- a/observability/src/metrics_names.rs
+++ b/observability/src/metrics_names.rs
@@ -32,6 +32,7 @@ pub const OP_PUBLIC_DECRYPT_REQUEST: &str = "public_decrypt_request";
 pub const OP_PUBLIC_DECRYPT_RESULT: &str = "public_decrypt_result";
 pub const OP_USER_DECRYPT_REQUEST: &str = "user_decrypt_request";
 pub const OP_USER_DECRYPT_RESULT: &str = "user_decrypt_result";
+pub const OP_USER_DECRYPT_SYNC: &str = "user_decrypt_sync";
 // Inner variants of the OP
 // Corresponds to a single ciphertext
 pub const OP_PUBLIC_DECRYPT_INNER: &str = "public_decrypt_inner";


### PR DESCRIPTION
## Description

Adds a new gRPC endpoint, `UserDecryptSync`, which does a user decryption in a sync way.

Today a client has to call `UserDecrypt` to start the job, then poll `GetUserDecryptionResult` to pick up the answer. `UserDecryptSync` takes the exact same request, starts the exact same decryption, waits for it internally, and returns the `UserDecryptionResponse` directly.

Nothing else about the flow changes:
- The request is still recorded in the meta-store, so the result stays available via `GetUserDecryptionResult` afterwards.
- If the result isn't ready before the server's waiting window closes (same waiting window as the async flow for now), the call returns `UNAVAILABLE`. The decryption keeps running in the background, so the caller can either fetch it with `GetUserDecryptionResult` or just re-send the same request.
- Re-sending a request whose `request_id` was already used does not start a second decryption: the call attaches to the existing entry and returns its result (idempotent retry; the rest of the request body is ignored). If the previous attempt failed, the request is redone under the same ID, exactly as re-sending it to the async endpoint would be.

Implemented for both the centralized and threshold KMS. In both, the new endpoint is a thin wrapper around the existing `user_decrypt` + `get_result` code paths, so there is no new decryption logic to review.

Also included:
  - `--sync` flag on `kms-core-client` `user-decrypt` (both `from-args` and `from-file`, including rate mode) to exercise the new endpoint. It's rejected with a clear error for public-decrypt, which doesn't have a sync variant yet.
- New `user_decrypt_sync` metric: counts sync calls, measures end-to-end latency (wait included), and carries every error the sync client sees. As a decryption always runs as a background job, its compute duration and background failures stay under `user_decrypt_request` whichever endpoint (sync/async) started it.

### Related issue(s)

Partial handling of https://github.com/zama-ai/kms-internal/issues/3148 (user-decrypt only).

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
