### PR TITLE
chore: fix meta store on boot v0.14.x

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -165,6 +165,10 @@ when the optional `[threshold]` section is present; see the sample
 files in `core/service/config/` (`default_centralized.toml`,
 `default_1.toml`..`default_4.toml`, and the compose-specific variants).
 
+In both modes, when the same key or CRS ID has metadata under multiple epochs,
+startup loads the metadata from the greatest epoch ID into the result meta
+store. Epoch IDs are compared as big-endian integers.
+
 ### Centralized
 
 A single `RealCentralizedKms` instance holds all key material. No MPC; keys

--- a/core/grpc/proto/kms.v1.proto
+++ b/core/grpc/proto/kms.v1.proto
@@ -699,7 +699,7 @@ message RecoveryRequest {
   // The ephemeral encryption key of the operator used when signcrypting the recovered data during transit to the operator.
   bytes ephem_op_enc_key = 1;
   // The public verification key of the KMS server. MUST be manually validated by custodian
-  bytes operator_verf_key = 2; 
+  bytes operator_verf_key = 2;
   /// The ciphertexts that are the backup. Indexed by the custodian role.
   map<uint64, OperatorBackupOutput> cts = 3;
 }
@@ -815,9 +815,10 @@ message NewMpcEpochRequest {
   // The KMS context of the parties that will receive
   // the shares of the private key at the end of the reshare execution
   RequestId context_id = 1;
-  // The epoch number placeholder (zama-ai/kms-internal#2743).
-  // This is the epochId we reshare the shares from.
-  // Note: currently unused but reserved for future use.
+  // The ID of the new epoch being created by this request.
+  // The caller must ensure the epoch IDs are chronological (based on raw bytes
+  // as a big-endian integer), i.e., every new epoch ID must be greater than the
+  // previous one.
   RequestId epoch_id = 2;
   // Information about the previous epoch, used to perform resharing.
   // If not set, no keys will exist for the new epoch. (e.g. during init)

--- a/core/grpc/src/identifiers.rs
+++ b/core/grpc/src/identifiers.rs
@@ -54,6 +54,9 @@ pub struct KeyId([u8; ID_LENGTH]);
 pub struct RequestId([u8; ID_LENGTH]);
 
 /// EpochId represents a unique identifier for an epoch/PRSS.
+///
+/// Epoch IDs are ordered chronologically by comparing their raw bytes as a
+/// big-endian integer.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Copy)]
 pub struct EpochId([u8; ID_LENGTH]);
 
@@ -80,6 +83,18 @@ impl PartialOrd for RequestId {
 }
 
 impl Ord for RequestId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl PartialOrd for EpochId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for EpochId {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.0.cmp(&other.0)
     }
@@ -759,5 +774,18 @@ mod tests {
         assert!(base < base_larger_2);
         assert!(base > base_smaller_1);
         assert!(base > base_smaller_2);
+    }
+
+    #[test]
+    fn epoch_id_ordering_treats_bytes_as_big_endian_integer() {
+        let lower_suffix = EpochId::try_from(1_u128).unwrap();
+        let higher_suffix = EpochId::try_from(2_u128).unwrap();
+        let higher_prefix = EpochId::from_bytes([
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ]);
+
+        assert!(lower_suffix < higher_suffix);
+        assert!(higher_suffix < higher_prefix);
     }
 }

--- a/core/service/src/engine/centralized/central_kms.rs
+++ b/core/service/src/engine/centralized/central_kms.rs
@@ -25,7 +25,9 @@ use crate::engine::validation::DSEP_USER_DECRYPTION;
 use crate::grpc::metastore_status_service::CustodianMetaStore;
 use crate::util::key_setup::FhePublicKey;
 use crate::util::meta_store::MetaStore;
-use crate::vault::storage::{StorageExt, read_all_data_from_all_epochs_versioned};
+use crate::vault::storage::{
+    StorageExt, read_all_data_from_all_epochs_versioned, select_data_from_max_epoch,
+};
 #[cfg(feature = "non-wasm")]
 use observability::conf::TelemetryConfig;
 use observability::metrics_names::OP_BOOT;
@@ -904,18 +906,18 @@ impl<
             "loaded key_info with key_ids: {:?}",
             key_info.keys().collect::<Vec<_>>()
         );
-        let public_key_info = key_info
-            .iter()
-            .map(|((id, _), info)| (id.to_owned(), info.public_key_info.to_owned()))
-            .collect();
-        let crs_info: HashMap<RequestId, CrsGenMetadata> = read_all_data_from_all_epochs_versioned(
-            &private_storage,
-            &PrivDataType::CrsInfo.to_string(),
-        )
-        .await?
-        .into_iter()
-        .map(|((req, _epoch), v)| (req, v))
-        .collect();
+        let public_key_info = select_data_from_max_epoch(
+            key_info
+                .iter()
+                .map(|((id, epoch_id), info)| ((*id, *epoch_id), info.public_key_info.clone())),
+        );
+        let crs_info: HashMap<RequestId, CrsGenMetadata> = select_data_from_max_epoch(
+            read_all_data_from_all_epochs_versioned(
+                &private_storage,
+                &PrivDataType::CrsInfo.to_string(),
+            )
+            .await?,
+        );
 
         sanity_check_crs_materials(&public_storage, &crs_info).await?;
 

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -554,6 +554,8 @@ where
     }
 
     // Build public_key_info map using the chronologically latest epoch for each key ID.
