### PR TITLE
chore: pin attestation-doc-validation to upstream rev to drop vulnerable serde_with 2.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
- "serde_with 3.21.0",
+ "serde_with",
  "thiserror 2.0.18",
 ]
 
@@ -239,7 +239,7 @@ dependencies = [
  "derive_more",
  "either",
  "serde",
- "serde_with 3.21.0",
+ "serde_with",
  "sha2 0.10.9",
 ]
 
@@ -387,7 +387,7 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "serde_json",
- "serde_with 3.21.0",
+ "serde_with",
  "thiserror 2.0.18",
 ]
 
@@ -525,7 +525,7 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -882,7 +882,7 @@ dependencies = [
  "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint",
- "serde_with 3.21.0",
+ "serde_with",
 ]
 
 [[package]]
@@ -1236,14 +1236,13 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "attestation-doc-validation"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d09f8ce9c08df11cc4626c2b1ad1c58c52e9470b086622ae3ab7c05cb68500"
+source = "git+https://github.com/evervault/attestation-doc-validation?rev=50b084885c7d3ca59c52ce17d6c261eee0e78b27#50b084885c7d3ca59c52ce17d6c261eee0e78b27"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api 0.4.0",
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "der 0.7.10",
  "ecdsa",
@@ -1255,7 +1254,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "serde_with 2.3.3",
+ "serde_with",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "time",
@@ -1358,7 +1357,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_repr",
- "serde_with 3.21.0",
+ "serde_with",
 ]
 
 [[package]]
@@ -1946,12 +1945,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -2895,36 +2888,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2943,22 +2912,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.118",
 ]
@@ -4178,7 +4136,7 @@ dependencies = [
  "ipnet",
  "serde",
  "serde_json",
- "serde_with 3.21.0",
+ "serde_with",
 ]
 
 [[package]]
@@ -7221,22 +7179,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "serde",
- "serde_json",
- "serde_with_macros 2.3.3",
- "time",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
@@ -7251,20 +7193,8 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
- "serde_with_macros 3.21.0",
+ "serde_with_macros",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -7273,7 +7203,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -8804,7 +8734,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240e4b81c20a1d6d50d1d7265c658dfbd204e8b9ac4d80f3c931f39462196335"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro-error3",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,8 @@ assert_cmd = "=2.2.2"  # Assert command for testing - LOW RISK: assert-rs team, 
 async-std = { version = "=1.13.2", features = ["attributes", "tokio1"] }  # Async runtime for testing - LOW RISK: async-rs team, 55M+ downloads
 async-trait = "=0.1.89"  # Async trait support -  MEDIUM RISK: Reputable individual maintainer (dtolnay), 292M downloads
 # AWS Nitro attestation validation - LOW RISK: Evervault (reputable security company), security-critical but trusted.
-# Pinned to an upstream rev because crates.io 0.10.0 (latest release) pulls vulnerable serde_with 2.3.3
+# Pinned to an upstream rev because crates.io 0.10.0 pulls vulnerable serde_with 2.3.3.
+# TODO: Revert to a crates.io release once Evervault ships a version that no longer pulls serde_with 2.3.3.
 attestation-doc-validation = { git = "https://github.com/evervault/attestation-doc-validation", rev = "50b084885c7d3ca59c52ce17d6c261eee0e78b27" }
 aws-config = { version = "=1.8.18" }  # AWS SDK configuration - LOW RISK: Official AWS SDK, actively maintained
 aws-lc-rs = { version = "=1.17.0" } # AWS-LC cryptographic library - LOW RISK: Official AWS SDK

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,6 @@ async-std = { version = "=1.13.2", features = ["attributes", "tokio1"] }  # Asyn
 async-trait = "=0.1.89"  # Async trait support -  MEDIUM RISK: Reputable individual maintainer (dtolnay), 292M downloads
 # AWS Nitro attestation validation - LOW RISK: Evervault (reputable security company), security-critical but trusted.
 # Pinned to an upstream rev because crates.io 0.10.0 (latest release) pulls vulnerable serde_with 2.3.3
-# (KeyValueMap serialize panic, Dependabot #183); this rev only bumps deps (serde_with 3.8, base64 0.22),
-# no source changes vs 0.10.0. Return to a crates.io pin once Evervault cuts the next release.
 attestation-doc-validation = { git = "https://github.com/evervault/attestation-doc-validation", rev = "50b084885c7d3ca59c52ce17d6c261eee0e78b27" }
 aws-config = { version = "=1.8.18" }  # AWS SDK configuration - LOW RISK: Official AWS SDK, actively maintained
 aws-lc-rs = { version = "=1.17.0" } # AWS-LC cryptographic library - LOW RISK: Official AWS SDK

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,11 @@ anyhow = "=1.0.102"  # Error handling - MEDIUM RISK: Reputable individual mainta
 assert_cmd = "=2.2.2"  # Assert command for testing - LOW RISK: assert-rs team, 1M+ downloads
 async-std = { version = "=1.13.2", features = ["attributes", "tokio1"] }  # Async runtime for testing - LOW RISK: async-rs team, 55M+ downloads
 async-trait = "=0.1.89"  # Async trait support -  MEDIUM RISK: Reputable individual maintainer (dtolnay), 292M downloads
