### PR TITLE
chore: performance testing - stabilize the nightly decrypt rate suite

### DIFF
--- a/ci/perf-testing/PERF_TEST_README.md
+++ b/ci/perf-testing/PERF_TEST_README.md
@@ -23,40 +23,49 @@ file is the source of truth for both public- and user-decrypt rate ladders.
 
 ```toml
 [defaults]              # applied to every rate unless the rate overrides it
-duration = 60           # measurement window, seconds
-pause = 10              # cooldown after each completed measurement
+duration = 30           # measurement window, seconds
+pause = 10              # cooldown after each rate and between its samples
 maxfail = 0             # max failed requests, % of offered
 maxshed = 0             # max shed (rate-limited) requests, % of offered
 pct = 98                # min achieved/target rate, %
+maxp50 = 0              # max median p50, ms (0 = do not check latency)
+maxp99 = 0              # max median p99, ms (0 = do not check latency)
 allowfail = false       # false → a breach fails the run; true → warns only
 
 [scenarios.pdec]
 key = "udec-key-gen"    # task providing the decryption key
 after = ["crs-gen"]     # dependencies for the first rate
 rates = [
-  { rate = 1100 },
-  { rate = 1300, maxfail = 1, maxshed = 1, pct = 90 },
+  { rate = 1300, maxshed = 1, pct = 95, maxp50 = 25, maxp99 = 150 },     # gate
   { rate = 1500, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
+  { rate = 1700, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
 ]
 
 [scenarios.udec]
 key = "udec-key-gen"
 after = ["pdec"]
 rates = [
-  { rate = 2400 },                                              # uses the defaults
-  { rate = 2700, maxfail = 1, maxshed = 1, pct = 95 },          # override some limits
-  { rate = 2750, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
+  { rate = 2300, maxshed = 1, pct = 95, maxp50 = 75, maxp99 = 1500 },    # gate
+  { rate = 2500, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
+  { rate = 2700, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
+  { rate = 2900, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
 ]
 ```
 
-Rules:
+Rules, all enforced by the generator before submit:
 
-- every `rates` entry is an inline table with a `rate` key;
-- anything unspecified falls back to `[defaults]`;
-- `key` names the task that supplies the key ID; `after` is an optional list of
-  dependencies that must run before the first rate of a ladder. The list can be either an Argo DAG task, e.g. `crs-gen`, or an entry from the `scenarios` table, e.g. `pdec`.
+- every `rates` entry is an inline table with a `rate` key.
+- anything unspecified falls back to `[defaults]`.
+- `key` names the task that supplies the key ID.
+- `after` is an optional list of dependencies that must run before the first rate of a ladder.
+  An entry is either an Argo DAG task, such as `crs-gen`, or a name from the `scenarios` table, such as `pdec`.
+  A scenario name resolves to the last rate of that ladder.
+- `maxp50` and `maxp99` come as a pair.
+  Setting one alone is a half-configured gate and the generator rejects it.
+- a rate cannot carry a latency limit while `allowfail = true`.
+  A probe never fails, so the limit could not be enforced.
 
-`keygen`/`crs` are one-shot setup and not configured here.
+`keygen` and `crs` are one-shot setup and not configured here.
 
 To preview the fully-expanded workflow locally:
 
@@ -90,39 +99,135 @@ they produce are real regardless of this setting.
 
 ## Reading the results
 
-The public- and user-decrypt rates, their durations, and their budgets
-are defined in [`perf-scenarios.toml`](perf-scenarios.toml). The Slack report
-labels each result by its target rate, for example `✅ 2400/s`.
+Each rate is a **rung**.
+The rates, their windows and their limits live in [`perf-scenarios.toml`](perf-scenarios.toml).
+The Slack report labels each result by its target rate, for example `✅ 2300/s`.
 
-The budget percentages (`maxfail`, `maxshed`) are shares of *offered* requests,
-not raw counts — `maxshed=25` means "no more than 25% of offered requests were
-shed." The rate percentage (`pct`) is the minimum acceptable ratio of achieved
-rate to target rate.
+The lowest rate of each kind is the **gate**.
+A gate is the highest rate whose latency repeats, so a failure there comes from the code and not from the load the cluster carries.
+Every rate above a gate is a **probe**.
+A probe runs at or past the point where latency collapses, so it reports and warns but never fails the run.
+A probe is the rate that carries `allowfail = true`.
 
-Each scenario lands on one of these outcomes:
+The budget percentages (`maxfail`, `maxshed`) are shares of *offered* requests, not raw counts.
+`maxshed=25` means "no more than 25% of offered requests were shed".
+The rate percentage (`pct`) is the minimum acceptable ratio of achieved rate to target rate.
 
-- **✅ pass** — stayed inside its budget with zero failed, shed, or saturated
-  traffic.
-- **⚠️ warn** — either stayed inside budget but saw *some* failed/shed/saturated
-  traffic, or has `allowfail = true` and exceeded its budget.
-- **❌ fail** — a scenario without `allowfail = true` went outside its budget.
-- **⏭️ skipped** — an earlier scenario failed, so this one didn't run (scenarios
-  run in ascending order and stop climbing once one falls over).
+Every rung so far met its offered rate to within 0.2%, up to 2,800 req/s.
+The budgets catch a collapse.
+Latency degrades first, so the latency limits below are the real check.
+
+### Latency limits
+
+A gate must also hold its median latencies inside `maxp50` and `maxp99`, or the run fails.
+A probe leaves both at 0, which turns the check off.
+Without these limits, a build that meets the offered rate but takes much longer per request counts as a pass.
+
+Each limit is about twice the worst median measured on any run so far.
+A gate therefore fires on a gross regression rather than on how busy the cluster is.
+That margin is deliberate and was bought the hard way.
+The first limits were 2.5x the medians of a single quiet run.
+Both gates then failed run 31800216785, a midday run whose medians were 1.5x to 7x that baseline at identical rate, payload and `max_in_flight`.
+Nothing in the code explained the difference.
+Treat a gate failure as a signal to compare against recent runs at the same time of day before you look for a regression.
+
+The Slack line for a gate shows its limits as `gate=p50=...,p99=...`.
+
+### When the suite stops
+
+Each rung decides whether the next rung runs.
+Any rung stops the suite when it misses its budget.
+A gate also stops the suite when its median p99 passes **3000 ms**.
+A gate that slow means the rates above it measure a system that already collapsed.
+This limit stays above every gate `maxp99`, so a gate reports which limit it broke instead of silently stopping the run.
+The suite reports every rung above a stopped rung as `⏭️ skipped`.
+
+A probe never stops the suite on latency, however slow it gets.
+Above a gate the rungs are not ordered by latency.
+On 2026-08-10 udec 2700 measured a median p99 of 2302 ms.
+Then udec 2750 ran clean at a p50 of 13.87 ms.
+On 2026-08-13 the order was reversed.
+A slow probe therefore says nothing about the rung above it, and a stop there would hide a rate that works.
+
+The gate latency limits are not part of this decision either.
+A gate that breaks its `maxp50` fails the run and still lets the higher rungs measure.
+A red run therefore still shows where the ceiling was.
+
+### Samples
+
+The suite measures each rung three times in the same pod.
+It reports the **median** achieved rate, p50 and p99 over those samples.
+The budget check, the latency limits and the stop decision all run on those medians rather than on one draw.
+One unlucky window no longer decides the run.
+Samples settle for the same `pause` that separates rates.
+
+Slack marks a line that carries medians with `n=3`.
+The per-sample values live in the `samples` block of the rung JSON artifact.
+The request counters on a line (`failed`, `shed`, `saturated`, `completed`, `offered`) belong to the sample that gave the median rate.
+`samples.median_sample` names that sample.
+
+Each median rounds against the rung, never in its favor.
+The two directions are opposite:
+
+- **Achieved rate** uses every sample and takes the *lower* median.
+  An invalid sample counts as 0/s, the worst possible rate, so it can only make the rung look slower.
+- **Latency** uses only the valid samples and takes the *upper* median.
+  An invalid sample records 0 ms, the fastest possible value.
+  It would pull the median down and let a rung pass its latency limit on a measurement that never ran.
+  `samples.valid_samples` gives the count.
+
+For p99 samples of 250 ms, invalid and 900 ms, the gate reads 900 ms and fails.
+It does not read 250 ms and pass.
+When all three samples are valid, both conventions return the middle value.
+Slack marks a rung that has an invalid sample with `bad_samples=N`.
+
+The first sample encrypts the ciphertext and writes it to disk.
+Later samples read that file, which skips the key-set download and the switch-and-squash precompute.
+A repeat costs about the measurement window, not a full setup.
+
+To change the count, pass `-p samples=N` when you submit the Argo workflow by hand.
+`samples=1` gives the old single-measurement behavior.
+The GitHub Actions form does not offer this parameter.
+
+### Outcomes
+
+- **✅ pass** — inside budget, with no failed, shed or saturated traffic.
+- **⚠️ warn** — inside budget but with some failed, shed or saturated traffic, or a probe outside budget.
+  A probe never fails the run.
+- **❌ fail** — a gate that misses its budget, breaks its latency limits, or reports a median p99 above 3000 ms.
+  Such a rung also carries `stopped_climb=p99>3000ms`.
+- **⏭️ skipped** — an earlier rung stopped the suite.
 
 ### Metric glossary
 
 The Slack report and JSON artifacts use these fields.
 