+    // Epoch IDs are ordered chronologically by comparing their raw bytes as a
+    // big-endian integer.
     let public_key_info = select_data_from_max_epoch(
         key_info_versioned
             .iter()

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -91,6 +91,7 @@ use crate::{
         storage::{
             Storage, StorageExt, crypto_material::ThresholdCryptoMaterialStorage,
             read_all_data_from_all_epochs_versioned, read_all_data_versioned,
+            select_data_from_max_epoch,
         },
     },
 };
@@ -539,7 +540,6 @@ where
         )
         .await?;
 
-    let mut public_key_info = HashMap::new();
     let validation_material: HashMap<RequestId, RecoveryValidationMaterial> =
         read_all_data_versioned(&public_storage, &PubDataType::RecoveryMaterial.to_string())
             .await?;
@@ -553,10 +553,12 @@ where
         }
     }
 
-    // Build public_key_info map
-    for ((id, _), info) in &key_info_versioned {
-        public_key_info.insert(*id, info.meta_data.clone());
-    }
+    // Build public_key_info map using the chronologically latest epoch for each key ID.
+    let public_key_info = select_data_from_max_epoch(
+        key_info_versioned
+            .iter()
+            .map(|((id, epoch_id), info)| ((*id, *epoch_id), info.meta_data.clone())),
+    );
 
     // sanity check the public materials
     let entries: Vec<_> = key_info_versioned
@@ -566,14 +568,13 @@ where
     sanity_check_public_materials(&public_storage, &entries).await?;
 
     // load crs_info (roughly hashes of CRS) from storage
-    let crs_info: HashMap<RequestId, CrsGenMetadata> = read_all_data_from_all_epochs_versioned(
-        &private_storage,
-        &PrivDataType::CrsInfo.to_string(),
-    )
-    .await?
-    .into_iter()
-    .map(|((req, _epoch), v)| (req, v))
-    .collect();
+    let crs_info: HashMap<RequestId, CrsGenMetadata> = select_data_from_max_epoch(
+        read_all_data_from_all_epochs_versioned(
+            &private_storage,
+            &PrivDataType::CrsInfo.to_string(),
+        )
+        .await?,
+    );
 
     sanity_check_crs_materials(&public_storage, &crs_info).await?;
 

--- a/core/service/src/vault/storage/mod.rs
+++ b/core/service/src/vault/storage/mod.rs
@@ -556,6 +556,33 @@ pub async fn read_all_data_from_all_epochs_versioned<
     Ok(res)
 }
 
+/// Select the data stored at the greatest epoch ID for each request ID.
+///
+/// The selection compares epoch IDs explicitly, so it does not depend on the
+/// iteration order of the input collection.
+pub(crate) fn select_data_from_max_epoch<T>(
+    entries: impl IntoIterator<Item = ((RequestId, EpochId), T)>,
+) -> HashMap<RequestId, T> {
+    let mut selected = HashMap::<RequestId, (EpochId, T)>::new();
+    for ((request_id, epoch_id), data) in entries {
+        match selected.entry(request_id) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert((epoch_id, data));
+            }
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if epoch_id > entry.get().0 {
+                    entry.insert((epoch_id, data));
+                }
+            }
+        }
+    }
+
+    selected
+        .into_iter()
+        .map(|(request_id, (_epoch_id, data))| (request_id, data))
+        .collect()
+}
+
 /// Helper method for reading all data of a specific type.
 pub async fn read_all_data_versioned<
     S: StorageReader,
@@ -778,6 +805,38 @@ pub mod tests {
             .delete_data_at_epoch(&id4, &epoch2, &data_type)
             .await
             .unwrap();
+    }
+
+    #[test]
+    fn select_data_from_max_epoch_selects_maximum_for_each_request() {
+        let request_id_1 = derive_request_id("max_epoch_request_1").unwrap();
+        let request_id_2 = derive_request_id("max_epoch_request_2").unwrap();
+        let earlier_epoch = EpochId::try_from(1_u128).unwrap();
+        let later_epoch = EpochId::try_from(2_u128).unwrap();
+
+        let selected = select_data_from_max_epoch([
+            ((request_id_1, earlier_epoch), 10),
+            ((request_id_2, earlier_epoch), 20),
+            ((request_id_1, later_epoch), 11),
+        ]);
+
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected.get(&request_id_1), Some(&11));
+        assert_eq!(selected.get(&request_id_2), Some(&20));
+    }
+
+    #[test]
+    fn select_data_from_max_epoch_ignores_later_lower_epoch_entry() {
+        let request_id = derive_request_id("max_epoch_reverse_order").unwrap();
+        let earlier_epoch = EpochId::try_from(1_u128).unwrap();
+        let later_epoch = EpochId::try_from(2_u128).unwrap();
+
+        let selected = select_data_from_max_epoch([
+            ((request_id, later_epoch), 11),
+            ((request_id, earlier_epoch), 10),
+        ]);
+
+        assert_eq!(selected.get(&request_id), Some(&11));
     }
 
     pub async fn test_batch_helper_methods<S: Storage>(storage: &mut S) {


### PR DESCRIPTION
## Description
This is a cherry-pick of https://github.com/zama-ai/kms/pull/767

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
