### PR TITLE
chore: unified decryption metrics

### DIFF
--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -374,9 +374,13 @@ fn spawn_public_decrypt_sync(
                 .public_decrypt_sync(tonic::Request::new(req_cloned.clone()))
                 .await;
             let mut ctr = 0_usize;
-            while response.is_err()
-                && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
-            {
+
+            // `Unavailable`: the result is not ready yet. `ResourceExhausted`: the rate limiter
+            // rejected the submission. Both are recoverable by re-sending the exact same request.
+            while matches!(
+                response.as_ref().map_err(|e| e.code()),
+                Err(tonic::Code::Unavailable | tonic::Code::ResourceExhausted)
+            ) {
                 tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
@@ -384,8 +388,8 @@ fn spawn_public_decrypt_sync(
                     );
                 }
                 ctr += 1;
-                // Re-sending the same request attaches to the in-flight
-                // decryption instead of starting a new one.
+                // Re-sending the request attaches to the in-flight decryption instead of starting
+                // a new one.
                 response = cur_client
                     .public_decrypt_sync(tonic::Request::new(req_cloned.clone()))
                     .await;
@@ -1093,9 +1097,13 @@ fn spawn_user_decrypt_sync(
                 .user_decrypt_sync(tonic::Request::new(req_cloned.clone()))
                 .await;
             let mut ctr = 0_usize;
-            while response.is_err()
-                && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
-            {
+
+            // `Unavailable`: the result is not ready yet. `ResourceExhausted`: the rate limiter
+            // rejected the submission. Both are recoverable by re-sending the exact same request.
+            while matches!(
+                response.as_ref().map_err(|e| e.code()),
+                Err(tonic::Code::Unavailable | tonic::Code::ResourceExhausted)
+            ) {
                 tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
@@ -1103,8 +1111,8 @@ fn spawn_user_decrypt_sync(
                     );
                 }
                 ctr += 1;
-                // Re-sending the same request attaches to the in-flight
-                // decryption instead of starting a new one.
+                // Re-sending the request attaches to the in-flight decryption instead of starting
+                // a new one.
                 response = cur_client
                     .user_decrypt_sync(tonic::Request::new(req_cloned.clone()))
                     .await;

--- a/core-client/tests/kind-testing/kubernetes_test_threshold.rs
+++ b/core-client/tests/kind-testing/kubernetes_test_threshold.rs
@@ -18,7 +18,7 @@
 //! | `k8s_test_keygen_and_crs` | Basic keygen + CRS generation |
 //! | `k8s_test_keygen_uniqueness` | Multiple keygens produce unique keys |
 //! | `k8s_test_crs_uniqueness` | Multiple CRS generations produce unique IDs |
-//! | `k8s_test_insecure_keygen_encrypt_and_public_decrypt` | End-to-end: insecure keygen → encrypt → public decrypt |
+//! | `k8s_test_insecure_keygen_encrypt_and_public_decrypt` | End-to-end: insecure keygen → encrypt → public decrypt, through both the async and the sync endpoint |
 //! | `k8s_test_insecure_keygen_encrypt_multiple_types` | One key, multiple FHE types: encrypt + decrypt `Ebool` and `Euint8` |
 //!
 //! ## Architecture
@@ -233,10 +233,14 @@ impl K8sTestContext {
     /// parties, and internally calls `check_external_decryption_signature` which compares
     /// every party's decrypted bytes against the original plaintext stored in the file —
     /// panics on any mismatch. A successful return means decryption is correct.
-    async fn public_decrypt_from_file(&self, enc: &EncryptionResult) {
+    ///
+    /// With `sync == true` the request goes to the synchronous `public_decrypt_sync` endpoint,
+    /// which returns the result in the same call; otherwise the asynchronous endpoint is used
+    /// and the result is polled from `get_public_decryption_result`.
+    async fn public_decrypt_from_file(&self, enc: &EncryptionResult, sync: bool) {
         info!(
-            "[K8S-THRESHOLD] Decrypting {:?} via threshold MPC",
-            enc.cipher_path
+            "[K8S-THRESHOLD] Decrypting {:?} via threshold MPC (sync={})",
+            enc.cipher_path, sync
         );
         let start = std::time::Instant::now();
 
@@ -245,7 +249,7 @@ impl K8sTestContext {
                 DecryptFile {
                     input_path: enc.cipher_path.clone(),
                     batch_size: 1,
-                    sync: false,
+                    sync,
                     rate_options: DecryptRateOptions::default(),
                 },
             )))
@@ -365,6 +369,7 @@ async fn k8s_test_keygen_uniqueness() {
 /// 1. Cluster wiring: all 4 parties reachable, gRPC + mTLS functional
 /// 2. Key material round-trip: keygen → S3 → encrypt → decrypt
 /// 3. MPC decryption correctness: `check_external_decryption_signature` passes
+/// 4. Both decryption endpoints: the async request/poll pair and the sync `public_decrypt_sync`
 #[tokio::test]
 async fn k8s_test_insecure_keygen_encrypt_and_public_decrypt() {
     let ctx = K8sTestContext::new("k8s_test_insecure_keygen_encrypt_and_public_decrypt");
@@ -388,7 +393,12 @@ async fn k8s_test_insecure_keygen_encrypt_and_public_decrypt() {
     // Step 4: send ciphertext to all 4 threshold parties for decryption.
     // Internally verifies decrypted result == original `plaintext` bytes;
     // panics on any mismatch → test fails.
-    ctx.public_decrypt_from_file(&enc).await;
+    ctx.public_decrypt_from_file(&enc, false).await;
+
+    // Step 5: decrypt the same ciphertext through the synchronous endpoint, which returns the
+    // result in the same call instead of being polled. Uses a fresh request ID, so it exercises
+    // the sync endpoint end-to-end rather than re-reading the step 4 result.
+    ctx.public_decrypt_from_file(&enc, true).await;
 
     ctx.pass();
 }
@@ -416,7 +426,7 @@ async fn k8s_test_insecure_keygen_encrypt_multiple_types() {
         FheType::Ebool,
         "EncryptionResult must carry the correct FHE type"
     );
-    ctx.public_decrypt_from_file(&enc_bool).await;
+    ctx.public_decrypt_from_file(&enc_bool, false).await;
 
     // Step 3: encrypt an 8-bit unsigned integer and decrypt it with the same key
     let enc_uint = ctx.encrypt(&key_id, "0x2a", FheType::Euint8).await;
@@ -425,7 +435,7 @@ async fn k8s_test_insecure_keygen_encrypt_multiple_types() {
         FheType::Euint8,
         "EncryptionResult must carry the correct FHE type"
     );
-    ctx.public_decrypt_from_file(&enc_uint).await;
+    ctx.public_decrypt_from_file(&enc_uint, false).await;
 
     ctx.pass();
 }

--- a/core/service/src/engine/centralized/endpoint.rs
+++ b/core/service/src/engine/centralized/endpoint.rs
@@ -169,7 +169,9 @@ impl<
     }
 
     // NOTE: unlike other endpoints, the decryption counters are incremented inside the
-    // implementations rather than here, so that async/sync endpoints share metric handling.
+    // shared implementation, not here: one place instead of two (sync/async), and the
+    // sync path calls `get_result` directly, bypassing this dispatch, so incrementing
+    // here would skip that counter bump entirely.
 
     #[tracing::instrument(skip(self, request))]
     async fn user_decrypt(

--- a/core/service/src/engine/centralized/endpoint.rs
+++ b/core/service/src/engine/centralized/endpoint.rs
@@ -168,12 +168,14 @@ impl<
             .map_err(|e| e.into())
     }
 
+    // NOTE: unlike other endpoints, the decryption counters are incremented inside the
+    // implementations rather than here, so that async/sync endpoints share metric handling.
+
     #[tracing::instrument(skip(self, request))]
     async fn user_decrypt(
         &self,
         request: Request<kms_grpc::kms::v1::UserDecryptionRequest>,
     ) -> Result<Response<Empty>, Status> {
-        METRICS.increment_request_counter(OP_USER_DECRYPT_REQUEST);
         user_decrypt_impl(self, request).await.map_err(|e| e.into())
     }
 
@@ -182,7 +184,6 @@ impl<
         &self,
         request: Request<v1::RequestId>,
     ) -> Result<Response<kms_grpc::kms::v1::UserDecryptionResponse>, Status> {
-        METRICS.increment_request_counter(OP_USER_DECRYPT_RESULT);
         get_user_decryption_result_impl(self, request)
             .await
             .map_err(|e| e.into())
@@ -193,7 +194,6 @@ impl<
         &self,
         request: Request<kms_grpc::kms::v1::UserDecryptionRequest>,
     ) -> Result<Response<kms_grpc::kms::v1::UserDecryptionResponse>, Status> {
-        METRICS.increment_request_counter(OP_USER_DECRYPT_SYNC);
         user_decrypt_sync_impl(self, request)
             .await
             .map_err(|e| e.into())
@@ -204,7 +204,6 @@ impl<
         &self,
         request: Request<kms_grpc::kms::v1::PublicDecryptionRequest>,
     ) -> Result<Response<Empty>, Status> {
-        METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_REQUEST);
         public_decrypt_impl(self, request)
             .await
             .map_err(|e| e.into())
@@ -215,7 +214,6 @@ impl<
         &self,
         request: Request<v1::RequestId>,
     ) -> Result<Response<kms_grpc::kms::v1::PublicDecryptionResponse>, Status> {
-        METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_RESULT);
         get_public_decryption_result_impl(self, request)
             .await
             .map_err(|e| e.into())
@@ -226,7 +224,6 @@ impl<
         &self,
         request: Request<kms_grpc::kms::v1::PublicDecryptionRequest>,
     ) -> Result<Response<kms_grpc::kms::v1::PublicDecryptionResponse>, Status> {
-        METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_SYNC);
         public_decrypt_sync_impl(self, request)
             .await
             .map_err(|e| e.into())

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -11,18 +11,19 @@ use crate::engine::validation::{
     parse_optional_grpc_request_id, validate_public_decrypt_req, validate_user_decrypt_req,
 };
 use crate::util::meta_store::{
-    EntryState, add_or_redo_failed_in_meta_store, retrieve_from_meta_store_with_timeout,
+    add_or_redo_failed_in_meta_store, retrieve_from_meta_store_with_timeout,
     update_req_in_meta_store,
 };
 use crate::vault::storage::{Storage, StorageExt};
+use kms_grpc::RequestId;
 use kms_grpc::kms::v1::{
     Empty, PublicDecryptionRequest, PublicDecryptionResponse, PublicDecryptionResponsePayload,
     UserDecryptionRequest, UserDecryptionResponse,
 };
 use observability::metrics::METRICS;
 use observability::metrics_names::{
-    CENTRAL_TAG, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT, OP_PUBLIC_DECRYPT_SYNC,
-    OP_USER_DECRYPT_REQUEST, OP_USER_DECRYPT_RESULT, OP_USER_DECRYPT_SYNC, TAG_PARTY_ID,
+    CENTRAL_TAG, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT, OP_USER_DECRYPT_REQUEST,
+    OP_USER_DECRYPT_RESULT, TAG_PARTY_ID,
 };
 use std::sync::Arc;
 use tonic::{Code, Request, Response};
@@ -38,6 +39,8 @@ pub async fn user_decrypt_impl<
     service: &CentralizedKms<PubS, PrivS, CM, BO>,
     request: Request<UserDecryptionRequest>,
 ) -> Result<Response<Empty>, MetricedError> {
+    METRICS.increment_request_counter(OP_USER_DECRYPT_REQUEST);
+
     let permit = service.rate_limiter.start_user_decrypt().await?;
     let timer = METRICS
         .time_operation(OP_USER_DECRYPT_REQUEST)
@@ -158,42 +161,24 @@ pub async fn user_decrypt_sync_impl<
     service: &CentralizedKms<PubS, PrivS, CM, BO>,
     request: Request<UserDecryptionRequest>,
 ) -> Result<Response<UserDecryptionResponse>, MetricedError> {
-    // Time the whole call, wait included: this is the latency the sync endpoint exists to cut.
-    let _timer = METRICS
-        .time_operation(OP_USER_DECRYPT_SYNC)
-        .tag(TAG_PARTY_ID, CENTRAL_TAG.to_string())
-        .start();
+    // `user_decrypt_impl` consumes the request, so keep the raw id for fetching the result below.
+    let raw_request_id = request.get_ref().request_id.clone();
 
-    let request_id = parse_optional_grpc_request_id(
-        &request.get_ref().request_id,
-        RequestIdParsingErr::UserDecRequest,
-    )
-    .map_err(|e| MetricedError::new(OP_USER_DECRYPT_SYNC, None, e, tonic::Code::InvalidArgument))?;
-
-    let should_start = match service
-        .user_dec_meta_store
-        .read()
-        .await
-        .retrieve(&request_id)
-    {
-        None => true,                           // fresh request ID
-        Some(EntryState::Done(Err(_))) => true, // previously failed, redo it under the same ID
-        Some(EntryState::Done(Ok(_))) => false, // already succeeded, return the stored result
-        Some(EntryState::Pending) => false,     // in flight, attach to it
-        Some(EntryState::Deleted) => false,     // tombstoned, let the wait report `NotFound`
-    };
-    if should_start {
-        match user_decrypt_impl(service, request).await {
-            Ok(_empty) => (),
-            // Another call won the race to start or redo this request: attach to that attempt
-            Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
-            Err(e) => return Err(e.retag(OP_USER_DECRYPT_SYNC)),
-        }
+    match user_decrypt_impl(service, request).await {
+        Ok(_empty) => (),
+        // Already succeeded, in flight, or tombstoned: attach to the existing entry
+        Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
+        Err(e) => return Err(e),
     }
 
-    get_user_decryption_result_impl(service, Request::new(request_id.into()))
-        .await
-        .map_err(|e| e.retag(OP_USER_DECRYPT_SYNC))
+    // `user_decrypt_impl` accepted the request, so its id must parse.
+    let request_id: RequestId =
+        parse_optional_grpc_request_id(&raw_request_id, RequestIdParsingErr::UserDecRequest)
+            .map_err(|e| {
+                MetricedError::new(OP_USER_DECRYPT_REQUEST, None, e, Code::InvalidArgument)
+            })?;
+
+    get_user_decryption_result_impl(service, Request::new(request_id.into())).await
 }
 
 /// Implementation of the get_user_decryption_result endpoint
@@ -206,6 +191,8 @@ pub async fn get_user_decryption_result_impl<
     service: &CentralizedKms<PubS, PrivS, CM, BO>,
     request: Request<kms_grpc::kms::v1::RequestId>,
 ) -> Result<Response<UserDecryptionResponse>, MetricedError> {
+    METRICS.increment_request_counter(OP_USER_DECRYPT_RESULT);
+
     let request_id =
         parse_grpc_request_id(&request.into_inner(), RequestIdParsingErr::UserDecRequest).map_err(
             |e| {
@@ -266,6 +253,8 @@ pub async fn public_decrypt_impl<
     service: &CentralizedKms<PubS, PrivS, CM, BO>,
     request: Request<PublicDecryptionRequest>,
 ) -> Result<Response<Empty>, MetricedError> {
+    METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_REQUEST);
+
     let permit = service.rate_limiter.start_pub_decrypt().await?;
     let timer = METRICS
         .time_operation(OP_PUBLIC_DECRYPT_REQUEST)
@@ -393,37 +382,24 @@ pub async fn public_decrypt_sync_impl<
     service: &CentralizedKms<PubS, PrivS, CM, BO>,
     request: Request<PublicDecryptionRequest>,
 ) -> Result<Response<PublicDecryptionResponse>, MetricedError> {
-    // Time the whole call, wait included: this is the latency the sync endpoint exists to cut.
-    let _timer = METRICS
-        .time_operation(OP_PUBLIC_DECRYPT_SYNC)
-        .tag(TAG_PARTY_ID, CENTRAL_TAG.to_string())
-        .start();
+    // `public_decrypt_impl` consumes the request, so keep the raw id for fetching the result below
+    let raw_request_id = request.get_ref().request_id.clone();
 
-    let req_id = parse_optional_grpc_request_id(
-        &request.get_ref().request_id,
-        RequestIdParsingErr::PublicDecRequest,
-    )
-    .map_err(|e| MetricedError::new(OP_PUBLIC_DECRYPT_SYNC, None, e, Code::InvalidArgument))?;
-
-    let should_start = match service.pub_dec_meta_store.read().await.retrieve(&req_id) {
-        None => true,                           // fresh request ID
-        Some(EntryState::Done(Err(_))) => true, // previously failed, redo it under the same ID
-        Some(EntryState::Done(Ok(_))) => false, // already succeeded, return the stored result
-        Some(EntryState::Pending) => false,     // in flight, attach to it
-        Some(EntryState::Deleted) => false,     // tombstoned, let the wait report `NotFound`
-    };
-    if should_start {
-        match public_decrypt_impl(service, request).await {
-            Ok(_empty) => (),
-            // Another call won the race to start or redo this request: attach to that attempt
-            Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
-            Err(e) => return Err(e.retag(OP_PUBLIC_DECRYPT_SYNC)),
-        }
+    match public_decrypt_impl(service, request).await {
+        Ok(_empty) => (),
+        // Already succeeded, in flight, or tombstoned: attach to the existing entry
+        Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
+        Err(e) => return Err(e),
     }
 
-    get_public_decryption_result_impl(service, Request::new(req_id.into()))
-        .await
-        .map_err(|e| e.retag(OP_PUBLIC_DECRYPT_SYNC))
+    // `public_decrypt_impl` accepted the request, so its id must parse.
+    let req_id: RequestId =
+        parse_optional_grpc_request_id(&raw_request_id, RequestIdParsingErr::PublicDecRequest)
+            .map_err(|e| {
+                MetricedError::new(OP_PUBLIC_DECRYPT_REQUEST, None, e, Code::InvalidArgument)
+            })?;
+
+    get_public_decryption_result_impl(service, Request::new(req_id.into())).await
 }
 
 /// Implementation of the get_public_decryption_result endpoint
@@ -436,6 +412,8 @@ pub async fn get_public_decryption_result_impl<
     service: &CentralizedKms<PubS, PrivS, CM, BO>,
     request: Request<kms_grpc::kms::v1::RequestId>,
 ) -> Result<Response<PublicDecryptionResponse>, MetricedError> {
+    METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_RESULT);
+
     let request_id = parse_grpc_request_id(
         &request.into_inner(),
         RequestIdParsingErr::PublicDecResponse,
@@ -832,6 +810,26 @@ mod tests_public_decryption {
     }
 
     #[tokio::test]
+    async fn sync_call_shares_request_and_result_counters() {
+        let mut rng = AesRng::seed_from_u64(1234);
+        let key_id = derive_request_id("keyid_decryption_sync_counters").unwrap();
+        let (kms, pk, _) = setup_test_kms_with_key(&mut rng, &key_id).await;
+        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
+        let request_id = derive_request_id("req_id_decryption_sync_counters").unwrap();
+        let (_msg, ciphertexts) = make_test_msg_ct(&pk, true);
+        let request = make_valid_request(request_id, key_id, ciphertexts, &domain);
+
+        let requests_before = METRICS.request_counter_value(OP_PUBLIC_DECRYPT_REQUEST);
+        let results_before = METRICS.request_counter_value(OP_PUBLIC_DECRYPT_RESULT);
+        public_decrypt_sync_impl(&kms, tonic::Request::new(request))
+            .await
+            .unwrap();
+        // Check global growth: the counters are shared at the process level.
+        assert!(METRICS.request_counter_value(OP_PUBLIC_DECRYPT_REQUEST) > requests_before);
+        assert!(METRICS.request_counter_value(OP_PUBLIC_DECRYPT_RESULT) > results_before);
+    }
+
+    #[tokio::test]
     async fn sunshine_sync() {
         let mut rng = AesRng::seed_from_u64(1234);
         let key_id = derive_request_id("keyid_decryption_sunshine_sync").unwrap();
@@ -1188,6 +1186,27 @@ mod test_user_decryption {
             recorded_errors_before,
             "attaching to an already-known request ID must not report a failure"
         );
+    }
+
+    #[tokio::test]
+    async fn sync_call_shares_request_and_result_counters() {
+        let mut rng = AesRng::seed_from_u64(1234);
+        let key_id = derive_request_id("keyid_decryption_sync_counters").unwrap();
+        let (kms, pk, _verf_key) = setup_test_kms_with_key(&mut rng, &key_id).await;
+        let domain = alloy_to_protobuf_domain(&dummy_domain()).unwrap();
+        let request_id = derive_request_id("req_id_decryption_sync_counters").unwrap();
+        let (_msg, ciphertexts) = make_test_msg_ct(&pk, true);
+        let (enc_key_buf, _enc_sk) = make_test_pk(&mut rng);
+        let request = make_valid_request(request_id, key_id, ciphertexts, enc_key_buf, &domain);
+
+        let requests_before = METRICS.request_counter_value(OP_USER_DECRYPT_REQUEST);
+        let results_before = METRICS.request_counter_value(OP_USER_DECRYPT_RESULT);
+        user_decrypt_sync_impl(&kms, tonic::Request::new(request))
+            .await
+            .unwrap();
+        // Check global growth: the counters are shared at the process level.
+        assert!(METRICS.request_counter_value(OP_USER_DECRYPT_REQUEST) > requests_before);
+        assert!(METRICS.request_counter_value(OP_USER_DECRYPT_RESULT) > results_before);
     }
 
     #[tokio::test]

--- a/core/service/src/engine/threshold/endpoint.rs
+++ b/core/service/src/engine/threshold/endpoint.rs
@@ -126,12 +126,14 @@ impl_endpoint! {
             self.keygen_preprocessor.abort_key_gen_preproc(preproc_id, key_gen_abort_res).await.map_err(|e| e.into())
         }
 
+        // NOTE: unlike other endpoints, the decryption counters are incremented inside the
+        // implementations rather than here, so that async/sync endpoints share metric handling.
+
         #[tracing::instrument(skip(self, request))]
         async fn user_decrypt(
             &self,
             request: Request<UserDecryptionRequest>,
         ) -> Result<Response<Empty>, Status> {
-            METRICS.increment_request_counter(OP_USER_DECRYPT_REQUEST);
             self.user_decryptor.user_decrypt(request).await.map_err(|e| e.into())
         }
 
@@ -140,7 +142,6 @@ impl_endpoint! {
             &self,
             request: Request<RequestId>,
         ) -> Result<Response<UserDecryptionResponse>, Status> {
-            METRICS.increment_request_counter(OP_USER_DECRYPT_RESULT);
             self.user_decryptor.get_result(request).await.map_err(|e| e.into())
         }
 
@@ -149,7 +150,6 @@ impl_endpoint! {
             &self,
             request: Request<UserDecryptionRequest>,
         ) -> Result<Response<UserDecryptionResponse>, Status> {
-            METRICS.increment_request_counter(OP_USER_DECRYPT_SYNC);
             self.user_decryptor.user_decrypt_sync(request).await.map_err(|e| e.into())
         }
 
@@ -158,7 +158,6 @@ impl_endpoint! {
             &self,
             request: Request<PublicDecryptionRequest>,
         ) -> Result<Response<Empty>, Status> {
-            METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_REQUEST);
             self.decryptor.public_decrypt(request).await.map_err(|e| e.into())
         }
 
@@ -167,7 +166,6 @@ impl_endpoint! {
             &self,
             request: Request<RequestId>,
         ) -> Result<Response<PublicDecryptionResponse>, Status> {
-            METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_RESULT);
             self.decryptor.get_result(request).await.map_err(|e| e.into())
        }
 
@@ -176,7 +174,6 @@ impl_endpoint! {
             &self,
             request: Request<PublicDecryptionRequest>,
         ) -> Result<Response<PublicDecryptionResponse>, Status> {
-            METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_SYNC);
             self.decryptor.public_decrypt_sync(request).await.map_err(|e| e.into())
         }
 

