### PR TITLE
feat: sync public decrypt endpoint

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -147,10 +147,11 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   and persists a fresh OPRF share for such legacy material before regenerating
   public keys.
 - **Decryption** — `PublicDecrypt` (returns plaintext) and `UserDecrypt`
-  (user-initiated, EIP-712 authenticated). `UserDecryptSync` starts a user
-  decryption and waits for its result in the same call, so the caller does not
-  need `GetUserDecryptionResult`; a known `request_id` attaches to the running or
-  succeeded attempt, and redoes a failed one, just like `UserDecrypt`.
+  (user-initiated, EIP-712 authenticated). `PublicDecryptSync` / `UserDecryptSync`
+  start a decryption and wait for its result in the same call, so the caller does
+  not need the `Get*DecryptionResult` round trip; a known `request_id` attaches to
+  the running or succeeded attempt, and redoes a failed one, just like the async
+  variants.
 - **CRS** — `CrsGen` for ZK-proof common reference strings.
 - **Resharing** — `NewMpcEpoch` with `previous_epoch` set rotates parties /
   refreshes secret shares as part of epoch creation; the outcome is fetched

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -359,21 +359,54 @@ async fn collect_decrypt_responses<Resp: Send + 'static>(
     Ok((resp_response_vec, collect_duration))
 }
 