-**Outcome:**
+The rung artifact holds two durations.
+`total_duration_secs` at the top level is the wall time of every sample together.
+`duration` inside `performance_metrics` is the measurement window of one sample.
+
+**Outcome:** `offered`, `completed`, `failed`, `shed` and `saturated` come from the sample that gave the median rate.
+The three percentiles are medians across samples.
+A line can therefore pair `failed=0` with a p99 measured in a different window.
 
 | Metric | Meaning |
 | --- | --- |
 | `offered` | Requests the rate generator scheduled. |
 | `completed` | Requests that collected enough KMS responses. |
-| `failed` | Requests that were sent but didn't collect enough responses in time. |
+| `failed` | Requests the client sent that did not collect enough responses in time. |
 | `shed` | Requests dropped before sending because `max_in_flight` was already reached. |
 | `saturated` | `true` if anything was shed, or the post-run drain timed out with requests still in flight. |
 | `achieved_rate` | `completed / collection_elapsed_seconds`. |
+| `samples.count` | Measurements taken for this rung. |
+| `samples.median_sample` | The sample (1-based) that supplied the reported counters. |
+| `samples.achieved_rate` | Per-sample achieved rates, in submission order. |
+| `samples.p50_ms` / `samples.p95_ms` / `samples.p99_ms` | Per-sample request latency percentiles. |
+| `samples.valid` | Per-sample flag: did that measurement produce a metrics record. |
+| `samples.exit_code` | Per-sample `kms-core-client` exit code. |
+| `samples.valid_samples` | How many of `samples.count` were valid. This is the divisor for the latency medians. |
+| `samples.median_achieved_rate` | Lower median of `samples.achieved_rate` over **all** samples. The budget check uses this value. |
+| `samples.median_p50_ms` / `samples.median_p95_ms` / `samples.median_p99_ms` | Upper medians over the **valid** samples only. The report and the gate use these values. |
+| `samples.records` | The full metrics record of every sample, in submission order. Each record holds its own `network` block, payload throughput and percentiles, plus `sample_number`, `start_epoch` and `end_epoch`. Use these to diagnose one bad sample, or to line a sample up against the `core-cpu-samples.log` artifact. |
 
 **Payload throughput** (protobuf-encoded body only — excludes gRPC/TLS/header
 overhead):

--- a/ci/perf-testing/PERF_TEST_README.md
+++ b/ci/perf-testing/PERF_TEST_README.md
@@ -1,25 +1,20 @@
 # KMS Performance Testing
 
-This is a guide to the **Performance testing** GitHub Actions workflow
-(`.github/workflows/performance-testing.yml`), which you trigger manually from
-the Actions tab ("Run workflow").
+This is a guide to the **Performance testing** GitHub Actions workflow (`.github/workflows/performance-testing.yml`), which you trigger manually from the Actions tab ("Run workflow").
 
-The workflow spins up a real KMS deployment in Kubernetes, runs a suite of perf
-tests against it (keygen, CRS generation, public decrypt, and user decrypt),
-and posts a summary to Slack. This document focuses on user/public decryption rate tests,
-which are the part most people come here to run.
+The workflow spins up a real KMS deployment in Kubernetes, runs a suite of perf tests against it (keygen, CRS generation, public decrypt, and user decrypt), and posts a summary to Slack.
+This document focuses on user/public decryption rate tests, which are the part most people come here to run.
 
 ## Decryption rate tests
 
-The public- and user-decrypt tests offer a fixed number of requests per second
-for a fixed duration, then report whether the KMS kept up. The current CI suite
-uses this to measure how many decryptions per second the deployment can handle.
+The public- and user-decrypt tests offer a fixed number of requests per second for a fixed duration, then report whether the KMS kept up.
+The current CI suite uses this to measure how many decryptions per second the deployment can handle.
 
 ## Managing rate scenarios
 
-The rates to test and their pass/fail limits live in [`perf-scenarios.toml`](perf-scenarios.toml). At submit time
-`generate-perf-workflow.py` expands it into the Argo workflow (filling the `# <<GENERATED:…>>` markers). That TOML
-file is the source of truth for both public- and user-decrypt rate ladders.
+The rates to test and their pass/fail limits live in [`perf-scenarios.toml`](perf-scenarios.toml).
+At submit time `generate-perf-workflow.py` expands it into the Argo workflow (filling the `# <<GENERATED:…>>` markers).
+That TOML file is the source of truth for both public- and user-decrypt rate ladders.
 
 ```toml
 [defaults]              # applied to every rate unless the rate overrides it
@@ -93,9 +88,8 @@ To iterate on the decrypt tests, trigger the workflow with these values:
 | KMS Core image tag | Leave empty (build fills it in) |
 | KMS Core client image tag | Leave empty (build fills it in) |
 
-Note that `FHE parameters` only affects preprocessing and keygen. The decrypt
-scenarios always run with production-size `Default` parameters, so the numbers
-they produce are real regardless of this setting.
+Note that `FHE parameters` only affects preprocessing and keygen.
+The decrypt scenarios always run with production-size `Default` parameters, so the numbers they produce are real regardless of this setting.
 
 ## Reading the results
 
@@ -229,8 +223,7 @@ A line can therefore pair `failed=0` with a p99 measured in a different window.
 | `samples.median_p50_ms` / `samples.median_p95_ms` / `samples.median_p99_ms` | Upper medians over the **valid** samples only. The report and the gate use these values. |
 | `samples.records` | The full metrics record of every sample, in submission order. Each record holds its own `network` block, payload throughput and percentiles, plus `sample_number`, `start_epoch` and `end_epoch`. Use these to diagnose one bad sample, or to line a sample up against the `core-cpu-samples.log` artifact. |
 
-**Payload throughput** (protobuf-encoded body only — excludes gRPC/TLS/header
-overhead):
+**Payload throughput** (protobuf-encoded body only — excludes gRPC/TLS/header overhead):
 
 | Metric | Meaning |
 | --- | --- |
@@ -241,22 +234,17 @@ overhead):
 | `response_payload_mib_per_sec` | Response bytes per second, in MiB/s. |
 | `response_payload_avg_bytes` | Average encoded size of one accepted response. |
 
-The `request_payload_messages` / `response_payload_messages` counters record how
-many payloads went into the corresponding `_bytes` totals.
+The `request_payload_messages` / `response_payload_messages` counters record how many payloads went into the corresponding `_bytes` totals.
 
 ## Reusing Docker image tags
 
-Building images is the slow part of a run. If you just want to re-run the tests
-against images you already built, you can skip the rebuild.
+Building images is the slow part of a run.
+If you just want to re-run the tests against images you already built, you can skip the rebuild.
 
-**Find the tags from a previous run** — a run with `Build new Docker images`
-checked prints them in three places:
+**Find the tags from a previous run** — a run with `Build new Docker images` checked prints them in three places:
 
-- A `KMS PERF IMAGE TAGS` block in the `performance-testing` job log, plus a
-  matching section in the GitHub job summary.
-- Earliest of all, a `KMS DOCKER IMAGE TAG` block from the `docker-build` job's
-  first step, `KMS Docker image tag` — readable while the build is still
-  running.
+- A `KMS PERF IMAGE TAGS` block in the `performance-testing` job log, plus a matching section in the GitHub job summary.
+- Earliest of all, a `KMS DOCKER IMAGE TAG` block from the `docker-build` job's first step, `KMS Docker image tag` — readable while the build is still running.
 - The `Determine image tags` step logs.
 
 Or pull them with `gh` once the run finishes:
@@ -266,8 +254,7 @@ gh run view <run-id> --repo zama-ai/kms --log \
   | rg "KMS DOCKER IMAGE TAG|KMS PERF IMAGE TAGS|KMS Core image tag|KMS Core client image tag"
 ```
 
-If the logs aren't up yet, the tag is usually the first seven characters of the
-run's head commit SHA — but prefer the logged value when you can get it.
+If the logs aren't up yet, the tag is usually the first seven characters of the run's head commit SHA — but prefer the logged value when you can get it.
 
 **Then re-run without building:**
 
@@ -279,16 +266,12 @@ run's head commit SHA — but prefer the logged value when you can get it.
 
 ## Common pitfalls
 