--- a/core/service/src/engine/threshold/endpoint.rs
+++ b/core/service/src/engine/threshold/endpoint.rs
@@ -127,7 +127,9 @@ impl_endpoint! {
         }
 
         // NOTE: unlike other endpoints, the decryption counters are incremented inside the
-        // implementations rather than here, so that async/sync endpoints share metric handling.
+        // shared implementation, not here: one place instead of two (sync/async), and the
+        // sync path calls `get_result` directly, bypassing this dispatch, so incrementing
+        // here would skip that counter bump entirely.
 
         #[tracing::instrument(skip(self, request))]
         async fn user_decrypt(

--- a/core/service/src/engine/threshold/service/public_decryptor.rs
+++ b/core/service/src/engine/threshold/service/public_decryptor.rs
@@ -10,6 +10,7 @@ use algebra::{
 use anyhow::anyhow;
 use itertools::Itertools;
 use kms_grpc::{
+    RequestId,
     identifiers::{ContextId, EpochId},
     kms::v1::{
         self, CiphertextFormat, Empty, PublicDecryptionRequest, PublicDecryptionResponse,
@@ -19,8 +20,8 @@ use kms_grpc::{
 use observability::{
     metrics::{self},
     metrics_names::{
-        OP_PUBLIC_DECRYPT_INNER, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT,
-        OP_PUBLIC_DECRYPT_SYNC, TAG_PARTY_ID, TAG_PUBLIC_DECRYPTION_KIND, TAG_TFHE_TYPE,
+        OP_PUBLIC_DECRYPT_INNER, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT, TAG_PARTY_ID,
+        TAG_PUBLIC_DECRYPTION_KIND, TAG_TFHE_TYPE,
     },
 };
 use tfhe::FheTypes;
@@ -63,9 +64,8 @@ use crate::{
     },
     util::{
         meta_store::{
-            EntryState, MetaStore, add_or_redo_failed_in_meta_store,
-            retrieve_from_meta_store_with_timeout, update_err_req_in_meta_store,
-            update_req_in_meta_store,
+            MetaStore, add_or_redo_failed_in_meta_store, retrieve_from_meta_store_with_timeout,
+            update_err_req_in_meta_store, update_req_in_meta_store,
         },
         rate_limiter::RateLimiter,
     },
@@ -275,6 +275,8 @@ impl<
         &self,
         request: Request<PublicDecryptionRequest>,
     ) -> Result<Response<Empty>, MetricedError> {
+        metrics::METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_REQUEST);
+
         // Check for resource exhaustion once all the other checks are ok
         // because resource exhaustion can be recovered by sending the exact same request
         // but the errors above cannot be tried again.
@@ -620,41 +622,32 @@ impl<
         &self,
         request: Request<PublicDecryptionRequest>,
     ) -> Result<Response<PublicDecryptionResponse>, MetricedError> {
-        let _timer = metrics::METRICS
-            .time_operation(OP_PUBLIC_DECRYPT_SYNC)
-            .start();
+        // `public_decrypt` consumes the request, so keep the raw id for fetching the result below.
+        let raw_request_id = request.get_ref().request_id.clone();
 
-        let req_id = parse_optional_grpc_request_id(
-            &request.get_ref().request_id,
-            RequestIdParsingErr::PublicDecRequest,
-        )
-        .map_err(|e| MetricedError::new(OP_PUBLIC_DECRYPT_SYNC, None, e, Code::InvalidArgument))?;
-
-        let should_start = match self.pub_dec_meta_store.read().await.retrieve(&req_id) {
-            None => true,                           // fresh request ID
-            Some(EntryState::Done(Err(_))) => true, // previously failed, redo it under the same ID
-            Some(EntryState::Done(Ok(_))) => false, // already succeeded, return the stored result
-            Some(EntryState::Pending) => false,     // in flight, attach to it
-            Some(EntryState::Deleted) => false,     // tombstoned, let the wait report `NotFound`
-        };
-        if should_start {
-            match self.public_decrypt(request).await {
-                Ok(_empty) => (),
-                // Another call won the race to start or redo this request: attach to that attempt
-                Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
-                Err(e) => return Err(e.retag(OP_PUBLIC_DECRYPT_SYNC)),
-            }
+        match self.public_decrypt(request).await {
+            Ok(_empty) => (),
+            // Already succeeded, in flight, or tombstoned: attach to the existing entry
+            Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
+            Err(e) => return Err(e),
         }
 
-        self.get_result(Request::new(req_id.into()))
-            .await
-            .map_err(|e| e.retag(OP_PUBLIC_DECRYPT_SYNC))
+        // `public_decrypt` accepted the request, so its id must parse.
+        let req_id: RequestId =
+            parse_optional_grpc_request_id(&raw_request_id, RequestIdParsingErr::PublicDecRequest)
+                .map_err(|e| {
+                    MetricedError::new(OP_PUBLIC_DECRYPT_REQUEST, None, e, Code::InvalidArgument)
+                })?;
+
+        self.get_result(Request::new(req_id.into())).await
     }
 
     async fn get_result(
         &self,
         request: Request<v1::RequestId>,
     ) -> Result<Response<PublicDecryptionResponse>, MetricedError> {
+        metrics::METRICS.increment_request_counter(OP_PUBLIC_DECRYPT_RESULT);
+
         let request_id = parse_grpc_request_id(
             &request.into_inner(),
             RequestIdParsingErr::PublicDecResponse,
@@ -743,6 +736,7 @@ fn format_public_request(request: &PublicDecryptionRequest) -> String {
         request.ciphertexts.len()
     )
 }
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -750,6 +744,7 @@ mod tests {
         cryptography::signatures::gen_sig_keys,
         dummy_domain,
         engine::threshold::service::session::SessionMaker,
+        util::meta_store::EntryState,
         vault::storage::{crypto_material::PublicKeySet, ram},
     };
     use aes_prng::AesRng;
@@ -1240,6 +1235,26 @@ mod tests {
             recorded_errors_before,
             "attaching to an already-known request ID must not report a failure"
         );
+    }
+
+    #[tokio::test]
+    async fn sync_call_shares_request_and_result_counters() {
+        let mut rng = AesRng::seed_from_u64(42);
+        let (key_id, epoch_id, ct_buf, public_decryptor) = setup_public_decryptor(&mut rng).await;
+        let req_id = RequestId::new_random(&mut rng);
+        let request = make_valid_request(req_id, key_id, epoch_id, ct_buf);
+
+        let requests_before = metrics::METRICS.request_counter_value(OP_PUBLIC_DECRYPT_REQUEST);
+        let results_before = metrics::METRICS.request_counter_value(OP_PUBLIC_DECRYPT_RESULT);
+        public_decryptor
+            .public_decrypt_sync(Request::new(request))
+            .await
+            .unwrap();
+        // Check global growth: the counters are shared at the process level.
+        assert!(
+            metrics::METRICS.request_counter_value(OP_PUBLIC_DECRYPT_REQUEST) > requests_before
+        );
+        assert!(metrics::METRICS.request_counter_value(OP_PUBLIC_DECRYPT_RESULT) > results_before);
     }
 
     #[tokio::test]

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -27,8 +27,8 @@ use kms_grpc::{
 use observability::{
     metrics,
     metrics_names::{
-        OP_USER_DECRYPT_INNER, OP_USER_DECRYPT_REQUEST, OP_USER_DECRYPT_RESULT,
-        OP_USER_DECRYPT_SYNC, TAG_PARTY_ID, TAG_TFHE_TYPE, TAG_USER_DECRYPTION_KIND,
+        OP_USER_DECRYPT_INNER, OP_USER_DECRYPT_REQUEST, OP_USER_DECRYPT_RESULT, TAG_PARTY_ID,
+        TAG_TFHE_TYPE, TAG_USER_DECRYPTION_KIND,
     },
 };
 use rand::{CryptoRng, RngCore};
@@ -43,7 +43,7 @@ use threshold_execution::{
 };
 use tokio::sync::{OwnedRwLockReadGuard, RwLock};
 use tokio_util::task::TaskTracker;
-use tonic::{Request, Response};
+use tonic::{Code, Request, Response};
 use tracing::Instrument;
 
 // === Internal Crate ===
@@ -72,8 +72,8 @@ use crate::{
     },
     util::{
         meta_store::{
-            EntryState, MetaStore, add_or_redo_failed_in_meta_store,
-            retrieve_from_meta_store_with_timeout, update_req_in_meta_store,
+            MetaStore, add_or_redo_failed_in_meta_store, retrieve_from_meta_store_with_timeout,
+            update_req_in_meta_store,
         },
         rate_limiter::RateLimiter,
     },
@@ -439,11 +439,13 @@ impl<
         &self,
         request: Request<UserDecryptionRequest>,
     ) -> Result<Response<Empty>, MetricedError> {
+        metrics::METRICS.increment_request_counter(OP_USER_DECRYPT_REQUEST);
+
         // Check for resource exhaustion once all the other checks are ok
         // because resource exhaustion can be recovered by sending the exact same request
         // but the errors above cannot be tried again.
         let permit = self.rate_limiter.start_user_decrypt().await?;
-        // Start timing and counting before any operations
+        // Start timing before any operations
         let mut timer = metrics::METRICS
             .time_operation(OP_USER_DECRYPT_REQUEST)
             .start();
@@ -570,43 +572,32 @@ impl<
         &self,
         request: Request<UserDecryptionRequest>,
     ) -> Result<Response<UserDecryptionResponse>, MetricedError> {
-        let _timer = metrics::METRICS
-            .time_operation(OP_USER_DECRYPT_SYNC)
-            .start();
+        // `user_decrypt` consumes the request, so keep the raw id for fetching the result below.
+        let raw_request_id = request.get_ref().request_id.clone();
 
-        let req_id = parse_optional_grpc_request_id(
-            &request.get_ref().request_id,
-            RequestIdParsingErr::UserDecRequest,
-        )
-        .map_err(|e| {
-            MetricedError::new(OP_USER_DECRYPT_SYNC, None, e, tonic::Code::InvalidArgument)
-        })?;
-
-        let should_start = match self.user_decrypt_meta_store.read().await.retrieve(&req_id) {
-            None => true,                           // fresh request ID
-            Some(EntryState::Done(Err(_))) => true, // previously failed, redo it under the same ID
-            Some(EntryState::Done(Ok(_))) => false, // already succeeded, return the stored result
-            Some(EntryState::Pending) => false,     // in flight, attach to it
-            Some(EntryState::Deleted) => false,     // tombstoned, let the wait report `NotFound`
-        };
-        if should_start {
-            match self.user_decrypt(request).await {
-                Ok(_empty) => (),
-                // Another call won the race to start or redo this request: attach to that attempt
-                Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
-                Err(e) => return Err(e.retag(OP_USER_DECRYPT_SYNC)),
-            }
+        match self.user_decrypt(request).await {
+            Ok(_empty) => (),
+            // Already succeeded, in flight, or tombstoned: attach to the existing entry
+            Err(e) if e.code() == tonic::Code::AlreadyExists => e.defuse(),
+            Err(e) => return Err(e),
         }
 
-        self.get_result(Request::new(req_id.into()))
-            .await
-            .map_err(|e| e.retag(OP_USER_DECRYPT_SYNC))
+        // `user_decrypt` accepted the request, so its id must parse.
+        let req_id: RequestId =
+            parse_optional_grpc_request_id(&raw_request_id, RequestIdParsingErr::UserDecRequest)
+                .map_err(|e| {
+                    MetricedError::new(OP_USER_DECRYPT_REQUEST, None, e, Code::InvalidArgument)
+                })?;
+
+        self.get_result(Request::new(req_id.into())).await
     }
 
     async fn get_result(
         &self,
         request: Request<v1::RequestId>,
     ) -> Result<Response<UserDecryptionResponse>, MetricedError> {
+        metrics::METRICS.increment_request_counter(OP_USER_DECRYPT_RESULT);
+
         let request_id =
             parse_grpc_request_id(&request.into_inner(), RequestIdParsingErr::UserDecResponse)
                 .map_err(|e| {
@@ -694,6 +685,7 @@ mod tests {
         },
         dummy_domain,
         engine::threshold::service::session::SessionMaker,
+        util::meta_store::EntryState,
         vault::storage::{crypto_material::PublicKeySet, ram},
     };
 
@@ -1134,6 +1126,24 @@ mod tests {
             recorded_errors_before,
             "attaching to an already-known request ID must not report a failure"
         );
+    }
+
+    #[tokio::test]
+    async fn sync_call_shares_request_and_result_counters() {
+        let mut rng = AesRng::seed_from_u64(42);
+        let (key_id, epoch_id, ct_buf, user_decryptor) = setup_user_decryptor(&mut rng).await;
+        let req_id = RequestId::new_random(&mut rng);
+        let request = make_valid_request(&mut rng, req_id, key_id, epoch_id, ct_buf);
+
+        let requests_before = metrics::METRICS.request_counter_value(OP_USER_DECRYPT_REQUEST);
+        let results_before = metrics::METRICS.request_counter_value(OP_USER_DECRYPT_RESULT);
+        user_decryptor
+            .user_decrypt_sync(Request::new(request))
+            .await
+            .unwrap();
+        // Check global growth: the counters are shared at the process level.
+        assert!(metrics::METRICS.request_counter_value(OP_USER_DECRYPT_REQUEST) > requests_before);
+        assert!(metrics::METRICS.request_counter_value(OP_USER_DECRYPT_RESULT) > results_before);
     }
 
     #[tokio::test]

--- a/core/service/src/engine/utils.rs
+++ b/core/service/src/engine/utils.rs
@@ -546,12 +546,6 @@ impl MetricedError {
         self.error_code
     }
 
-    /// Re-attribute this error to another operation metric.
-    pub(crate) fn retag(mut self, op_metric: &'static str) -> Self {
-        self.op_metric = op_metric;
-        self
-    }
-
     /// Consume an error that the caller expected and has already accounted for, without recording
     /// it.
     pub(crate) fn defuse(mut self) {

--- a/docs/developer/metrics.md
+++ b/docs/developer/metrics.md
@@ -37,10 +37,8 @@ pub const OP_DECOMPRESSION_COMPRESSED_KEYGEN: &str = "decompression_compressed_k
 // Corresponds to a request, a request may contain several ciphertexts
 pub const OP_PUBLIC_DECRYPT_REQUEST: &str = "public_decrypt_request";
 pub const OP_PUBLIC_DECRYPT_RESULT: &str = "public_decrypt_result";
-pub const OP_PUBLIC_DECRYPT_SYNC: &str = "public_decrypt_sync";
 pub const OP_USER_DECRYPT_REQUEST: &str = "user_decrypt_request";
 pub const OP_USER_DECRYPT_RESULT: &str = "user_decrypt_result";
-pub const OP_USER_DECRYPT_SYNC: &str = "user_decrypt_sync";
 // Inner variants of the OP
 // Corresponds to a single ciphertext
 pub const OP_PUBLIC_DECRYPT_INNER: &str = "public_decrypt_inner";

--- a/docs/operations/advanced/metrics.md
+++ b/docs/operations/advanced/metrics.md
@@ -52,14 +52,18 @@ KMS exposes metrics via Prometheus format on the configured metrics endpoint (de
 - `decompression_keygen` - Decompression key generation
 
 *Decryption Operations*:
-- `user_decrypt_request` - Asynchronous user decryption requests
-- `user_decrypt_result` - User decryption result retrievals through `GetUserDecryptionResult`
-- `user_decrypt_sync` - Synchronous user decryption requests
+- `user_decrypt_request` - User decryption requests
+- `user_decrypt_result` - User decryption result retrievals
 - `user_decrypt_inner` - Individual user decryption operations *(duration only)*
-- `public_decrypt_request` - Asynchronous public decryption requests
-- `public_decrypt_result` - Public decryption result retrievals through `GetPublicDecryptionResult`
-- `public_decrypt_sync` - Synchronous public decryption requests
+- `public_decrypt_request` - Public decryption requests
+- `public_decrypt_result` - Public decryption result retrievals
 - `public_decrypt_inner` - Individual public decryption operations *(duration only)*
+
+The synchronous decryption endpoints (`UserDecryptSync` / `PublicDecryptSync`) have no
+operations of their own: a sync call counts as one `*_decrypt_request` operation plus one
+`*_decrypt_result` operation (its internal wait for the result), exactly like an async client
+that sends the request and then polls `Get*DecryptionResult`. Dashboards and alerts built on
+these operations therefore work unchanged whether clients use the async or the sync endpoints.
 
 *CRS Operations*:
 - `crs_gen_request` - CRS generation requests

--- a/observability/src/metrics.rs
+++ b/observability/src/metrics.rs
@@ -436,6 +436,13 @@ impl CoreMetrics {
             .inc();
     }
 
+    /// Current value of `kms_operations_total` for `operation`.
+    pub fn request_counter_value(&self, operation: impl AsRef<str>) -> u64 {
+        self.request_counter
+            .with_label_values(&[operation.as_ref()])
+            .get()
+    }
+
     pub fn increment_error_counter(&self, operation: impl AsRef<str>, error: impl AsRef<str>) {
         self.error_counter
             .with_label_values(&[operation.as_ref(), error.as_ref()])
@@ -1167,6 +1174,18 @@ mod tests {
         assert!(
             !operation_values.iter().any(|v| v == "_test_spoofed"),
             "a TAG_OPERATION_TYPE tag must not override the operation_type label"
+        );
+    }
+
+    #[test]
+    fn request_counter_value_tracks_increments() {
+        assert_eq!(METRICS.request_counter_value("_test_counter_unused"), 0);
+
+        let before = METRICS.request_counter_value("_test_counter_op");
+        METRICS.increment_request_counter("_test_counter_op");
+        assert_eq!(
+            METRICS.request_counter_value("_test_counter_op"),
+            before + 1
         );
     }
 

--- a/observability/src/metrics_names.rs
+++ b/observability/src/metrics_names.rs
@@ -30,10 +30,8 @@ pub const OP_DECOMPRESSION_COMPRESSED_KEYGEN: &str = "decompression_compressed_k
 // Corresponds to a request, a request may contain several ciphertexts
 pub const OP_PUBLIC_DECRYPT_REQUEST: &str = "public_decrypt_request";
 pub const OP_PUBLIC_DECRYPT_RESULT: &str = "public_decrypt_result";
-pub const OP_PUBLIC_DECRYPT_SYNC: &str = "public_decrypt_sync";
 pub const OP_USER_DECRYPT_REQUEST: &str = "user_decrypt_request";
 pub const OP_USER_DECRYPT_RESULT: &str = "user_decrypt_result";
-pub const OP_USER_DECRYPT_SYNC: &str = "user_decrypt_sync";
 // Inner variants of the OP
 // Corresponds to a single ciphertext
 pub const OP_PUBLIC_DECRYPT_INNER: &str = "public_decrypt_inner";


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->
This unifies decryption metrics between the async and sync endpoints. The dedicated `user_decrypt_sync` / `public_decrypt_sync` operations are gone, and the sync endpoints now just delegate to the shared async decryption implementation: submit the request, then wait for the result via `get_result` (with `AlreadyExists` defused so a sync call can attach to a request that's already in flight or already failed). We also dropped the `should_start` pre-check, since `add_or_redo_failed_in_meta_store` already handles that.

**The problem:** Counters and timers disagreed on what counted as a sync call. The counter was incremented at the endpoint level, so a sync call only ever bumped `*_decrypt_sync`. But the duration histogram started inside the shared decryption implementation, which both sync and async go through, so that same call was timed under `*_decrypt_request`. In other words, a sync request added duration to `*_decrypt_request` without adding a matching count. Any dashboard dividing duration by count for the async operation (average latency, per-request cost) would skew as soon as sync traffic showed up, and skew worse the more sync dominated. The same problem existed in reverse for `*_decrypt_result`, which never saw the sync call's internal wait at all.

**The tradeoff:** The issue suggested an alternative: keep the two flows separate and tag both signals with `origin=sync|async`. That's more informative, but it means adding a tag parameter to `increment_request_counter` in the `observability` crate (the timer already supports tags), plus rewriting every existing decryption dashboard, alert, and recording rule to sum over the new tag: otherwise they start under-reporting. We went with the simpler option instead: merge the two flows. Sync endpoints delegate to the shared implementation, and the counters get bumped there, right next to where the timer starts, instead of in the endpoint wrappers. A sync call now counts as one `*_decrypt_request` plus one `*_decrypt_result`, just like an async client that submits and then polls, so the counter and timer describe the same set of operations by construction and can't drift apart again. The cost is that `kms_operations_total` alone can no longer tell sync and async traffic apart. We're fine with that trade because production deployments run either 100% sync or 100% async, so that split wouldn't carry any signal anyway. In exchange, every existing dashboard and alert keeps working as-is, with no observability API change and no query migration needed.

**Behavioral note:** The sync attach/retry path now goes through request validation and the rate limiter just like any other submission. This means that under saturation, a sync call returns `ResourceExhausted` instead of attaching to an existing request (matching what the async flow already does).

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->
Closes https://github.com/zama-ai/kms-internal/issues/3163

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