-#[expect(clippy::too_many_arguments)]
-async fn send_and_collect_public_decrypt(
-    rate: u64,
-    req_id: RequestId,
-    dec_req: PublicDecryptionRequest,
-    core_endpoints_req: CoreEndpointClients,
-    core_endpoints_resp: CoreEndpointClients,
-    num_parties: usize,
+/// Fan out the request to the sync endpoint, which returns the decryption result directly.
+fn spawn_public_decrypt_sync(
+    dec_req: &PublicDecryptionRequest,
+    core_endpoints: &CoreEndpointClients,
     max_iter: usize,
-    num_expected_responses: usize,
-) -> anyhow::Result<CollectedPublicDecrypt> {
-    let request_start = Instant::now();
+) -> JoinSet<anyhow::Result<PublicDecryptionResponse>> {
+    let mut resp_tasks = JoinSet::new();
+    for ce in core_endpoints.iter() {
+        let req_cloned = dec_req.clone();
+        let mut cur_client = ce.clone();
+        resp_tasks.spawn(async move {
+            let mut response = cur_client
+                .public_decrypt_sync(tonic::Request::new(req_cloned.clone()))
+                .await;
+            let mut ctr = 0_usize;
+            while response.is_err()
+                && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
+            {
+                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                if ctr >= max_iter {
+                    anyhow::bail!(
+                        "timeout while waiting for sync public decryption after {max_iter} retries."
+                    );
+                }
+                ctr += 1;
+                // Re-sending the same request attaches to the in-flight
+                // decryption instead of starting a new one.
+                response = cur_client
+                    .public_decrypt_sync(tonic::Request::new(req_cloned.clone()))
+                    .await;
+            }
+            let resp =
+                response.map_err(|e| anyhow::anyhow!("sync public decryption failed: {e}"))?;
+            Ok(resp.into_inner())
+        });
+    }
+    resp_tasks
+}
 
+/// Fan out the request to the async endpoint and check that enough cores accepted it.
+async fn send_public_decrypt_requests(
+    dec_req: &PublicDecryptionRequest,
+    core_endpoints: &CoreEndpointClients,
+    num_parties: usize,
+    num_expected_responses: usize,
+) -> anyhow::Result<()> {
     let mut req_tasks = JoinSet::new();
-    for ce in core_endpoints_req.iter() {
+    for ce in core_endpoints.iter() {
         let req_cloned = dec_req.clone();
         let mut cur_client = ce.clone();
         req_tasks.spawn(async move {
@@ -383,10 +416,10 @@ async fn send_and_collect_public_decrypt(
         });
     }
 
-    let mut req_response_vec = Vec::with_capacity(core_endpoints_req.len());
+    let mut succeeded = 0_usize;
     while let Some(inner) = req_tasks.join_next().await {
         match inner {
-            Ok(Ok(resp)) => req_response_vec.push(resp.into_inner()),
+            Ok(Ok(_resp)) => succeeded += 1,
             Ok(Err(e)) => {
                 tracing::debug!("Public decrypt request to a core failed: {e}");
             }
@@ -395,17 +428,22 @@ async fn send_and_collect_public_decrypt(
             }
         }
     }
-    if req_response_vec.len() < num_expected_responses {
+    if succeeded < num_expected_responses {
         anyhow::bail!(
-            "Only {}/{} public decrypt requests succeeded, need at least {}",
-            req_response_vec.len(),
-            num_parties,
-            num_expected_responses
+            "Only {succeeded}/{num_parties} public decrypt requests succeeded, need at least {num_expected_responses}"
         );
     }
+    Ok(())
+}
 
+/// Poll the async endpoint until every core has a decryption result available.
+fn spawn_get_public_decrypt_result(
+    req_id: RequestId,
+    core_endpoints: &CoreEndpointClients,
+    max_iter: usize,
+) -> JoinSet<anyhow::Result<PublicDecryptionResponse>> {
     let mut resp_tasks = JoinSet::new();
-    for ce in core_endpoints_resp.iter() {
+    for ce in core_endpoints.iter() {
         let mut cur_client = ce.clone();
         resp_tasks.spawn(async move {
             let mut response = cur_client
@@ -431,9 +469,40 @@ async fn send_and_collect_public_decrypt(
             Ok(resp.into_inner())
         });
     }
+    resp_tasks
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn send_and_collect_public_decrypt(
+    rate: u64,
+    req_id: RequestId,
+    dec_req: PublicDecryptionRequest,
+    core_endpoints_req: CoreEndpointClients,
+    core_endpoints_resp: CoreEndpointClients,
+    num_parties: usize,
+    max_iter: usize,
+    num_expected_responses: usize,
+    use_sync_endpoint: bool,
+) -> anyhow::Result<CollectedPublicDecrypt> {
+    let request_start = Instant::now();
+
+    let (label, resp_tasks) = if use_sync_endpoint {
+        let tasks = spawn_public_decrypt_sync(&dec_req, &core_endpoints_req, max_iter);
+        ("sync public decrypt", tasks)
+    } else {
+        send_public_decrypt_requests(
+            &dec_req,
+            &core_endpoints_req,
+            num_parties,
+            num_expected_responses,
+        )
+        .await?;
+        let tasks = spawn_get_public_decrypt_result(req_id, &core_endpoints_resp, max_iter);
+        ("public decrypt", tasks)
+    };
 
     let (resp_response_vec, collect_duration) = collect_decrypt_responses(
-        "public decrypt",
+        label,
         rate,
         request_start,
         resp_tasks,
@@ -511,6 +580,7 @@ pub(crate) async fn do_public_decrypt_once<R: Rng + CryptoRng>(
     max_iter: usize,
     num_expected_responses: usize,
     domain: Eip712Domain,
+    use_sync_endpoint: bool,
 ) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
     let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
     let core_endpoints_req = endpoint_clients(core_endpoints_req);
@@ -536,6 +606,7 @@ pub(crate) async fn do_public_decrypt_once<R: Rng + CryptoRng>(
         num_parties,
         max_iter,
         num_expected_responses,
+        use_sync_endpoint,
     )
     .await?;
     let collect_duration = collected.collect_duration;
@@ -582,6 +653,7 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
     max_iter: usize,
     num_expected_responses: usize,
     domain: Eip712Domain,
+    use_sync_endpoint: bool,
 ) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
     let total_requests = (rate * duration_secs) as usize;
     let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
@@ -629,6 +701,7 @@ pub(crate) async fn do_public_decrypt<R: Rng + CryptoRng>(
                 num_parties,
                 max_iter,
                 num_expected_responses,
+                use_sync_endpoint,
             )
         },
     )

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -741,7 +741,7 @@ pub struct DecryptParameters {
     /// Optionally dump the ciphertext to a file.
     #[clap(long)]
     pub ciphertext_output_path: Option<PathBuf>,
-    /// Whether to use the synchronous endpoint. Currently only supported for `user-decrypt`.
+    /// Whether to use the synchronous endpoint (request and result in a single call).
     #[clap(long, default_value_t = false)]
     pub sync: bool,
     #[clap(flatten)]
@@ -785,7 +785,7 @@ pub struct DecryptFile {
     /// Number of copies of the ciphertext to process in a single request.
     #[clap(long, short = 'b', default_value_t = 1)]
     pub batch_size: usize,
-    /// Whether to use the synchronous endpoint. Currently only supported for `user-decrypt`.
+    /// Whether to use the synchronous endpoint (request and result in a single call).
     #[clap(long, default_value_t = false)]
     pub sync: bool,
     #[clap(flatten)]
@@ -1983,11 +1983,6 @@ pub async fn execute_cmd(
     let res = match command {
         CCCommand::PublicDecrypt(cipher_args) => {
             validate_decrypt_rate_args(cipher_args)?;
-            if cipher_args.get_sync() {
-                return Err(
-                    anyhow::anyhow!("--sync is not yet supported for public-decrypt").into(),
-                );
-            }
             let internal_client = Arc::new(RwLock::new(internal_client.unwrap()));
             let num_expected_responses = if expect_all_responses {
                 num_parties
@@ -2070,6 +2065,7 @@ pub async fn execute_cmd(
                         max_iter,
                         num_expected_responses,
                         cc_conf.default_domain()?,
+                        cipher_args.get_sync(),
                     )
                     .await?
                 }
@@ -2089,6 +2085,7 @@ pub async fn execute_cmd(
                         max_iter,
                         num_expected_responses,
                         cc_conf.default_domain()?,
+                        cipher_args.get_sync(),
                     )
                     .await?
                 }
@@ -3036,6 +3033,45 @@ mod tests {
         .unwrap();
         let CCCommand::UserDecrypt(args) = conf.command else {
             panic!("expected a user-decrypt command");
+        };
+        assert!(args.get_sync());
+    }
+
+    #[test]
+    fn test_public_decrypt_sync_flag() {
+        // `--sync` is off by default and enabled by the flag
+        let conf = CmdConfig::try_parse_from([
+            "core-client",
+            "public-decrypt",
+            "from-args",
+            "--to-encrypt",
+            "0x1",
+            "--data-type",
+            "ebool",
+            "--key-id",
+            "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+        ])
+        .unwrap();
+        let CCCommand::PublicDecrypt(args) = conf.command else {
+            panic!("expected a public-decrypt command");
+        };
+        assert!(!args.get_sync());
+
+        let conf = CmdConfig::try_parse_from([
+            "core-client",
+            "public-decrypt",
+            "from-args",
+            "--to-encrypt",
+            "0x1",
+            "--data-type",
+            "ebool",
+            "--key-id",
+            "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+            "--sync",
+        ])
+        .unwrap();
+        let CCCommand::PublicDecrypt(args) = conf.command else {
+            panic!("expected a public-decrypt command");
         };
         assert!(args.get_sync());
     }

--- a/core-client/tests/integration/integration_test.rs
+++ b/core-client/tests/integration/integration_test.rs
@@ -1186,6 +1186,11 @@ async fn integration_test_commands(
             sync: true,
             ..ucp("0x1", FheType::Ebool, 1, false, true)
         })),
+        // Same public decryption through the synchronous endpoint (single round trip)
+        CCCommand::PublicDecrypt(DecryptArguments::FromArgs(DecryptParameters {
+            sync: true,
+            ..pdp("0x1", FheType::Ebool, 1, false, true)
+        })),
         CCCommand::PublicDecrypt(DecryptArguments::FromArgs(pdp(
             "0x6F",
             FheType::Euint8,

--- a/core/grpc/proto/kms-service-insecure.v1.proto
+++ b/core/grpc/proto/kms-service-insecure.v1.proto
@@ -48,6 +48,8 @@ service CoreServiceEndpoint {
 
   rpc GetPublicDecryptionResult(kms.v1.RequestId) returns (kms.v1.PublicDecryptionResponse);
 
+  rpc PublicDecryptSync(kms.v1.PublicDecryptionRequest) returns (kms.v1.PublicDecryptionResponse);
+
   rpc UserDecrypt(kms.v1.UserDecryptionRequest) returns (kms.v1.Empty);
 
   rpc GetUserDecryptionResult(kms.v1.RequestId) returns (kms.v1.UserDecryptionResponse);

--- a/core/grpc/proto/kms-service.v1.proto
+++ b/core/grpc/proto/kms-service.v1.proto
@@ -196,6 +196,39 @@ service CoreServiceEndpoint {
   // * The `request_id` in `request` can be used to retrieve the result of the public decryption again in the future. However there is no guarantee on how long the result will be stored.
   rpc GetPublicDecryptionResult(kms.v1.RequestId) returns (kms.v1.PublicDecryptionResponse);
 
+  // Synchronous variant of public decryption.
+  //
+  // That is, it starts the public decryption exactly as `PublicDecrypt` does and then waits for
+  // the result within the same call, returning this KMS' `PublicDecryptionResponse` directly.
+  // This saves the caller the second round trip through `GetPublicDecryptionResult`.
+  //
+  // The request is still recorded in the meta-store, so the result of a public decryption started
+  // through this method can also be retrieved (again) with `GetPublicDecryptionResult`.
+  // If the result is not ready before the server's waiting window expires, the call returns
+  // `Unavailable`; the decryption keeps running in the background and the result can be fetched
+  // with `GetPublicDecryptionResult`, or by calling this method again with the same request.
+  //
+  // # Parameters
+  // * `request` - Struct containing all the data of the request.
+  //
+  // # Returns
+  // * `Response<PublicDecryptionResponse>` - Identical to what `GetPublicDecryptionResult` returns.
+  //
+  // # Conditions
+  // ## Pre-condition:
+  // * Same pre-conditions as `PublicDecrypt`, except that `request_id` in `request` does not need
+  //   to be fresh: unlike `PublicDecrypt`, this method never rejects a known `request_id` with
+  //   `AlreadyExists`. Instead:
+  //   * if a decryption for it is still running, or has already succeeded, no new decryption is
+  //     started: this call attaches to that attempt and returns its result. The remaining
+  //     content of `request` is ignored in this case.
+  //   * if the previous attempt for it failed, a new decryption is started from the content of
+  //     this `request` (the same redo-on-failure rule as `PublicDecrypt`), and this call returns
+  //     the outcome of that new attempt.
+  // ## Post-condition:
+  // * The result can be retrieved again with `GetPublicDecryptionResult`.
+  rpc PublicDecryptSync(kms.v1.PublicDecryptionRequest) returns (kms.v1.PublicDecryptionResponse);
+
   // Start the user decryption protocol.
   //
   // That is, it decrypts a ciphertext and encrypts the result under a user's public key.

--- a/core/service/src/engine/centralized/endpoint.rs
+++ b/core/service/src/engine/centralized/endpoint.rs
@@ -25,7 +25,7 @@ use crate::engine::centralized::service::{crs_gen_impl, get_crs_gen_result_impl}
 use crate::engine::centralized::service::{get_key_gen_result_impl, key_gen_impl};
 use crate::engine::centralized::service::{
     get_public_decryption_result_impl, get_user_decryption_result_impl, public_decrypt_impl,
-    user_decrypt_impl, user_decrypt_sync_impl,
+    public_decrypt_sync_impl, user_decrypt_impl, user_decrypt_sync_impl,
 };
 #[cfg(feature = "insecure")]
 use crate::engine::utils::MetricedError;
@@ -217,6 +217,17 @@ impl<
     ) -> Result<Response<kms_grpc::kms::v1::PublicDecryptionResponse>, Status> {
         METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_RESULT);
         get_public_decryption_result_impl(self, request)
+            .await
+            .map_err(|e| e.into())
+    }
+
+    #[tracing::instrument(skip(self, request))]
+    async fn public_decrypt_sync(
+        &self,
+        request: Request<kms_grpc::kms::v1::PublicDecryptionRequest>,
+    ) -> Result<Response<kms_grpc::kms::v1::PublicDecryptionResponse>, Status> {
+        METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_SYNC);
+        public_decrypt_sync_impl(self, request)
             .await
             .map_err(|e| e.into())
     }

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -21,11 +21,11 @@ use kms_grpc::kms::v1::{
 };
 use observability::metrics::METRICS;
 use observability::metrics_names::{
-    CENTRAL_TAG, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT, OP_USER_DECRYPT_REQUEST,
-    OP_USER_DECRYPT_RESULT, OP_USER_DECRYPT_SYNC, TAG_PARTY_ID,
+    CENTRAL_TAG, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT, OP_PUBLIC_DECRYPT_SYNC,
+    OP_USER_DECRYPT_REQUEST, OP_USER_DECRYPT_RESULT, OP_USER_DECRYPT_SYNC, TAG_PARTY_ID,
 };
 use std::sync::Arc;
-use tonic::{Request, Response};
+use tonic::{Code, Request, Response};
 use tracing::Instrument;
 
 /// Implementation of the user_decrypt endpoint
@@ -383,6 +383,49 @@ pub async fn public_decrypt_impl<
     Ok(Response::new(Empty {}))
 }
 
+/// Implementation of the public_decrypt_sync endpoint
+pub async fn public_decrypt_sync_impl<
+    PubS: Storage + Sync + Send + 'static,
+    PrivS: StorageExt + Sync + Send + 'static,
+    CM: ContextManager + Sync + Send + 'static,
+    BO: BackupOperator + Sync + Send + 'static,
+>(
+    service: &CentralizedKms<PubS, PrivS, CM, BO>,
+    request: Request<PublicDecryptionRequest>,
+) -> Result<Response<PublicDecryptionResponse>, MetricedError> {
+    // Time the whole call, wait included: this is the latency the sync endpoint exists to cut.
+    let _timer = METRICS
+        .time_operation(OP_PUBLIC_DECRYPT_SYNC)
+        .tag(TAG_PARTY_ID, CENTRAL_TAG.to_string())
+        .start();
+
+    let req_id = parse_optional_grpc_request_id(
+        &request.get_ref().request_id,
+        RequestIdParsingErr::PublicDecRequest,
+    )
+    .map_err(|e| MetricedError::new(OP_PUBLIC_DECRYPT_SYNC, None, e, Code::InvalidArgument))?;
+
+    let should_start = match service.pub_dec_meta_store.read().await.retrieve(&req_id) {
+        None => true,                           // fresh request ID
+        Some(EntryState::Done(Err(_))) => true, // previously failed, redo it under the same ID
+        Some(EntryState::Done(Ok(_))) => false, // already succeeded, return the stored result
+        Some(EntryState::Pending) => false,     // in flight, attach to it
+        Some(EntryState::Deleted) => false,     // tombstoned, let the wait report `NotFound`
+    };
+    if should_start {
+        match public_decrypt_impl(service, request).await {
+            Ok(_empty) => (),
+            // Another call won the race to start or redo this request: attach to that attempt
+            Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
+            Err(e) => return Err(e.retag(OP_PUBLIC_DECRYPT_SYNC)),
+        }
+    }
+
+    get_public_decryption_result_impl(service, Request::new(req_id.into()))
+        .await
+        .map_err(|e| e.retag(OP_PUBLIC_DECRYPT_SYNC))
+}
+
 /// Implementation of the get_public_decryption_result endpoint
 pub async fn get_public_decryption_result_impl<
     PubS: Storage + Sync + Send + 'static,
@@ -554,6 +597,7 @@ pub(crate) mod tests {
 mod tests_public_decryption {
     use aes_prng::AesRng;
     use kms_grpc::rpc_types::alloy_to_protobuf_domain;
+    use kms_grpc::{RequestId, kms::v1::TypedCiphertext};
     use rand::SeedableRng;
 
     use crate::{
@@ -567,6 +611,23 @@ mod tests_public_decryption {
 
     use super::*;
 
+    fn make_valid_request(
+        request_id: RequestId,
+        key_id: RequestId,
+        ciphertexts: Vec<TypedCiphertext>,
+        domain: &kms_grpc::kms::v1::Eip712DomainMsg,
+    ) -> PublicDecryptionRequest {
+        PublicDecryptionRequest {
+            request_id: Some(request_id.into()),
+            ciphertexts,
+            key_id: Some(key_id.into()),
+            domain: Some(domain.clone()),
+            extra_data: vec![],
+            context_id: None,
+            epoch_id: None,
+        }
+    }
+
     #[tokio::test]
     async fn sunshine() {
         let mut rng = AesRng::seed_from_u64(1234);
@@ -576,15 +637,7 @@ mod tests_public_decryption {
         let request_id = derive_request_id("req_id_decryption_sunshine").unwrap();
         let (msg, ciphertexts) = make_test_msg_ct(&pk, true);
 
-        let request = PublicDecryptionRequest {
-            request_id: Some(request_id.into()),
-            ciphertexts,
-            key_id: Some(key_id.into()),
-            domain: Some(domain.clone()),
-            extra_data: vec![],
-            context_id: None,
-            epoch_id: None,
-        };
+        let request = make_valid_request(request_id, key_id, ciphertexts, &domain);
 
         let _ = public_decrypt_impl(&kms, tonic::Request::new(request))
             .await
@@ -609,20 +662,18 @@ mod tests_public_decryption {
         let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
         let request_id = derive_request_id("req_id_decryption_invalid_args").unwrap();
         let (_msg, ct) = make_test_msg_ct(&pk, true);
+        let valid_request = make_valid_request(request_id, key_id, ct, &domain);
 
         // missing request Id
         {
-            let request = PublicDecryptionRequest {
-                request_id: None, // missing
-                ciphertexts: ct.clone(),
-                key_id: Some(key_id.into()),
-                domain: Some(domain.clone()),
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
+            let mut request = valid_request.clone();
+            request.request_id = None;
+            let err = public_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
 
-            let err = public_decrypt_impl(&kms, tonic::Request::new(request))
+            let err = public_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::InvalidArgument);
@@ -630,20 +681,16 @@ mod tests_public_decryption {
 
         // wrong request id
         {
-            let wrong_request_id = kms_grpc::kms::v1::RequestId {
+            let mut request = valid_request.clone();
+            request.request_id = Some(kms_grpc::kms::v1::RequestId {
                 request_id: "wrong_id".to_string(),
-            };
-            let request = PublicDecryptionRequest {
-                request_id: Some(wrong_request_id),
-                ciphertexts: ct.clone(),
-                key_id: Some(key_id.into()),
-                domain: Some(domain.clone()),
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
+            });
+            let err = public_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
 
-            let err = public_decrypt_impl(&kms, tonic::Request::new(request))
+            let err = public_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::InvalidArgument);
@@ -651,16 +698,14 @@ mod tests_public_decryption {
 
         // missing domain
         {
-            let request = PublicDecryptionRequest {
-                request_id: Some(request_id.into()),
-                ciphertexts: ct.clone(),
-                key_id: Some(key_id.into()),
-                domain: None, // missing
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
-            let err = public_decrypt_impl(&kms, tonic::Request::new(request))
+            let mut request = valid_request.clone();
+            request.domain = None;
+            let err = public_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = public_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::InvalidArgument);
@@ -668,16 +713,14 @@ mod tests_public_decryption {
 
         // missing ciphertexts
         {
-            let request = PublicDecryptionRequest {
-                request_id: Some(request_id.into()),
-                ciphertexts: vec![], // missing
-                key_id: Some(key_id.into()),
-                domain: Some(domain.clone()),
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
-            let err = public_decrypt_impl(&kms, tonic::Request::new(request))
+            let mut request = valid_request.clone();
+            request.ciphertexts.clear();
+            let err = public_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = public_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::InvalidArgument);
@@ -696,17 +739,14 @@ mod tests_public_decryption {
         // request with unknown key id
         {
             let wrong_key_id = derive_request_id("wrong_keyid_decryption_not_found").unwrap();
-            let request = PublicDecryptionRequest {
-                request_id: Some(request_id.into()),
-                ciphertexts: ct.clone(),
-                key_id: Some(wrong_key_id.into()), // wrong
-                domain: Some(domain.clone()),
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
+            let request = make_valid_request(request_id, wrong_key_id, ct, &domain);
 
-            let err = public_decrypt_impl(&kms, tonic::Request::new(request))
+            let err = public_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
+
+            let err = public_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::NotFound);
@@ -740,16 +780,13 @@ mod tests_public_decryption {
 
         // make a normal request then it should fail
         {
-            let request = PublicDecryptionRequest {
-                request_id: Some(request_id.into()),
-                ciphertexts: ct.clone(),
-                key_id: Some(key_id.into()),
-                domain: Some(domain.clone()),
-                extra_data: vec![],
-                context_id: None,
-                epoch_id: None,
-            };
-            let err = public_decrypt_impl(&kms, tonic::Request::new(request))
+            let request = make_valid_request(request_id, key_id, ct, &domain);
+            let err = public_decrypt_impl(&kms, tonic::Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+
+            let err = public_decrypt_sync_impl(&kms, tonic::Request::new(request))
                 .await
                 .unwrap_err();
             assert_eq!(err.code(), tonic::Code::ResourceExhausted);
@@ -763,17 +800,9 @@ mod tests_public_decryption {
         let (kms, pk, _) = setup_test_kms_with_key(&mut rng, &key_id).await;
         let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
         let request_id = derive_request_id("req_id_decryption_already_exists").unwrap();
-        let (_msg, ct) = make_test_msg_ct(&pk, true);
+        let (msg, ct) = make_test_msg_ct(&pk, true);
 
-        let request = PublicDecryptionRequest {
-            request_id: Some(request_id.into()),
-            ciphertexts: ct.clone(),
-            key_id: Some(key_id.into()),
-            domain: Some(domain.clone()),
-            extra_data: vec![],
-            context_id: None,
-            epoch_id: None,
-        };
+        let request = make_valid_request(request_id, key_id, ct, &domain);
 
         // make a normal request, which should pass
         let _ = public_decrypt_impl(&kms, tonic::Request::new(request.clone()))
@@ -781,10 +810,101 @@ mod tests_public_decryption {
             .unwrap();
 
         // this should fail since it's using the same ID
-        let err = public_decrypt_impl(&kms, tonic::Request::new(request))
+        let err = public_decrypt_impl(&kms, tonic::Request::new(request.clone()))
             .await
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::AlreadyExists);
+
+        // The sync endpoint instead attaches to the existing entry and returns its result.
+        // Attaching is a success path, so it must not record an error: the `AlreadyExists`
+        // signal is defused rather than dropped.
+        let recorded_errors_before = crate::engine::utils::handle_error_call_count();
+        let response = public_decrypt_sync_impl(&kms, tonic::Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.payload.unwrap().plaintexts[0].clone(), msg.into());
+        assert_eq!(
+            crate::engine::utils::handle_error_call_count(),
+            recorded_errors_before,
+            "attaching to an already-known request ID must not report a failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn sunshine_sync() {
+        let mut rng = AesRng::seed_from_u64(1234);
+        let key_id = derive_request_id("keyid_decryption_sunshine_sync").unwrap();
+        let (kms, pk, _) = setup_test_kms_with_key(&mut rng, &key_id).await;
+        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
+        let request_id = derive_request_id("req_id_decryption_sunshine_sync").unwrap();
+        let (msg, ciphertexts) = make_test_msg_ct(&pk, true);
+
+        let request = make_valid_request(request_id, key_id, ciphertexts, &domain);
+
+        // The sync endpoint returns the response directly, no polling needed.
+        let payload = public_decrypt_sync_impl(&kms, tonic::Request::new(request.clone()))
+            .await
+            .unwrap()
+            .into_inner()
+            .payload
+            .unwrap();
+        assert_eq!(payload.plaintexts[0].clone(), msg.into());
+
+        // The request went through the meta-store, so the result stays
+        // retrievable through the async result endpoint...
+        let again = get_public_decryption_result_impl(&kms, tonic::Request::new(request_id.into()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(Some(&payload), again.payload.as_ref());
+
+        // ...and re-sending the same sync request attaches to the existing
+        // entry and returns the result instead of failing with `AlreadyExists`.
+        let retry = public_decrypt_sync_impl(&kms, tonic::Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(Some(&payload), retry.payload.as_ref());
+    }
+
+    /// A `request_id` whose previous attempt failed is redone, exactly as re-sending it to the
+    /// async endpoint would be, and the sync call returns the new attempt's outcome.
+    #[tokio::test]
+    async fn sync_redoes_failed_request() {
+        let mut rng = AesRng::seed_from_u64(1234);
+        let key_id = derive_request_id("keyid_decryption_sync_redo").unwrap();
+        let (kms, pk, _) = setup_test_kms_with_key(&mut rng, &key_id).await;
+        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
+        let request_id = derive_request_id("req_id_decryption_sync_redo").unwrap();
+        let (msg, ciphertexts) = make_test_msg_ct(&pk, true);
+
+        let request = make_valid_request(request_id, key_id, ciphertexts, &domain);
+
+        // Leave the request ID in the state a failed attempt would leave it in.
+        let permit = kms
+            .pub_dec_meta_store
+            .write()
+            .await
+            .insert(&request_id)
+            .unwrap();
+        crate::util::meta_store::update_err_req_in_meta_store(
+            &kms.pub_dec_meta_store,
+            permit,
+            "forced failure".to_string(),
+            OP_PUBLIC_DECRYPT_REQUEST,
+        )
+        .await;
+
+        // The sync call redoes the decryption instead of returning the stored failure, and the
+        // plaintext it produces is the one this request asked for.
+        let payload = public_decrypt_sync_impl(&kms, tonic::Request::new(request))
+            .await
+            .unwrap()
+            .into_inner()
+            .payload
+            .unwrap();
+        assert_eq!(payload.plaintexts[0].clone(), msg.into());
     }
 }
 

--- a/core/service/src/engine/threshold/endpoint.rs
+++ b/core/service/src/engine/threshold/endpoint.rs
@@ -172,6 +172,15 @@ impl_endpoint! {
        }
 
         #[tracing::instrument(skip(self, request))]
+        async fn public_decrypt_sync(
+            &self,
+            request: Request<PublicDecryptionRequest>,
+        ) -> Result<Response<PublicDecryptionResponse>, Status> {
+            METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_SYNC);
+            self.decryptor.public_decrypt_sync(request).await.map_err(|e| e.into())
+        }
+
+        #[tracing::instrument(skip(self, request))]
         async fn crs_gen(&self, request: Request<CrsGenRequest>) -> Result<Response<Empty>, Status> {
             METRICS.increment_request_counter(OP_CRS_GEN_REQUEST);
             self.crs_generator.crs_gen(request).await.map_err(|e| e.into())

--- a/core/service/src/engine/threshold/service/public_decryptor.rs
+++ b/core/service/src/engine/threshold/service/public_decryptor.rs
@@ -19,8 +19,8 @@ use kms_grpc::{
 use observability::{
     metrics::{self},
     metrics_names::{
-        OP_PUBLIC_DECRYPT_INNER, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT, TAG_PARTY_ID,
-        TAG_PUBLIC_DECRYPTION_KIND, TAG_TFHE_TYPE,
+        OP_PUBLIC_DECRYPT_INNER, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT,
+        OP_PUBLIC_DECRYPT_SYNC, TAG_PARTY_ID, TAG_PUBLIC_DECRYPTION_KIND, TAG_TFHE_TYPE,
     },
 };
 use tfhe::FheTypes;
@@ -37,7 +37,7 @@ use threshold_execution::{
 use threshold_types::session_id::SessionId;
 use tokio::sync::RwLock;
 use tokio_util::task::TaskTracker;
-use tonic::{Request, Response};
+use tonic::{Code, Request, Response};
 use tracing::Instrument;
 
 // === Internal Crate ===
@@ -58,13 +58,14 @@ use crate::{
         utils::MetricedError,
         validation::{
             DSEP_PUBLIC_DECRYPTION, RequestIdParsingErr, parse_grpc_request_id,
-            validate_public_decrypt_req,
+            parse_optional_grpc_request_id, validate_public_decrypt_req,
         },
     },
     util::{
         meta_store::{
-            MetaStore, add_or_redo_failed_in_meta_store, retrieve_from_meta_store_with_timeout,
-            update_err_req_in_meta_store, update_req_in_meta_store,
+            EntryState, MetaStore, add_or_redo_failed_in_meta_store,
+            retrieve_from_meta_store_with_timeout, update_err_req_in_meta_store,
+            update_req_in_meta_store,
         },
         rate_limiter::RateLimiter,
     },
@@ -615,6 +616,41 @@ impl<
         Ok(Response::new(Empty {}))
     }
 
+    async fn public_decrypt_sync(
+        &self,
+        request: Request<PublicDecryptionRequest>,
+    ) -> Result<Response<PublicDecryptionResponse>, MetricedError> {
+        let _timer = metrics::METRICS
+            .time_operation(OP_PUBLIC_DECRYPT_SYNC)
+            .start();
+
+        let req_id = parse_optional_grpc_request_id(
+            &request.get_ref().request_id,
+            RequestIdParsingErr::PublicDecRequest,
+        )
+        .map_err(|e| MetricedError::new(OP_PUBLIC_DECRYPT_SYNC, None, e, Code::InvalidArgument))?;
+
+        let should_start = match self.pub_dec_meta_store.read().await.retrieve(&req_id) {
+            None => true,                           // fresh request ID
+            Some(EntryState::Done(Err(_))) => true, // previously failed, redo it under the same ID
+            Some(EntryState::Done(Ok(_))) => false, // already succeeded, return the stored result
+            Some(EntryState::Pending) => false,     // in flight, attach to it
+            Some(EntryState::Deleted) => false,     // tombstoned, let the wait report `NotFound`
+        };
+        if should_start {
+            match self.public_decrypt(request).await {
+                Ok(_empty) => (),
+                // Another call won the race to start or redo this request: attach to that attempt
+                Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
+                Err(e) => return Err(e.retag(OP_PUBLIC_DECRYPT_SYNC)),
+            }
+        }
+
+        self.get_result(Request::new(req_id.into()))
+            .await
+            .map_err(|e| e.retag(OP_PUBLIC_DECRYPT_SYNC))
+    }
+
     async fn get_result(
         &self,
         request: Request<v1::RequestId>,
@@ -817,6 +853,30 @@ mod tests {
         }
     }
 
+    fn make_valid_request(
+        req_id: RequestId,
+        key_id: RequestId,
+        epoch_id: EpochId,
+        ct_buf: Vec<u8>,
+    ) -> PublicDecryptionRequest {
+        PublicDecryptionRequest {
+            request_id: Some(req_id.into()),
+            ciphertexts: vec![TypedCiphertext {
+                ciphertext: ct_buf,
+                fhe_type: FheTypes::Uint8 as i32,
+                external_handle: vec![],
+                // NOTE: because the way [setup_public_decryptor] is implemented,
+                // the ciphertext format must be SmallExpanded for the dummy decryptor to work
+                ciphertext_format: CiphertextFormat::SmallExpanded as i32,
+            }],
+            key_id: Some(key_id.into()),
+            domain: Some(alloy_to_protobuf_domain(&dummy_domain()).unwrap()),
+            extra_data: vec![],
+            context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
+            epoch_id: Some(epoch_id.into()),
+        }
+    }
+
     async fn setup_public_decryptor(
         rng: &mut AesRng,
     ) -> (
@@ -903,30 +963,20 @@ mod tests {
         // Set bucket size to zero, so no operations are allowed
         public_decryptor.set_bucket_size(0);
 
-        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
         let req_id = RequestId::new_random(&mut rng);
-        let request = Request::new(PublicDecryptionRequest {
-            request_id: Some(req_id.into()),
-            ciphertexts: vec![TypedCiphertext {
-                ciphertext: ct_buf.clone(),
-                fhe_type: FheTypes::Uint8 as i32,
-                external_handle: vec![],
-                ciphertext_format: CiphertextFormat::SmallCompressed as i32,
-            }],
-            key_id: Some(key_id.into()),
-            domain: Some(domain),
-            extra_data: vec![],
-            context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-            epoch_id: Some(epoch_id.into()),
-        });
-        assert_eq!(
-            public_decryptor
-                .public_decrypt(request)
-                .await
-                .unwrap_err()
-                .code(),
-            tonic::Code::ResourceExhausted
-        );
+        let request = make_valid_request(req_id, key_id, epoch_id, ct_buf);
+        let err = public_decryptor
+            .public_decrypt(Request::new(request.clone()))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+
+        // the sync endpoint is rate-limited the same way
+        let err = public_decryptor
+            .public_decrypt_sync(Request::new(request))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::ResourceExhausted);
 
         // finally reset the bucket size to a non-zero value
         public_decryptor.set_bucket_size(100);
@@ -937,260 +987,192 @@ mod tests {
         let mut rng = AesRng::seed_from_u64(12);
         let (key_id, epoch_id, ct_buf, public_decryptor) = setup_public_decryptor(&mut rng).await;
         let req_id = RequestId::new_random(&mut rng);
-        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
-        let request = PublicDecryptionRequest {
-            request_id: Some(req_id.into()),
-            ciphertexts: vec![TypedCiphertext {
-                ciphertext: ct_buf,
-                fhe_type: FheTypes::Uint8 as i32,
-                external_handle: vec![],
-                ciphertext_format: CiphertextFormat::SmallExpanded as i32,
-            }],
-            key_id: Some(key_id.into()),
-            domain: Some(domain),
-            extra_data: vec![],
-            context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-            epoch_id: Some(epoch_id.into()),
-        };
+        let request = make_valid_request(req_id, key_id, epoch_id, ct_buf);
         public_decryptor
             .public_decrypt(Request::new(request.clone()))
             .await
             .unwrap();
-        assert_eq!(
-            public_decryptor
-                .public_decrypt(Request::new(request))
-                .await
-                .unwrap_err()
-                .code(),
-            tonic::Code::AlreadyExists
-        );
+
+        // try sending the same request again
+        let err = public_decryptor
+            .public_decrypt(Request::new(request))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::AlreadyExists);
     }
 
     #[tokio::test]
     async fn not_found() {
         let mut rng = AesRng::seed_from_u64(1123);
         let (key_id, epoch_id, ct_buf, public_decryptor) = setup_public_decryptor(&mut rng).await;
-        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
+
+        let req_id = RequestId::new_random(&mut rng);
+        let valid_request = make_valid_request(req_id, key_id, epoch_id, ct_buf);
 
         {
-            // bad key ID
-            let req_id = RequestId::new_random(&mut rng);
-            let bad_key_id = RequestId::new_random(&mut rng);
-            let request = Request::new(PublicDecryptionRequest {
-                request_id: Some(req_id.into()),
-                ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf.clone(),
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::SmallExpanded as i32,
-                }],
-                key_id: Some(bad_key_id.into()),
-                domain: Some(domain.clone()),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
-            });
-            assert_eq!(
-                public_decryptor
-                    .public_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::NotFound
-            );
+            // unknown key ID
+            let mut request = valid_request.clone();
+            request.key_id = Some(RequestId::new_random(&mut rng).into());
+            let err = public_decryptor
+                .public_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
+
+            let err = public_decryptor
+                .public_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
         }
 
         {
-            // bad epoch ID
-            let req_id = RequestId::new_random(&mut rng);
-            let bad_epoch_id = EpochId::new_random(&mut rng);
-            let request = Request::new(PublicDecryptionRequest {
-                request_id: Some(req_id.into()),
-                ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf,
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::SmallExpanded as i32,
-                }],
-                key_id: Some(key_id.into()),
-                domain: Some(domain),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(bad_epoch_id.into()),
-            });
-            assert_eq!(
-                public_decryptor
-                    .public_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::NotFound
-            );
+            // unknown epoch ID
+            let mut request = valid_request.clone();
+            request.epoch_id = Some(EpochId::new_random(&mut rng).into());
+            let err = public_decryptor
+                .public_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
+
+            let err = public_decryptor
+                .public_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
         }
 
-        // try to get result for a non-existing request ID
-        let another_req_id = RequestId::new_random(&mut rng);
-        assert_eq!(
-            public_decryptor
+        {
+            // unknown request ID on the result endpoint
+            let another_req_id = RequestId::new_random(&mut rng);
+            let err = public_decryptor
                 .get_result(Request::new(another_req_id.into()))
                 .await
-                .unwrap_err()
-                .code(),
-            tonic::Code::NotFound
-        );
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
+        }
     }
 
     #[tokio::test]
     async fn invalid_argument() {
         let mut rng = AesRng::seed_from_u64(13);
         let (key_id, epoch_id, ct_buf, public_decryptor) = setup_public_decryptor(&mut rng).await;
+
+        let req_id = RequestId::new_random(&mut rng);
+        let valid_request = make_valid_request(req_id, key_id, epoch_id, ct_buf);
         {
-            // Bad request ID
-            let bad_req_id = kms_grpc::kms::v1::RequestId {
+            // missing request ID
+            let mut request = valid_request.clone();
+            request.request_id = None;
+            let err = public_decryptor
+                .public_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = public_decryptor
+                .public_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        }
+        {
+            // wrongly formatted request ID
+            let mut request = valid_request.clone();
+            request.request_id = Some(kms_grpc::kms::v1::RequestId {
                 request_id: "invalid_request_id".to_string(),
-            };
-            let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
-            let request = Request::new(PublicDecryptionRequest {
-                request_id: Some(bad_req_id),
-                ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf.clone(),
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::SmallExpanded as i32,
-                }],
-                key_id: Some(key_id.into()),
-                domain: Some(domain),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
             });
-            assert_eq!(
-                public_decryptor
-                    .public_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            let err = public_decryptor
+                .public_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = public_decryptor
+                .public_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
         {
             // empty ciphertexts
-            let req_id = RequestId::new_random(&mut rng);
-            let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
-            let request = Request::new(PublicDecryptionRequest {
-                request_id: Some(req_id.into()),
-                ciphertexts: vec![],
-                key_id: Some(key_id.into()),
-                domain: Some(domain),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
-            });
-            assert_eq!(
-                public_decryptor
-                    .public_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            let mut request = valid_request.clone();
+            request.ciphertexts.clear();
+            let err = public_decryptor
+                .public_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = public_decryptor
+                .public_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
         {
-            // bad key ID
-            let req_id = RequestId::new_random(&mut rng);
-            let bad_key_id = kms_grpc::kms::v1::RequestId {
+            // wrongly formatted key ID
+            let mut request = valid_request.clone();
+            request.key_id = Some(kms_grpc::kms::v1::RequestId {
                 request_id: "invalid_request_id".to_string(),
-            };
-            let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
-            let request = Request::new(PublicDecryptionRequest {
-                request_id: Some(req_id.into()),
-                ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf.clone(),
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::SmallExpanded as i32,
-                }],
-                key_id: Some(bad_key_id),
-                domain: Some(domain),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
             });
-            assert_eq!(
-                public_decryptor
-                    .public_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            let err = public_decryptor
+                .public_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = public_decryptor
+                .public_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
         {
             // missing domain
-            let req_id = RequestId::new_random(&mut rng);
-            let request = Request::new(PublicDecryptionRequest {
-                request_id: Some(req_id.into()),
-                ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf.clone(),
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::SmallExpanded as i32,
-                }],
-                key_id: Some(key_id.into()),
-                domain: None,
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
-            });
-            assert_eq!(
-                public_decryptor
-                    .public_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            let mut request = valid_request.clone();
+            request.domain = None;
+            let err = public_decryptor
+                .public_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = public_decryptor
+                .public_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
         {
             // wrong domain
-            let req_id = RequestId::new_random(&mut rng);
+            let mut request = valid_request.clone();
             let mut domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
             domain.verifying_contract = "invalid_contract".to_string();
-            let request = Request::new(PublicDecryptionRequest {
-                request_id: Some(req_id.into()),
-                ciphertexts: vec![TypedCiphertext {
-                    ciphertext: ct_buf,
-                    fhe_type: FheTypes::Uint8 as i32,
-                    external_handle: vec![],
-                    ciphertext_format: CiphertextFormat::SmallExpanded as i32,
-                }],
-                key_id: Some(key_id.into()),
-                domain: Some(domain),
-                extra_data: vec![],
-                context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-                epoch_id: Some(epoch_id.into()),
-            });
-            assert_eq!(
-                public_decryptor
-                    .public_decrypt(request)
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            request.domain = Some(domain);
+            let err = public_decryptor
+                .public_decrypt(Request::new(request.clone()))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            let err = public_decryptor
+                .public_decrypt_sync(Request::new(request))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
         {
-            // bad request ID while getting response
-            assert_eq!(
-                public_decryptor
-                    .get_result(Request::new(kms_grpc::kms::v1::RequestId {
-                        request_id: "invalid_request_id".to_string(),
-                    },))
-                    .await
-                    .unwrap_err()
-                    .code(),
-                tonic::Code::InvalidArgument
-            );
+            // wrongly formatted request ID on the result endpoint
+            let bad_req_id = kms_grpc::kms::v1::RequestId {
+                request_id: "invalid_request_id".to_string(),
+            };
+            let err = public_decryptor
+                .get_result(Request::new(bad_req_id))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
         }
     }
 
@@ -1199,24 +1181,11 @@ mod tests {
         let mut rng = AesRng::seed_from_u64(13);
         let (key_id, epoch_id, ct_buf, public_decryptor) = setup_public_decryptor(&mut rng).await;
         let req_id = RequestId::new_random(&mut rng);
-        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
-        let request = Request::new(PublicDecryptionRequest {
-            request_id: Some(req_id.into()),
-            ciphertexts: vec![TypedCiphertext {
-                ciphertext: ct_buf,
-                fhe_type: FheTypes::Uint8 as i32,
-                external_handle: vec![],
-                // NOTE: because the way [setup_public_decryptor] is implemented,
-                // the ciphertext format must be SmallExpanded for the dummy decryptor to work
-                ciphertext_format: CiphertextFormat::SmallExpanded as i32,
-            }],
-            key_id: Some(key_id.into()),
-            domain: Some(domain),
-            extra_data: vec![],
-            context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
-            epoch_id: Some(epoch_id.into()),
-        });
-        public_decryptor.public_decrypt(request).await.unwrap();
+        let request = make_valid_request(req_id, key_id, epoch_id, ct_buf);
+        public_decryptor
+            .public_decrypt(Request::new(request))
+            .await
+            .unwrap();
         // there's no need to check the decryption result since it's a dummy protocol
         // and always produces the same response.
         crate::testing::utils::poll_result_until_ready(|| {
@@ -1224,5 +1193,201 @@ mod tests {
         })
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn sunshine_sync() {
+        let mut rng = AesRng::seed_from_u64(13);
+        let (key_id, epoch_id, ct_buf, public_decryptor) = setup_public_decryptor(&mut rng).await;
+
+        let req_id = RequestId::new_random(&mut rng);
+        let request = make_valid_request(req_id, key_id, epoch_id, ct_buf);
+
+        // The sync endpoint returns the response directly, no polling needed.
+        let response = public_decryptor
+            .public_decrypt_sync(Request::new(request.clone()))
+            .await
+            .unwrap()
+            .into_inner();
+        let payload = response
+            .payload
+            .clone()
+            .expect("sync response carries a payload");
+        assert_eq!(payload.plaintexts.len(), 1);
+        assert!(!response.signature.is_empty());
+
+        // The request went through the meta-store, so the result stays retrievable through the
+        // async result endpoint...
+        let again = public_decryptor
+            .get_result(Request::new(req_id.into()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.payload, again.payload);
+
+        // ...and re-sending the same sync request returns that stored result instead of failing
+        // with `AlreadyExists`. Attaching is a success path, so nothing may be recorded as a
+        // failure along the way.
+        let recorded_errors_before = crate::engine::utils::handle_error_call_count();
+        let retry = public_decryptor
+            .public_decrypt_sync(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.payload, retry.payload);
+        assert_eq!(
+            crate::engine::utils::handle_error_call_count(),
+            recorded_errors_before,
+            "attaching to an already-known request ID must not report a failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_attaches_to_async_request() {
+        let mut rng = AesRng::seed_from_u64(13);
+        let (key_id, epoch_id, ct_buf, public_decryptor) = setup_public_decryptor(&mut rng).await;
+
+        let req_id = RequestId::new_random(&mut rng);
+        let request = make_valid_request(req_id, key_id, epoch_id, ct_buf);
+
+        // Start the decryption through the async endpoint...
+        public_decryptor
+            .public_decrypt(Request::new(request.clone()))
+            .await
+            .unwrap();
+
+        // ...then a sync request with the same request ID attaches to that entry rather than
+        // starting a second decryption, without reporting a failure along the way.
+        let recorded_errors_before = crate::engine::utils::handle_error_call_count();
+        let response = public_decryptor
+            .public_decrypt_sync(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            response
+                .payload
+                .clone()
+                .expect("sync response carries a payload")
+                .plaintexts
+                .len(),
+            1
+        );
+        assert_eq!(
+            crate::engine::utils::handle_error_call_count(),
+            recorded_errors_before,
+            "attaching to an in-flight request must not report a failure"
+        );
+
+        // The entry the sync call waited on is the one the async request created.
+        let stored = public_decryptor
+            .get_result(Request::new(req_id.into()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.payload, stored.payload);
+    }
+
+    /// A `request_id` whose previous attempt failed is redone, exactly as re-sending it to the
+    /// async endpoint would be, and the sync call returns the new attempt's outcome.
+    #[tokio::test]
+    async fn sync_redoes_failed_request() {
+        let mut rng = AesRng::seed_from_u64(13);
+        let (key_id, epoch_id, ct_buf, public_decryptor) = setup_public_decryptor(&mut rng).await;
+
+        let req_id = RequestId::new_random(&mut rng);
+        let request = make_valid_request(req_id, key_id, epoch_id, ct_buf);
+
+        // Leave the request ID in the state a failed attempt would leave it in.
+        let permit = public_decryptor
+            .pub_dec_meta_store
+            .write()
+            .await
+            .insert(&req_id)
+            .unwrap();
+        crate::util::meta_store::update_err_req_in_meta_store(
+            &public_decryptor.pub_dec_meta_store,
+            permit,
+            "forced failure".to_string(),
+            OP_PUBLIC_DECRYPT_REQUEST,
+        )
+        .await;
+        assert!(matches!(
+            public_decryptor
+                .pub_dec_meta_store
+                .read()
+                .await
+                .retrieve(&req_id),
+            Some(EntryState::Done(Err(_)))
+        ));
+
+        // The sync call redoes the decryption instead of returning the stored failure.
+        let response = public_decryptor
+            .public_decrypt_sync(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            response
+                .payload
+                .expect("redone decryption carries a payload")
+                .plaintexts
+                .len(),
+            1
+        );
+    }
+
+    /// A failed entry that is still permit-held cannot be redone, so `public_decrypt` answers
+    /// `AlreadyExists`, which the sync endpoint reads as "attach to the existing entry". That
+    /// internal signal must be defused rather than dropped: dropping a `MetricedError` records
+    /// an error and logs a failure for what is only a control-flow decision.
+    #[tokio::test]
+    async fn sync_attach_signal_is_not_recorded_as_error() {
+        let mut rng = AesRng::seed_from_u64(13);
+        let (key_id, epoch_id, ct_buf, public_decryptor) = setup_public_decryptor(&mut rng).await;
+
+        let req_id = RequestId::new_random(&mut rng);
+        let request = make_valid_request(req_id, key_id, epoch_id, ct_buf);
+
+        // Fail the entry, then hold a permit on it so that `redo_failed` reports `Locked`.
+        let permit = public_decryptor
+            .pub_dec_meta_store
+            .write()
+            .await
+            .insert(&req_id)
+            .unwrap();
+        crate::util::meta_store::update_err_req_in_meta_store(
+            &public_decryptor.pub_dec_meta_store,
+            permit,
+            "forced failure".to_string(),
+            OP_PUBLIC_DECRYPT_REQUEST,
+        )
+        .await;
+        let _held_permit = public_decryptor
+            .pub_dec_meta_store
+            .write()
+            .await
+            .lock_entry(&req_id)
+            .unwrap();
+
+        let recorded_errors_before = crate::engine::utils::handle_error_call_count();
+        let err = public_decryptor
+            .public_decrypt_sync(Request::new(request))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Internal);
+        // `err` has not been returned to a caller yet, so nothing should have been recorded so
+        // far: an `AlreadyExists` dropped instead of defused would already show up here.
+        assert_eq!(
+            crate::engine::utils::handle_error_call_count(),
+            recorded_errors_before,
+            "the internal attach signal must not be recorded as a failure"
+        );
+        // Handing the error back to the caller records it exactly once.
+        drop(err);
+        assert_eq!(
+            crate::engine::utils::handle_error_call_count(),
+            recorded_errors_before + 1
+        );
     }
 }

--- a/core/service/src/engine/threshold/traits.rs
+++ b/core/service/src/engine/threshold/traits.rs
@@ -28,6 +28,10 @@ pub trait PublicDecryptor {
         &self,
         request: Request<RequestId>,
     ) -> Result<Response<PublicDecryptionResponse>, MetricedError>;
+    async fn public_decrypt_sync(
+        &self,
+        request: Request<PublicDecryptionRequest>,
+    ) -> Result<Response<PublicDecryptionResponse>, MetricedError>;
 }
 
 #[tonic::async_trait]

--- a/docs/developer/metrics.md
+++ b/docs/developer/metrics.md
@@ -37,6 +37,7 @@ pub const OP_DECOMPRESSION_COMPRESSED_KEYGEN: &str = "decompression_compressed_k
 // Corresponds to a request, a request may contain several ciphertexts
 pub const OP_PUBLIC_DECRYPT_REQUEST: &str = "public_decrypt_request";
 pub const OP_PUBLIC_DECRYPT_RESULT: &str = "public_decrypt_result";
+pub const OP_PUBLIC_DECRYPT_SYNC: &str = "public_decrypt_sync";
 pub const OP_USER_DECRYPT_REQUEST: &str = "user_decrypt_request";
 pub const OP_USER_DECRYPT_RESULT: &str = "user_decrypt_result";
 pub const OP_USER_DECRYPT_SYNC: &str = "user_decrypt_sync";

--- a/docs/guides/core_client.md
+++ b/docs/guides/core_client.md
@@ -586,6 +586,7 @@ $ cargo run --bin kms-core-client -- -f <path-to-toml-config-file> public-decryp
 
 Note that the key must have been previously generated using the (secure or insecure) [keygen](#key-generation) above.
 
+Public decryption also supports `--sync`, which uses the synchronous `PublicDecryptSync` endpoint: each request returns the decryption result directly in a single call instead of polling `GetPublicDecryptionResult`. The request still goes through the meta-store on the server, so the result remains retrievable via `GetPublicDecryptionResult` afterwards.
 
 It is also possible to fetch the result of a public decryption through its `REQUEST_ID` using the following command:
 ```{bash}
@@ -648,14 +649,14 @@ Options shared by public and user decryption are:
  - `--context-id <CONTEXT_ID>`: optionally specify the context ID to use for the decryption. Defaults to the default context if not specified.
  - `--epoch-id <EPOCH_ID>`: optionally specify the epoch ID to use for the decryption. Defaults to the default epoch if not specified.
  - `--ciphertext-output-path <FILENAME>`: optionally write the ciphertext (the encryption of `to-encrypt`) to file
- - `--sync`: use the synchronous endpoint (request and result in a single call). Currently only supported for `user-decrypt`.
+ - `--sync`: use the synchronous endpoint (request and result in a single call).
 
 Public/user-decrypt rate-mode options are:
  - `--rate <REQUESTS_PER_SECOND>`: request launch rate. Must be used together with `--duration`.
  - `--duration <SECONDS>`: load-test duration. Must be used together with `--rate`.
  - `--max-in-flight <NUM>`: optional rate-mode cap for in-flight requests before the client starts shedding requests.
 
- __NOTE__: For public and user decrypt from file, only `-b`/`--batch-size <BATCH_SIZE>`, `--rate <REQUESTS_PER_SECOND>`, `--duration <SECONDS>`, and `--max-in-flight <NUM>` are supported, plus `--sync` for user decrypt only.
+ __NOTE__: For public and user decrypt from file, only `-b`/`--batch-size <BATCH_SIZE>`, `--sync`, `--rate <REQUESTS_PER_SECOND>`, `--duration <SECONDS>`, and `--max-in-flight <NUM>` are supported.
 
 ### Custodian context
 

--- a/docs/operations/advanced/metrics.md
+++ b/docs/operations/advanced/metrics.md
@@ -56,8 +56,9 @@ KMS exposes metrics via Prometheus format on the configured metrics endpoint (de
 - `user_decrypt_result` - User decryption result retrievals through `GetUserDecryptionResult`
 - `user_decrypt_sync` - Synchronous user decryption requests
 - `user_decrypt_inner` - Individual user decryption operations *(duration only)*
-- `public_decrypt_request` - Public decryption requests
-- `public_decrypt_result` - Public decryption result retrievals
+- `public_decrypt_request` - Asynchronous public decryption requests
+- `public_decrypt_result` - Public decryption result retrievals through `GetPublicDecryptionResult`
+- `public_decrypt_sync` - Synchronous public decryption requests
 - `public_decrypt_inner` - Individual public decryption operations *(duration only)*
 
 *CRS Operations*:

--- a/docs/references/api/core_grpc.md
+++ b/docs/references/api/core_grpc.md
@@ -664,10 +664,13 @@ If the call is successful, the `CrsGenResult` will contain the `request_id` used
 
 ```proto
 message PublicDecryptionRequest {
-  repeated TypedCiphertext ciphertexts = 1;
-  RequestId key_id = 2;
-  Eip712DomainMsg domain = 3;
-  RequestId request_id = 4;
+  RequestId request_id = 1;
+  repeated TypedCiphertext ciphertexts = 2;
+  RequestId key_id = 3;
+  Eip712DomainMsg domain = 4;
+  bytes extra_data = 5;
+  RequestId context_id = 6;
+  RequestId epoch_id = 7;
 }
 
 
@@ -689,14 +692,17 @@ message Empty {}
 ### Description
 
 This RPC initiates the __asynchronous__ public decryption of the provided `ciphertexts`.
-The status or result can be retrieved with a call to the `GetDecryptResult` endpoint.
+The status or result can be retrieved with a call to the `GetPublicDecryptionResult` endpoint.
 
 It expects:
 
+- `request_id`: A unique uint256 RequestId for the decryption request.
 - `ciphertexts`: an array of the `TypedCiphertext`s (described below) to decrypt.
 - `key_id`: the `RequestId` that corresponds to the TFHE key the ciphertexts are encrypted under.
-- `request_id`: A unique uint256 RequestId for the decryption request.
 - `domain`: EIP712 domain information which will be used when signing the decrypted plaintext.
+- `extra_data`: Extra data used in the EIP712 signature - `external_signature`.
+- `context_id`: The MPC context ID used to identify the context to use for this request. If unset, the server's default context is used.
+- `epoch_id`: The MPC epoch ID identifying which epoch's key material and session to use for this request.
 
 Each ciphertext to be decrypted comes accompanied by some metadata in the `TypedCiphertext` structure:
 
@@ -722,14 +728,15 @@ message RequestId { string request_id = 1; }
 ```proto
 message PublicDecryptionResponse {
   bytes signature = 1;
-  PublicDecryptionResponsePayload payload = 2;
+  bytes external_signature = 2;
+  PublicDecryptionResponsePayload payload = 3;
+  bytes extra_data = 4;
 }
 
 message PublicDecryptionResponsePayload {
   bytes verification_key = 1;
-  bytes digest = 2;
-  repeated TypedPlaintext plaintexts = 3;
-  optional bytes external_signature = 4;
+  repeated TypedPlaintext plaintexts = 2;
+  RequestId request_id = 3;
 }
 
 ```
@@ -740,12 +747,55 @@ This RPC allows to retrieve the plaintexts if the `request_id` is that of a fini
 
 The `signature` is a `secp256k1` signature on the `bincode::serialize` of the `payload` using the core's private key.
 
+- `signature`: the `secp256k1` signature described above.
+- `external_signature`: The `EIP-712` signature on the encoding of the uint256 handles of the ciphertexts, concatenated with big endian encoding of the `TypedPlaintext`s using the KMS core's private key.
+- `extra_data`: Extra data used in the EIP712 signature - `external_signature`.
+
 #### The `payload` is composed of
 
 - `verification_key`: the `bincode::serialize` `ECDSA/secp256k1` verification key of the core.
-- `digest`: The 256 bits `SHAKE-256` digest of the corresponding `bincode::serialize` `PublicDecrypt` request.
 - `plaintexts`: An array of plaintexts and their meta information that are the requested decryptions.
-- `external_signature`: The `EIP-712` signature on the encoding of the uint256 handles of the ciphertexts, concatenated with big endian encoding of the `TypedPlaintext`s using the KMS core's private key.
+- `request_id`: The `RequestId` of the request this response corresponds to.
+
+</details>
+
+<details>
+    <summary> PublicDecryptSync </summary>
+
+### Input
+
+```proto
+message PublicDecryptionRequest {
+  RequestId request_id = 1;
+  repeated TypedCiphertext ciphertexts = 2;
+  RequestId key_id = 3;
+  Eip712DomainMsg domain = 4;
+  bytes extra_data = 5;
+  RequestId context_id = 6;
+  RequestId epoch_id = 7;
+}
+```
+
+### Output
+
+```proto
+message PublicDecryptionResponse {
+  bytes signature = 1;
+  bytes external_signature = 2;
+  PublicDecryptionResponsePayload payload = 3;
+  bytes extra_data = 4;
+}
+```
+
+### Description
+
+This is the same request and response as `PublicDecrypt`/`GetPublicDecryptionResult` above, see the `PublicDecryption` and `PublicDecryptionResponse` sections for a description of each field.
+
+`PublicDecryptSync` is the __synchronous__ variant of `PublicDecrypt`: it starts the public decryption exactly as `PublicDecrypt` does and then waits for the result within the same call, returning the same `PublicDecryptionResponse` that `GetPublicDecryptionResult` would return. This saves the caller the second round trip.
+
+The request is still recorded internally, so the result also remains retrievable through `GetPublicDecryptionResult`. If the result is not ready before the server's waiting window expires, the call returns `UNAVAILABLE` while the decryption keeps running in the background; the result can then be fetched with `GetPublicDecryptionResult` or by re-sending the same request to `PublicDecryptSync`.
+
+Unlike `PublicDecrypt`, this method never rejects a `request_id` that is already known with `ALREADY_EXISTS`. If a decryption for that `request_id` is still running or has already succeeded, no new decryption is started: the call attaches to that attempt and returns its result, ignoring the rest of the request. If the previous attempt failed, a new decryption is started from the content of the new request (the same redo-on-failure rule as `PublicDecrypt`), and the call returns the outcome of that new attempt.
 
 </details>
 

--- a/observability/src/metrics_names.rs
+++ b/observability/src/metrics_names.rs
@@ -30,6 +30,7 @@ pub const OP_DECOMPRESSION_COMPRESSED_KEYGEN: &str = "decompression_compressed_k
 // Corresponds to a request, a request may contain several ciphertexts
 pub const OP_PUBLIC_DECRYPT_REQUEST: &str = "public_decrypt_request";
 pub const OP_PUBLIC_DECRYPT_RESULT: &str = "public_decrypt_result";
+pub const OP_PUBLIC_DECRYPT_SYNC: &str = "public_decrypt_sync";
 pub const OP_USER_DECRYPT_REQUEST: &str = "user_decrypt_request";
 pub const OP_USER_DECRYPT_RESULT: &str = "user_decrypt_result";
 pub const OP_USER_DECRYPT_SYNC: &str = "user_decrypt_sync";


### PR DESCRIPTION
## Description
Should be the same as https://github.com/zama-ai/kms/pull/745 but for public decryption.

See https://github.com/zama-ai/kms-internal/issues/3163 for already identified next steps. Goal was to keep this PR as close as the user decryption one, and handle improvements for both case in a follow-up.

### Related issue(s)
Closes https://github.com/zama-ai/kms-internal/issues/3148

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