-- **TLS + `threshold` fails fast.** Non-enclave threshold TLS times out during
-  deploy, so the workflow rejects it up front. Use `tls=false`, or switch to
-  `thresholdWithEnclave`.
-- **`kms_chart_version=repository` pulls the chart from a branch.** It uses
-  `KMS chart source ref`, falling back to the "Use workflow from" ref when that's
-  empty.
-- **`build=true` ignores the image-tag fields.** Only fill those in when build is
-  unchecked *and* you know the tags already exist in the registry.
-- **Leave FHE params at `Test`** unless you specifically want production-size
-  preproc/keygen. It doesn't touch the decrypt scenarios either way.
+- **TLS + `threshold` fails fast.** Non-enclave threshold TLS times out during deploy, so the workflow rejects it up front.
+  Use `tls=false`, or switch to `thresholdWithEnclave`.
+- **`kms_chart_version=repository` pulls the chart from a branch.** It uses `KMS chart source ref`, falling back to the "Use workflow from" ref when that's empty.
+- **`build=true` ignores the image-tag fields.** Only fill those in when build is unchecked *and* you know the tags already exist in the registry.
+- **Leave FHE params at `Test`** unless you specifically want production-size preproc/keygen.
+  It doesn't touch the decrypt scenarios either way.
 
 ## Run flow
 
@@ -300,30 +283,23 @@ What the workflow does, end to end:
 4. Verify the required image tags exist in the registry.
 5. Deploy KMS to the `kms-ci` namespace via `ci/scripts/deploy.sh`.
 6. Print a terse `before-perf` placement and network-counter snapshot.
-7. Submit the Argo workflow
-   (`ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml`).
+7. Submit the Argo workflow (`ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml`).
 8. Stream the Argo logs and send the Slack report.
 9. Print terse `after-perf` KMS core pod network-counter deltas in the CI logs.
 
 ## Network diagnostics
 
-Network diagnostics are printed directly in the GitHub Actions log. The output
-is intentionally terse: node placement, KMS core pod placement, and after-run
-`eth0` rx/tx deltas for each running KMS core pod plus a total.
+Network diagnostics are printed directly in the GitHub Actions log.
+The output is intentionally terse: node placement, KMS core pod placement, and after-run `eth0` rx/tx deltas for each running KMS core pod plus a total.
 
-Each decrypt scenario also captures its own `eth0` rx/tx counters *inside* the
-Argo test pod, reported as `net_rx`/`net_tx` in Slack — the outer before/after
-diagnostics only include KMS core pods that are still running when the snapshot
-is taken.
+Each decrypt scenario also captures its own `eth0` rx/tx counters *inside* the Argo test pod, reported as `net_rx`/`net_tx` in Slack — the outer before/after diagnostics only include KMS core pods that are still running when the snapshot is taken.
 
-Pod-level `ethtool` can't see AWS ENA allowance counters; those need a
-privileged node-level probe.
+Pod-level `ethtool` can't see AWS ENA allowance counters; those need a privileged node-level probe.
 
 ## Reference: workflow form fields
 
-The full mapping from each form field to its internal effect. Most runs only
-need the [Quick start](#quick-start) values above; this table is for when you
-need to understand or override something specific.
+The full mapping from each form field to its internal effect.
+Most runs only need the [Quick start](#quick-start) values above; this table is for when you need to understand or override something specific.
 
 | Field | Effect |
 | --- | --- |

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -37,6 +37,10 @@ spec:
       value: "GitHub Actions"
     - name: fhe-params
       value: "Test"
+    # Measurements per rate rung. The reported rate and latencies are medians over
+    # these samples. One sample carries too much run-to-run spread.
+    - name: samples
+      value: "3"
     - name: max-in-flight
       value: "10000"
     - name: data-type
@@ -53,7 +57,11 @@ spec:
     - name: kms-perf
       dag:
         tasks:
+          - name: validate-parameters
+            template: validate-parameters
+
           - name: preproc-key-gen
+            dependencies: ["validate-parameters"]
             template: run-test
             continueOn:
               failed: true
@@ -154,8 +162,32 @@ spec:
                 value: "{{workflow.parameters.job_url}}"
               - name: job_label
                 value: "{{workflow.parameters.job_label}}"
+              - name: samples
+                value: "{{workflow.parameters.samples}}"
               - name: max-in-flight
                 value: "{{workflow.parameters.max-in-flight}}"
+
+    # Checks the workflow parameters that every later template trusts, so a typo fails
+    # once here with a readable message instead of once per rung pod.
+    - name: validate-parameters
+      script:
+        image: public.ecr.aws/docker/library/alpine:3.23
+        command: ["/bin/sh", "-c"]
+        source: |
+          set -e
+          samples="{{workflow.parameters.samples}}"
+          case "$samples" in
+            ''|*[!0-9]*|0)
+              echo "ERROR: samples must be a positive integer, got '${samples}'"
+              exit 1
+              ;;
+          esac
+          # The suite measures every rung `samples` times, so this value multiplies the
+          # whole run. Warn instead of refusing. A long deliberate run is legitimate.
+          if [ "$samples" -gt 10 ]; then
+            echo "WARNING: samples=${samples} multiplies every rung's measurement time; check activeDeadlineSeconds before you rely on this run"
+          fi
+          echo "samples=${samples} accepted"
 
     - name: run-test
       inputs:
@@ -486,7 +518,12 @@ spec:
 
           test_name="${kind}-rate-{{inputs.parameters.rate}}"
           key_id="{{inputs.parameters.key_id}}"
-          test_command="${command_name} from-args -d {{workflow.parameters.data-type}} -k ${key_id} -e ffffffffffffffff --batch-size {{workflow.parameters.batch-size}} --rate {{inputs.parameters.rate}} --duration {{inputs.parameters.duration}} --max-in-flight {{workflow.parameters.max-in-flight}}"
+          rate_args="--batch-size {{workflow.parameters.batch-size}} --rate {{inputs.parameters.rate}} --duration {{inputs.parameters.duration}} --max-in-flight {{workflow.parameters.max-in-flight}}"
+          ciphertext_path="/tmp/${test_name}-ciphertext.bin"
+          test_command="${command_name} from-args -d {{workflow.parameters.data-type}} -k ${key_id} -e ffffffffffffffff --ciphertext-output-path ${ciphertext_path} ${rate_args}"
+          # Repeated samples load the ciphertext the first sample stored, which skips the
+          # key-set download and the SnS precompute that `from-args` redoes every run.
+          reuse_command="${command_name} from-file --input-path ${ciphertext_path} ${rate_args}"
           mkdir -p /tmp/artifacts
 
           capture_net_snapshot() {
@@ -502,6 +539,56 @@ spec:
               tr -d '\n' < "${iface_path}/mtu" >> "$output" 2>/dev/null || printf '0' >> "$output"
               printf '\n' >> "$output"
             done
+          }
+
+          # Prints a top-level numeric field of a metrics JSON object, 0 when absent. The
+          # leading quote keeps "failed" from matching "verification_failed".
+          json_number() {
+            if [[ "$1" =~ \"$2\":([-+0-9.eE]+) ]]; then
+              echo "${BASH_REMATCH[1]}"
+            else
+              echo "0"
+            fi
+          }
+
+          # Prints the lower median of its numeric arguments.
+          median_of() {
+            printf '%s\n' "$@" \
+              | awk '{ printf "%.6f\n", $1 + 0 }' \
+              | sort -n \
+              | awk '{ value[NR] = $1 } END { if (NR == 0) { print "0" } else { print value[int((NR + 1) / 2)] } }'
+          }
+
+          # Prints the upper median of its numeric arguments, or 0 when given none.
+          # Latency rounds up where the rate rounds down. On an even count the pessimistic
+          # value is the lower one for a rate and the higher one for a latency. Both gates
+          # must round against the rung. Unlike `median_of` this takes no arguments when
+          # every sample of a rung is invalid.
+          upper_median_of() {
+            if [ "$#" -eq 0 ]; then
+              echo "0"
+              return
+            fi
+            printf '%s\n' "$@" \
+              | awk '{ printf "%.6f\n", $1 + 0 }' \
+              | sort -n \
+              | awk '{ value[NR] = $1 } END { print value[int(NR / 2) + 1] }'
+          }
+
+          # Prints the 0-based index of the sample holding the median achieved rate.
+          median_sample_index() {
+            local index
+            for index in "${!sample_rate[@]}"; do
+              printf '%.6f %s\n' "${sample_rate[$index]}" "$index"
+            done | sort -n | awk -v position="$(( (${#sample_rate[@]} + 1) / 2 ))" 'NR == position { print $2 }'
+          }
+
+          # Prints the arguments as the body of a JSON array. Callers pass bare JSON
+          # values: numbers, the strings true/false, or whole objects.
+          join_values() {
+            local joined
+            joined="$(printf ',%s' "$@")"
+            echo "${joined#,}"
           }
 
           # Prints a latency_ms percentile of a metrics JSON object, 0 when absent. The
@@ -557,7 +644,7 @@ spec:
           allowed_failure="{{inputs.parameters.allowfail}}"
 
           if [ -z "$key_id" ]; then
-            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "failed",\n  "exit_code": 1,\n  "duration": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": {\n      "target_rate": %s,\n      "failed": 1,\n      "parameter_set": "%s",\n      "within_parameter_set": false,\n      "allowed_failure": %s\n    }\n  }\n}\n' \
+            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "failed",\n  "exit_code": 1,\n  "total_duration_secs": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": {\n      "target_rate": %s,\n      "failed": 1,\n      "parameter_set": "%s",\n      "within_parameter_set": false,\n      "allowed_failure": %s\n    }\n  }\n}\n' \
               "$test_name" \
               "$test_command" \
               "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
@@ -572,7 +659,7 @@ spec:
           fi
 
           if [ "{{inputs.parameters.previous-ok}}" != "true" ]; then
-            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "skipped",\n  "exit_code": 0,\n  "duration": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": {\n      "target_rate": %s,\n      "parameter_set": "%s",\n      "within_parameter_set": false,\n      "allowed_failure": %s\n    }\n  }\n}\n' \
+            printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "skipped",\n  "exit_code": 0,\n  "total_duration_secs": 0,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": {\n      "target_rate": %s,\n      "parameter_set": "%s",\n      "within_parameter_set": false,\n      "allowed_failure": %s\n    }\n  }\n}\n' \
               "$test_name" \
               "$test_command" \
               "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
