### PR TITLE
chore!: upgrade to tfhe v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7776,9 +7776,9 @@ dependencies = [
 
 [[package]]
 name = "tfhe"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12600f0ef012f68dffa8adf9a254407366a8bffcbdcc277e5edbaec49192e8cc"
+checksum = "f341a7a6fe90bf813ecb2b098f04c0e5bca82436ddd1b256e6f1ec68be58da52"
 dependencies = [
  "aligned-vec",
  "bincode 1.3.3",
@@ -7803,9 +7803,9 @@ dependencies = [
 
 [[package]]
 name = "tfhe-csprng"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995c7a17e55a75f380fb1706a988a142a01ad942a0b175fc6f79ac5ec8403570"
+checksum = "a9c677a5732dd133544c5e76e448da8d8bc26c4131e30c50920165472a9d6a3c"
 dependencies = [
  "aes 0.8.4",
  "getrandom 0.2.17",
@@ -7877,9 +7877,9 @@ dependencies = [
 
 [[package]]
 name = "tfhe-zk-pok"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d348d45bfbf7a3946a4555f58c2114bb0cdc92e9b6af4369d1b2604f5524b3b"
+checksum = "89cc1188ff876ceb0e2611f2d7ed3f46fc007448f68a29e879520efc55f2475e"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,11 +198,11 @@ sysinfo = "0.38.4"  # System information gathering - MEDIUM RISK: Reputable indi
 tempfile = "=3.20.0"  # Temporary file handling - MEDIUM RISK: Individual maintainers (Stebalien, KodrAus), 345M+ downloads, test-only dependency
 test-context = "=0.4.1"  # Test context utilities - MEDIUM RISK: Individual maintainers (markhildreth, JasperV), test-only dependency
 # NOTE: when changing the tfhe dependency, consider also updating the pinned version of dylint lints from tfhe (see dylint.toml)
-tfhe = "=1.6.2"  # Fully Homomorphic Encryption library - LOW RISK: Zama
-tfhe-csprng = "=0.9.1"  # Cryptographically secure PRNG for TFHE - LOW RISK: Zama
+tfhe = "=1.7.0"  # Fully Homomorphic Encryption library - LOW RISK: Zama
+tfhe-csprng = "=0.9.2"  # Cryptographically secure PRNG for TFHE - LOW RISK: Zama
 tfhe-safe-serialize = "=0.1.1" # TFHE safe serialization - LOW RISK: Zama
 tfhe-versionable = "=0.8.0"  # TFHE versioning support - LOW RISK: Zama
-tfhe-zk-pok = "=0.8.2"  # Zero-knowledge proofs for TFHE - LOW RISK: Zama
+tfhe-zk-pok = "=0.8.3"  # Zero-knowledge proofs for TFHE - LOW RISK: Zama
 thiserror = "=2.0.18"  # Error derive macro - MEDIUM RISK: Reputable individual maintainer (dtolnay), 545M downloads
 tokio = { version = "=1.52.3", features = ["full"] }  # Async runtime - LOW RISK: tokio team, industry standard
 tokio-rustls = { version = "=0.26.4", default-features = false, features = ["aws_lc_rs"] }  # Async TLS - LOW RISK: rustls team, memory-safe TLS implementation

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -3394,11 +3394,7 @@ mod tests {
             key_id.into(),
         )
         .unwrap();
-        let (public_key, _server_key) = compressed_keyset
-            .clone()
-            .decompress()
-            .unwrap()
-            .into_raw_parts();
+        let (public_key, _server_key) = compressed_keyset.clone().decompress().into_raw_parts();
 
         let mut remote_storage = FileStorage::new(
             Some(remote_root.path()),

--- a/core/experiments/benches/non-threshold/tfhe-rs/memory/basic_ops.rs
+++ b/core/experiments/benches/non-threshold/tfhe-rs/memory/basic_ops.rs
@@ -113,10 +113,7 @@ fn main() {
     for (name, params) in ALL_PARAMS {
         let (client_key, compressed_server_key) = generate_tfhe_keys(&params);
 
-        let (public_key, server_key) = compressed_server_key
-            .decompress()
-            .expect("Decompression failed")
-            .into_raw_parts();
+        let (public_key, server_key) = compressed_server_key.decompress().into_raw_parts();
 
         set_server_key(server_key);
         let bench_name = format!("non-threshold_basic-ops_{name}");

--- a/core/experiments/benches/non-threshold/tfhe-rs/memory/erc20.rs
+++ b/core/experiments/benches/non-threshold/tfhe-rs/memory/erc20.rs
@@ -96,10 +96,7 @@ fn main() {
 
         let (client_key, compressed_server_key) = generate_tfhe_keys(&params);
 
-        let (public_key, server_key) = compressed_server_key
-            .decompress()
-            .expect("Decompression failed")
-            .into_raw_parts();
+        let (public_key, server_key) = compressed_server_key.decompress().into_raw_parts();
 
         set_server_key(server_key);
         let mut rng = AesRng::from_entropy();

--- a/core/experiments/benches/non-threshold/tfhe-rs/speed/basic_ops.rs
+++ b/core/experiments/benches/non-threshold/tfhe-rs/speed/basic_ops.rs
@@ -103,10 +103,7 @@ fn main() {
     for (name, params) in ALL_PARAMS {
         let (client_key, compressed_server_key) = generate_tfhe_keys(&params);
 
-        let (public_key, server_key) = compressed_server_key
-            .decompress()
-            .expect("Decompression failed")
-            .into_raw_parts();
+        let (public_key, server_key) = compressed_server_key.decompress().into_raw_parts();
 
         set_server_key(server_key);
 

--- a/core/experiments/benches/non-threshold/tfhe-rs/speed/erc20.rs
+++ b/core/experiments/benches/non-threshold/tfhe-rs/speed/erc20.rs
@@ -76,10 +76,7 @@ fn main() {
         }
         let (client_key, compressed_server_key) = generate_tfhe_keys(&params);
 
-        let (public_key, server_key) = compressed_server_key
-            .decompress()
-            .expect("Decompression failed")
-            .into_raw_parts();
+        let (public_key, server_key) = compressed_server_key.decompress().into_raw_parts();
 
         let mut rng = AesRng::from_entropy();
         let from_amount = FheUint64::encrypt(rng.r#gen::<u64>(), &client_key);

--- a/core/experiments/src/bin/non-threshold/tfhe-kat.rs
+++ b/core/experiments/src/bin/non-threshold/tfhe-kat.rs
@@ -147,13 +147,7 @@ fn main() {
 
     let (client_key, compressed_server_key) = generate_keys(params);
 
-    set_server_key(
-        compressed_server_key
-            .decompress()
-            .expect("Decompression failed")
-            .into_raw_parts()
-            .1,
-    );
+    set_server_key(compressed_server_key.decompress().into_raw_parts().1);
 
     let (ciphertext_43, ciphertext_4445, ciphertext_add, ciphertext_mult) =
         generate_ciphertexts(&client_key);

--- a/core/experiments/src/bin/threshold-tfhe/mobygo.rs
+++ b/core/experiments/src/bin/threshold-tfhe/mobygo.rs
@@ -626,9 +626,7 @@ async fn encrypt_command(params: EncryptArgs) -> Result<(), Box<dyn std::error::
         bc2wrap::deserialize_from(File::open(params.pub_key_file)?)?;
 
     let (compact_key, server_key) = match pk {
-        KeySetMaybeCompressed::Compressed(comp_pk) => {
-            comp_pk.decompress().unwrap().into_raw_parts()
-        }
+        KeySetMaybeCompressed::Compressed(comp_pk) => comp_pk.decompress().into_raw_parts(),
         KeySetMaybeCompressed::Uncompressed(uncomp_pk) => {
             (uncomp_pk.public_key, uncomp_pk.server_key)
         }
@@ -698,9 +696,7 @@ async fn threshold_decrypt_command(
         bc2wrap::deserialize_from(File::open(params.pub_key_file)?)?;
 
     let (compact_key, server_key) = match pk {
-        KeySetMaybeCompressed::Compressed(comp_pk) => {
-            comp_pk.decompress().unwrap().into_raw_parts()
-        }
+        KeySetMaybeCompressed::Compressed(comp_pk) => comp_pk.decompress().into_raw_parts(),
         KeySetMaybeCompressed::Uncompressed(uncomp_pk) => {
             (uncomp_pk.public_key, uncomp_pk.server_key)
         }

--- a/core/experiments/src/choreography/tfhe_rs/grpc.rs
+++ b/core/experiments/src/choreography/tfhe_rs/grpc.rs
@@ -177,7 +177,7 @@ where
         keys: (CompressedXofKeySet, PrivateKeySet<EXTENSION_DEGREE>),
         params: DKGParams,
     ) -> Self {
-        let (public_key, server_key) = keys.0.decompress().unwrap().into_raw_parts();
+        let (public_key, server_key) = keys.0.decompress().into_raw_parts();
         Self {
             pub_keyset: Arc::new(Some(keys.0)),
             pub_keyset_decompressed: Arc::new(FhePubKeySet {

--- a/core/service/src/client/tests/centralized/key_gen_tests.rs
+++ b/core/service/src/client/tests/centralized/key_gen_tests.rs
@@ -322,8 +322,7 @@ pub async fn run_key_gen_centralized(
                 )
                 .await
                 .unwrap();
-            let (derived_public_key, server_key) =
-                compressed_keyset.decompress().unwrap().into_raw_parts();
+            let (derived_public_key, server_key) = compressed_keyset.decompress().into_raw_parts();
             // For fresh compressed keygen the stored public key must match the one we derive
             // from the compressed keyset (migration flow would differ, but this test path is
             // always a fresh keygen). CompactPublicKey does not implement PartialEq, so we
@@ -410,7 +409,7 @@ pub async fn run_key_gen_centralized(
                 .get_key(&keyid_1, PubDataType::CompressedXofKeySet, &pub_storage)
                 .await
                 .unwrap();
-            let (_pk_1, server_key_1) = compressed_keyset_1.decompress().unwrap().into_raw_parts();
+            let (_pk_1, server_key_1) = compressed_keyset_1.decompress().into_raw_parts();
 
             // get decompression key
             let decompression_key = internal_client

--- a/core/service/src/client/tests/threshold/key_gen_tests.rs
+++ b/core/service/src/client/tests/threshold/key_gen_tests.rs
@@ -128,7 +128,7 @@ impl TestKeyGenResult {
                 (client_key, public_key.clone(), server_key.clone())
             }
             TestKeyGenResult::Compressed((client_key, keyset, public_key)) => {
-                let (_derived_pk, server_key) = keyset.decompress().unwrap().into_raw_parts();
+                let (_derived_pk, server_key) = keyset.decompress().into_raw_parts();
                 (client_key, public_key.clone(), server_key)
             }
         };
@@ -615,7 +615,7 @@ pub(crate) async fn preproc_and_keygen(
     fn validate_keyset(keyset: TestKeyGenResult, key_id: &RequestId, compressed: bool) {
         let (client_key, public_key, server_key) = if compressed {
             let (client_key, keyset, public_key) = keyset.get_compressed();
-            let (_derived_pk, server_key) = keyset.decompress().unwrap().into_raw_parts();
+            let (_derived_pk, server_key) = keyset.decompress().into_raw_parts();
             (client_key, public_key, server_key)
         } else {
             keyset.get_uncompressed()
@@ -1917,7 +1917,7 @@ async fn run_threshold_compressed_keygen_from_existing(
             let compressed_keyset: tfhe::xof_key_set::CompressedXofKeySet =
                 CryptoMaterialReader::read_from_storage(storage, &keygen_id_2).await?;
 
-            let (pk, server_key) = compressed_keyset.decompress().unwrap().into_raw_parts();
+            let (pk, server_key) = compressed_keyset.decompress().into_raw_parts();
             let (_, _, _, _, _, _, _, oprf_key, _) = server_key.clone().into_raw_parts();
             assert!(
                 oprf_key.is_some(),
@@ -2276,10 +2276,7 @@ async fn test_insecure_threshold_decompression_keygen() -> anyhow::Result<()> {
     .await
     .expect("keygen 1 verification failed");
     let (client_key_1, compressed_keyset_1, _public_key_1) = keys_1.get_compressed();
-    let (_, server_key_1) = compressed_keyset_1
-        .decompress()
-        .expect("decompress keyset 1")
-        .into_raw_parts();
+    let (_, server_key_1) = compressed_keyset_1.decompress().into_raw_parts();
 
     // Step 2: Generate second keyset (insecure mode), reconstruct ClientKey
     let key_id_2 = derive_request_id("decom_dkg_key_2")?;

--- a/core/service/src/client/tests/threshold/mpc_epoch_tests.rs
+++ b/core/service/src/client/tests/threshold/mpc_epoch_tests.rs
@@ -475,8 +475,7 @@ async fn run_new_epoch(
             .expect("Failed to verify reshare responses");
 
             let (client_key, compressed_keyset, pk) = out.0.clone().get_compressed();
-            let (decompressed_pk, server_key) =
-                compressed_keyset.decompress().unwrap().into_raw_parts();
+            let (decompressed_pk, server_key) = compressed_keyset.decompress().into_raw_parts();
             crate::client::key_gen::tests::check_conformance(server_key, client_key);
 
             // The reshared compressed keyset is freshly generated from the existing

--- a/core/service/src/cryptography/decompression.rs
+++ b/core/service/src/cryptography/decompression.rs
@@ -91,8 +91,8 @@ mod test {
     use tfhe::prelude::{CiphertextList, FheDecrypt, FheEncrypt};
     use tfhe::set_server_key;
     use tfhe::shortint::parameters::{
-        COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
-        PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+        COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
+        PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
     };
     use tfhe::{ClientKey, HlCompressible, generate_keys};
     use tfhe::{
@@ -109,9 +109,9 @@ mod test {
     #[test]
     fn test_bad_ciphertext() {
         let config = tfhe::ConfigBuilder::with_custom_parameters(
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+            PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         )
-        .enable_compression(COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64)
+        .enable_compression(COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
         .build();
         let (client_key, server_key) = generate_keys(config);
         set_server_key(server_key);
@@ -132,9 +132,9 @@ mod test {
     #[test]
     fn test_bad_fhe_type() {
         let config = tfhe::ConfigBuilder::with_custom_parameters(
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+            PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         )
-        .enable_compression(COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64)
+        .enable_compression(COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
         .build();
         let (client_key, server_key) = generate_keys(config);
         let decompression_key = server_key.clone().into_raw_parts().3.unwrap();
@@ -242,9 +242,9 @@ mod test {
         clear_value: StaticUnsignedBigInt<N>,
     ) {
         let config = tfhe::ConfigBuilder::with_custom_parameters(
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+            PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         )
-        .enable_compression(COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64)
+        .enable_compression(COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
         .build();
         let (client_key, server_key) = generate_keys(config);
         let (_, _, compression_key, decompression_key, _, _, _, _, _) =
@@ -270,9 +270,9 @@ mod test {
     fn test_bool() {
         let clear_value = true;
         let config = tfhe::ConfigBuilder::with_custom_parameters(
-            PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64,
+            PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128,
         )
-        .enable_compression(COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64)
+        .enable_compression(COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
         .build();
         let (client_key, server_key) = generate_keys(config);
         let compression_key = server_key.clone().into_raw_parts().2;
@@ -302,8 +302,8 @@ mod test {
     #[test]
     fn test_full_chain_client_copro_kms_uint8(#[case] default_config: bool) {
         let config = if default_config {
-            ConfigBuilder::with_custom_parameters(PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64)
-                .enable_compression(COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64)
+            ConfigBuilder::with_custom_parameters(PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
+                .enable_compression(COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
                 .build()
         } else {
             let params = PARAMS_TEST_BK_SNS;

--- a/core/service/src/engine/centralized/central_kms.rs
+++ b/core/service/src/engine/centralized/central_kms.rs
@@ -274,7 +274,7 @@ pub(crate) fn generate_fhe_keys(
         tag,
     )?;
 
-    let (public_key, server_key) = compressed_keyset.decompress()?.into_raw_parts();
+    let (public_key, server_key) = compressed_keyset.decompress().into_raw_parts();
     let (_, _, _, decompression_key, _, _, _, _, _) = server_key.into_raw_parts();
 
     let handles = KmsFheKeyHandles::new_compressed(
@@ -1404,14 +1404,9 @@ pub(crate) mod tests {
             _ => panic!("Expected Current variant of KeyGenMetadata"),
         }
 
-        // Verify the compressed keyset can be decompressed
-        let decompressed = compressed_keyset.decompress();
-        assert!(
-            decompressed.is_ok(),
-            "Compressed keyset should be decompressible"
-        );
-
-        let (_pk, server_key) = decompressed.unwrap().into_raw_parts();
+        // Verify the compressed keyset can be decompressed. `decompress` is infallible since
+        // tfhe 1.7.0, so this only asserts it does not panic.
+        let (_pk, server_key) = compressed_keyset.decompress().into_raw_parts();
         let (_, _, _, _, _, _, _, oprf_key, _) = server_key.into_raw_parts();
         assert!(
             oprf_key.is_some(),

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -469,7 +469,7 @@ pub(crate) mod tests {
                 .await
                 .unwrap()
         };
-        let (pk, key) = compressed_keyset.decompress().unwrap().into_raw_parts();
+        let (pk, key) = compressed_keyset.decompress().into_raw_parts();
         tfhe::set_server_key(key);
 
         (kms, pk, verf_key)

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -712,13 +712,7 @@ impl<
                     // from the newly generated compressed keyset. Revisit whether it should
                     // instead preserve the old keyset's CompactPublicKey to keep the
                     // externally visible public key stable across epochs of the same key_id.
-                    let compact_public_key = compressed_keyset
-                        .decompress()
-                        .map_err(|e| {
-                            anyhow::anyhow!("Failed to decompress reshared compressed keyset: {e}")
-                        })?
-                        .into_raw_parts()
-                        .0;
+                    let compact_public_key = compressed_keyset.decompress().into_raw_parts().0;
 
                     let info = match compute_info_compressed_keygen(
                         sk,

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -1627,21 +1627,7 @@ impl<
                 // derived from the newly generated compressed keyset.
                 let compact_public_key = match existing_compact_pk {
                     Some(old_pk) => old_pk,
-                    None => match compressed_keyset.decompress() {
-                        Ok(ks) => ks.into_raw_parts().0,
-                        Err(e) => {
-                            let _ = update_err_req_in_meta_store(
-                                &meta_store,
-                                meta_permit,
-                                format!(
-                                    "Failed to decompress freshly generated compressed keyset: {e}"
-                                ),
-                                op_tag,
-                            )
-                            .await;
-                            return;
-                        }
-                    },
+                    None => compressed_keyset.decompress().into_raw_parts().0,
                 };
 
                 // Compute info for compressed keygen

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -339,10 +339,7 @@ impl ThresholdFheKeys {
                 decompression_key: decompression_key.clone(),
             },
             PublicKeyMaterial::Compressed { keyset } => {
-                let (_pk, sk) = keyset
-                    .decompress()
-                    .expect("Call is infallible")
-                    .into_raw_parts();
+                let (_pk, sk) = keyset.decompress().into_raw_parts();
                 let (isk, _, _, decompk, snsk, _, _, _, _) = sk.into_raw_parts();
                 UncompressedKeys {
                     integer_server_key: Arc::new(isk),

--- a/core/service/src/engine/utils.rs
+++ b/core/service/src/engine/utils.rs
@@ -1363,12 +1363,7 @@ mod tests {
             tag,
         )
         .unwrap();
-        let compact_public_key = compressed_keyset
-            .clone()
-            .decompress()
-            .unwrap()
-            .into_raw_parts()
-            .0;
+        let compact_public_key = compressed_keyset.clone().decompress().into_raw_parts().0;
 
         let compressed_keyset_digest =
             hash_versioned(&crate::engine::base::DSEP_PUBDATA_KEY, &compressed_keyset).unwrap();

--- a/core/service/src/testing/utils.rs
+++ b/core/service/src/testing/utils.rs
@@ -348,10 +348,7 @@ pub async fn compute_cipher_from_stored_key(
             storage_prefix,
         )
         .await;
-        compressed_keyset
-            .decompress()
-            .expect("decompress of CompressedXofKeySet is infallible")
-            .into_raw_parts()
+        compressed_keyset.decompress().into_raw_parts()
     } else if probe.data_exists(key_id, &public_key_type).await.unwrap() {
         let pk = load_pk_from_pub_storage(pub_path, key_id, storage_prefix).await;
         let server_key: ServerKey = load_material_from_pub_storage(

--- a/core/service/src/util/key_setup/mod.rs
+++ b/core/service/src/util/key_setup/mod.rs
@@ -1104,13 +1104,7 @@ where
 
     // Derive the CompactPublicKey from the compressed keyset once; store and sign it
     // along with the compressed keyset for each party.
-    let compact_public_key = match compressed_keyset.decompress() {
-        Ok(ks) => ks.into_raw_parts().0,
-        Err(e) => {
-            tracing::error!("Failed to decompress compressed keyset: {}", e);
-            return false;
-        }
-    };
+    let compact_public_key = compressed_keyset.decompress().into_raw_parts().0;
 
     // Hash the compact public key once; reuse per party.
     let public_key_digest = match hash_versioned(&DSEP_PUBDATA_KEY, &compact_public_key) {

--- a/core/service/src/util/key_setup/test_tools.rs
+++ b/core/service/src/util/key_setup/test_tools.rs
@@ -353,10 +353,7 @@ pub async fn compute_cipher_from_stored_key(
             storage_prefix,
         )
         .await;
-        xof_keyset
-            .decompress()
-            .expect("decompress of CompressedXofKeySet is infallible")
-            .into_raw_parts()
+        xof_keyset.decompress().into_raw_parts()
     } else if probe.data_exists(key_id, &public_key_type).await.unwrap() {
         let pk = load_pk_from_pub_storage(pub_path, key_id, storage_prefix).await;
         let server_key: ServerKey = load_material_from_pub_storage(

--- a/core/threshold-execution/src/endpoints/keygen.rs
+++ b/core/threshold-execution/src/endpoints/keygen.rs
@@ -154,7 +154,7 @@ pub trait OnlineDistributedKeyGen<Z, const EXTENSION_DEGREE: usize>: Send + Sync
     {
         let (pub_key_set, priv_key_set) =
             Self::compressed_keygen(session, preprocessing, params, tag).await?;
-        let (public_key, server_key) = pub_key_set.decompress()?.into_raw_parts();
+        let (public_key, server_key) = pub_key_set.decompress().into_raw_parts();
         Ok((
             FhePubKeySet {
                 public_key,
@@ -190,7 +190,7 @@ pub trait OnlineDistributedKeyGen<Z, const EXTENSION_DEGREE: usize>: Send + Sync
             existing_private_keyset,
         )
         .await?;
-        let (public_key, server_key) = pub_key_set.decompress()?.into_raw_parts();
+        let (public_key, server_key) = pub_key_set.decompress().into_raw_parts();
         Ok(FhePubKeySet {
             public_key,
             server_key,
@@ -1903,34 +1903,33 @@ pub mod tests {
             assert_ne!(0, dkg_preproc.randoms_len());
 
             let my_role = session.my_role();
-            let (pk, sk) = if compressed_keygen {
-                let (compressed_pk, sk) =
-                    super::SecureOnlineDistributedKeyGen128::<EXTENSION_DEGREE>::compressed_keygen(
-                        &mut session,
-                        &mut dkg_preproc,
-                        params,
-                        tag.clone(),
+            let (pk, sk) =
+                if compressed_keygen {
+                    let (compressed_pk, sk) = super::SecureOnlineDistributedKeyGen128::<
+                        EXTENSION_DEGREE,
+                    >::compressed_keygen(
+                        &mut session, &mut dkg_preproc, params, tag.clone()
                     )
                     .await
                     .unwrap();
-                let (public_key, server_key) = compressed_pk.decompress().unwrap().into_raw_parts();
-                (
-                    FhePubKeySet {
-                        public_key,
-                        server_key,
-                    },
-                    sk,
-                )
-            } else {
-                super::SecureOnlineDistributedKeyGen128::<EXTENSION_DEGREE>::keygen(
-                    &mut session,
-                    &mut dkg_preproc,
-                    params,
-                    tag,
-                )
-                .await
-                .unwrap()
-            };
+                    let (public_key, server_key) = compressed_pk.decompress().into_raw_parts();
+                    (
+                        FhePubKeySet {
+                            public_key,
+                            server_key,
+                        },
+                        sk,
+                    )
+                } else {
+                    super::SecureOnlineDistributedKeyGen128::<EXTENSION_DEGREE>::keygen(
+                        &mut session,
+                        &mut dkg_preproc,
+                        params,
+                        tag,
+                    )
+                    .await
+                    .unwrap()
+                };
 
             // make sure we used up all the preprocessing materials
             assert_eq!(0, dkg_preproc.bits_len());
@@ -1996,34 +1995,33 @@ pub mod tests {
                 })
                 .unwrap_or_default();
 
-            let (pk, sk) = if run_compressed {
-                let (compressed_pk, sk) =
-                    super::SecureOnlineDistributedKeyGen128::<EXTENSION_DEGREE>::compressed_keygen(
-                        &mut session,
-                        &mut dkg_preproc,
-                        params,
-                        tag.clone(),
+            let (pk, sk) =
+                if run_compressed {
+                    let (compressed_pk, sk) = super::SecureOnlineDistributedKeyGen128::<
+                        EXTENSION_DEGREE,
+                    >::compressed_keygen(
+                        &mut session, &mut dkg_preproc, params, tag.clone()
                     )
                     .await
                     .unwrap();
-                let (public_key, server_key) = compressed_pk.decompress().unwrap().into_raw_parts();
-                (
-                    FhePubKeySet {
-                        public_key,
-                        server_key,
-                    },
-                    sk,
-                )
-            } else {
-                super::SecureOnlineDistributedKeyGen128::<EXTENSION_DEGREE>::keygen(
-                    &mut session,
-                    &mut dkg_preproc,
-                    params,
-                    tag,
-                )
-                .await
-                .unwrap()
-            };
+                    let (public_key, server_key) = compressed_pk.decompress().into_raw_parts();
+                    (
+                        FhePubKeySet {
+                            public_key,
+                            server_key,
+                        },
+                        sk,
+                    )
+                } else {
+                    super::SecureOnlineDistributedKeyGen128::<EXTENSION_DEGREE>::keygen(
+                        &mut session,
+                        &mut dkg_preproc,
+                        params,
+                        tag,
+                    )
+                    .await
+                    .unwrap()
+                };
 
             (my_role, pk, sk)
         };
@@ -2456,7 +2454,8 @@ pub mod tests {
         let mut mismatches = 0u64;
         for s in 0u128..NUM_SEEDS {
             let seed = Seed(s);
-            let img = wrong_oprf_server_key.generate_oblivious_pseudo_random(
+            let img = crate::tfhe_internals::test_feature::oprf_single_block(
+                &wrong_oprf_server_key,
                 seed,
                 random_bits_count,
                 &target_shortint_server_key,
@@ -2736,7 +2735,7 @@ pub mod tests {
     fn assert_compressed_xof_keyset_decompression_matches_raw_parts(
         compressed_pk: &tfhe::xof_key_set::CompressedXofKeySet,
     ) {
-        let (public_key, server_key) = compressed_pk.decompress().unwrap().into_raw_parts();
+        let (public_key, server_key) = compressed_pk.decompress().into_raw_parts();
         let decompressed_keyset = FhePubKeySet {
             public_key,
             server_key,
@@ -2815,7 +2814,7 @@ pub mod tests {
                     .await
                     .unwrap();
                 assert_compressed_xof_keyset_decompression_matches_raw_parts(&compressed_pk);
-                let (public_key, server_key) = compressed_pk.decompress().unwrap().into_raw_parts();
+                let (public_key, server_key) = compressed_pk.decompress().into_raw_parts();
                 FhePubKeySet {
                     public_key,
                     server_key,

--- a/core/threshold-execution/src/tfhe_internals/parameters.rs
+++ b/core/threshold-execution/src/tfhe_internals/parameters.rs
@@ -1507,7 +1507,7 @@ impl DkgParamsAvailable {
 pub const BC_PARAMS_SNS: DKGParams = DKGParams {
     dkg_mode: DkgMode::Z128,
     sec: 128,
-    meta: tfhe::shortint::parameters::v1_6::meta::cpu::V1_6_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
+    meta: tfhe::shortint::parameters::v1_7::meta::cpu::V1_7_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     secret_key_deviations: None,
 };
 

--- a/core/threshold-execution/src/tfhe_internals/test_feature.rs
+++ b/core/threshold-execution/src/tfhe_internals/test_feature.rs
@@ -189,22 +189,65 @@ impl KeySet {
     }
 }
 
-/// Derives the seed used by tfhe-rs 1.6.1 to create the modulus-switched
+/// Derives the seed used by tfhe-rs 1.7.0 to create the modulus-switched
 /// PRF input. This mirrors `create_random_from_seed_modulus_switched` in
 /// tfhe-rs so the expected plaintext is computed independently from the
 /// encrypted OPRF path.
+///
+/// Only the single-block layout is mirrored, i.e. one chunk of
+/// `random_bits_count` bits requested with a per-block budget of
+/// `random_bits_count`, which is what [`oprf_single_block`] asks for. The
+/// run-length encoding hashed in for that layout is
+/// `bits_per_block || random_bits_count || 1 block || 1 full block ||
+/// random_bits_count`, where `bits_per_block` is the total usable width of a
+/// block (message + carry + padding bit).
 pub fn oprf_modulus_switched_seed(
     seed: tfhe_csprng::seeders::Seed,
     random_bits_count: u64,
+    bits_per_block: u64,
 ) -> Vec<u8> {
     use sha3::{Digest, Sha3_256};
 
     let mut hasher = Sha3_256::default();
     hasher.update(b"TFHE_PRF");
     hasher.update(seed.0.to_le_bytes());
+    hasher.update(bits_per_block.to_le_bytes());
+    hasher.update(random_bits_count.to_le_bytes());
+    // A single chunk that exactly fills one block: 1 block in total, 1 of them
+    // full, carrying `random_bits_count` bits. No trailing partial block.
+    hasher.update(1u64.to_le_bytes());
     hasher.update(1u64.to_le_bytes());
     hasher.update(random_bits_count.to_le_bytes());
     hasher.finalize().to_vec()
+}
+
+/// Generates a single OPRF block for `seed`, standing in for the
+/// `generate_oblivious_pseudo_random` helper that tfhe-rs removed in 1.7.0.
+///
+/// `random_bits_count` must equal the target server key's message-modulus bit
+/// width, since that is the per-block bit budget the chunked API uses. The
+/// request therefore yields exactly one chunk holding exactly one block.
+pub fn oprf_single_block(
+    oprf_server_key: &tfhe::shortint::oprf::OprfServerKey,
+    seed: tfhe_csprng::seeders::Seed,
+    random_bits_count: u64,
+    target_sks: &tfhe::shortint::ServerKey,
+) -> tfhe::shortint::Ciphertext {
+    assert_eq!(
+        random_bits_count,
+        target_sks.message_modulus.0.ilog2() as u64,
+        "oprf_single_block requires random_bits_count to match the message modulus bit width"
+    );
+    let mut chunks = oprf_server_key.generate_oblivious_pseudo_random_bits_chunks(
+        seed,
+        &[random_bits_count],
+        target_sks,
+    );
+    // One chunk was requested, and `random_bits_count` fills exactly one block.
+    assert_eq!(chunks.len(), 1, "expected exactly one chunk");
+    let mut blocks = chunks.remove(0);
+    assert_eq!(blocks.len(), 1, "expected exactly one block");
+    blocks.remove(0)
 }
 
 /// Plaintext reference for the shortint OPRF — mirrors
@@ -230,7 +273,10 @@ pub fn oprf_expected_plaintext(
     let log_input_p = input_p.ilog2() as usize;
     let log_modulus = polynomial_size.to_blind_rotation_input_modulus_log().0;
 
-    let seed = oprf_modulus_switched_seed(seed, random_bits_count);
+    // Total usable width of a block: message bits + carry bits + the padding bit.
+    let bits_per_block =
+        1 + params.message_modulus().0.ilog2() as u64 + params.carry_modulus().0.ilog2() as u64;
+    let seed = oprf_modulus_switched_seed(seed, random_bits_count, bits_per_block);
     let mut xof = RandomGenerator::<DefaultRandomGenerator>::new(XofSeed::new(seed, *b"PRF_INIT"));
     let mask = (0..lwe_size.to_lwe_dimension().0)
         .map(|_| {
@@ -253,7 +299,7 @@ pub fn oprf_expected_plaintext(
     let plain_prf_input = pt.wrapping_add(1u64 << (u64::BITS as usize - log_input_p - 1))
         >> (u64::BITS as usize - log_input_p);
 
-    tfhe::shortint::oprf::test_utils::cleatext_prf(
+    tfhe::shortint::oprf::test_utils::cleartext_prf(
         plain_prf_input,
         random_bits_count,
         2 * params.carry_modulus().0 * params.message_modulus().0,
@@ -275,7 +321,8 @@ pub fn assert_oprf_matches_plaintext(
 
     for s in 0u128..num_seeds {
         let seed = tfhe_csprng::seeders::Seed(s);
-        let img = oprf_server_key.generate_oblivious_pseudo_random(
+        let img = oprf_single_block(
+            oprf_server_key,
             seed,
             random_bits_count,
             target_shortint_server_key,
@@ -344,7 +391,7 @@ where
         CompressedXofKeySet::generate(config, seed_bytes, security_bits, max_norm_hwt, tag)?;
 
     // Decompress once to get the public keys needed for KeySet / share generation.
-    let (public_key, server_key) = compressed_keyset.decompress()?.into_raw_parts();
+    let (public_key, server_key) = compressed_keyset.decompress().into_raw_parts();
 
     let keyset = KeySet {
         client_key,
@@ -1763,13 +1810,16 @@ mod tests {
                     .await
                     .unwrap();
             // Regenerate a compressed keyset from the existing secret key.
-            let (compressed_b, sk_b) = insecure_initialize_compressed_key_material_from_existing::<
-                _,
-                EXT,
-            >(&mut session, params, tag, &sk_a)
-            .await
-            .unwrap();
-            (session.my_role(), compressed_b, sk_a, sk_b)
+            let (_compressed_b, sk_b) =
+                insecure_initialize_compressed_key_material_from_existing::<_, EXT>(
+                    &mut session,
+                    params,
+                    tag,
+                    &sk_a,
+                )
+                .await
+                .unwrap();
+            (session.my_role(), sk_a, sk_b)
         };
 
         let mut tasks = JoinSet::new();
@@ -1790,13 +1840,6 @@ mod tests {
         }
         assert_eq!(results.len(), num_parties);
 
-        // Every party must end up with a valid, decompressable compressed keyset.
-        for (role, compressed_b, _, _) in &results {
-            compressed_b.decompress().unwrap_or_else(|e| {
-                panic!("party {role} produced an invalid compressed keyset: {e:?}")
-            });
-        }
-
         // Reconstruct the GLWE secret key (Z128) from the original shares and from the re-shared
         // shares and assert they match: the migration must preserve the secret key.
         let mut glwe_a: HashMap<Role, Vec<Share<ResiduePoly<Z128, EXT>>>> = HashMap::new();
@@ -1813,7 +1856,7 @@ mod tests {
             LweSecretKeyShareEnum::Z128(_) => panic!("expected lwe compute shares to be z64"),
         };
 
-        for (role, _, sk_a, sk_b) in &results {
+        for (role, sk_a, sk_b) in &results {
             glwe_a.insert(*role, extract_glwe(sk_a));
             glwe_b.insert(*role, extract_glwe(sk_b));
             lwe_a.insert(*role, extract_lwe(sk_a));

--- a/dylint.toml
+++ b/dylint.toml
@@ -4,7 +4,7 @@ libraries = [
     # The nightly toolchain + components needed to build this library are read
     # from `utils/tfhe-lints/rust-toolchain` in the tfhe-rs repo at the tag
     # below, and auto-installed by rustup on first `cargo dylint --all` run.
-    { git = "https://github.com/zama-ai/tfhe-rs", tag = "tfhe-rs-1.6.2", pattern = "utils/tfhe-lints/lints" },
+    { git = "https://github.com/zama-ai/tfhe-rs", tag = "tfhe-rs-1.7.0", pattern = "utils/tfhe-lints/lints" },
 ]
 
 [non_local_effect_before_error_return]


### PR DESCRIPTION
## Description

This PR upgrades tfhe from v1.6 to v1.7. Consequently the parameters also changed a bit. So this is a breaking change if consumers of the key expects the key to match the v1.6 parameters. The exact change is show here:

```
  ┌─────────────────────┬──────┬──────┐
  │        Field        │ V1_6 │ V1_7 │
  ├─────────────────────┼──────┼──────┤
  │ packing_ks_level    │ 1    │ 2    │
  ├─────────────────────┼──────┼──────┤
  │ packing_ks_base_log │ 61   │ 41   │
  └─────────────────────┴──────┴──────┘
```

On the other hand, it should not affect the other components, or most of the operations we do, this is because 
- public/user decryption still works since the coprocessors must be synchronized on which key to use, thus the KMS will all receive either v1_6 or v1_7 post sns ciphertexts, there will not be a mixture, ciphertext sizes will not change as well
- resharing only depends on the size of the secret key which is unchanged
- preprocessing and keygen will *not* work when different versions of the kms is mixed since the amount of preprocessing materials needed is different. so we need to make sure no keygen happens when the upgrade is still in progress.
- upgrading the software to v1.7 tfhe while keeping the older keys (from a much older version of tfhe) also should not be a problem as tfhe is backward compatible and we do not do any conformance checks against parameters


### Related issue(s)
Closes zama-ai/kms-internal#3157

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