-attestation-doc-validation = { version = "=0.10.0" }  # AWS Nitro attestation validation - LOW RISK: Evervault (reputable security company), security-critical but trusted
+# AWS Nitro attestation validation - LOW RISK: Evervault (reputable security company), security-critical but trusted.
+# Pinned to an upstream rev because crates.io 0.10.0 (latest release) pulls vulnerable serde_with 2.3.3
+# (KeyValueMap serialize panic, Dependabot #183); this rev only bumps deps (serde_with 3.8, base64 0.22),
+# no source changes vs 0.10.0. Return to a crates.io pin once Evervault cuts the next release.
+attestation-doc-validation = { git = "https://github.com/evervault/attestation-doc-validation", rev = "50b084885c7d3ca59c52ce17d6c261eee0e78b27" }
 aws-config = { version = "=1.8.18" }  # AWS SDK configuration - LOW RISK: Official AWS SDK, actively maintained
 aws-lc-rs = { version = "=1.17.0" } # AWS-LC cryptographic library - LOW RISK: Official AWS SDK
 aws-nitro-enclaves-nsm-api = { version = "=0.5.1" }  # AWS Nitro Enclaves NSM API - LOW RISK: Official AWS SDK

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ async-trait = "=0.1.89"  # Async trait support -  MEDIUM RISK: Reputable individ
 # AWS Nitro attestation validation - LOW RISK: Evervault (reputable security company), security-critical but trusted.
 # Pinned to an upstream rev because crates.io 0.10.0 pulls vulnerable serde_with 2.3.3.
 # TODO: Revert to a crates.io release once Evervault ships a version that no longer pulls serde_with 2.3.3.
+# Issue: https://github.com/zama-ai/kms-internal/issues/3158
 attestation-doc-validation = { git = "https://github.com/evervault/attestation-doc-validation", rev = "50b084885c7d3ca59c52ce17d6c261eee0e78b27" }
 aws-config = { version = "=1.8.18" }  # AWS SDK configuration - LOW RISK: Official AWS SDK, actively maintained
 aws-lc-rs = { version = "=1.17.0" } # AWS-LC cryptographic library - LOW RISK: Official AWS SDK


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->

Two security dependency fixes, no code changes.

**serde_with 2.3.3 → gone** (Dependabot alert: `KeyValueMap` serialize panic → DoS, patched only in 3.21.0). Pinned to upstream rev `50b0848`, which vs the released 0.10.0 only bumps deps (serde_with 3.8, base64 0.22) — zero source changes in the crate. serde_with now unifies on the already-present patched 3.21.0; `serde_with 2.3.3`, `serde_with_macros 2.3.3`, `base64 0.21.7`, and `darling 0.20.11` drop from the lock. serde_with is actually unused in the crate's source, so exploitability was nil — this clears the alert. Revert to a crates.io pin once Evervault cuts a release (noted in Cargo.toml).

**ruint 1.19.0 → 1.20.0** (RUSTSEC-2026-0220: incorrect shift overflow flags; fails `cargo-audit` in CI). Lockfile-only `cargo update -p ruint --precise 1.20.0`; the alloy pins accept it (`^1.16.0`). Only other churn is Windows-only `windows-sys` re-unification (0.59.0 removed).

Verified: `cargo update -w --locked`, `cargo-deny check licenses`, `cargo audit` (0 vulnerabilities), and `cargo clippy --all-targets -- -D warnings` with and without `--all-features` — all clean.

### Related issue(s)

Closes https://github.com/zama-ai/kms/security/dependabot/183. No issue exists for the ruint advisory.

## PR Checklist

- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased. *(no code changes)*
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes. *(two security fixes bundled, both minimal)*
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)

**attestation-doc-validation** (crates.io =0.10.0 → git rev `50b0848`): no ownership change — same maintainer (Evervault), official repo, immutable SHA; popularity/docs/CI/disclosure posture unchanged; no version jump (same 0.10.0 source, dep bumps only); no size increase.

**ruint** (1.19.0 → 1.20.0, transitive, lockfile-only): same maintainers (Paradigm ecosystem, core alloy dep, high popularity); patch-level bump to the exact advisory-fixed version; CI'd upstream; tree shrinks.

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