@@ -586,8 +673,12 @@ spec:
             exit 0
           fi
 
+          # Already validated once by the validate-parameters task at the head of the DAG.
+          samples="{{workflow.parameters.samples}}"
+
           echo "=========================================="
           echo "Starting test: $test_command"
+          echo "Samples: ${samples} (the median sample decides capacity-ok)"
           echo "=========================================="
 
           client_logs_arg=""
@@ -595,73 +686,148 @@ spec:
             client_logs_arg="--logs"
           fi
           rate_timeout=$(({{inputs.parameters.duration}} + 300))
-          capture_net_snapshot /tmp/net-before.tsv
-          start_time=$(date +%s)
-          set +e
-          if command -v timeout >/dev/null 2>&1; then
-            timeout "${rate_timeout}s" ./bin/kms-core-client ${client_logs_arg} --max-iter 2880 -f config.toml $test_command 2>&1 | tee /tmp/test_logs.txt
-          else
-            echo "WARNING: timeout command not found; running without per-rate wall timeout"
-            ./bin/kms-core-client ${client_logs_arg} --max-iter 2880 -f config.toml $test_command 2>&1 | tee /tmp/test_logs.txt
-          fi
-          test_exit=${PIPESTATUS[0]}
-          set -e
-          end_time=$(date +%s)
-          duration=$((end_time - start_time))
-          capture_net_snapshot /tmp/net-after.tsv
 
-          # Keep the last valid metrics line; normal logs may contain many JSON records.
-          decrypt_metrics=""
-          while IFS= read -r metrics_line; do
-            candidate="${metrics_line#*${metrics_marker} }"
-            # Accept only the raw println! JSON, not an escaped copy inside tracing JSON logs.
-            if [[ "$candidate" == \{\"* ]] && [[ "$candidate" =~ \"failed\":[0-9]+ ]] && [[ "$candidate" =~ \"shed\":[0-9]+ ]] && [[ "$candidate" =~ \"saturated\":(true|false) ]]; then
-              decrypt_metrics="$candidate"
+          # Repeat the rung inside this pod: the deploy and the keygen chain are the
+          # expensive part of a run, one more measurement is not. Repeats separate a real
+          # per-request regression from the spread of a single draw.
+          sample_metrics=()
+          sample_valid=()
+          sample_exit=()
+          sample_rate=()
+          sample_p50=()
+          sample_p95=()
+          sample_p99=()
+          total_duration=0
+          for ((sample_number = 1; sample_number <= samples; sample_number++)); do
+            sample_command="$test_command"
+            if [ "$sample_number" -gt 1 ] && [ -s "$ciphertext_path" ]; then
+              sample_command="$reuse_command"
             fi
-          done < <(grep "$metrics_marker " /tmp/test_logs.txt || true)
+            # Settle between samples for the same reason rates settle after themselves. A
+            # rung that collapses leaves a backlog, and the next measurement inherits it.
+            if [ "$sample_number" -gt 1 ]; then
+              sleep "{{inputs.parameters.pause}}"
+            fi
+            echo "------ ${test_name} sample ${sample_number}/${samples} ------"
+            echo "Command: $sample_command"
+            capture_net_snapshot /tmp/net-before.tsv
+            start_time=$(date +%s)
+            # The script runs under `set -e`. A failing client must not abort the pod before
+            # PIPESTATUS is read, because a recorded failure is the measurement.
+            set +e
+            if command -v timeout >/dev/null 2>&1; then
+              timeout "${rate_timeout}s" ./bin/kms-core-client ${client_logs_arg} --max-iter 2880 -f config.toml $sample_command 2>&1 | tee /tmp/test_logs.txt
+            else
+              echo "WARNING: timeout command not found; running without per-rate wall timeout"
+              ./bin/kms-core-client ${client_logs_arg} --max-iter 2880 -f config.toml $sample_command 2>&1 | tee /tmp/test_logs.txt
+            fi
+            test_exit=${PIPESTATUS[0]}
+            set -e
+            end_time=$(date +%s)
+            duration=$((end_time - start_time))
+            total_duration=$((total_duration + duration))
+            capture_net_snapshot /tmp/net-after.tsv
 
-          if [[ -n "$decrypt_metrics" && "$decrypt_metrics" =~ \"failed\":([0-9]+) ]]; then
-            metrics_valid=true
-            metrics_failed="${BASH_REMATCH[1]}"
-            if [[ "$decrypt_metrics" =~ \"shed\":([0-9]+) ]]; then
-              metrics_shed="${BASH_REMATCH[1]}"
+            # Keep the last valid metrics line; normal logs contain many JSON records.
+            decrypt_metrics=""
+            while IFS= read -r metrics_line; do
+              candidate="${metrics_line#*${metrics_marker} }"
+              # Accept only the raw println! JSON, not an escaped copy inside tracing JSON logs.
+              if [[ "$candidate" == \{\"* ]] && [[ "$candidate" =~ \"failed\":[0-9]+ ]] && [[ "$candidate" =~ \"shed\":[0-9]+ ]] && [[ "$candidate" =~ \"saturated\":(true|false) ]]; then
+                decrypt_metrics="$candidate"
+              fi
+            done < <(grep "$metrics_marker " /tmp/test_logs.txt || true)
+
+            if [[ -n "$decrypt_metrics" && "$decrypt_metrics" =~ \"failed\":[0-9]+ ]]; then
+              metrics_valid=true
             else
-              metrics_shed=0
+              metrics_valid=false
+              decrypt_metrics="{\"target_rate\":{{inputs.parameters.rate}},\"failed\":1,\"shed\":0,\"saturated\":true}"
+              echo "ERROR: no valid $metrics_marker JSON with failed/shed/saturated found"
             fi
-            if [[ "$decrypt_metrics" =~ \"saturated\":(true|false) ]]; then
-              metrics_saturated="${BASH_REMATCH[1]}"
-            else
-              metrics_saturated=true
+            # `ci/scripts/sample_core_cpu.sh` records a timestamped CPU series for the run.
+            # To match a slow sample against it, use that sample's window, not the rung's.
+            sample_suffix=",\"sample_number\":${sample_number},\"start_epoch\":${start_time},\"end_epoch\":${end_time}"
+            # Escape the brace; ${var%}} does not trim the final JSON object brace in bash.
+            decrypt_metrics="${decrypt_metrics%\}}$(network_metrics_suffix "$duration")${sample_suffix}}"
+
+            rate_value="$(json_number "$decrypt_metrics" achieved_rate)"
+            p50_value="$(latency_number "$decrypt_metrics" p50)"
+            p95_value="$(latency_number "$decrypt_metrics" p95)"
+            p99_value="$(latency_number "$decrypt_metrics" p99)"
+            sample_metrics+=("$decrypt_metrics")
+            sample_valid+=("$metrics_valid")
+            sample_exit+=("$test_exit")
+            sample_rate+=("$rate_value")
+            sample_p50+=("$p50_value")
+            sample_p95+=("$p95_value")
+            sample_p99+=("$p99_value")
+            echo "sample ${sample_number}/${samples}: exit=${test_exit} valid=${metrics_valid} achieved=${rate_value}/s p50=${p50_value}ms p95=${p95_value}ms p99=${p99_value}ms (${duration}s)"
+          done
+
+          # An invalid sample reports achieved_rate 0, so it sorts to the bottom and cannot
+          # become the median while most samples are valid.
+          median_index="$(median_sample_index)"
+          decrypt_metrics="${sample_metrics[$median_index]}"
+          metrics_valid="${sample_valid[$median_index]}"
+          test_exit="${sample_exit[$median_index]}"
+          median_rate="$(median_of "${sample_rate[@]}")"
+
+          # Latency medians ignore invalid samples. An invalid sample records 0 ms, the
+          # fastest value there is. That value would lower the median and clear the gate on
+          # a sample that never ran. For achieved_rate 0 is the worst value, so the rate
+          # median keeps every sample and stays conservative.
+          valid_p50=()
+          valid_p95=()
+          valid_p99=()
+          for sample_index in "${!sample_valid[@]}"; do
+            if [ "${sample_valid[$sample_index]}" != "true" ]; then
+              continue
             fi
-          else
-            metrics_valid=false
-            metrics_failed=1
-            metrics_shed=0
-            metrics_saturated=true
-            decrypt_metrics="{\"target_rate\":{{inputs.parameters.rate}},\"failed\":1,\"shed\":0,\"saturated\":true}"
-            echo "ERROR: no valid $metrics_marker JSON with failed/shed/saturated found"
+            valid_p50+=("${sample_p50[$sample_index]}")
+            valid_p95+=("${sample_p95[$sample_index]}")
+            valid_p99+=("${sample_p99[$sample_index]}")
+          done
+          valid_samples="${#valid_p99[@]}"
+          metrics_p50="$(upper_median_of "${valid_p50[@]}")"
+          metrics_p95="$(upper_median_of "${valid_p95[@]}")"
+          metrics_p99="$(upper_median_of "${valid_p99[@]}")"
+          echo "median rate over ${samples} samples: achieved=${median_rate}/s (median is sample $((median_index + 1)))"
+          echo "median latencies over ${valid_samples}/${samples} valid samples: p50=${metrics_p50}ms p95=${metrics_p95}ms p99=${metrics_p99}ms"
+
+          metrics_failed="$(json_number "$decrypt_metrics" failed)"
+          metrics_shed="$(json_number "$decrypt_metrics" shed)"
+          metrics_saturated=true
+          if [[ "$decrypt_metrics" =~ \"saturated\":(true|false) ]]; then
+            metrics_saturated="${BASH_REMATCH[1]}"
           fi
-          network_metrics="$(network_metrics_suffix "$duration")"
-          metrics_p50="$(latency_number "$decrypt_metrics" p50)"
-          metrics_p99="$(latency_number "$decrypt_metrics" p99)"
+          samples_metrics=",\"samples\":{\"count\":${samples},\"median_sample\":$((median_index + 1))"
+          samples_metrics="${samples_metrics},\"achieved_rate\":[$(join_values "${sample_rate[@]}")]"
+          samples_metrics="${samples_metrics},\"p50_ms\":[$(join_values "${sample_p50[@]}")]"
+          samples_metrics="${samples_metrics},\"p95_ms\":[$(join_values "${sample_p95[@]}")]"
+          samples_metrics="${samples_metrics},\"p99_ms\":[$(join_values "${sample_p99[@]}")]"
+          # Per-sample validity and exit codes: without them a rung where one sample crashed
+          # the client is indistinguishable from a clean rung in this artifact.
+          samples_metrics="${samples_metrics},\"valid\":[$(join_values "${sample_valid[@]}")]"
+          samples_metrics="${samples_metrics},\"exit_code\":[$(join_values "${sample_exit[@]}")]"
+          # The latency medians use this many samples. The rate median uses all of them.
+          samples_metrics="${samples_metrics},\"valid_samples\":${valid_samples}"
+          samples_metrics="${samples_metrics},\"median_achieved_rate\":${median_rate}"
+          samples_metrics="${samples_metrics},\"median_p50_ms\":${metrics_p50},\"median_p95_ms\":${metrics_p95},\"median_p99_ms\":${metrics_p99}"
+          # Every sample's full record, not only the median one. Each carries its own network
+          # block, payload throughput and verification timings, so this artifact alone
+          # explains a rung that failed on one sample. The arrays above are the quick view.
+          # These records are the evidence.
+          samples_metrics="${samples_metrics},\"records\":[$(join_values "${sample_metrics[@]}")]}"
           maxfail="{{inputs.parameters.maxfail}}"
           maxshed="{{inputs.parameters.maxshed}}"
           pct="{{inputs.parameters.pct}}"
-          if [[ "$decrypt_metrics" =~ \"offered\":([0-9]+) ]]; then
-            metrics_offered="${BASH_REMATCH[1]}"
-          else
-            metrics_offered=0
-          fi
-          if [[ "$decrypt_metrics" =~ \"achieved_rate\":([-0-9.eE]+) ]]; then
-            metrics_achieved_rate="${BASH_REMATCH[1]}"
-          else
-            metrics_achieved_rate=0
-          fi
+          metrics_offered="$(json_number "$decrypt_metrics" offered)"
           within_parameter_set=$(awk \
             -v offered="$metrics_offered" \
             -v failed="$metrics_failed" \
             -v shed="$metrics_shed" \
-            -v achieved="$metrics_achieved_rate" \
+            -v achieved="$median_rate" \
             -v target="{{inputs.parameters.rate}}" \
             -v maxfail="$maxfail" \
             -v maxshed="$maxshed" \
@@ -742,7 +908,7 @@ spec:
           if [ -n "$latency_limits" ]; then
             limit_metrics="${limit_metrics},\"latency_limits\":\"${latency_limits}\",\"within_latency_limits\":${within_latency_limits}"
           fi
-          decrypt_metrics="${decrypt_metrics%\}}${network_metrics}${limit_metrics}}"
+          decrypt_metrics="${decrypt_metrics%\}}${samples_metrics}${limit_metrics}}"
 
           # Task success means "measurement exists"; capacity-ok gates the next rung.
           if [ "$test_exit" -eq 0 ] && [ "$metrics_valid" = "true" ]; then
@@ -759,12 +925,12 @@ spec:
             echo "Not climbing past ${test_name}: status=${status} within_parameter_set=${within_parameter_set} within_climb_limit=${within_climb_limit}"
           fi
 
-          printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "%s",\n  "exit_code": %s,\n  "duration": %s,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": %s\n  }\n}\n' \
+          printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "%s",\n  "exit_code": %s,\n  "total_duration_secs": %s,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": %s\n  }\n}\n' \
             "$test_name" \
             "$test_command" \
             "$status" \
             "$test_exit" \
-            "$duration" \
+            "$total_duration" \
             "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
             "$metrics_key" \
             "$decrypt_metrics" \
@@ -803,6 +969,7 @@ spec:
         - name: run_url
         - name: job_url
         - name: job_label
+        - name: samples
         - name: max-in-flight
       script:
         image: public.ecr.aws/docker/library/alpine:3.23
@@ -834,7 +1001,7 @@ spec:
           echo "Payload: {{workflow.parameters.batch-size}} x {{workflow.parameters.data-type}} per request"
           echo "Preproc/keygen FHE params: {{workflow.parameters.fhe-params}}"
           echo "Decrypt FHE params: Default"
-          echo "Rate durations: per scenario, max in-flight: {{inputs.parameters.max-in-flight}}"
+          echo "Rate durations: per scenario x {{inputs.parameters.samples}} samples per rung (reported rate and latencies are medians), max in-flight: {{inputs.parameters.max-in-flight}}"
           echo ""
 
           keygen_total=0
@@ -981,6 +1148,12 @@ spec:
               latency_limits=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].latency_limits // empty' "$result")
               # `// true` would read a stored false as true, so test for the key instead.
               within_latency_limits=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k] | if has("within_latency_limits") then .within_latency_limits else true end' "$result")
+              samples_count=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].samples.count // empty' "$result")
+              bad_samples=$(jq -r --arg k "$metrics_key" '(.performance_metrics[$k].samples.valid // []) | map(select(. == false)) | length' "$result")
+              median_achieved_rate=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].samples.median_achieved_rate // 0' "$result")
+              median_p50=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].samples.median_p50_ms // 0' "$result")
+              median_p95=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].samples.median_p95_ms // 0' "$result")
+              median_p99=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].samples.median_p99_ms // 0' "$result")
               extra_failed=$(jq -r --arg k "$metrics_key" --arg f "$extra_failed_key" '.performance_metrics[$k][$f] // 0' "$result")
               p50=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].latency_ms.p50 // empty' "$result")
               p95=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].latency_ms.p95 // empty' "$result")
@@ -996,6 +1169,16 @@ spec:
               [ -n "$shed" ] || shed=0
               [ -n "$achieved_rate" ] || achieved_rate=0
               [ -n "$saturated" ] || saturated=false
+              # Report the medians over the rung's samples, so every percentile on a line
+              # means the same thing. The counters stay those of the median sample.
+              samples_note=""
+              if [ -n "$samples_count" ]; then
+                achieved_rate="$median_achieved_rate"
+                p50="$median_p50"
+                p95="$median_p95"
+                p99="$median_p99"
+                samples_note=" n=${samples_count}"
+              fi
               achieved_short="$(fmt_1 "$achieved_rate")"
               p50_short="$(fmt_ms_2 "$p50")"
               p95_short="$(fmt_ms_2 "$p95")"
@@ -1058,6 +1241,11 @@ spec:
                 line="$(status_label "$outcome") ${target_rate}/s outside params achieved=${achieved_short}/s p50=${p50_short} p99=${p99_short}"
               fi
 
+              line="${line}${samples_note}"
+              # A rung can report a healthy median while one of its samples died.
+              if [ -n "$bad_samples" ] && [ "$bad_samples" != "0" ]; then
+                line="${line} bad_samples=${bad_samples}"
+              fi
               # Say which rung ended the ladder, so a run of skips has a stated cause.
               if [ "$within_climb_limit" != "true" ] && [ "$status" != "skipped" ]; then
                 line="${line} stopped_climb=p99>${climb_max_p99}ms"
@@ -1080,7 +1268,7 @@ spec:
 
               echo "$line"
               append_operation_line "$kind" "$line"
-              append_decrypt_raw_line "$kind" "$(status_label "$outcome") rate=${target_rate}/s achieved=${achieved_short}/s completed=${completed}/${offered} failed=${failed_requests} shed=${shed} p50=${p50_short} p95=${p95_short} p99=${p99_short} app_req=$(fmt_1 "$request_payload_mib_per_sec")MiB/s app_resp=$(fmt_1 "$response_payload_mib_per_sec")MiB/s ${timing_label}_avg=$(fmt_ms_2 "$timing_avg") ${timing_label}_p50=$(fmt_ms_2 "$timing_p50") ${timing_label}_p99=$(fmt_ms_2 "$timing_p99") net_rx=${network_rx_short}Gbps net_tx=${network_tx_short}Gbps params=${parameter_set}"
+              append_decrypt_raw_line "$kind" "$(status_label "$outcome") rate=${target_rate}/s achieved=${achieved_short}/s completed=${completed}/${offered} failed=${failed_requests} shed=${shed} p50=${p50_short} p95=${p95_short} p99=${p99_short} app_req=$(fmt_1 "$request_payload_mib_per_sec")MiB/s app_resp=$(fmt_1 "$response_payload_mib_per_sec")MiB/s ${timing_label}_avg=$(fmt_ms_2 "$timing_avg") ${timing_label}_p50=$(fmt_ms_2 "$timing_p50") ${timing_label}_p99=$(fmt_ms_2 "$timing_p99") net_rx=${network_rx_short}Gbps net_tx=${network_tx_short}Gbps params=${parameter_set}${samples_note}"
             done
           }
 

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -367,6 +367,8 @@ spec:
         - name: maxfail
         - name: maxshed
         - name: pct
+        - name: maxp50
+        - name: maxp99
         - name: allowfail
       outputs:
         parameters:
@@ -502,6 +504,17 @@ spec:
             done
           }
 
+          # Prints a latency_ms percentile of a metrics JSON object, 0 when absent. The
+          # latency_ms prefix keeps this off the other percentile blocks in the same object,
+          # such as verification_ms.
+          latency_number() {
+            if [[ "$1" =~ \"latency_ms\":\{[^}]*\"$2\":([-+0-9.eE]+) ]]; then
+              echo "${BASH_REMATCH[1]}"
+            else
+              echo "0"
+            fi
+          }
+
           network_metrics_suffix() {
             local sample_secs="$1"
             awk -F '\t' -v sample_secs="$sample_secs" '
@@ -629,6 +642,8 @@ spec:
             echo "ERROR: no valid $metrics_marker JSON with failed/shed/saturated found"
           fi
           network_metrics="$(network_metrics_suffix "$duration")"
+          metrics_p50="$(latency_number "$decrypt_metrics" p50)"
+          metrics_p99="$(latency_number "$decrypt_metrics" p99)"
           maxfail="{{inputs.parameters.maxfail}}"
           maxshed="{{inputs.parameters.maxshed}}"
           pct="{{inputs.parameters.pct}}"
@@ -662,8 +677,71 @@ spec:
                   print "false"
                 }
               }')
+          # A rung can meet its offered rate and still be slow per request, which the rate
+          # check misses. Only a gating rate sets these bounds. A probe leaves them at 0,
+          # which turns the check off. See perf-scenarios.toml for how they were chosen.
+          max_p50="{{inputs.parameters.maxp50}}"
+          max_p99="{{inputs.parameters.maxp99}}"
+          latency_limits=""
+          within_latency_limits=true
+          if [ "$max_p50" -gt 0 ] && [ "$max_p99" -gt 0 ]; then
+            latency_limits="p50=${max_p50},p99=${max_p99}"
+            # A rung with no valid measurement reports 0 ms, which must not read as fast.
+            within_latency_limits=$(awk \
+              -v p50="$metrics_p50" \
+              -v p99="$metrics_p99" \
+              -v max_p50="$max_p50" \
+              -v max_p99="$max_p99" '
+                BEGIN {
+                  if (p50 <= 0 || p99 <= 0) {
+                    print "false"
+                  } else if (p50 <= max_p50 && p99 <= max_p99) {
+                    print "true"
+                  } else {
+                    print "false"
+                  }
+                }')
+            echo "latency gate: p50=${metrics_p50}ms (limit ${max_p50}ms), p99=${metrics_p99}ms (limit ${max_p99}ms), within=${within_latency_limits}"
+          fi
+
+          # Every rung meets its offered rate, so the rate budget alone would let the
+          # ladder climb forever. Stop a gating rung once its p99 crosses this limit. This
+          # does not replace the gate limit above, which fails the run and still lets the
+          # higher rungs measure. Keep this value above every gate p99 limit. A lower value
+          # fires first, and the run then stops without naming the limit it broke.
+          #
+          # A probe rung never stops the climb on latency. Above a gate the ladder is not
+          # ordered by latency. On 2026-08-10 udec 2700 measured p99 2302ms, and udec 2750
+          # then ran clean at p50 13.87ms. A probe still stops the climb when it misses its
+          # own budget, which is what a real collapse looks like.
+          climb_max_p99_ms=3000
+          within_climb_limit=true
+          if [ "$allowed_failure" != "true" ]; then
+            within_climb_limit=$(awk \
+              -v p99="$metrics_p99" \
+              -v max_p99="$climb_max_p99_ms" '
+                BEGIN {
+                  if (p99 <= 0 || p99 > max_p99) {
+                    print "false"
+                  } else {
+                    print "true"
+                  }
+                }')
+            echo "climb check: p99=${metrics_p99}ms (stop above ${climb_max_p99_ms}ms), continue=${within_climb_limit}"
+          else
+            echo "climb check: skipped, ${test_name} is a probe rung and never stops the climb on latency"
+          fi
+
           # Escape the brace; ${var%}} does not trim the final JSON object brace in bash.
           limit_metrics=",\"parameter_set\":\"${parameter_set}\",\"within_parameter_set\":${within_parameter_set},\"allowed_failure\":${allowed_failure}"
+          # Only a rung the limit applies to records it. The summary reads a missing
+          # `within_climb_limit` as true, so a probe rung never reports `stopped_climb`.
+          if [ "$allowed_failure" != "true" ]; then
+            limit_metrics="${limit_metrics},\"climb_max_p99_ms\":${climb_max_p99_ms},\"within_climb_limit\":${within_climb_limit}"
+          fi
+          if [ -n "$latency_limits" ]; then
+            limit_metrics="${limit_metrics},\"latency_limits\":\"${latency_limits}\",\"within_latency_limits\":${within_latency_limits}"
+          fi
           decrypt_metrics="${decrypt_metrics%\}}${network_metrics}${limit_metrics}}"
 
           # Task success means "measurement exists"; capacity-ok gates the next rung.
@@ -672,10 +750,13 @@ spec:
           else
             status="failed"
           fi
-          if [ "$status" = "passed" ] && [ "$within_parameter_set" = "true" ]; then
+          if [ "$status" = "passed" ] && [ "$within_parameter_set" = "true" ] && [ "$within_climb_limit" = "true" ]; then
             capacity_ok="true"
           else
             capacity_ok="false"
+          fi
+          if [ "$capacity_ok" != "true" ]; then
+            echo "Not climbing past ${test_name}: status=${status} within_parameter_set=${within_parameter_set} within_climb_limit=${within_climb_limit}"
           fi
 
           printf '{\n  "test_name": "%s",\n  "test_command": "%s",\n  "status": "%s",\n  "exit_code": %s,\n  "duration": %s,\n  "timestamp": "%s",\n  "fhe_params": "Default",\n  "performance_metrics": {\n    "%s": %s\n  }\n}\n' \
@@ -894,6 +975,12 @@ spec:
               parameter_set=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].parameter_set // empty' "$result")
               within_parameter_set=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].within_parameter_set // false' "$result")
               allowed_failure=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].allowed_failure // false' "$result")
+              climb_max_p99=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].climb_max_p99_ms // empty' "$result")
+              # `// true` would read a stored false as true, so test for the key instead.
+              within_climb_limit=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k] | if has("within_climb_limit") then .within_climb_limit else true end' "$result")
+              latency_limits=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].latency_limits // empty' "$result")
+              # `// true` would read a stored false as true, so test for the key instead.
+              within_latency_limits=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k] | if has("within_latency_limits") then .within_latency_limits else true end' "$result")
               extra_failed=$(jq -r --arg k "$metrics_key" --arg f "$extra_failed_key" '.performance_metrics[$k][$f] // 0' "$result")
               p50=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].latency_ms.p50 // empty' "$result")
               p95=$(jq -r --arg k "$metrics_key" '.performance_metrics[$k].latency_ms.p95 // empty' "$result")
@@ -916,8 +1003,8 @@ spec:
               network_rx_short="$(fmt_1 "$network_rx_gbps")"
               network_tx_short="$(fmt_1 "$network_tx_gbps")"
 
-              # WARN is accepted-but-degraded. The top rate for each decrypt type
-              # is an exploratory probe and can exceed its parameter set.
+              # WARN means accepted but degraded. The probe rungs above each gate are
+              # exploratory and may exceed their parameter set.
               if [ "$status" = "skipped" ]; then
                 outcome=skipped
                 inc_decrypt_counter "$kind" skipped
@@ -931,6 +1018,26 @@ spec:
                   inc_decrypt_counter "$kind" failed
                 fi
                 line="$(status_label "$outcome") ${target_rate}/s measurement failed"
+              elif [ "$within_parameter_set" = "true" ] && [ "$within_latency_limits" != "true" ]; then
+                # Met its offered rate but was too slow per request.
+                if [ "$allowed_failure" = "true" ]; then
+                  outcome=warned
+                  inc_decrypt_counter "$kind" warned
+                else
+                  outcome=failed
+                  inc_decrypt_counter "$kind" failed
+                fi
+                line="$(status_label "$outcome") ${target_rate}/s over latency limits (${latency_limits}) p50=${p50_short} p99=${p99_short}"
+              elif [ "$within_parameter_set" = "true" ] && [ "$within_climb_limit" != "true" ]; then
+                # Inside its budget but slow enough to end the ladder, so not a clean pass.
+                if [ "$allowed_failure" = "true" ]; then
+                  outcome=warned
+                  inc_decrypt_counter "$kind" warned
+                else
+                  outcome=failed
+                  inc_decrypt_counter "$kind" failed
+                fi
+                line="$(status_label "$outcome") ${target_rate}/s p50=${p50_short} p99=${p99_short}"
               elif [ "$within_parameter_set" = "true" ]; then
                 if [ "$failed_requests" != "0" ] || [ "$shed" != "0" ] || [ "$saturated" = "true" ]; then
                   outcome=warned
@@ -951,6 +1058,13 @@ spec:
                 line="$(status_label "$outcome") ${target_rate}/s outside params achieved=${achieved_short}/s p50=${p50_short} p99=${p99_short}"
               fi
 
+              # Say which rung ended the ladder, so a run of skips has a stated cause.
+              if [ "$within_climb_limit" != "true" ] && [ "$status" != "skipped" ]; then
+                line="${line} stopped_climb=p99>${climb_max_p99}ms"
+              fi
+              if [ -n "$latency_limits" ]; then
+                line="${line} gate=${latency_limits}"
+              fi
               if [ -n "$network_rx_gbps" ] && [ "$network_rx_gbps" != "null" ]; then
                 line="${line} net_rx=${network_rx_short}Gbps net_tx=${network_tx_short}Gbps"
               fi

--- a/ci/perf-testing/generate-perf-workflow.py
+++ b/ci/perf-testing/generate-perf-workflow.py
@@ -28,8 +28,8 @@ import textwrap
 import tomllib
 import unittest
 
-RATE_KEYS = {"rate", "duration", "pause", "maxfail", "maxshed", "pct", "allowfail"}
-DEFAULT_KEYS = {"duration", "pause", "maxfail", "maxshed", "pct", "allowfail"}
+RATE_KEYS = {"rate", "duration", "pause", "maxfail", "maxshed", "pct", "maxp50", "maxp99", "allowfail"}
+DEFAULT_KEYS = {"duration", "pause", "maxfail", "maxshed", "pct", "maxp50", "maxp99", "allowfail"}
 NAME_PATTERN = r"[a-z][a-z0-9_-]*"
 
 
@@ -101,12 +101,18 @@ def load_scenarios(path):
             merged = {**defaults, **entry}
             if not isinstance(merged["rate"], int):
                 die(f"{kind}.rates[{i}].rate must be an int, got {merged['rate']!r}")
-            for k in ("duration", "pause", "maxfail", "maxshed", "pct"):
+            for k in ("duration", "pause", "maxfail", "maxshed", "pct", "maxp50", "maxp99"):
                 v = merged[k]
                 if not isinstance(v, int) or v < 0:
                     die(f"{kind}.rates[{i}].{k} must be a non-negative int, got {v!r}")
             if not isinstance(merged["allowfail"], bool):
                 die(f"{kind}.rates[{i}].allowfail must be a bool, got {merged['allowfail']!r}")
+            # A latency check needs both bounds. One alone is a half-configured gate.
+            if bool(merged["maxp50"]) != bool(merged["maxp99"]):
+                die(f"{kind}.rates[{i}] (rate {merged['rate']}) sets only one of maxp50/maxp99; set both or neither")
+            # A probe never fails, so a latency limit on one could not be enforced.
+            if merged["allowfail"] and (merged["maxp50"] or merged["maxp99"]):
+                die(f"{kind}.rates[{i}] (rate {merged['rate']}) is allowfail with a latency limit; limits only apply to gating rates")
 
             rates.append(merged)
         resolved[kind] = {"key": scen["key"], "after": after, "rates": rates}
@@ -151,6 +157,8 @@ def dag_tasks(kind, scen):
             f'    - {{name: maxfail, value: "{r["maxfail"]}"}}',
             f'    - {{name: maxshed, value: "{r["maxshed"]}"}}',
             f'    - {{name: pct, value: "{r["pct"]}"}}',
+            f'    - {{name: maxp50, value: "{r["maxp50"]}"}}',
+            f'    - {{name: maxp99, value: "{r["maxp99"]}"}}',
             f'    - {{name: allowfail, value: "{allowfail}"}}',
             "",
         ]
@@ -233,6 +241,8 @@ class LoadScenariosTest(unittest.TestCase):
             maxfail = 0
             maxshed = 0
             pct = 98
+            maxp50 = 0
+            maxp99 = 0
             allowfail = false
 
             {scenarios}
@@ -242,6 +252,45 @@ class LoadScenariosTest(unittest.TestCase):
             config.write(contents)
             config.flush()
             return load_scenarios(config.name)
+
+    def test_latency_limits_default_to_off(self):
+        scenarios = self.load(
+            """
+            [scenarios.pdec]
+            key = "udec-key-gen"
+            after = ["crs-gen"]
+            rates = [{ rate = 1100 }]
+            """
+        )
+
+        self.assertEqual(scenarios["pdec"]["rates"][0]["maxp50"], 0)
+        self.assertEqual(scenarios["pdec"]["rates"][0]["maxp99"], 0)
+
+    def test_latency_limit_needs_both_bounds(self):
+        with self.assertRaises(SystemExit) as error:
+            self.load(
+                """
+                [scenarios.pdec]
+                key = "udec-key-gen"
+                after = ["crs-gen"]
+                rates = [{ rate = 1100, maxp50 = 25 }]
+                """
+            )
+
+        self.assertIn("sets only one of maxp50/maxp99", str(error.exception))
+
+    def test_latency_limit_rejected_on_an_allowfail_rate(self):
+        with self.assertRaises(SystemExit) as error:
+            self.load(
+                """
+                [scenarios.pdec]
+                key = "udec-key-gen"
+                after = ["crs-gen"]
+                rates = [{ rate = 1100, maxp50 = 25, maxp99 = 150, allowfail = true }]
+                """
+            )
+
+        self.assertIn("allowfail with a latency limit", str(error.exception))
 
     def test_scenario_dependency_resolves_to_its_terminal_rate(self):
         scenarios = self.load(

--- a/ci/perf-testing/perf-scenarios.toml
+++ b/ci/perf-testing/perf-scenarios.toml
@@ -13,27 +13,33 @@
 
 # Per-rate baseline, applied unless a rate overrides it.
 [defaults]
-duration = 60      # measurement window, seconds
+duration = 30      # measurement window, seconds
 pause = 10         # post-measurement cooldown, seconds (skipped rates don't wait)
 maxfail = 0        # max failed requests, % of offered
 maxshed = 0        # max shed (rate-limited) requests, % of offered
 pct = 98           # min achieved/target rate, %
 allowfail = false  # false → a limit breach fails the run; true → warns only
 
+# The lowest rate of each kind is the gate. It is the highest rate whose latency
+# repeats, so a failure there comes from the code and not from the load the cluster
+# carries. Every rate above a gate is a probe: it runs at or past the point where
+# latency collapses, so it reports and warns but never fails the run.
+
 [scenarios.pdec]
 key = "udec-key-gen"
 after = ["crs-gen"]
 rates = [
-  { rate = 1100 },
-  { rate = 1300, maxfail = 1, maxshed = 1, pct = 90 },
+  { rate = 1300, maxshed = 1, pct = 95 },                                # gate
   { rate = 1500, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
+  { rate = 1700, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
 ]
 
 [scenarios.udec]
 key = "udec-key-gen"                          # task whose request-id becomes each rate's key_id
-after = ["pdec"]                              # extra deps for the first rate (run after pdec)
+after = ["pdec"]                              # extra deps: the whole pdec ladder
 rates = [
-  { rate = 2400 },
-  { rate = 2700, maxfail = 1, maxshed = 1, pct = 95 },
-  { rate = 2750, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
+  { rate = 2300, maxshed = 1, pct = 95 },                                # gate
+  { rate = 2500, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
+  { rate = 2700, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
+  { rate = 2900, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
 ]

--- a/ci/perf-testing/perf-scenarios.toml
+++ b/ci/perf-testing/perf-scenarios.toml
@@ -21,7 +21,7 @@
 # Per-rate baseline, applied unless a rate overrides it.
 [defaults]
 duration = 30      # measurement window, seconds
-pause = 10         # post-measurement cooldown, seconds (skipped rates don't wait)
+pause = 10         # cooldown seconds, after each rate and between its samples
 maxfail = 0        # max failed requests, % of offered
 maxshed = 0        # max shed (rate-limited) requests, % of offered
 pct = 98           # min achieved/target rate, %

--- a/ci/perf-testing/perf-scenarios.toml
+++ b/ci/perf-testing/perf-scenarios.toml
@@ -4,6 +4,13 @@
 # time (see the "Run performance testing" step). Adding/removing a rate = editing a
 # list here; no DAG or summary surgery.
 #
+# Only a gate sets maxp50/maxp99. A probe leaves them at 0, which turns the latency
+# check off. Each limit is about twice the worst median measured on any run so far, so
+# a gate fires on a gross regression and not on how busy the cluster is. Run 30925605278
+# set the first values at 2.5x the medians of one quiet run. Both gates then failed run
+# 31800216785, a midday run 1.5x to 7x slower at the same rate and payload. Read both
+# runs before you tighten these.
+#
 # Rules (enforced by the generator, which fails before submit on any breach):
 #   - every `rates` entry MUST be an inline table with a `rate` key (a bare int is rejected);
 #   - unknown keys are rejected (typo protection);
@@ -18,6 +25,8 @@ pause = 10         # post-measurement cooldown, seconds (skipped rates don't wai
 maxfail = 0        # max failed requests, % of offered
 maxshed = 0        # max shed (rate-limited) requests, % of offered
 pct = 98           # min achieved/target rate, %
+maxp50 = 0         # max median p50, ms (0 = do not check latency)
+maxp99 = 0         # max median p99, ms (0 = do not check latency)
 allowfail = false  # false → a limit breach fails the run; true → warns only
 
 # The lowest rate of each kind is the gate. It is the highest rate whose latency
@@ -29,7 +38,7 @@ allowfail = false  # false → a limit breach fails the run; true → warns only
 key = "udec-key-gen"
 after = ["crs-gen"]
 rates = [
-  { rate = 1300, maxshed = 1, pct = 95 },                                # gate
+  { rate = 1300, maxshed = 1, pct = 95, maxp50 = 25, maxp99 = 150 },     # gate
   { rate = 1500, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
   { rate = 1700, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
 ]
@@ -38,7 +47,7 @@ rates = [
 key = "udec-key-gen"                          # task whose request-id becomes each rate's key_id
 after = ["pdec"]                              # extra deps: the whole pdec ladder
 rates = [
-  { rate = 2300, maxshed = 1, pct = 95 },                                # gate
+  { rate = 2300, maxshed = 1, pct = 95, maxp50 = 75, maxp99 = 1500 },    # gate
   { rate = 2500, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
   { rate = 2700, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
   { rate = 2900, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },


### PR DESCRIPTION
## Description

This PR changes the rungs used in the performance-testing workflow and adds 3 repetitions to every benchmark run.
We also change the gate that makes the workflow pass or fail. The gate gives an indication of build quality, while higher hungs tell us more about infra / hardware fluctutations.


### Rungs

| kind | rungs (dec/s) | gate |
| --- | --- | --- |
| public decrypt | 1300, 1500, 1700 | 1300 |
| user decrypt | 2300, 2500, 2700, 2900 | 2300 |

The gate is the lowest rung of each kind, at `maxfail=0,maxshed=1,pct=95`. It is the highest rate whose latency repeats, and the only rung that can fail the run. Every rung above a gate is a probe at `10/25/70` with `allowfail = true`, measured and reported but never fatal. pdec 1100 is dropped: it has always been safe, and 1300 is the rung the run gates on.

Every rung meets its offered rate to within 0.2%, up to 2800, so the rate budgets catch only a collapse. Latency degrades first, and that is what the gates and the climb rule check.

### Where the configuration lives

This builds on #707. The rates and their limits are entries in `ci/perf-testing/perf-scenarios.toml`, and `generate-perf-workflow.py` expands them into the workflow at submit time.

`maxp50` and `maxp99` are new: the median latency bounds for a gate. A probe leaves both at 0, which turns the check off. The generator rejects one bound alone, and rejects a latency limit on an `allowfail` rate that could never enforce it. `--self-test` covers both.

`duration` stays at 30 s, not the 60 s default that #707 added. The limits below come from 30-second windows, and a longer window shifts the tail.

### Three samples per rung

Each rung runs the rate test `samples` times, 3 by default, in its own pod. It settles for `pause` between samples and after the rung. The reported rate and percentiles are medians. Repeats read the ciphertext the first sample wrote, which skips the key-set download and the SnS precompute.

Both medians round against the rung, in opposite directions:

- the **rate** takes the lower median over every sample. An invalid sample records 0/s, the worst rate there is.
- the **latencies** take the upper median over the valid samples only. An invalid sample records 0 ms, the fastest value there is, and would otherwise clear the gate on a measurement that never ran. `samples.valid_samples` records the divisor.

The artifact keeps a `samples` block: per-sample rates, latencies, validity flags and exit codes. `samples.records` adds every sample's full record, stamped with its own window. One bad sample can therefore be diagnosed from the artifact and matched against `core-cpu-samples.log`. The report marks medians `n=3`, gate rungs `gate=p50=…,p99=…`, and a healthy median hiding an invalid sample `bad_samples=N`.

The `samples` parameter is validated once at the head of the DAG, not per rung pod. The artifact's top-level duration becomes `total_duration_secs`, because it now sums the samples.

## Latency limits on the gates

| rung | median p50 | median p99 |
| --- | ---: | ---: |
| pdec 1300 | ≤ 25 ms | ≤ 150 ms |
| udec 2300 | ≤ 75 ms | ≤ 1500 ms |

A gate that meets its rate but breaks a limit fails the run. It does not stop the ladder, so a red run still shows where the ceiling was.

Each limit is about twice the worst median across six observations: run 30925605278, four `main` nightlies of 2026-08-10 to 08-13, and run 31800216785. The first values were 2.5x the medians of one quiet run. Both gates then failed 31800216785, a midday run 1.5x to 7x slower at identical rate and payload. Nothing in the code explained it. Read a gate failure as a signal to compare against recent runs at the same time of day first.

The p50 limit carries most of the detection value. Across the four nightlies the pdec p50 bands do not overlap at all: 7.95–8.33, 8.89–9.02 and 10.36–12.93 ms. The p99 bands overlap completely, and pdec 1100 reached 113.56 ms one night.

udec 2500 is not a gate. Its three samples returned p99 223 ms, 749 ms and 8277 ms, one after a collapse to 1083/s. No limit there is both meaningful and stable.

### Climb rule

A rung stops the ladder when it misses its budget. A gate also stops it when the median p99 passes 3000 ms, and the report marks it `stopped_climb=p99>3000ms`. Everything above a stopped rung is `⏭️ skipped`. The 3000 ms value stays above every gate `maxp99`, so a gate names the limit it broke instead of stopping the run silently.

A probe never stops the ladder on latency, however slow it gets. Above a gate the rungs are not ordered by latency. On 2026-08-10 udec 2700 measured a median p99 of 2302 ms, and udec 2750 then ran clean at p50 13.87 ms. On 2026-08-13 the order was reversed. A probe still stops the ladder by missing its own budget, which is what a real collapse looks like.

### Worth watching after the first nightly

- Whether the raised limits hold. All six observations pass with at least 43% headroom. The tightest is udec p99 at 57% of its limit.
- Wall time. 21 measurements at 30 s plus pauses take about 14 min, against 5.7 min for the six single-sample rungs before this change.
- pdec 1700 is new and collapses hard under load: 412/s of 1700 offered, 24501 shed on 31800216785. It only warns, but it runs immediately before the udec gate.

`ci/perf-testing/PERF_TEST_README.md` documents the rungs, samples, limits and the climb rule.

### Related issue(s)
https://github.com/zama-ai/kms-internal/issues/3161

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

