### PR TITLE
bench: dkg and ddec

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -226,10 +226,14 @@ graph LR
 
 The two binaries jobs compile the secure production flavor and the insecure test
 flavor. The downstream jobs only assemble runtime layers around the matching
-binaries. All published service and client jobs build the `prod` target. Release
-tags use fat LTO and other builds use thin LTO. Builds use OIDC auth, GHCR + CGR
-publishing, and an S3-backed cache. The workflow outputs `image_tag` and the
-insecure test enclave PCR values.
+binaries. All published service and client jobs build the `prod` target. The
+insecure flavor always uses thin LTO — never `off`, since pr-preview and
+perf-testing take their measurements from it; the secure flavor uses fat LTO on
+release tags and thin LTO otherwise. Both are built for the `x86-64-v3` CPU
+baseline (see
+[`docker/kms-binaries/Dockerfile`](../../docker/kms-binaries/Dockerfile)).
+Builds use OIDC auth, GHCR + CGR publishing, and an S3-backed cache. The
+workflow outputs `image_tag` and the insecure test enclave PCR values.
 
 ---
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -390,7 +390,16 @@ jobs:
       packages: write # Required to publish Docker images
       attestations: write # Required to create build attestations
     with:
-      lto-release: ${{ github.event_name == 'release' && 'release' || 'release-lto-off' }}
+      # These binaries are what pr-preview, perf-testing and rolling-upgrade
+      # actually deploy, so they must not be built with LTO off: cross-CGU and
+      # cross-crate inlining is worth double digits on the PRSS-heavy
+      # preprocessing path, and losing it makes every measurement taken against
+      # a preview or perf cluster an underestimate. Thin captures nearly all of
+      # that; fat costs a lot of link time for a further 1-3% that is below the
+      # noise floor of a 13-party cluster. Unconditional (rather than fat on
+      # release tags, as the secure flavor does) so that perf numbers stay
+      # comparable across every trigger.
+      lto-release: 'release-lto-thin'
       docker-file: './docker/kms-binaries/Dockerfile'
       working-directory: './docker/kms-binaries'
       image-name: 'kms/kms-binaries-insecure'

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -81,10 +81,10 @@ jobs:
         run: |
           echo "Deployment type: ${DEPLOYMENT_TYPE}"
           if [[ "${DEPLOYMENT_TYPE}" == *"threshold"* ]]; then
-            { echo "NB_KMS_PARTIES=4"; \
-              echo "THRESHOLD_VALUE=1"; \
-              echo "NUM_MAJORITY=2"; \
-              echo "NUM_RECONSTRUCT=3"
+            { echo "NB_KMS_PARTIES=13"; \
+              echo "THRESHOLD_VALUE=4"; \
+              echo "NUM_MAJORITY=5"; \
+              echo "NUM_RECONSTRUCT=9"
             } >> "$GITHUB_ENV"
           elif [[ "${DEPLOYMENT_TYPE}" == *"centralized"* ]]; then
             { echo "NB_KMS_PARTIES=1"; \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,31 +625,31 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
 name = "ark-ec"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-poly",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -712,7 +712,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rayon",
  "zeroize",
 ]
 
@@ -730,6 +729,7 @@ dependencies = [
  "educe",
  "num-bigint",
  "num-traits",
+ "rayon",
  "zeroize",
 ]
 
@@ -826,17 +826,17 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "rayon",
 ]
 
@@ -867,12 +867,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
  "num-bigint",
- "rayon",
 ]
 
 [[package]]
@@ -881,22 +879,12 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
- "ark-serialize-derive 0.6.0",
+ "ark-serialize-derive",
  "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint",
+ "rayon",
  "serde_with",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -938,7 +926,6 @@ checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
- "rayon",
 ]
 
 [[package]]
@@ -949,6 +936,7 @@ checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
+ "rayon",
 ]
 
 [[package]]
@@ -3852,7 +3840,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
  "foldhash 0.1.5",
 ]
 
@@ -3873,6 +3860,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -4404,6 +4392,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -7683,16 +7680,15 @@ dependencies = [
 
 [[package]]
 name = "tfhe"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f341a7a6fe90bf813ecb2b098f04c0e5bca82436ddd1b256e6f1ec68be58da52"
+version = "1.8.0"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?rev=2277991cd81c2995054889b8e512d1c048baab3b#2277991cd81c2995054889b8e512d1c048baab3b"
 dependencies = [
  "aligned-vec",
  "bincode 1.3.3",
  "blake3",
  "bytemuck",
  "dyn-stack",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "paste",
  "pulp",
  "rand_core 0.6.4",
@@ -7710,11 +7706,10 @@ dependencies = [
 
 [[package]]
 name = "tfhe-csprng"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c677a5732dd133544c5e76e448da8d8bc26c4131e30c50920165472a9d6a3c"
+version = "0.10.0"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?rev=2277991cd81c2995054889b8e512d1c048baab3b#2277991cd81c2995054889b8e512d1c048baab3b"
 dependencies = [
- "aes 0.8.4",
+ "aes 0.9.1",
  "getrandom 0.2.17",
  "libc",
  "rayon",
@@ -7725,8 +7720,7 @@ dependencies = [
 [[package]]
 name = "tfhe-fft"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960a6a2ef1869320837e3d45ab60bbc031c045005eb2578b20fe074a982c2e56"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?rev=2277991cd81c2995054889b8e512d1c048baab3b#2277991cd81c2995054889b8e512d1c048baab3b"
 dependencies = [
  "aligned-vec",
  "bytemuck",
@@ -7740,8 +7734,7 @@ dependencies = [
 [[package]]
 name = "tfhe-ntt"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10650c743ade46b166c698c8349902ed5986784a7db418c51f810bea25f09e3d"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?rev=2277991cd81c2995054889b8e512d1c048baab3b#2277991cd81c2995054889b8e512d1c048baab3b"
 dependencies = [
  "aligned-vec",
  "bytemuck",
@@ -7751,8 +7744,7 @@ dependencies = [
 [[package]]
 name = "tfhe-safe-serialize"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc6480b20057adbb99ec2cd510561f181863e57303a32bc2eca5c3ea163097"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?rev=2277991cd81c2995054889b8e512d1c048baab3b#2277991cd81c2995054889b8e512d1c048baab3b"
 dependencies = [
  "bincode 1.3.3",
  "serde",
@@ -7762,8 +7754,7 @@ dependencies = [
 [[package]]
 name = "tfhe-versionable"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fb1f1e4dd17a046df5be453e82459305e391d66ab2f9067ef3d5f7a04875c9"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?rev=2277991cd81c2995054889b8e512d1c048baab3b#2277991cd81c2995054889b8e512d1c048baab3b"
 dependencies = [
  "aligned-vec",
  "num-complex",
@@ -7774,8 +7765,7 @@ dependencies = [
 [[package]]
 name = "tfhe-versionable-derive"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a35478dc88bf6978e21c9849cde5fd72bc63331e80732bbb64df2d94bfc688"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?rev=2277991cd81c2995054889b8e512d1c048baab3b#2277991cd81c2995054889b8e512d1c048baab3b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7784,16 +7774,15 @@ dependencies = [
 
 [[package]]
 name = "tfhe-zk-pok"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc1188ff876ceb0e2611f2d7ed3f46fc007448f68a29e879520efc55f2475e"
+version = "0.9.0"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?rev=2277991cd81c2995054889b8e512d1c048baab3b#2277991cd81c2995054889b8e512d1c048baab3b"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-poly",
  "getrandom 0.2.17",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "num-bigint",
  "rand 0.8.6",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,11 +202,16 @@ sysinfo = "0.38.4"  # System information gathering - MEDIUM RISK: Reputable indi
 tempfile = "=3.20.0"  # Temporary file handling - MEDIUM RISK: Individual maintainers (Stebalien, KodrAus), 345M+ downloads
 test-context = "=0.4.1"  # Test context utilities - MEDIUM RISK: Individual maintainers (markhildreth, JasperV), test-only dependency
 # NOTE: when changing the tfhe dependency, consider also updating the pinned version of dylint lints from tfhe (see dylint.toml)
-tfhe = "=1.7.0"  # Fully Homomorphic Encryption library - LOW RISK: Zama
-tfhe-csprng = "=0.9.2"  # Cryptographically secure PRNG for TFHE - LOW RISK: Zama
-tfhe-safe-serialize = "=0.1.1" # TFHE safe serialization - LOW RISK: Zama
-tfhe-versionable = "=0.8.0"  # TFHE versioning support - LOW RISK: Zama
-tfhe-zk-pok = "=0.8.3"  # Zero-knowledge proofs for TFHE - LOW RISK: Zama
+# TEMPORARY pre-release pin on an unreleased commit of tfhe-rs `main`. It is the only source of the
+# transciphering key material (`tfhe::transciphering`) that the DKG needs; no released version
+# carries it. All five crates must come from the same source, otherwise `tfhe-csprng` types that
+# appear in our own signatures (`XofSeed`, `SoftwareRandomGenerator`) exist twice and do not unify.
+# Revert to the crates.io versions once a release carries the transciphering keys.
+tfhe = { git = "https://github.com/zama-ai/tfhe-rs.git", rev = "2277991cd81c2995054889b8e512d1c048baab3b" }  # Fully Homomorphic Encryption library - LOW RISK: Zama
+tfhe-csprng = { git = "https://github.com/zama-ai/tfhe-rs.git", rev = "2277991cd81c2995054889b8e512d1c048baab3b" }  # Cryptographically secure PRNG for TFHE - LOW RISK: Zama
+tfhe-safe-serialize = { git = "https://github.com/zama-ai/tfhe-rs.git", rev = "2277991cd81c2995054889b8e512d1c048baab3b" } # TFHE safe serialization - LOW RISK: Zama
+tfhe-versionable = { git = "https://github.com/zama-ai/tfhe-rs.git", rev = "2277991cd81c2995054889b8e512d1c048baab3b" }  # TFHE versioning support - LOW RISK: Zama
+tfhe-zk-pok = { git = "https://github.com/zama-ai/tfhe-rs.git", rev = "2277991cd81c2995054889b8e512d1c048baab3b" }  # Zero-knowledge proofs for TFHE - LOW RISK: Zama
 thiserror = "=2.0.18"  # Error derive macro - MEDIUM RISK: Reputable individual maintainer (dtolnay), 545M downloads
 tokio = { version = "=1.52.3", features = ["full"] }  # Async runtime - LOW RISK: tokio team, industry standard
 tokio-rustls = { version = "=0.26.4", default-features = false, features = ["aws_lc_rs"] }  # Async TLS - LOW RISK: rustls team, memory-safe TLS implementation

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -480,8 +480,12 @@ exact commands.
   [docker/kms-binaries/Dockerfile](docker/kms-binaries/Dockerfile) and pass the
   desired tag explicitly; production CI builds its secure `prod` target and
   retags it as `:latest` before packaging the `prod` targets of `core-service`
-  and `core-client`. Release compilation uses fat LTO, while other CI builds use
-  thin LTO. The published runtime image for the service remains
+  and `core-client`. Secure compilation uses fat LTO on release tags and thin
+  LTO otherwise; the insecure flavor always uses thin LTO, and must never be
+  built with LTO off, because pr-preview and perf-testing deploy it and take
+  their numbers from it. Both flavors target the
+  `x86-64-v3` CPU baseline, overridable via the `TARGET_CPU` build arg. The
+  published runtime image for the service remains
   `ghcr.io/zama-ai/kms/core-service`.
 - **Kubernetes** — a Helm chart is provided at
   [charts/kms-core/](charts/kms-core/) for both centralized and threshold

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -110,12 +110,12 @@ The service crate is the main surface area. Key subdirectories under
   private objects: its ECDSA signing key (`PrivDataType::SigningKey`, the
   authoritative on-chain identity) and an independent, CSPRNG-generated
   `RootSigningSeed` (`PrivDataType::SigningSeed`), both under `SIGNING_KEY_ID`.
-  The seed will eventuall be the root of *every* signing key of the node, ECDSA 
+  The seed will eventuall be the root of *every* signing key of the node, ECDSA
   included: keys are derived on demand from the *seed*. However to ensure backward
-  compatibility and avoid requiring nodes to roll their ECDSA keys, legacy ECDSA 
-  are derived and stored seperately, and the seed is only used to derive every 
-  non-ECDSA key. That is, if a legacy ECDSA key is stored, then the seed will *not* 
-  be used to derive ECDSA material. 
+  compatibility and avoid requiring nodes to roll their ECDSA keys, legacy ECDSA
+  are derived and stored seperately, and the seed is only used to derive every
+  non-ECDSA key. That is, if a legacy ECDSA key is stored, then the seed will *not*
+  be used to derive ECDSA material.
   The seed is carried in memory on `PrivateSigKey` (a `#[serde(skip)]` field, so
   the persisted format is unchanged) and attached by `get_core_signing_key`; a key
   without it — a client wallet key, or a node that has not yet run `kms-gen-keys` —
@@ -189,6 +189,10 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   field are upgraded with the OPRF share absent; `UseExisting` keygen generates
   and persists a fresh OPRF share for such legacy material before regenerating
   public keys.
+  When the parameter set carries transciphering parameters, keygen additionally
+  persists a *second*, independently sampled LWE secret-key share and includes the
+  matching transciphering server key. Similar to the OPRF key, a new
+  transciphering key is created when keygen uses the `UseExisting` option.
 - **Decryption** — `PublicDecrypt` (returns plaintext) and `UserDecrypt`
   (user-initiated, EIP-712 authenticated). `PublicDecryptSync` / `UserDecryptSync`
   start a decryption and wait for its result in the same call, so the caller does
@@ -206,8 +210,10 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   both sets must hold the key material, so failing to read it rejects the
   request, whereas a pure set 2 party (a node joining the new context) never held
   the key and logs a warning instead. When resharing legacy key material that
-  has no dedicated OPRF secret-key share, the OPRF sub-protocol is skipped and
-  the reshared private keyset keeps that field absent. A storage failure during
+  has no dedicated OPRF/transciphering secret-key share, the OPRF/transciphering
+  sub-protocol is skipped and the reshared private keyset keeps that field
+  absent. Which of these optional shares to reshare is decided from the input
+  keyset, and every party must agree. A storage failure during
   resharing rolls the new epoch back on the party that fails. That party attempts
   to delete the key shares, the CRS metadata and the epoch data of the new epoch.
   Public data remains because an epoch change does not affect it. If cleanup

--- a/charts/kms-core/Chart.yaml
+++ b/charts/kms-core/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-core
 description: A helm chart to distribute and deploy the Zama KMS core service.
-version: 1.9.1   # 1.9.x for release 0.15.x
+version: 1.9.2   # 1.9.x for release 0.15.x
 appVersion: 0.14.0   # Minimum kms version to run this chart
 apiVersion: v2
 keywords:

--- a/charts/kms-core/Chart.yaml
+++ b/charts/kms-core/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-core
 description: A helm chart to distribute and deploy the Zama KMS core service.
-version: 1.9.2   # 1.9.x for release 0.15.x
+version: 1.9.3   # 1.9.x for release 0.15.x
 appVersion: 0.14.0   # Minimum kms version to run this chart
 apiVersion: v2
 keywords:

--- a/charts/kms-core/templates/_helpers.tpl
+++ b/charts/kms-core/templates/_helpers.tpl
@@ -211,6 +211,11 @@ args:
       exit 1
     fi
 
+    # Jumbo MTU to match the enclave-side TUN (init_enclave.sh TUN_MTU): fewer,
+    # larger packets => fewer userspace relay hops per MPC message. Non-fatal.
+    ifconfig "$TUN_IF" mtu {{ .networkTunnel.mtu | default 8500 }} \
+      || echo "enclave-network-tunnel: warning: could not set MTU on $TUN_IF" >&2
+
     {{- if gt (len .ingressPorts) 0 }}
     add_ingress_dnat() {
       port="$1"

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -135,13 +135,17 @@ kmsCore:
     memoryGiB: 96
     networkTunnel:
       enabled: true
-      # If unset, queueCount defaults to a heuristic based on the threshold
-      # party topology: 8 queues minimum, or the next power of two above the
-      # hot peer-flow count (2 * (party_count - 1)) in threshold mode.
-      queueCount:
-      # If unset, tokioWorkerThreads defaults to a smaller scheduler pool than
-      # queueCount: 4 workers for up to 16 queues, otherwise 8 workers.
-      tokioWorkerThreads:
+      # Set explicitly (vs the party-topology heuristic, which can fall to the
+      # floor of 8) so the ~24 hot peer flows of a 13-party committee don't
+      # head-of-line block on too few relay queues.
+      queueCount: 32
+      # More relay scheduler threads to keep up with the DKG packet storm; the
+      # heuristic default is only 4-8.
+      tokioWorkerThreads: 8
+      # Jumbo MTU for the parent-side TUN; MUST match the enclave-side
+      # init_enclave.sh TUN_MTU. Reduces fragmentation of large MPC messages.
+      # Keep <= 9001 (AWS VPC jumbo ceiling) so the parent eth0 hop doesn't drop.
+      mtu: 8500
       # interfaceName is local to the parent-side network namespace, so it does
       # not need to match the enclave-side TUN_IF constant. The address values
       # are served to the enclave by the parent-side vsocktun bootstrap over the

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -113,14 +113,14 @@ kmsCore:
     enableSysMetrics: true
     refreshIntervalMs: 5000
     tokioWorkerThreads: 10
-    rayonNumThreads: 40
+    rayonNumThreads: 60
     # Threshold value is the number of corruptions that the protocol handles.
     # 1 for 4 parties, 4 for 13 parties
     thresholdValue: 4
     decCapacity: 10000
     minDecCache: 6000
     # Number of sessions to pre-process should be equal to number of vCPUs
-    numSessionsPreproc: 100
+    numSessionsPreproc: 90
     decryptionMode: "NoiseFloodSmall"
   # Add the following to enable nitro enclave:
   # Nitro enclave needs specific instance types

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -130,7 +130,7 @@ kmsCore:
     # Enclave bootstrap support sockets.
     webIdentityTokenPort: 4100
     # Enclave CPU count, must be a multiple of 2 since whole cores (not hyperthreads) are sliced off and dedicated to the enclave
-    cpuCount: 48
+    cpuCount: 52
     # Enclave Memory in GiB
     memoryGiB: 96
     networkTunnel:

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -44,7 +44,7 @@ kmsCore:
         backupVaultKeychainAWSKMSRootKeySpec: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_SPEC
         backupVaultKeychainAWSKMSRootKeyID: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
   rateLimiter:
-    bucketSize: 50000
+    bucketSize: 100000
   # One-time migration input associating existing epochs with the context they belong to.
   # Consumed once by the epoch-data migration on startup; idempotent, so it can be left in place.
   # Each epoch belongs to exactly one context, so a given epoch ID must appear under a single entry.

--- a/ci/pr-preview/threshold/kms-service/values-kms-ci.yaml
+++ b/ci/pr-preview/threshold/kms-service/values-kms-ci.yaml
@@ -12,10 +12,14 @@ kmsCore:
     enabled: false
   resources:
     requests:
-      memory: 12Gi
-      cpu: 4
+      # Compute runs in-container here (not in an enclave VM), so reserve a
+      # large slice to force scheduling onto a big, ~exclusive node.
+      memory: 32Gi
+      cpu: 48
     limits:
-      memory: 24Gi
+      # Match the enclave VM's 96Gi ceiling (nitroEnclave.memoryGiB). NOTE: the
+      # chart does not render a cpu limit, so CPU is bounded by node size only.
+      memory: 96Gi
       ephemeralStorage: 10Gi
       grpcTimeout: 360
       grpcMaxMessageSize: 104857600
@@ -29,11 +33,26 @@ kmsCore:
       prefix:
   storage:
     storageClassName: gp3
-    capacity: 5Gi
+    capacity: 15Gi
   serviceMonitor:
     enabled: false
   nodeSelector:
     karpenter.sh/nodepool: kms-bench-spot-64
+    # To bound CPU to the enclave's 52 cores on the same c7a family, pin a
+    # ~52-vCPU on-demand node instead. Uncomment (and ensure a nodepool can
+    # actually provision it — the spot-64 pool above may not):
+    # node.kubernetes.io/instance-type: c7a.13xlarge
+  affinity:
+    # One party per host, matching the enclave's podAntiAffinity.
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - kms-core
+          topologyKey: kubernetes.io/hostname
   tolerations:
     - key: karpenter.sh/nodepool
       effect: NoSchedule

--- a/ci/pr-preview/thresholdWithEnclave/tkms-infra/values-kms-ci.yaml
+++ b/ci/pr-preview/thresholdWithEnclave/tkms-infra/values-kms-ci.yaml
@@ -62,7 +62,7 @@ kmsParties:
     deletionPolicy: Delete
     # Override resources spec for the enclave node group
     resources:
-      cpuAllocatable: 60
+      cpuAllocatable: 52
       memoryAllocatableInGiB: 96
     # Find the release version here: https://github.com/awslabs/amazon-eks-ami/releases
     releaseVersion: "1.32.3-20250620"

--- a/ci/pr-preview/thresholdWithEnclave/tkms-infra/values-kms-ci.yaml
+++ b/ci/pr-preview/thresholdWithEnclave/tkms-infra/values-kms-ci.yaml
@@ -62,7 +62,7 @@ kmsParties:
     deletionPolicy: Delete
     # Override resources spec for the enclave node group
     resources:
-      cpuAllocatable: 48
+      cpuAllocatable: 60
       memoryAllocatableInGiB: 96
     # Find the release version here: https://github.com/awslabs/amazon-eks-ami/releases
     releaseVersion: "1.32.3-20250620"

--- a/ci/pr-preview/thresholdWithEnclave/tkms-infra/values-kms-ci.yaml
+++ b/ci/pr-preview/thresholdWithEnclave/tkms-infra/values-kms-ci.yaml
@@ -62,7 +62,7 @@ kmsParties:
     deletionPolicy: Delete
     # Override resources spec for the enclave node group
     resources:
-      cpuAllocatable: 60
+      cpuAllocatable: 52
       memoryAllocatableInGiB: 96
     # Find the release version here: https://github.com/awslabs/amazon-eks-ami/releases
     releaseVersion: "1.34.9-20260810"

--- a/ci/pr-preview/thresholdWithEnclave/tkms-infra/values-kms-ci.yaml
+++ b/ci/pr-preview/thresholdWithEnclave/tkms-infra/values-kms-ci.yaml
@@ -62,7 +62,7 @@ kmsParties:
     deletionPolicy: Delete
     # Override resources spec for the enclave node group
     resources:
-      cpuAllocatable: 48
+      cpuAllocatable: 60
       memoryAllocatableInGiB: 96
     # Find the release version here: https://github.com/awslabs/amazon-eks-ami/releases
     releaseVersion: "1.34.9-20260810"

--- a/core-client/src/crsgen.rs
+++ b/core-client/src/crsgen.rs
@@ -237,7 +237,7 @@ pub(crate) async fn get_crsgen_responses(
 
         resp_tasks.spawn(async move {
             // Sleep to give the server some time to complete crs generation
-            tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+            tokio::time::sleep(tokio::time::Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
 
             let mut response = if insecure {
                 cur_client
@@ -253,7 +253,7 @@ pub(crate) async fn get_crsgen_responses(
             while response.is_err()
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
-                tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                tokio::time::sleep(tokio::time::Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 // do at most max_iter retries
                 if ctr >= max_iter {
                     anyhow::bail!(
@@ -360,7 +360,7 @@ pub(crate) async fn do_abort_crs_gen(
         resp_tasks.spawn(async move {
             // Sleep to give the server some time to complete CRS generation
             tokio::time::sleep(tokio::time::Duration::from_millis(
-                SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                *SLEEP_TIME_BETWEEN_REQUESTS_MS,
             ))
             .await;
 
@@ -372,7 +372,7 @@ pub(crate) async fn do_abort_crs_gen(
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
                 tokio::time::sleep(tokio::time::Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                    *SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
                 // do at most max_iter retries

--- a/core-client/src/crsgen.rs
+++ b/core-client/src/crsgen.rs
@@ -245,7 +245,7 @@ pub(crate) async fn get_crsgen_responses(
 
         resp_tasks.spawn(async move {
             // Sleep to give the server some time to complete crs generation
-            tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+            tokio::time::sleep(tokio::time::Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
 
             let mut response = if insecure {
                 #[cfg(feature = "insecure")]
@@ -270,7 +270,7 @@ pub(crate) async fn get_crsgen_responses(
             while response.is_err()
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
-                tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                tokio::time::sleep(tokio::time::Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 // do at most max_iter retries
                 if ctr >= max_iter {
                     anyhow::bail!(
@@ -386,7 +386,7 @@ pub(crate) async fn do_abort_crs_gen(
         resp_tasks.spawn(async move {
             // Sleep to give the server some time to complete CRS generation
             tokio::time::sleep(tokio::time::Duration::from_millis(
-                SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                *SLEEP_TIME_BETWEEN_REQUESTS_MS,
             ))
             .await;
 
@@ -398,7 +398,7 @@ pub(crate) async fn do_abort_crs_gen(
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
                 tokio::time::sleep(tokio::time::Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                    *SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
                 // do at most max_iter retries

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -381,7 +381,7 @@ fn spawn_public_decrypt_sync(
                 response.as_ref().map_err(|e| e.code()),
                 Err(tonic::Code::Unavailable | tonic::Code::ResourceExhausted)
             ) {
-                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                tokio::time::sleep(Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
                         "timeout while waiting for sync public decryption after {max_iter} retries."
@@ -457,7 +457,7 @@ fn spawn_get_public_decrypt_result(
             while response.is_err()
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
-                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                tokio::time::sleep(Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
                         "timeout while waiting for public decryption after {max_iter} retries."
@@ -1104,7 +1104,7 @@ fn spawn_user_decrypt_sync(
                 response.as_ref().map_err(|e| e.code()),
                 Err(tonic::Code::Unavailable | tonic::Code::ResourceExhausted)
             ) {
-                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                tokio::time::sleep(Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
                         "timeout while waiting for sync user decryption after {max_iter} retries."
@@ -1186,7 +1186,7 @@ fn spawn_get_user_decrypt_result(
             while response.is_err()
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
-                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                tokio::time::sleep(Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
                         "timeout while waiting for user decryption after {max_iter} retries."
@@ -1651,7 +1651,7 @@ pub(crate) async fn get_public_decrypt_responses(
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
                 tokio::time::sleep(Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                    *SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
                 // do at most max_iter retries

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -862,7 +862,7 @@ fn spawn_public_decrypt_sync(
                 response.as_ref().map_err(|e| e.code()),
                 Err(tonic::Code::Unavailable | tonic::Code::ResourceExhausted)
             ) {
-                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                tokio::time::sleep(Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
                         "timeout while waiting for sync public decryption after {max_iter} retries."
@@ -954,7 +954,7 @@ fn spawn_get_public_decrypt_result(
             while response.is_err()
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
-                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                tokio::time::sleep(Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
                         "timeout while waiting for public decryption after {max_iter} retries."
@@ -1699,7 +1699,7 @@ fn spawn_user_decrypt_sync(
                 response.as_ref().map_err(|e| e.code()),
                 Err(tonic::Code::Unavailable | tonic::Code::ResourceExhausted)
             ) {
-                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                tokio::time::sleep(Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
                         "timeout while waiting for sync user decryption after {max_iter} retries."
@@ -1765,7 +1765,7 @@ fn spawn_user_decrypt(
             while response.is_err()
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
-                tokio::time::sleep(Duration::from_millis(SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
+                tokio::time::sleep(Duration::from_millis(*SLEEP_TIME_BETWEEN_REQUESTS_MS)).await;
                 if ctr >= max_iter {
                     anyhow::bail!(
                         "timeout while waiting for user decryption after {max_iter} retries."
@@ -2242,7 +2242,7 @@ pub(crate) async fn get_public_decrypt_responses(
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
                 tokio::time::sleep(Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                    *SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
                 // do at most max_iter retries

--- a/core-client/src/keygen.rs
+++ b/core-client/src/keygen.rs
@@ -374,7 +374,7 @@ pub(crate) async fn get_keygen_responses(
 
         resp_tasks.spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_millis(
-                SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                *SLEEP_TIME_BETWEEN_REQUESTS_MS,
             ))
             .await;
 
@@ -393,7 +393,7 @@ pub(crate) async fn get_keygen_responses(
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
                 tokio::time::sleep(tokio::time::Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                    *SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
                 if ctr >= max_iter {
@@ -472,7 +472,7 @@ pub(crate) async fn do_abort_key_gen(
 
         resp_tasks.spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_millis(
-                SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                *SLEEP_TIME_BETWEEN_REQUESTS_MS,
             ))
             .await;
 
@@ -484,7 +484,7 @@ pub(crate) async fn do_abort_key_gen(
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
                 tokio::time::sleep(tokio::time::Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                    *SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
                 // do at most max_iter retries
@@ -802,7 +802,7 @@ pub(crate) async fn get_preproc_keygen_responses(
         resp_tasks.spawn(async move {
             // Sleep to give the server some time to complete preprocessing
             tokio::time::sleep(tokio::time::Duration::from_millis(
-                SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                *SLEEP_TIME_BETWEEN_REQUESTS_MS,
             ))
             .await;
 
@@ -816,7 +816,7 @@ pub(crate) async fn get_preproc_keygen_responses(
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
                 tokio::time::sleep(tokio::time::Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                    *SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
                 // do at most max_iter retries

--- a/core-client/src/keygen.rs
+++ b/core-client/src/keygen.rs
@@ -383,7 +383,7 @@ pub(crate) async fn get_keygen_responses(
 
         resp_tasks.spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_millis(
-                SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                *SLEEP_TIME_BETWEEN_REQUESTS_MS,
             ))
             .await;
 
@@ -411,7 +411,7 @@ pub(crate) async fn get_keygen_responses(
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
                 tokio::time::sleep(tokio::time::Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                    *SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
                 if ctr >= max_iter {
@@ -499,7 +499,7 @@ pub(crate) async fn do_abort_key_gen(
 
         resp_tasks.spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_millis(
-                SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                *SLEEP_TIME_BETWEEN_REQUESTS_MS,
             ))
             .await;
 
@@ -511,7 +511,7 @@ pub(crate) async fn do_abort_key_gen(
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
                 tokio::time::sleep(tokio::time::Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                    *SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
                 // do at most max_iter retries
@@ -848,7 +848,7 @@ pub(crate) async fn get_preproc_keygen_responses(
         resp_tasks.spawn(async move {
             // Sleep to give the server some time to complete preprocessing
             tokio::time::sleep(tokio::time::Duration::from_millis(
-                SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                *SLEEP_TIME_BETWEEN_REQUESTS_MS,
             ))
             .await;
 
@@ -862,7 +862,7 @@ pub(crate) async fn get_preproc_keygen_responses(
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
                 tokio::time::sleep(tokio::time::Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                    *SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
                 // do at most max_iter retries

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -58,7 +58,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 use strum_macros::{Display, EnumString};
 use tfhe::FheTypes as TfheFheType;
@@ -67,8 +67,20 @@ use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 use validator::{Validate, ValidationError};
 
-// time to sleep between `get_result` poll requests in milliseconds
-const SLEEP_TIME_BETWEEN_REQUESTS_MS: u64 = 500;
+/// Delay between successive `get_*_result` poll requests to each core, in milliseconds.
+///
+/// Overridable at runtime via the `KMS_CLIENT_POLL_INTERVAL_MS` environment
+/// variable (default 500). Raising it makes long-running operations such as DKG
+/// preprocessing poll less aggressively, which lightens core-side logs and load;
+/// it also delays result retrieval by up to this interval, so keep it small (the
+/// 500 ms default) for latency-sensitive commands like decryption.
+static SLEEP_TIME_BETWEEN_REQUESTS_MS: LazyLock<u64> = LazyLock::new(|| {
+    std::env::var("KMS_CLIENT_POLL_INTERVAL_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&ms| ms > 0)
+        .unwrap_or(500)
+});
 const DECRYPT_RATE_DRAIN_TIMEOUT_SECS: u64 = 30;
 
 /// Retries a function a given number of times with a given interval between retries.

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -58,7 +58,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 use strum_macros::{Display, EnumString};
 use test_utils::{read_element_async as read_element, write_element_owned};
@@ -68,8 +68,20 @@ use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 use validator::{Validate, ValidationError};
 
-// time to sleep between `get_result` poll requests in milliseconds
-const SLEEP_TIME_BETWEEN_REQUESTS_MS: u64 = 500;
+/// Delay between successive `get_*_result` poll requests to each core, in milliseconds.
+///
+/// Overridable at runtime via the `KMS_CLIENT_POLL_INTERVAL_MS` environment
+/// variable (default 500). Raising it makes long-running operations such as DKG
+/// preprocessing poll less aggressively, which lightens core-side logs and load;
+/// it also delays result retrieval by up to this interval, so keep it small (the
+/// 500 ms default) for latency-sensitive commands like decryption.
+static SLEEP_TIME_BETWEEN_REQUESTS_MS: LazyLock<u64> = LazyLock::new(|| {
+    std::env::var("KMS_CLIENT_POLL_INTERVAL_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&ms| ms > 0)
+        .unwrap_or(500)
+});
 const DECRYPT_RATE_DRAIN_TIMEOUT_SECS: u64 = 30;
 
 /// Retries a function a given number of times with a given interval between retries.

--- a/core-client/src/mpc_epoch.rs
+++ b/core-client/src/mpc_epoch.rs
@@ -184,7 +184,7 @@ pub(crate) async fn do_new_epoch(
             let response_request: tonic::Request<kms_grpc::kms::v1::RequestId> =
                 tonic::Request::new(new_epoch_id.into());
             tokio::time::sleep(tokio::time::Duration::from_millis(
-                SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                *SLEEP_TIME_BETWEEN_REQUESTS_MS,
             ))
             .await;
             let mut response = cur_client.get_epoch_result(response_request).await;
@@ -194,7 +194,7 @@ pub(crate) async fn do_new_epoch(
                 && response.as_ref().unwrap_err().code() == tonic::Code::Unavailable
             {
                 tokio::time::sleep(tokio::time::Duration::from_millis(
-                    SLEEP_TIME_BETWEEN_REQUESTS_MS,
+                    *SLEEP_TIME_BETWEEN_REQUESTS_MS,
                 ))
                 .await;
                 let response_request: tonic::Request<kms_grpc::kms::v1::RequestId> =

--- a/core/experiments/src/choreography/tfhe_rs/grpc.rs
+++ b/core/experiments/src/choreography/tfhe_rs/grpc.rs
@@ -53,7 +53,7 @@ use threshold_execution::endpoints::keygen::{
     OnlineDistributedKeyGen, SecureOnlineDistributedKeyGen,
 };
 use threshold_execution::endpoints::reshare_sk::{
-    ResharePreprocRequired, ReshareSecretKeys, SecureReshareSecretKeys,
+    DedicatedKeysPresent, ResharePreprocRequired, ReshareSecretKeys, SecureReshareSecretKeys,
 };
 use threshold_execution::keyset_config::KeySetConfig;
 use threshold_execution::large_execution::offline::SecureLargePreprocessing;
@@ -2615,11 +2615,11 @@ where
             let public_key_set_decompressed = key_ref.pub_keyset_decompressed.clone();
             let old_private_key_set = key_ref.priv_keyset.as_ref().clone();
             let params = key_ref.as_ref().params;
-            let oprf_key_present = old_private_key_set.oprf_secret_key_share.is_some();
+            let dedicated_keys = DedicatedKeysPresent::from_private_keyset(&old_private_key_set);
 
             //Perform preprocessing
             let num_needed_preproc =
-                ResharePreprocRequired::new(num_parties, params, oprf_key_present);
+                ResharePreprocRequired::new(num_parties, params, dedicated_keys);
 
             let span = tracing::info_span!(
                 "RESHARE-PREPROC",
@@ -2737,7 +2737,7 @@ where
                     &mut preprocessing_64,
                     &mut Some(old_private_key_set),
                     params,
-                    oprf_key_present,
+                    dedicated_keys,
                 )
                 .await
                 .unwrap();

--- a/core/service/src/client/key_gen.rs
+++ b/core/service/src/client/key_gen.rs
@@ -460,6 +460,7 @@ pub(crate) mod tests {
                                     _noise_squashing_compression_key,
                                     _rerand_parameters,
                                     _oprf_private_key,
+                                    _transciphering_private_key,
                                     _tag,
                                 ) = client_key.into_raw_parts();
 
@@ -527,7 +528,7 @@ pub(crate) mod tests {
         #[cfg(feature = "slow_tests")]
         const NUM_SEEDS: u128 = 50;
 
-        let (integer_server_key, _, _, _, _, _, _, oprf_server_key, _) =
+        let (integer_server_key, _, _, _, _, _, _, oprf_server_key, _, _) =
             server_key.clone().into_raw_parts();
         let Some(oprf_server_key) = oprf_server_key else {
             panic!("expected oprf_server_key")
@@ -542,6 +543,7 @@ pub(crate) mod tests {
             _noise_squashing_compression_key,
             _rerand_parameters,
             oprf_private_key,
+            _transciphering_private_key,
             _tag,
         ) = client_key.clone().into_raw_parts();
         let Some(oprf_private_key) = oprf_private_key else {

--- a/core/service/src/client/tests/centralized/key_gen_tests.rs
+++ b/core/service/src/client/tests/centralized/key_gen_tests.rs
@@ -351,7 +351,7 @@ pub async fn run_key_gen_centralized(
         assert_eq!(&tag, public_key.tag());
         assert_eq!(&tag, server_key.tag());
 
-        let (_, _, _, _, _, _, _, oprf_key, _) = server_key.clone().into_raw_parts();
+        let (_, _, _, _, _, _, _, oprf_key, _, _) = server_key.clone().into_raw_parts();
         assert!(
             oprf_key.is_some(),
             "centralized full keygen must embed a dedicated OPRF server key"

--- a/core/service/src/client/tests/threshold/key_gen_tests.rs
+++ b/core/service/src/client/tests/threshold/key_gen_tests.rs
@@ -1043,6 +1043,7 @@ fn try_reconstruct_shares(
     tfhe::core_crypto::prelude::GlweSecretKeyOwned<u128>,
     Option<NoiseSquashingCompressionPrivateKey>,
     Option<tfhe::core_crypto::prelude::LweSecretKeyOwned<u64>>,
+    Option<tfhe::core_crypto::prelude::LweSecretKeyOwned<u64>>,
 ) {
     use tfhe::core_crypto::prelude::GlweSecretKeyOwned;
     use threshold_execution::tfhe_internals::{
@@ -1178,12 +1179,35 @@ fn try_reconstruct_shares(
         None
     };
 
+    let transciphering_lwe_shares = all_threshold_fhe_keys
+        .iter()
+        .filter_map(|(k, v)| {
+            v.private_keys
+                .transciphering_secret_key_share
+                .clone()
+                .map(|share| (*k, share.convert_to_z64().data))
+        })
+        .collect::<HashMap<_, _>>();
+    let transciphering_lwe_secret_key =
+        if transciphering_lwe_shares.len() == all_threshold_fhe_keys.len() {
+            Some(
+                tfhe::core_crypto::prelude::LweSecretKeyOwned::from_container(reconstruct_bit_vec(
+                    transciphering_lwe_shares,
+                    param.lwe_dimension().0,
+                    threshold,
+                )),
+            )
+        } else {
+            None
+        };
+
     (
         lwe_secret_key,
         glwe_sk,
         sns_glwe_sk,
         sns_compression_private_key,
         oprf_lwe_secret_key,
+        transciphering_lwe_secret_key,
     )
 }
 
@@ -1303,11 +1327,12 @@ pub(crate) async fn verify_keygen_responses(
     }
 
     let threshold = total_num_parties.div_ceil(3) - 1;
-    let (lwe_sk, glwe_sk, sns_glwe_sk, sns_compression_sk, oprf_lwe_sk) = try_reconstruct_shares(
-        internal_client.params,
-        threshold,
-        all_threshold_fhe_keys.clone(),
-    );
+    let (lwe_sk, glwe_sk, sns_glwe_sk, sns_compression_sk, oprf_lwe_sk, transciphering_lwe_sk) =
+        try_reconstruct_shares(
+            internal_client.params,
+            threshold,
+            all_threshold_fhe_keys.clone(),
+        );
 
     let client_key = to_hl_client_key(
         &internal_client.params,
@@ -1319,6 +1344,7 @@ pub(crate) async fn verify_keygen_responses(
         Some(sns_glwe_sk),
         sns_compression_sk,
         oprf_lwe_sk,
+        transciphering_lwe_sk,
     )
     .unwrap();
 
@@ -1922,7 +1948,7 @@ async fn run_threshold_compressed_keygen_from_existing(
                 CryptoMaterialReader::read_from_storage(storage, &keygen_id_2).await?;
 
             let (pk, server_key) = compressed_keyset.decompress().into_raw_parts();
-            let (_, _, _, _, _, _, _, oprf_key, _) = server_key.clone().into_raw_parts();
+            let (_, _, _, _, _, _, _, oprf_key, _, _) = server_key.clone().into_raw_parts();
             assert!(
                 oprf_key.is_some(),
                 "Party {party_id}: compressed UseExisting keygen must embed a dedicated OPRF key"
@@ -2151,6 +2177,7 @@ async fn remove_oprf_from_existing_keyset(
             noise_squashing_compression_key,
             cpk_re_randomization_key,
             oprf_key,
+            transciphering_key,
             tag,
         ) = server_key.into_raw_parts();
         assert!(
@@ -2166,6 +2193,7 @@ async fn remove_oprf_from_existing_keyset(
             noise_squashing_compression_key,
             cpk_re_randomization_key,
             None,
+            transciphering_key,
             tag,
         );
 

--- a/core/service/src/client/tests/threshold/mpc_epoch_tests.rs
+++ b/core/service/src/client/tests/threshold/mpc_epoch_tests.rs
@@ -269,6 +269,7 @@ pub(crate) async fn new_epoch_with_reshare_and_crs(
                 lwe_encryption_secret_key_share,
                 lwe_compute_secret_key_share,
                 oprf_secret_key_share,
+                transciphering_secret_key_share,
                 glwe_secret_key_share,
                 glwe_secret_key_share_sns_as_lwe,
                 glwe_secret_key_share_compression,
@@ -280,6 +281,7 @@ pub(crate) async fn new_epoch_with_reshare_and_crs(
                 lwe_encryption_secret_key_share: reshared_lwe_encryption_secret_key_share,
                 lwe_compute_secret_key_share: reshared_lwe_compute_secret_key_share,
                 oprf_secret_key_share: reshared_oprf_secret_key_share,
+                transciphering_secret_key_share: reshared_transciphering_secret_key_share,
                 glwe_secret_key_share: reshared_glwe_secret_key_share,
                 glwe_secret_key_share_sns_as_lwe: reshared_glwe_secret_key_share_sns_as_lwe,
                 glwe_secret_key_share_compression: reshared_glwe_secret_key_share_compression,
@@ -300,6 +302,12 @@ pub(crate) async fn new_epoch_with_reshare_and_crs(
             );
             if oprf_secret_key_share.is_some() {
                 assert_ne!(oprf_secret_key_share, reshared_oprf_secret_key_share);
+            }
+            if transciphering_secret_key_share.is_some() {
+                assert_ne!(
+                    transciphering_secret_key_share,
+                    reshared_transciphering_secret_key_share
+                );
             }
             assert_ne!(glwe_secret_key_share, reshared_glwe_secret_key_share);
             if glwe_secret_key_share_sns_as_lwe.is_some() {

--- a/core/service/src/cryptography/decompression.rs
+++ b/core/service/src/cryptography/decompression.rs
@@ -247,7 +247,7 @@ mod test {
         .enable_compression(COMP_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M128)
         .build();
         let (client_key, server_key) = generate_keys(config);
-        let (_, _, compression_key, decompression_key, _, _, _, _, _) =
+        let (_, _, compression_key, decompression_key, _, _, _, _, _, _) =
             server_key.clone().into_raw_parts();
         assert!(compression_key.is_some());
         assert!(decompression_key.is_some());

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -2582,6 +2582,7 @@ pub(crate) mod tests {
             _noise_squashing_compression_key,
             _rerand_key,
             _oprf_key,
+            _transciphering_key,
             _tag,
         ) = pubkeyset.server_key.clone().into_raw_parts();
         assert!(compression_key.is_some());

--- a/core/service/src/engine/centralized/central_kms.rs
+++ b/core/service/src/engine/centralized/central_kms.rs
@@ -290,7 +290,7 @@ pub(crate) fn generate_fhe_keys(
     )?;
 
     let (public_key, server_key) = compressed_keyset.decompress().into_raw_parts();
-    let (_, _, _, decompression_key, _, _, _, _, _) = server_key.into_raw_parts();
+    let (_, _, _, decompression_key, _, _, _, _, _, _) = server_key.into_raw_parts();
 
     let handles = KmsFheKeyHandles::new_compressed(
         sk,
@@ -342,6 +342,7 @@ pub fn generate_uncompressed_fhe_keys(
             server_key.6,
             server_key.7,
             server_key.8,
+            server_key.9,
         );
         let public_key = FhePublicKey::new(&client_key);
         let pks = FhePubKeySet {
@@ -1471,7 +1472,7 @@ pub(crate) mod tests {
         // Verify the compressed keyset can be decompressed. `decompress` is infallible since
         // tfhe 1.7.0, so this only asserts it does not panic.
         let (_pk, server_key) = compressed_keyset.decompress().into_raw_parts();
-        let (_, _, _, _, _, _, _, oprf_key, _) = server_key.into_raw_parts();
+        let (_, _, _, _, _, _, _, oprf_key, _, _) = server_key.into_raw_parts();
         assert!(
             oprf_key.is_some(),
             "centralized full keygen must embed a dedicated OPRF server key"

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -43,7 +43,7 @@ use std::{collections::HashMap, future::Future, marker::PhantomData, sync::Arc};
 use tfhe::{Versionize, zk::CompactPkeCrs};
 use tfhe_versionable::VersionsDispatch;
 use threshold_execution::{
-    endpoints::reshare_sk::{ResharePreprocRequired, ReshareSecretKeys},
+    endpoints::reshare_sk::{DedicatedKeysPresent, ResharePreprocRequired, ReshareSecretKeys},
     online::preprocessing::BasePreprocessing,
     runtime::sessions::{
         base_session::{BaseSession, TwoSetsBaseSession},
@@ -568,22 +568,19 @@ impl<
                             .await?
                     }
                 };
-                // S1 has the previous epoch's private shares, so we read
-                // `oprf_key_present` from local state. The S2-only path in
-                // `reshare_as_set_2` has no private share and derives the same
-                // flag from the verified public `ServerKey` instead. Both
-                // derivations must yield the same value for the reshare
-                // sub-protocols to converge; this holds by construction
-                // because public and private OPRF material are produced
-                // together (legacy keysets predating the dedicated OPRF share
-                // have neither).
-                let oprf_key_present = private_keys.oprf_secret_key_share.is_some();
+                // S1 has the previous epoch's private shares, so we read which
+                // dedicated key shares exist from local state. The S2-only path
+                // in `reshare_as_set_2` has no private share and derives the
+                // same flags from the verified public material instead. For
+                // uncompressed keys this is the `ServerKey`; for compressed
+                // keys it is the `CompressedXofKeySet`.
+                let dedicated_keys = DedicatedKeysPresent::from_private_keyset(&private_keys);
 
                 Reshare::reshare_sk_two_sets_as_s1(
                     &mut two_sets_session,
                     &mut private_keys,
                     key_info.key_parameters,
-                    oprf_key_present,
+                    dedicated_keys,
                 )
                 .await?;
                 keys_metadata.push(key_metadata);
@@ -705,7 +702,7 @@ impl<
                         }
                     };
 
-                    let (integer_server_key, _, _, decompression_key, sns_key, _, _, _, _) =
+                    let (integer_server_key, _, _, decompression_key, sns_key, _, _, _, _, _) =
                         fhe_pubkeys.server_key.clone().into_raw_parts();
 
                     let threshold_fhe_keys = ThresholdFheKeys::new(
@@ -909,16 +906,17 @@ impl<
                 .zip_eq(verified_fhe_public_materials.iter())
             {
                 // S2 has no private share for the previous epoch, so unlike
-                // the S1 / both-sets paths (which read
-                // `private_keys.oprf_secret_key_share.is_some()`) we derive
-                // `oprf_key_present` from the verified public `ServerKey`.
-                // The protocol assumes both derivations yield the same value
-                // — see the comment in `reshare_as_set_1`.
-                let oprf_key_present = verified_material.has_oprf_key();
+                // the S1 / both-sets paths (which read the flags off the local
+                // `PrivateKeySet`) we derive them from the verified
+                // public material.
+                let dedicated_keys = DedicatedKeysPresent {
+                    oprf: verified_material.has_oprf_key(),
+                    transciphering: verified_material.has_transciphering_key(),
+                };
                 let num_needed_preproc = ResharePreprocRequired::new(
                     num_parties_set_1,
                     key_info.key_parameters,
-                    oprf_key_present,
+                    dedicated_keys,
                 );
 
                 let (mut correlated_randomness_z64, mut correlated_randomness_z128) =
@@ -934,7 +932,7 @@ impl<
                     &mut correlated_randomness_z128,
                     &mut correlated_randomness_z64,
                     key_info.key_parameters,
-                    oprf_key_present,
+                    dedicated_keys,
                 )
                 .await?;
 
@@ -1048,16 +1046,13 @@ impl<
                             .await?
                     }
                 };
-                // Same as `reshare_as_set_1`: derived from local private
-                // state. The pure-S2 path in `reshare_as_set_2` derives the
-                // same flag from the verified public `ServerKey`; both must
-                // agree.
-                let oprf_key_present = private_keys.oprf_secret_key_share.is_some();
+
+                let dedicated_keys = DedicatedKeysPresent::from_private_keyset(&private_keys);
 
                 let num_needed_preproc = ResharePreprocRequired::new(
                     num_parties_set_1,
                     key_info.key_parameters,
-                    oprf_key_present,
+                    dedicated_keys,
                 );
                 let (mut correlated_randomness_z64, mut correlated_randomness_z128) =
                     Self::compute_s2_preproc(
@@ -1073,7 +1068,7 @@ impl<
                     &mut correlated_randomness_z64,
                     &mut private_keys,
                     key_info.key_parameters,
-                    oprf_key_present,
+                    dedicated_keys,
                 )
                 .await?;
                 new_private_keysets.push(new_private_keyset);

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -31,7 +31,7 @@ use tfhe::xof_key_set::CompressedXofKeySet;
 use threshold_execution::{
     endpoints::keygen::{
         OnlineDistributedKeyGen, distributed_decompression_keygen_z128,
-        ensure_oprf_secret_key_share_z128,
+        ensure_oprf_secret_key_share_z128, ensure_transciphering_secret_key_share_z128,
     },
     keyset_config as ddec_keyset_config,
     online::preprocessing::DKGPreprocessing,
@@ -1037,7 +1037,7 @@ impl<
                     )
                 });
 
-                let (client_key, _, _, _, _, _, _, _) = to_hl_client_key(
+                let (client_key, _, _, _, _, _, _, _, _) = to_hl_client_key(
                     &params,
                     req_id.into(),
                     dummy_lwe_secret_key,
@@ -1045,6 +1045,7 @@ impl<
                     None,
                     None,
                     dummy_sns_secret_key,
+                    None,
                     None,
                     None,
                 )?
@@ -1260,6 +1261,13 @@ impl<
             &mut dkg_sessions.session_z128,
         )
         .await?;
+        ensure_transciphering_secret_key_share_z128(
+            &mut existing_private_keys,
+            params,
+            preprocessing,
+            &mut dkg_sessions.session_z128,
+        )
+        .await?;
 
         let compressed_keyset = KG::compressed_keygen_from_existing_private_keyset(
             &mut dkg_sessions.session_z128,
@@ -1304,6 +1312,13 @@ impl<
             )
             .await?;
         ensure_oprf_secret_key_share_z128(
+            &mut existing_private_keys,
+            params,
+            preprocessing,
+            &mut dkg_sessions.session_z128,
+        )
+        .await?;
+        ensure_transciphering_secret_key_share_z128(
             &mut existing_private_keys,
             params,
             preprocessing,
@@ -1597,6 +1612,7 @@ impl<
                         _raw_noise_squashing_compression_key,
                         _raw_rerandomization_key,
                         _raw_oprf_key,
+                        _raw_transciphering_key,
                         _raw_tag,
                     ) = pub_key_set.server_key.clone().into_raw_parts();
                     (

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -600,6 +600,15 @@ where
         .new_server(TlsExtensionGetter::SslConnectInfo);
     let router = Server::builder()
         .http2_adaptive_window(Some(true))
+        // Match the client side: large HTTP/2 windows so the receive side does
+        // not throttle each MPC stream to 64KiB/RTT over the vsock tunnel, plus
+        // keepalive and generous stream concurrency for the ~90 DKG sessions
+        // that all multiplex over one connection per peer.
+        .initial_stream_window_size(Some(4u32 * 1024 * 1024))
+        .initial_connection_window_size(Some(32u32 * 1024 * 1024))
+        .http2_keepalive_interval(Some(std::time::Duration::from_secs(20)))
+        .http2_keepalive_timeout(Some(std::time::Duration::from_secs(10)))
+        .max_concurrent_streams(Some(1000u32))
         .add_service(networking_server)
         .add_service(threshold_health_service);
 

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -341,7 +341,7 @@ impl ThresholdFheKeys {
             },
             PublicKeyMaterial::Compressed { keyset } => {
                 let (_pk, sk) = keyset.decompress().into_raw_parts();
-                let (isk, _, _, decompk, snsk, _, _, _, _) = sk.into_raw_parts();
+                let (isk, _, _, decompk, snsk, _, _, _, _, _) = sk.into_raw_parts();
                 UncompressedKeys {
                     integer_server_key: Arc::new(isk),
                     sns_key: snsk.map(Arc::new),
@@ -1075,6 +1075,7 @@ mod tests {
                 _sns_compression_key,
                 _rerand_key,
                 _oprf_key,
+                _transciphering_key,
                 _tag,
             ) = keyset.public_keys.server_key.into_raw_parts();
 
@@ -1117,7 +1118,7 @@ mod tests {
         let (keyset, compressed_keyset) =
             gen_key_set(TEST_PARAM, tfhe::Tag::default(), &mut rng).unwrap();
 
-        let (integer_server_key, _, _, decompression_key, sns_key, _, _, _, _) =
+        let (integer_server_key, _, _, decompression_key, sns_key, _, _, _, _, _) =
             keyset.public_keys.server_key.into_raw_parts();
 
         let v0 = PublicKeyMaterialV0::Compressed {
@@ -1199,7 +1200,7 @@ mod tests {
         let mut rng = AesRng::seed_from_u64(42);
         let (keyset, compressed_keyset) =
             gen_key_set(TEST_PARAM, tfhe::Tag::default(), &mut rng).unwrap();
-        let (integer_server_key, _, _, decompression_key, sns_key, _, _, _, _) =
+        let (integer_server_key, _, _, decompression_key, sns_key, _, _, _, _, _) =
             keyset.public_keys.server_key.into_raw_parts();
 
         // V3 control

--- a/core/service/src/engine/threshold/service/reshare_utils.rs
+++ b/core/service/src/engine/threshold/service/reshare_utils.rs
@@ -60,6 +60,28 @@ impl VerifiedPublicMaterial {
             }
         }
     }
+
+    /// Whether the public material carries a transciphering server key.
+    ///
+    /// NOTE: tfhe-rs exposes cheap `has_*_key` predicates for every other optional key but not yet
+    /// for the transciphering one, so this has to clone the key and take it apart. The clone is
+    /// paid once per key per reshare, which is negligible next to running the reshare protocol
+    /// itself; replace this with `has_transciphering_key()` once tfhe-rs offers it.
+    pub(crate) fn has_transciphering_key(&self) -> bool {
+        match self {
+            VerifiedPublicMaterial::Uncompressed(fhe_pubkeys) => {
+                let (_, _, _, _, _, _, _, _, transciphering_key, _) =
+                    fhe_pubkeys.server_key.clone().into_raw_parts();
+                transciphering_key.is_some()
+            }
+            VerifiedPublicMaterial::Compressed(compressed_keyset) => {
+                let (_, _, compressed_server_key) = compressed_keyset.clone().into_raw_parts();
+                let (_, _, _, _, _, _, _, _, transciphering_key, _) =
+                    compressed_server_key.into_raw_parts();
+                transciphering_key.is_some()
+            }
+        }
+    }
 }
 
 async fn fetch_context_from_storage<

--- a/core/service/src/vault/storage/crypto_material/tests.rs
+++ b/core/service/src/vault/storage/crypto_material/tests.rs
@@ -853,7 +853,7 @@ where
 
     let fhe_key_set = keyset.public_keys.clone();
 
-    let (integer_server_key, _, _, _, sns_key, _, _, _, _) =
+    let (integer_server_key, _, _, _, sns_key, _, _, _, _, _) =
         keyset.public_keys.server_key.clone().into_raw_parts();
 
     let threshold_fhe_keys = ThresholdFheKeys::new(

--- a/core/service/tests/backward_compatibility_kms.rs
+++ b/core/service/tests/backward_compatibility_kms.rs
@@ -1211,7 +1211,7 @@ fn test_kms_fhe_key_handles(
     let original_versionized: KmsFheKeyHandles = load_and_unversionize(dir, test, format)?;
 
     // Retrieve the key parameters from the original KMS handle
-    let (original_integer_key, _, _, _, _, _, _, _) =
+    let (original_integer_key, _, _, _, _, _, _, _, _) =
         original_versionized.client_key.clone().into_raw_parts();
     let original_key_params = original_integer_key.parameters();
 
@@ -1251,7 +1251,7 @@ fn test_kms_fhe_key_handles(
     .unwrap();
 
     // Retrieve the key parameters from the new KMS handle
-    let (new_integer_key, _, _, _, _, _, _, _) =
+    let (new_integer_key, _, _, _, _, _, _, _, _) =
         new_versionized.client_key.clone().into_raw_parts();
     let new_key_params = new_integer_key.parameters();
 

--- a/core/service/tests/backward_compatibility_threshold_fhe.rs
+++ b/core/service/tests/backward_compatibility_threshold_fhe.rs
@@ -35,6 +35,7 @@ use threshold_execution::{
         parameters::BC_PARAMS_NO_SNS,
         private_keysets::{
             GlweSecretKeyShareEnum, LweSecretKeyShareEnum, PrivateKeySet, PrivateKeySetV2,
+            PrivateKeySetV3,
         },
     },
 };
@@ -280,6 +281,13 @@ fn test_private_key_gen(
         "legacy private keysets must upgrade with no dedicated OPRF private share"
     );
 
+    assert!(
+        original_versionized
+            .transciphering_secret_key_share
+            .is_none(),
+        "legacy private keysets must upgrade with no transciphering private share"
+    );
+
     Ok(test.success(format))
 }
 
@@ -350,4 +358,36 @@ fn test_private_keyset_v2_upgrade_sets_missing_oprf_share_to_none() {
 
     let upgraded = legacy.upgrade().unwrap();
     assert!(upgraded.oprf_secret_key_share.is_none());
+}
+
+/// Verifies that the V3 -> V4 `PrivateKeySet` upgrade path leaves the new
+/// `transciphering_secret_key_share` field as `None` for material that predates
+/// transciphering, while carrying the OPRF share added in V3 across unchanged.
+#[test]
+fn test_private_keyset_v3_upgrade_sets_missing_transciphering_share_to_none() {
+    use tfhe_versionable::Upgrade;
+
+    let params = *BC_PARAMS_NO_SNS;
+    let oprf_share = LweSecretKeyShareEnum::Z128(LweSecretKeyShare { data: vec![] });
+    let legacy = PrivateKeySetV3::<4> {
+        lwe_compute_secret_key_share: LweSecretKeyShareEnum::Z128(LweSecretKeyShare {
+            data: vec![],
+        }),
+        lwe_encryption_secret_key_share: LweSecretKeyShareEnum::Z128(LweSecretKeyShare {
+            data: vec![],
+        }),
+        oprf_secret_key_share: Some(oprf_share.clone()),
+        glwe_secret_key_share: GlweSecretKeyShareEnum::Z128(GlweSecretKeyShare {
+            data: vec![],
+            polynomial_size: params.polynomial_size(),
+        }),
+        glwe_secret_key_share_sns_as_lwe: None,
+        glwe_secret_key_share_compression: None,
+        glwe_sns_compression_key_as_lwe: None,
+        parameters: params.classic_pbs(),
+    };
+
+    let upgraded = legacy.upgrade().unwrap();
+    assert!(upgraded.transciphering_secret_key_share.is_none());
+    assert_eq!(upgraded.oprf_secret_key_share, Some(oprf_share));
 }

--- a/core/threshold-execution/src/endpoints/keygen.rs
+++ b/core/threshold-execution/src/endpoints/keygen.rs
@@ -45,8 +45,10 @@ use tfhe::{
         ClassicPBSParameters,
         list_compression::{CompressedDecompressionKey, DecompressionKey},
         oprf::{CompressedOprfBootstrappingKey, CompressedOprfServerKey},
+        parameters::TranscipheringParameters,
         server_key::CompressedModulusSwitchConfiguration,
     },
+    transciphering::CompressedTranscipheringServerKey,
     xof_key_set::CompressedXofKeySet,
 };
 use tfhe_csprng::{generators::SoftwareRandomGenerator, seeders::XofSeed};
@@ -460,10 +462,26 @@ where
         .await?,
     );
 
+    let transciphering_secret_key_share = if params.transciphering_params().is_some() {
+        tracing::info!("(Party {my_role}) Generating transciphering LWE secret key...Start");
+        let share = LweSecretKeyShare::new_from_preprocessing(
+            params.lwe_dimension(),
+            preprocessing,
+            params.pmax(),
+            session,
+        )
+        .await?;
+        tracing::info!("(Party {my_role}) Generating transciphering LWE secret key...Done");
+        Some(share)
+    } else {
+        None
+    };
+
     let priv_key_set = GenericPrivateKeySet {
         lwe_encryption_secret_key_share: lwe_hat_secret_key_share,
         lwe_secret_key_share,
         oprf_secret_key_share,
+        transciphering_secret_key_share,
         glwe_secret_key_share,
         glwe_secret_key_share_sns,
         glwe_secret_key_share_compression,
@@ -508,9 +526,52 @@ where
     Ok(())
 }
 
-/// Generates all compressed public keys from an existing private key set.
-/// Note to developers: the order for which the public materials are generated is important,
-/// it must match the NIST spec (and also what is in tfhe-rs).
+/// Ensures a Z128 finalized private keyset contains the transciphering LWE key share.
+///
+/// The counterpart of [`ensure_oprf_secret_key_share_z128`] for the transciphering key: keysets
+/// persisted before transciphering existed do not carry the share, so `UseExisting` keygen calls
+/// this before regenerating public material. Does nothing when the parameter set has no
+/// transciphering parameters, since then no transciphering key is generated at all.
+#[instrument(name="TFHE.EnsureTranscipheringSecretKeyShare", skip_all, fields(sid = ?session.session_id(), my_role = ?session.my_role()))]
+pub async fn ensure_transciphering_secret_key_share_z128<
+    S: BaseSessionHandles,
+    P: DKGPreprocessing<ResiduePoly<Z128, EXTENSION_DEGREE>> + Send + ?Sized,
+    const EXTENSION_DEGREE: usize,
+>(
+    private_key_set: &mut PrivateKeySet<EXTENSION_DEGREE>,
+    params: DKGParams,
+    preprocessing: &mut P,
+    session: &mut S,
+) -> anyhow::Result<()>
+where
+    ResiduePoly<Z128, EXTENSION_DEGREE>: ErrorCorrect,
+{
+    if params.transciphering_params().is_some()
+        && private_key_set.transciphering_secret_key_share.is_none()
+    {
+        private_key_set.transciphering_secret_key_share = Some(
+            crate::tfhe_internals::private_keysets::LweSecretKeyShareEnum::Z128(
+                LweSecretKeyShare::new_from_preprocessing(
+                    params.lwe_dimension(),
+                    preprocessing,
+                    params.pmax(),
+                    session,
+                )
+                .await?,
+            ),
+        );
+    }
+
+    Ok(())
+}
+
+/// Generates all compressed public keys from an existing private key set. Note
+/// to developers: the order for which the public materials are generated is
+/// important, it must match the NIST spec (and also what is in tfhe-rs). The
+/// tfhe-rs side of this contract is
+/// `CompressedXofKeySet::generate_with_pre_seeded_generator`, this function
+/// must consume XOF mask bytes in the same order or the resulting keyset
+/// decompresses to garbage.
 ///
 /// Inputs:
 /// - `session`: the session that holds necessary information for networking
@@ -784,7 +845,7 @@ where
         _ => None,
     };
 
-    let oprf_bsk = generate_compressed_oprf_bootstrap_key(
+    let oprf_bsk = generate_compressed_dedicated_bootstrap_key(
         &private_key_set.glwe_secret_key_share,
         private_key_set
             .oprf_secret_key_share
@@ -802,6 +863,48 @@ where
         },
     ));
 
+    // The transciphering key is generated last, matching tfhe-rs
+    // (`CompressedXofKeySet::generate_with_pre_seeded_generator`).
+    let transciphering_key = match params.transciphering_params() {
+        None => None,
+        Some(transciphering_params) => {
+            // `TranscipheringParameters` is `#[non_exhaustive]` upstream. Every variant we know of
+            // is a compute-parameter BK; refuse an unknown one rather than silently generating the
+            // wrong key material.
+            if !matches!(
+                transciphering_params,
+                TranscipheringParameters::SameAsCompute
+            ) {
+                return Err(anyhow_error_and_log(format!(
+                    "unsupported transciphering parameters {transciphering_params:?}, can not generate the transciphering key"
+                )));
+            }
+            let transciphering_sk_share = private_key_set
+                .transciphering_secret_key_share
+                .as_ref()
+                .ok_or_else(|| {
+                    anyhow_error_and_log(
+                        "parameters ask for transciphering but the private keyset has no transciphering secret key share".to_string(),
+                    )
+                })?;
+            let transciphering_bsk = generate_compressed_dedicated_bootstrap_key(
+                &private_key_set.glwe_secret_key_share,
+                transciphering_sk_share,
+                params,
+                mpc_encryption_rng,
+                preprocessing,
+                session,
+            )
+            .await?;
+            tracing::info!("(Party {my_role}) Opening transciphering BK...Done");
+            Some(CompressedTranscipheringServerKey::from_raw_parts(
+                CompressedOprfServerKey::from_raw_parts(CompressedOprfBootstrappingKey::Classic {
+                    seeded_bsk: transciphering_bsk,
+                }),
+            ))
+        }
+    };
+
     Ok(RawCompressedPubKeySet {
         lwe_public_key,
         ksk,
@@ -814,6 +917,7 @@ where
         sns_compression_key,
         cpk_re_randomization,
         oprf_key,
+        transciphering_key,
         seed,
     })
 }
@@ -900,7 +1004,12 @@ where
     .await
 }
 
-async fn generate_compressed_oprf_bootstrap_key<
+/// Bootstrap key from a *dedicated* LWE secret key share into the compute GLWE key, using the
+/// compute bootstrap parameters.
+///
+/// Both the general-purpose OPRF key and the transciphering key have this exact shape — they only
+/// differ in which dedicated LWE secret key share they bootstrap from.
+async fn generate_compressed_dedicated_bootstrap_key<
     Z: BaseRing,
     P: DKGPreprocessing<ResiduePoly<Z, EXTENSION_DEGREE>> + ?Sized,
     S: BaseSessionHandles,
@@ -909,7 +1018,7 @@ async fn generate_compressed_oprf_bootstrap_key<
     const EXTENSION_DEGREE: usize,
 >(
     glwe_secret_key_share: &GlweSecretKeyShare<Z, EXTENSION_DEGREE>,
-    oprf_lwe_secret_key_share: &LweSecretKeyShare<Z, EXTENSION_DEGREE>,
+    dedicated_lwe_secret_key_share: &LweSecretKeyShare<Z, EXTENSION_DEGREE>,
     params: DKGParams,
     mpc_encryption_rng: &mut MPCEncryptionRandomGenerator<Z, Gen, EXTENSION_DEGREE>,
     preprocessing: &mut P,
@@ -920,7 +1029,7 @@ where
 {
     generate_compressed_bootstrap_key(
         glwe_secret_key_share,
-        oprf_lwe_secret_key_share,
+        dedicated_lwe_secret_key_share,
         params.bk_params(),
         mpc_encryption_rng,
         session,
@@ -2095,7 +2204,8 @@ pub mod tests {
         );
 
         let pk: FhePubKeySet = read_element(prefix_path.join("pk.der")).unwrap();
-        let (integer_server_key, _, _, _, ck, _, _, _, _) = pk.server_key.clone().into_raw_parts();
+        let (integer_server_key, _, _, _, ck, _, _, _, _, _) =
+            pk.server_key.clone().into_raw_parts();
         let ck = ck.unwrap();
 
         set_server_key(pk.server_key);
@@ -2110,6 +2220,7 @@ pub mod tests {
             None,
             Some(sns_raw_private_key),
             sns_compression_sk,
+            None,
             None,
         )
         .unwrap();
@@ -2242,7 +2353,7 @@ pub mod tests {
         assert_has_dedicated_oprf_key(&pk.server_key);
         set_server_key(pk.server_key.clone());
         let (shortint_pk, tag) = {
-            let (shorint_pk, _, _, _, _, _, _, _, tag) = pk.server_key.clone().into_raw_parts();
+            let (shorint_pk, _, _, _, _, _, _, _, _, tag) = pk.server_key.clone().into_raw_parts();
             (shorint_pk.into_raw_parts(), tag)
         };
         for _ in 0..100 {
@@ -2252,6 +2363,7 @@ pub mod tests {
         if with_compact {
             let tfhe_sk = tfhe::ClientKey::from_raw_parts(
                 shortint_sk.into(),
+                None,
                 None,
                 None,
                 None,
@@ -2290,7 +2402,19 @@ pub mod tests {
 
         assert_eq!(expected_tag, small_ct.tag());
 
-        assert_oprf_correctness::<EXTENSION_DEGREE>(prefix_path, params, num_parties, threshold);
+        assert_oprf_correctness::<EXTENSION_DEGREE>(
+            prefix_path,
+            params,
+            num_parties,
+            threshold,
+            DedicatedOprfKey::Oprf,
+        );
+        assert_transciphering_correctness::<EXTENSION_DEGREE>(
+            prefix_path,
+            params,
+            num_parties,
+            threshold,
+        );
     }
 
     ///Runs both shortint and fheuint computation
@@ -2331,6 +2455,7 @@ pub mod tests {
             None,
             None,
             None,
+            None,
             tag.clone(),
         );
 
@@ -2342,29 +2467,52 @@ pub mod tests {
             try_tfhe_rerand(&tfhe_sk, &pk.public_key, params.uses_derived_rerand());
         }
 
-        assert_oprf_correctness::<EXTENSION_DEGREE>(prefix_path, params, num_parties, threshold);
+        assert_oprf_correctness::<EXTENSION_DEGREE>(
+            prefix_path,
+            params,
+            num_parties,
+            threshold,
+            DedicatedOprfKey::Oprf,
+        );
+        assert_transciphering_correctness::<EXTENSION_DEGREE>(
+            prefix_path,
+            params,
+            num_parties,
+            threshold,
+        );
     }
 
     fn assert_has_dedicated_oprf_key(server_key: &tfhe::ServerKey) {
-        let (_, _, _, _, _, _, _, oprf_key, _) = server_key.clone().into_raw_parts();
+        let (_, _, _, _, _, _, _, oprf_key, _, _) = server_key.clone().into_raw_parts();
         assert!(
             oprf_key.is_some(),
             "threshold full keygen must embed a dedicated OPRF server key"
         );
     }
 
-    /// Reconstructs the OPRF LWE secret key from each party's persisted
-    /// `PrivateKeySet`, then verifies that the OPRF server key embedded in
-    /// `pk.server_key` agrees with it by running the encrypted PRF for several
-    /// seeds and comparing each output to the cleartext reference. Also runs a
-    /// negative check: a fresh OPRF server key built from a one-bit-flipped
-    /// version of the same LWE key must produce some mismatches against the
-    /// cleartext reference.
+    #[derive(Clone, Copy)]
+    enum DedicatedOprfKey {
+        Oprf,
+        Transciphering,
+    }
+
+    impl DedicatedOprfKey {
+        fn name(self) -> &'static str {
+            match self {
+                Self::Oprf => "OPRF",
+                Self::Transciphering => "transciphering",
+            }
+        }
+    }
+
+    /// Verifies the selected dedicated OPRF server key against the corresponding
+    /// reconstructed private key.
     fn assert_oprf_correctness<const EXTENSION_DEGREE: usize>(
         prefix_path: &Path,
         params: DKGParams,
         num_parties: usize,
         threshold: usize,
+        key_kind: DedicatedOprfKey,
     ) where
         ResiduePoly<Z64, EXTENSION_DEGREE>: ErrorCorrect,
         ResiduePoly<Z128, EXTENSION_DEGREE>: ErrorCorrect,
@@ -2386,26 +2534,38 @@ pub mod tests {
         let shortint_params = tfhe::shortint::ShortintParameterSet::from(ciphertext_params);
         let random_bits_count: u64 = shortint_params.message_modulus().0.ilog2().into();
 
-        let mut oprf_shares_z128: HashMap<Role, Vec<_>> = HashMap::new();
+        let mut key_shares_z128: HashMap<Role, Vec<_>> = HashMap::new();
         for party in 1..=num_parties {
             let role = Role::indexed_from_one(party);
             let sk: PrivateKeySet<EXTENSION_DEGREE> =
                 read_element(prefix_path.join(format!("sk_p{party}.der"))).unwrap();
-            let z128_share = match sk
-                .oprf_secret_key_share
-                .expect("OPRF share missing in PrivateKeySet")
-            {
-                LweSecretKeyShareEnum::Z128(inner) => inner,
-                LweSecretKeyShareEnum::Z64(_) => {
-                    panic!("OPRF share unexpectedly in Z64; this helper assumes Z128 keygen")
+            let share_data = |share: &LweSecretKeyShareEnum<EXTENSION_DEGREE>, name: &str| {
+                match share {
+                    LweSecretKeyShareEnum::Z128(inner) => inner,
+                    LweSecretKeyShareEnum::Z64(_) => {
+                        panic!("{name} share unexpectedly in Z64; this helper assumes Z128 keygen")
+                    }
                 }
+                .data
+                .clone()
             };
-            oprf_shares_z128.insert(role, z128_share.data);
+
+            let key_share = match key_kind {
+                DedicatedOprfKey::Oprf => sk
+                    .oprf_secret_key_share
+                    .as_ref()
+                    .expect("OPRF share missing in PrivateKeySet"),
+                DedicatedOprfKey::Transciphering => sk
+                    .transciphering_secret_key_share
+                    .as_ref()
+                    .expect("transciphering share missing in PrivateKeySet"),
+            };
+            key_shares_z128.insert(role, share_data(key_share, key_kind.name()));
         }
-        let prf_lwe_key_bits =
-            reconstruct_bit_vec::<Z128, EXTENSION_DEGREE>(oprf_shares_z128, lwe_dim, threshold);
-        let prf_lwe_sk =
-            tfhe::core_crypto::prelude::LweSecretKey::from_container(prf_lwe_key_bits.clone());
+
+        let key_bits =
+            reconstruct_bit_vec::<Z128, EXTENSION_DEGREE>(key_shares_z128, lwe_dim, threshold);
+        let key_sk = tfhe::core_crypto::prelude::LweSecretKey::from_container(key_bits.clone());
 
         let (shortint_ck, pk) = retrieve_keys_from_files::<EXTENSION_DEGREE>(
             params,
@@ -2414,41 +2574,51 @@ pub mod tests {
             prefix_path,
         );
 
-        let (target_shortint_server_key, _, _, _, _, _, _, oprf_server_key, _) =
-            pk.server_key.clone().into_raw_parts();
+        let (
+            target_shortint_server_key,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            oprf_server_key,
+            transciphering_server_key,
+            _,
+        ) = pk.server_key.clone().into_raw_parts();
         let target_shortint_server_key = target_shortint_server_key.into_raw_parts();
-        let oprf_server_key = oprf_server_key
-            .expect("OPRF server key missing from pk.server_key")
-            .into_raw_parts();
+        let dedicated_server_key = match key_kind {
+            DedicatedOprfKey::Oprf => oprf_server_key
+                .expect("OPRF server key missing from pk.server_key")
+                .into_raw_parts(),
+            DedicatedOprfKey::Transciphering => transciphering_server_key
+                .expect("transciphering server key missing from pk.server_key")
+                .into_raw_parts(),
+        };
 
         #[cfg(not(feature = "slow_tests"))]
         const NUM_SEEDS: u128 = 2;
         #[cfg(feature = "slow_tests")]
         const NUM_SEEDS: u128 = 50;
 
-        // Positive: encrypted PRF output must match the cleartext reference.
         assert_oprf_matches_plaintext(
             &shortint_ck,
             &target_shortint_server_key,
-            &oprf_server_key,
-            &prf_lwe_sk,
+            &dedicated_server_key,
+            &key_sk,
             NUM_SEEDS,
         );
 
-        // Negative: a fresh OPRF server key built from a one-bit-flipped LWE
-        // key under the same shortint client key must disagree with the
-        // cleartext reference for at least one seed. Guarantees the BSK in
-        // `pk.server_key` actually encodes the saved OPRF private key — not
-        // some accidentally-matching key.
-        let mut wrong_lwe_key_bits = prf_lwe_key_bits;
-        wrong_lwe_key_bits[0] ^= 1;
-        let wrong_lwe_sk =
-            tfhe::core_crypto::prelude::LweSecretKey::from_container(wrong_lwe_key_bits);
-        let wrong_oprf_private_key = ShortintOprfPrivateKey::from_raw_parts(
+        // A fresh server key built from a one-bit-flipped key must disagree with the
+        // cleartext reference for at least one seed.
+        let mut wrong_key_bits = key_bits;
+        wrong_key_bits[0] ^= 1;
+        let wrong_lwe_sk = tfhe::core_crypto::prelude::LweSecretKey::from_container(wrong_key_bits);
+        let wrong_private_key = ShortintOprfPrivateKey::from_raw_parts(
             AtomicPatternOprfPrivateKey::Standard(wrong_lwe_sk),
         );
-        let wrong_oprf_server_key =
-            ShortintCompressedOprfServerKey::new(&wrong_oprf_private_key, &shortint_ck)
+        let wrong_server_key =
+            ShortintCompressedOprfServerKey::new(&wrong_private_key, &shortint_ck)
                 .unwrap()
                 .expand()
                 .to_fourier();
@@ -2456,14 +2626,14 @@ pub mod tests {
         for s in 0u128..NUM_SEEDS {
             let seed = Seed(s);
             let img = crate::tfhe_internals::test_feature::oprf_single_block(
-                &wrong_oprf_server_key,
+                &wrong_server_key,
                 seed,
                 random_bits_count,
                 &target_shortint_server_key,
             );
             let actual = shortint_ck.decrypt_message_and_carry(&img);
             let expected = crate::tfhe_internals::test_feature::oprf_expected_plaintext(
-                &prf_lwe_sk.as_view(),
+                &key_sk.as_view(),
                 seed,
                 shortint_params,
                 random_bits_count,
@@ -2474,7 +2644,40 @@ pub mod tests {
         }
         assert!(
             mismatches > 0,
-            "expected mismatches when using the wrong (non-PRF) server key, but all {NUM_SEEDS} matched"
+            "expected mismatches when using the wrong {} server key, but all {NUM_SEEDS} matched",
+            key_kind.name()
+        );
+    }
+
+    /// Verifies the transciphering key when enabled and otherwise asserts that
+    /// key generation produced no transciphering material.
+    fn assert_transciphering_correctness<const EXTENSION_DEGREE: usize>(
+        prefix_path: &Path,
+        params: DKGParams,
+        num_parties: usize,
+        threshold: usize,
+    ) where
+        ResiduePoly<Z64, EXTENSION_DEGREE>: ErrorCorrect,
+        ResiduePoly<Z128, EXTENSION_DEGREE>: ErrorCorrect,
+    {
+        let pk: FhePubKeySet = read_element(prefix_path.join("pk.der")).unwrap();
+        let (_, _, _, _, _, _, _, _, transciphering_server_key, _) =
+            pk.server_key.clone().into_raw_parts();
+
+        if params.transciphering_params().is_none() {
+            assert!(
+                transciphering_server_key.is_none(),
+                "no transciphering parameters, so no transciphering server key must be generated"
+            );
+            return;
+        }
+
+        assert_oprf_correctness::<EXTENSION_DEGREE>(
+            prefix_path,
+            params,
+            num_parties,
+            threshold,
+            DedicatedOprfKey::Transciphering,
         );
     }
 

--- a/core/threshold-execution/src/endpoints/reshare_sk.rs
+++ b/core/threshold-execution/src/endpoints/reshare_sk.rs
@@ -30,6 +30,35 @@ use threshold_types::role::TwoSetsRole;
 use tfhe::shortint::parameters::CompressionParameters;
 use tracing::instrument;
 
+/// Which of the optional dedicated LWE key shares the keyset being reshared carries.
+///
+/// Both are `Option` fields of [`PrivateKeySet`] that can legitimately be absent — legacy keysets
+/// predate them, and transciphering is only generated for parameter sets that enable it. Resharing
+/// must skip the corresponding round for *every* party in lockstep, so the flags are passed in
+/// explicitly instead of being derived per party from input shares that may be missing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DedicatedKeysPresent {
+    /// Whether the old keyset contains a dedicated OPRF key share.
+    pub oprf: bool,
+    /// Whether the old keyset contains a transciphering key share.
+    pub transciphering: bool,
+}
+
+impl DedicatedKeysPresent {
+    /// Reads the flags off a private keyset held locally.
+    ///
+    /// Parties that do not hold the old keyset (e.g. S2 in a two-set reshare) must derive the same
+    /// flags from the verified public material instead.
+    pub fn from_private_keyset<const EXTENSION_DEGREE: usize>(
+        private_key_set: &PrivateKeySet<EXTENSION_DEGREE>,
+    ) -> Self {
+        Self {
+            oprf: private_key_set.oprf_secret_key_share.is_some(),
+            transciphering: private_key_set.transciphering_secret_key_share.is_some(),
+        }
+    }
+}
+
 pub struct ResharePreprocRequired {
     pub batch_params_128: BatchParams,
     pub batch_params_64: BatchParams,
@@ -39,13 +68,13 @@ impl ResharePreprocRequired {
     /// Computes the number of randoms needed to reshare a private key set
     /// where `num_parties_reshare_from` is the number of parties holding the input shares
     /// (i.e. everyone in same set resharing, or the first set in two sets resharing)
-    /// and `oprf_key_present` says whether the old keyset contains a dedicated OPRF key.
+    /// and `dedicated_keys` says which optional dedicated key shares the old keyset contains.
     ///
     /// NOTE: A [`PrivateKeySet`] is expected to be either all Z64 or all Z128 depending on the DKG parameters.
     pub fn new(
         num_parties_reshare_from: usize,
         parameters: DKGParams,
-        oprf_key_present: bool,
+        dedicated_keys: DedicatedKeysPresent,
     ) -> Self {
         let mut num_randoms_128 = 0;
         let mut num_randoms_64 = 0;
@@ -54,7 +83,10 @@ impl ResharePreprocRequired {
             DkgMode::Z64 => {
                 num_randoms_64 += parameters.lwe_hat_dimension().0;
                 num_randoms_64 += parameters.lwe_dimension().0;
-                if oprf_key_present {
+                if dedicated_keys.oprf {
+                    num_randoms_64 += parameters.lwe_dimension().0;
+                }
+                if dedicated_keys.transciphering {
                     num_randoms_64 += parameters.lwe_dimension().0;
                 }
                 num_randoms_64 +=
@@ -63,7 +95,10 @@ impl ResharePreprocRequired {
             DkgMode::Z128 => {
                 num_randoms_128 += parameters.lwe_hat_dimension().0;
                 num_randoms_128 += parameters.lwe_dimension().0;
-                if oprf_key_present {
+                if dedicated_keys.oprf {
+                    num_randoms_128 += parameters.lwe_dimension().0;
+                }
+                if dedicated_keys.transciphering {
                     num_randoms_128 += parameters.lwe_dimension().0;
                 }
                 num_randoms_128 +=
@@ -98,7 +133,7 @@ pub trait ReshareSecretKeys: Send + Sync + Sized {
     /// - `input_share` is `Some` for parties holding an input share, and `None` otherwise (e.g. if DKG failed)
     /// - `preproc128` and `preproc64` are the preprocessing instances for Z128 and Z64 operations respectively. See [`ResharePreprocRequired`] to know how much preprocessing is needed.
     /// - `parameters` are the DKG parameters
-    /// - `oprf_key_present` is true only when the old keyset contains a dedicated OPRF key
+    /// - `dedicated_keys` says which optional dedicated key shares the old keyset contains
     ///
     /// Returns the party's new secret key share
     async fn reshare_sk_same_set<
@@ -112,7 +147,7 @@ pub trait ReshareSecretKeys: Send + Sync + Sized {
         preproc64: &mut P64,
         input_share: &mut Option<PrivateKeySet<EXTENSION_DEGREE>>,
         parameters: DKGParams,
-        oprf_key_present: bool,
+        dedicated_keys: DedicatedKeysPresent,
     ) -> anyhow::Result<PrivateKeySet<EXTENSION_DEGREE>>
     where
         ResiduePoly<Z64, EXTENSION_DEGREE>: ErrorCorrect + Invert + QuotientMaximalIdeal,
@@ -125,7 +160,7 @@ pub trait ReshareSecretKeys: Send + Sync + Sized {
     /// - `two_sets_session` is the session handle that contains parties in both Set1 and Set2
     /// - `input_share` is the input share held by the party in Set1 that will be reshared
     /// - `parameters` are the DKG parameters
-    /// - `oprf_key_present` is true only when the old keyset contains a dedicated OPRF key
+    /// - `dedicated_keys` says which optional dedicated key shares the old keyset contains
     ///
     /// Returns `()` since parties in Set1 do not receive any new share
     async fn reshare_sk_two_sets_as_s1<
@@ -135,7 +170,7 @@ pub trait ReshareSecretKeys: Send + Sync + Sized {
         two_sets_session: &mut S,
         input_share: &mut PrivateKeySet<EXTENSION_DEGREE>,
         parameters: DKGParams,
-        oprf_key_present: bool,
+        dedicated_keys: DedicatedKeysPresent,
     ) -> anyhow::Result<()>
     where
         ResiduePoly<Z64, EXTENSION_DEGREE>: ErrorCorrect + Invert + QuotientMaximalIdeal,
@@ -148,7 +183,7 @@ pub trait ReshareSecretKeys: Send + Sync + Sized {
     /// - `sessions` is a tuple containing the session handle that contains parties in both Set1 and Set2 as well as the regular session handle for parties in Set2
     /// - `preproc128` and `preproc64` are the preprocessing instances for Z128 and Z64 operations respectively. See [`ResharePreprocRequired`] to know how much preprocessing is needed.
     /// - `parameters` are the DKG parameters
-    /// - `oprf_key_present` is true only when the old keyset contains a dedicated OPRF key
+    /// - `dedicated_keys` says which optional dedicated key shares the old keyset contains
     ///
     /// Returns the party's new secret key share
     async fn reshare_sk_two_sets_as_s2<
@@ -162,7 +197,7 @@ pub trait ReshareSecretKeys: Send + Sync + Sized {
         preproc128: &mut P128,
         preproc64: &mut P64,
         parameters: DKGParams,
-        oprf_key_present: bool,
+        dedicated_keys: DedicatedKeysPresent,
     ) -> anyhow::Result<PrivateKeySet<EXTENSION_DEGREE>>
     where
         ResiduePoly<Z64, EXTENSION_DEGREE>: ErrorCorrect + Invert + QuotientMaximalIdeal,
@@ -176,7 +211,7 @@ pub trait ReshareSecretKeys: Send + Sync + Sized {
     /// - `preproc128` and `preproc64` are the preprocessing instances for Z128 and Z64 operations respectively. See [`ResharePreprocRequired`] to know how much preprocessing is needed.
     /// - `input_share` is the input share held by the party in Set1 that will be reshared
     /// - `parameters` are the DKG parameters
-    /// - `oprf_key_present` is true only when the old keyset contains a dedicated OPRF key
+    /// - `dedicated_keys` says which optional dedicated key shares the old keyset contains
     ///
     /// Returns the party's new secret key share
     async fn reshare_sk_two_sets_as_both_sets<
@@ -191,7 +226,7 @@ pub trait ReshareSecretKeys: Send + Sync + Sized {
         preproc64: &mut P64,
         input_share: &mut PrivateKeySet<EXTENSION_DEGREE>,
         parameters: DKGParams,
-        oprf_key_present: bool,
+        dedicated_keys: DedicatedKeysPresent,
     ) -> anyhow::Result<PrivateKeySet<EXTENSION_DEGREE>>
     where
         ResiduePoly<Z64, EXTENSION_DEGREE>: ErrorCorrect + Invert + QuotientMaximalIdeal,
@@ -219,7 +254,7 @@ impl ReshareSecretKeys for SecureReshareSecretKeys {
         preproc64: &mut P64,
         input_share: &mut Option<PrivateKeySet<EXTENSION_DEGREE>>,
         parameters: DKGParams,
-        oprf_key_present: bool,
+        dedicated_keys: DedicatedKeysPresent,
     ) -> anyhow::Result<PrivateKeySet<EXTENSION_DEGREE>>
     where
         ResiduePoly<Z64, EXTENSION_DEGREE>: ErrorCorrect + Invert + QuotientMaximalIdeal,
@@ -231,7 +266,7 @@ impl ReshareSecretKeys for SecureReshareSecretKeys {
             session,
             input_share.as_mut(),
             parameters,
-            oprf_key_present,
+            dedicated_keys,
         )
         .await?
         .ok_or_else(|| anyhow_error_and_log("Expected an output in same set reshare"))
@@ -249,7 +284,7 @@ impl ReshareSecretKeys for SecureReshareSecretKeys {
         two_sets_session: &mut S,
         input_share: &mut PrivateKeySet<EXTENSION_DEGREE>,
         parameters: DKGParams,
-        oprf_key_present: bool,
+        dedicated_keys: DedicatedKeysPresent,
     ) -> anyhow::Result<()>
     where
         ResiduePoly<Z64, EXTENSION_DEGREE>: ErrorCorrect + Invert + QuotientMaximalIdeal,
@@ -265,7 +300,7 @@ impl ReshareSecretKeys for SecureReshareSecretKeys {
             two_sets_session,
             Expected(input_share),
             parameters,
-            oprf_key_present,
+            dedicated_keys,
         )
         .await?;
         Ok(())
@@ -283,7 +318,7 @@ impl ReshareSecretKeys for SecureReshareSecretKeys {
         preproc128: &mut P128,
         preproc64: &mut P64,
         parameters: DKGParams,
-        oprf_key_present: bool,
+        dedicated_keys: DedicatedKeysPresent,
     ) -> anyhow::Result<PrivateKeySet<EXTENSION_DEGREE>>
     where
         ResiduePoly<Z64, EXTENSION_DEGREE>: ErrorCorrect + Invert + QuotientMaximalIdeal,
@@ -300,7 +335,7 @@ impl ReshareSecretKeys for SecureReshareSecretKeys {
                 _marker: std::marker::PhantomData,
             },
             parameters,
-            oprf_key_present,
+            dedicated_keys,
         )
         .await?
         .ok_or_else(|| anyhow_error_and_log("Expected an output in two sets reshare"))
@@ -319,7 +354,7 @@ impl ReshareSecretKeys for SecureReshareSecretKeys {
         preproc64: &mut P64,
         input_share: &mut PrivateKeySet<EXTENSION_DEGREE>,
         parameters: DKGParams,
-        oprf_key_present: bool,
+        dedicated_keys: DedicatedKeysPresent,
     ) -> anyhow::Result<PrivateKeySet<EXTENSION_DEGREE>>
     where
         ResiduePoly<Z64, EXTENSION_DEGREE>: ErrorCorrect + Invert + QuotientMaximalIdeal,
@@ -334,7 +369,7 @@ impl ReshareSecretKeys for SecureReshareSecretKeys {
             sessions,
             Expected(input_share),
             parameters,
-            oprf_key_present,
+            dedicated_keys,
         )
         .await?
         .ok_or_else(|| anyhow_error_and_log("Expected an output in two sets reshare"))
@@ -352,7 +387,7 @@ pub(crate) async fn reshare_sk<
     sessions: &mut R::ReshareSessions,
     input_share: R::MaybeExpectedInputShares<&mut PrivateKeySet<EXTENSION_DEGREE>>,
     parameters: DKGParams,
-    oprf_key_present: bool,
+    dedicated_keys: DedicatedKeysPresent,
 ) -> anyhow::Result<Option<PrivateKeySet<EXTENSION_DEGREE>>>
 where
     ResiduePoly<Z64, EXTENSION_DEGREE>: ErrorCorrect + Invert + QuotientMaximalIdeal,
@@ -477,7 +512,7 @@ where
     };
 
     // Reshare the dedicated OPRF LWE key only when the old keyset has one.
-    let oprf_secret_key_share = if oprf_key_present {
+    let oprf_secret_key_share = if dedicated_keys.oprf {
         let expected_key_size = parameters.lwe_dimension().0;
         match parameters.dkg_mode() {
             DkgMode::Z64 => {
@@ -506,6 +541,57 @@ where
                     .as_mut()
                     .and_then(|s| {
                         s.oprf_secret_key_share
+                            .as_mut()
+                            .map(|key| key.try_cast_mut_to_z128().map(|key| key.data.as_mut()))
+                    })
+                    .transpose()
+                    .map_err(|e| anyhow_error_and_log(e.to_string()))?;
+                let data = reshare
+                    .execute(
+                        sessions,
+                        &mut preproc128,
+                        &mut R::MaybeExpectedInputShares::from(maybe_key),
+                        expected_key_size,
+                    )
+                    .await?;
+                data.into()
+                    .map(|data| LweSecretKeyShareEnum::Z128(LweSecretKeyShare { data }))
+            }
+        }
+    } else {
+        None
+    };
+
+    // Reshare the transciphering LWE key only when the old keyset has one.
+    let transciphering_secret_key_share = if dedicated_keys.transciphering {
+        let expected_key_size = parameters.lwe_dimension().0;
+        match parameters.dkg_mode() {
+            DkgMode::Z64 => {
+                let maybe_key = input_share
+                    .as_mut()
+                    .and_then(|s| {
+                        s.transciphering_secret_key_share
+                            .as_mut()
+                            .map(|key| key.try_cast_mut_to_z64().map(|key| key.data.as_mut()))
+                    })
+                    .transpose()
+                    .map_err(|e| anyhow_error_and_log(e.to_string()))?;
+                let data = reshare
+                    .execute(
+                        sessions,
+                        &mut preproc64,
+                        &mut R::MaybeExpectedInputShares::from(maybe_key),
+                        expected_key_size,
+                    )
+                    .await?;
+                data.into()
+                    .map(|data| LweSecretKeyShareEnum::Z64(LweSecretKeyShare { data }))
+            }
+            DkgMode::Z128 => {
+                let maybe_key = input_share
+                    .as_mut()
+                    .and_then(|s| {
+                        s.transciphering_secret_key_share
                             .as_mut()
                             .map(|key| key.try_cast_mut_to_z128().map(|key| key.data.as_mut()))
                     })
@@ -745,6 +831,7 @@ where
                 lwe_encryption_secret_key_share,
                 lwe_compute_secret_key_share,
                 oprf_secret_key_share,
+                transciphering_secret_key_share,
                 glwe_secret_key_share,
                 glwe_secret_key_share_sns_as_lwe,
                 parameters: parameters.classic_pbs(),
@@ -944,16 +1031,30 @@ mod tests {
                 add_error,
             )
             .unwrap();
-            let oprf_key_present = key_shares
-                .iter()
-                .any(|share| share.oprf_secret_key_share.is_some());
+            let dedicated_keys = DedicatedKeysPresent {
+                oprf: key_shares
+                    .iter()
+                    .any(|share| share.oprf_secret_key_share.is_some()),
+                transciphering: key_shares
+                    .iter()
+                    .any(|share| share.transciphering_secret_key_share.is_some()),
+            };
+            // Guard against vacuous coverage: `PARAMS_TEST_RESHARE` enables transciphering, so
+            // the test keyset must carry both dedicated shares. Without this, a regression that
+            // stopped generating them would make every `assert_ne!`/`assert_same_client_key`
+            // below compare `None` against `None` and still pass.
+            assert!(dedicated_keys.oprf, "test keyset must carry the OPRF share");
+            assert!(
+                dedicated_keys.transciphering,
+                "test keyset must carry the transciphering share"
+            );
 
             let party_keyshare = session.my_role().get_from(&key_shares).unwrap().clone();
             let mut preproc = DummyPreprocessing::new(42, &session);
 
             //Testing ResharePreprocRequired
             let preproc_required =
-                ResharePreprocRequired::new(session.num_parties(), params, oprf_key_present);
+                ResharePreprocRequired::new(session.num_parties(), params, dedicated_keys);
 
             let mut new_preproc_64 = InMemoryBasePreprocessing {
                 available_triples: Vec::new(),
@@ -983,7 +1084,7 @@ mod tests {
                 &mut new_preproc_64,
                 &mut my_contribution,
                 params,
-                oprf_key_present,
+                dedicated_keys,
             )
             .await
             .unwrap();
@@ -991,7 +1092,11 @@ mod tests {
             //Making sure ResharPreprocRequired doesn't ask for too much preprocessing
             assert_eq!(new_preproc_64.available_randoms.len(), 0);
             assert_eq!(new_preproc_128.available_randoms.len(), 0);
-            assert_eq!(out.oprf_secret_key_share.is_some(), oprf_key_present);
+            assert_eq!(out.oprf_secret_key_share.is_some(), dedicated_keys.oprf);
+            assert_eq!(
+                out.transciphering_secret_key_share.is_some(),
+                dedicated_keys.transciphering
+            );
             (session.my_role(), out, my_contribution)
         };
 
@@ -1073,6 +1178,17 @@ mod tests {
             }
         }
 
+        if let Some(x) = keyset.transciphering_secret_key_share.as_ref() {
+            match x {
+                LweSecretKeyShareEnum::Z64(x) => {
+                    x.data.iter().for_each(|x| assert!(x.value().is_zero()))
+                }
+                LweSecretKeyShareEnum::Z128(x) => {
+                    x.data.iter().for_each(|x| assert!(x.value().is_zero()))
+                }
+            }
+        }
+
         match &keyset.glwe_secret_key_share {
             GlweSecretKeyShareEnum::Z64(x) => {
                 x.data.iter().for_each(|x| assert!(x.value().is_zero()))
@@ -1122,9 +1238,20 @@ mod tests {
                         session_set_2: Option<BaseSession>| async move {
             let new_params = PARAMS_TEST_RESHARE;
             let keyset = RESHARE_KEYSET.clone();
-            let oprf_key_present = ClientKeyView::new(&keyset.client_key)
-                .raw_oprf_client_key()
-                .is_some();
+            let client_key_view = ClientKeyView::new(&keyset.client_key);
+            let dedicated_keys = DedicatedKeysPresent {
+                oprf: client_key_view.raw_oprf_client_key().is_some(),
+                transciphering: client_key_view.raw_transciphering_client_key().is_some(),
+            };
+            // Guard against vacuous coverage: `PARAMS_TEST_RESHARE` enables transciphering, so
+            // the test keyset must carry both dedicated shares. Without this, a regression that
+            // stopped generating them would make every `assert_ne!`/`assert_same_client_key`
+            // below compare `None` against `None` and still pass.
+            assert!(dedicated_keys.oprf, "test keyset must carry the OPRF share");
+            assert!(
+                dedicated_keys.transciphering,
+                "test keyset must carry the transciphering share"
+            );
             let mut party_keyshare = if let Some(session_set_1) = session_set_1.as_ref() {
                 let key_shares = generate_key_with_error_in_s1(
                     keyset,
@@ -1146,38 +1273,37 @@ mod tests {
                 None
             };
 
-            let (mut preproc_64, mut preproc_128) = if let Some(session_set_2) =
-                session_set_2.as_ref()
-            {
-                let mut preproc = DummyPreprocessing::new(42, session_set_2);
+            let (mut preproc_64, mut preproc_128) =
+                if let Some(session_set_2) = session_set_2.as_ref() {
+                    let mut preproc = DummyPreprocessing::new(42, session_set_2);
 
-                //Testing ResharePreprocRequired
-                let num_parties_set_1 = common_session
-                    .roles()
-                    .iter()
-                    .filter(|p| p.is_set1())
-                    .count();
-                assert_eq!(num_parties_set_1, num_parties_s1);
-                let preproc_required =
-                    ResharePreprocRequired::new(num_parties_set_1, new_params, oprf_key_present);
+                    //Testing ResharePreprocRequired
+                    let num_parties_set_1 = common_session
+                        .roles()
+                        .iter()
+                        .filter(|p| p.is_set1())
+                        .count();
+                    assert_eq!(num_parties_set_1, num_parties_s1);
+                    let preproc_required =
+                        ResharePreprocRequired::new(num_parties_set_1, new_params, dedicated_keys);
 
-                let new_preproc_64 = InMemoryBasePreprocessing {
-                    available_triples: Vec::new(),
-                    available_randoms: preproc
-                        .next_random_vec(preproc_required.batch_params_64.randoms)
-                        .unwrap(),
+                    let new_preproc_64 = InMemoryBasePreprocessing {
+                        available_triples: Vec::new(),
+                        available_randoms: preproc
+                            .next_random_vec(preproc_required.batch_params_64.randoms)
+                            .unwrap(),
+                    };
+
+                    let new_preproc_128 = InMemoryBasePreprocessing {
+                        available_triples: Vec::new(),
+                        available_randoms: preproc
+                            .next_random_vec(preproc_required.batch_params_128.randoms)
+                            .unwrap(),
+                    };
+                    (Some(new_preproc_64), Some(new_preproc_128))
+                } else {
+                    (None, None)
                 };
-
-                let new_preproc_128 = InMemoryBasePreprocessing {
-                    available_triples: Vec::new(),
-                    available_randoms: preproc
-                        .next_random_vec(preproc_required.batch_params_128.randoms)
-                        .unwrap(),
-                };
-                (Some(new_preproc_64), Some(new_preproc_128))
-            } else {
-                (None, None)
-            };
 
             let my_role = common_session.my_role();
             let out = match my_role {
@@ -1187,7 +1313,7 @@ mod tests {
                         &mut common_session,
                         &mut party_keyshare,
                         new_params,
-                        oprf_key_present,
+                        dedicated_keys,
                     )
                     .await
                     .unwrap();
@@ -1198,7 +1324,7 @@ mod tests {
                     preproc_128.as_mut().unwrap(),
                     preproc_64.as_mut().unwrap(),
                     new_params,
-                    oprf_key_present,
+                    dedicated_keys,
                 )
                 .await
                 .unwrap(),
@@ -1208,7 +1334,7 @@ mod tests {
                     preproc_64.as_mut().unwrap(),
                     party_keyshare.as_mut().unwrap(),
                     new_params,
-                    oprf_key_present,
+                    dedicated_keys,
                 )
                 .await
                 .unwrap(),
@@ -1221,7 +1347,11 @@ mod tests {
             if let Some(p) = preproc_128 {
                 assert_eq!(p.available_randoms.len(), 0)
             }
-            assert_eq!(out.oprf_secret_key_share.is_some(), oprf_key_present);
+            assert_eq!(out.oprf_secret_key_share.is_some(), dedicated_keys.oprf);
+            assert_eq!(
+                out.transciphering_secret_key_share.is_some(),
+                dedicated_keys.transciphering
+            );
 
             (my_role, out)
         };
@@ -1473,10 +1603,10 @@ mod tests {
     /// Asserts two client keys are byte-identical, component by component (a
     /// whole-key byte compare only says "different"; this names the offending
     /// field). Covers every component: compute key, dedicated CPK, compression,
-    /// noise-squashing, SnS-compression, re-randomization params, OPRF, and tag.
+    /// noise-squashing, SnS-compression, re-randomization params, OPRF, transciphering, and tag.
     fn assert_same_client_key(a: &tfhe::ClientKey, b: &tfhe::ClientKey) {
-        let (ai, acpk, acomp, ans, ansc, arerand, aoprf, atag) = a.clone().into_raw_parts();
-        let (bi, bcpk, bcomp, bns, bnsc, brerand, boprf, btag) = b.clone().into_raw_parts();
+        let (ai, acpk, acomp, ans, ansc, arerand, aoprf, atc, atag) = a.clone().into_raw_parts();
+        let (bi, bcpk, bcomp, bns, bnsc, brerand, boprf, btc, btag) = b.clone().into_raw_parts();
         macro_rules! same_field {
             ($x:expr, $y:expr, $name:literal) => {
                 assert_eq!(
@@ -1493,6 +1623,7 @@ mod tests {
         same_field!(ansc, bnsc, "sns compression private key");
         same_field!(arerand, brerand, "re-randomization parameters");
         same_field!(aoprf, boprf, "oprf private key");
+        same_field!(atc, btc, "transciphering private key");
         same_field!(atag, btag, "tag");
     }
 
@@ -1609,6 +1740,22 @@ mod tests {
             ))
         });
 
+        let transciphering_private_lwe_sk = shares[0]
+            .transciphering_secret_key_share
+            .is_some()
+            .then(|| {
+                LweSecretKey::from_container(recon_lwe_enum_u64(
+                    shares,
+                    |s| {
+                        s.transciphering_secret_key_share.as_ref().expect(
+                            "transciphering share present on all parties when present on party 0",
+                        )
+                    },
+                    threshold,
+                    max_errors,
+                ))
+            });
+
         to_hl_client_key(
             &params,
             tag,
@@ -1619,6 +1766,7 @@ mod tests {
             sns_secret_key,
             sns_compression_secret_key,
             oprf_private_lwe_sk,
+            transciphering_private_lwe_sk,
         )
     }
 

--- a/core/threshold-execution/src/tfhe_internals/parameters.rs
+++ b/core/threshold-execution/src/tfhe_internals/parameters.rs
@@ -19,7 +19,8 @@ use tfhe::shortint::parameters::{
     ModulusSwitchType, NoiseEstimationMeasureBound, NoiseSquashingClassicParameters,
     NoiseSquashingCompressionParameters, NoiseSquashingParameters, PBSOrder, PBSParameters,
     PolynomialSize, RSigmaFactor, ReRandomizationConfiguration, ReRandomizationParameters,
-    ShortintKeySwitchingParameters, SupportedCompactPkeZkScheme, Variance,
+    ShortintKeySwitchingParameters, SupportedCompactPkeZkScheme, TranscipheringParameters,
+    Variance,
 };
 use tfhe::shortint::{CarryModulus, MaxNoiseLevel, MessageModulus};
 
@@ -252,6 +253,17 @@ impl DKGParams {
     /// [`Self::compression_decompression_params`].
     pub fn compression(&self) -> Option<CompressionParameters> {
         self.meta.compression_parameters
+    }
+
+    /// The parameters of the transciphering key material, or `None` when this
+    /// parameter set does not enable transciphering.
+    ///
+    /// [`TranscipheringParameters::SameAsCompute`] means the transciphering key is a
+    /// bootstrap key built with the compute parameters ([`Self::bk_params`]) from a
+    /// dedicated LWE secret key of dimension [`Self::lwe_dimension`] — the same shape
+    /// as the general-purpose OPRF key, but sampled independently of it.
+    pub fn transciphering_params(&self) -> Option<TranscipheringParameters> {
+        self.meta.transciphering_parameters
     }
 
     pub fn lwe_dimension(&self) -> LweDimension {
@@ -778,6 +790,13 @@ impl DKGParams {
             None => config,
         };
         let config = config.use_dedicated_oprf_key(true);
+        // TODO: the centralized and insecure engines get their transciphering key material for
+        // free from tfhe-rs through this config, but neither is covered by a test that asserts
+        // the key is present and usable.
+        let config = match self.transciphering_params() {
+            Some(transciphering_params) => config.enable_transciphering(transciphering_params),
+            None => config,
+        };
         config.build()
     }
 }
@@ -871,6 +890,20 @@ impl DKGParams {
         }
     }
 
+    /// Noise needed for the dedicated transciphering bootstrap key.
+    ///
+    /// The key is a compute-parameter BK ([`Self::num_needed_noise_bk`]), so the amount is the
+    /// same — but zero when the parameter set does not enable transciphering.
+    pub fn num_needed_noise_transciphering_bk(&self) -> NoiseInfo {
+        match self.transciphering_params() {
+            Some(_) => self.num_needed_noise_bk(),
+            None => NoiseInfo {
+                amount: 0,
+                bound: NoiseBounds::GlweNoise(self.glwe_tuniform_bound()),
+            },
+        }
+    }
+
     pub fn num_needed_noise_msnrk(&self) -> NoiseInfo {
         let amount = match self.classic_pbs().modulus_switch_noise_reduction_params {
             ModulusSwitchType::DriftTechniqueNoiseReduction(p) => p.modulus_switch_zeros_count.0,
@@ -938,6 +971,19 @@ impl DKGParams {
         }
     }
 
+    /// Raw bits needed to sample the dedicated transciphering LWE secret key, or `0` when the
+    /// parameter set does not enable transciphering.
+    ///
+    /// The key has the compute LWE dimension, so this is [`Self::lwe_sk_num_bits_to_sample`]
+    /// gated on the parameter.
+    pub fn transciphering_lwe_sk_num_bits_to_sample(&self) -> usize {
+        if self.transciphering_params().is_some() {
+            self.lwe_sk_num_bits_to_sample()
+        } else {
+            0
+        }
+    }
+
     pub fn lwe_hat_sk_num_bits_to_sample(&self) -> usize {
         if self.has_dedicated_compact_pk_params() {
             let key_size = self.lwe_hat_dimension().0;
@@ -1002,10 +1048,18 @@ impl DKGParams {
                     self.lwe_sk_num_bits_to_sample()
                         + self.lwe_hat_sk_num_bits_to_sample()
                         + self.lwe_sk_num_bits_to_sample() // second sk is for oprf
+                        + self.transciphering_lwe_sk_num_bits_to_sample()
                         + self.glwe_sk_num_bits_to_sample()
                         + self.compression_sk_num_bits_to_sample()
                 }
-                KeyGenSecretKeyConfig::UseExisting => self.lwe_sk_num_bits_to_sample(),
+                // `UseExisting` may have to back-fill the dedicated shares that legacy keysets
+                // lack, so budget for sampling them (see `ensure_oprf_secret_key_share_z128` and
+                // `ensure_transciphering_secret_key_share_z128`). This is a worst case: nothing is
+                // sampled when the shares are already present.
+                KeyGenSecretKeyConfig::UseExisting => {
+                    self.lwe_sk_num_bits_to_sample()
+                        + self.transciphering_lwe_sk_num_bits_to_sample()
+                }
             },
             KeySetConfig::DecompressionOnly => 0,
         }
@@ -1049,6 +1103,7 @@ impl DKGParams {
                 n += self.num_needed_noise_ksk().num_bits_needed();
                 n += self.num_needed_noise_bk().num_bits_needed();
                 n += self.num_needed_noise_bk().num_bits_needed(); // dedicated OPRF bk
+                n += self.num_needed_noise_transciphering_bk().num_bits_needed();
                 n += self.num_needed_noise_pksk().num_bits_needed();
                 n += self.num_needed_noise_compression_key().num_bits_needed();
                 n += self.num_needed_noise_msnrk().num_bits_needed();
@@ -1086,15 +1141,22 @@ impl DKGParams {
                 * (c.packing_ks_glwe_dimension().0 * c.packing_ks_polynomial_size().0)
         });
 
+        // The transciphering BK, when present, bootstraps into the same compute GLWE key as the
+        // regular and OPRF BKs, so it costs exactly one more of them.
+        let num_compute_bks = if self.transciphering_params().is_some() {
+            3
+        } else {
+            2
+        };
         let mut triples = match keyset_config {
             KeySetConfig::Standard(_) => match self.sns() {
-                // regular BK + OPRF BK + SnS BK
+                // regular BK + OPRF BK (+ transciphering BK) + SnS BK
                 Some(sns) => {
                     self.lwe_dimension().0
-                        * (2 * self.glwe_sk_num_bits() + sns.glwe_sk_num_bits_sns())
+                        * (num_compute_bks * self.glwe_sk_num_bits() + sns.glwe_sk_num_bits_sns())
                 }
-                // regular BK + OPRF BK
-                None => 2 * self.lwe_dimension().0 * self.glwe_sk_num_bits(),
+                // regular BK + OPRF BK (+ transciphering BK)
+                None => num_compute_bks * self.lwe_dimension().0 * self.glwe_sk_num_bits(),
             },
             KeySetConfig::DecompressionOnly => 0,
         };
@@ -1153,6 +1215,7 @@ impl DKGParams {
                 &[
                     self.num_needed_noise_bk(), // regular bk
                     self.num_needed_noise_bk(), // oprf bk
+                    self.num_needed_noise_transciphering_bk(),
                     self.num_needed_noise_pksk(),
                     self.num_needed_noise_decompression_key(),
                     self.num_needed_noise_rerand_ksk(),
@@ -1583,6 +1646,7 @@ pub const BC_PARAMS_NIGEL_SNS: DKGParams = DKGParams {
         rerand_configuration: Some(
             tfhe::shortint::parameters::ReRandomizationConfiguration::LegacyDedicatedCompactPublicKeyWithKeySwitch,
         ),
+        transciphering_parameters: None,
     },
     secret_key_deviations: None,
 };
@@ -1685,6 +1749,9 @@ pub const PARAMS_TEST_BK_SNS: DKGParams = DKGParams {
         rerand_configuration: Some(
             tfhe::shortint::parameters::ReRandomizationConfiguration::DerivedCompactPublicKeyWithoutKeySwitch,
         ),
+        // Transciphering is exercised only by the test parameter sets for now; the
+        // production sets above deliberately leave it off.
+        transciphering_parameters: Some(TranscipheringParameters::SameAsCompute),
     },
     secret_key_deviations: None,
 };
@@ -1806,6 +1873,9 @@ pub const PARAMS_TEST_RESHARE: DKGParams = DKGParams {
         rerand_configuration: Some(
             tfhe::shortint::parameters::ReRandomizationConfiguration::DerivedCompactPublicKeyWithoutKeySwitch,
         ),
+        // Transciphering is exercised only by the test parameter sets for now; the
+        // production sets above deliberately leave it off.
+        transciphering_parameters: Some(TranscipheringParameters::SameAsCompute),
     },
     secret_key_deviations: None,
 };
@@ -1832,6 +1902,7 @@ pub const NIST_PARAMS_P8_SNS_LWE: DKGParams = DKGParams {
             compression_parameters: None,
         }),
         rerand_configuration: None,
+        transciphering_parameters: None,
     },
     secret_key_deviations: Some(SecretKeyDeviations {
         log2_failure_proba: -80,
@@ -1861,6 +1932,7 @@ pub const NIST_PARAMS_P32_SNS_LWE: DKGParams = DKGParams {
             compression_parameters: None,
         }),
         rerand_configuration: None,
+        transciphering_parameters: None,
     },
     secret_key_deviations: Some(SecretKeyDeviations {
         log2_failure_proba: -80,
@@ -1894,6 +1966,7 @@ pub const NIST_PARAMS_P8_SNS_FGLWE: DKGParams = DKGParams {
         rerand_configuration: Some(
             tfhe::shortint::parameters::ReRandomizationConfiguration::LegacyDedicatedCompactPublicKeyWithKeySwitch,
         ),
+        transciphering_parameters: None,
     },
     secret_key_deviations: Some(SecretKeyDeviations {
         log2_failure_proba: -80,
@@ -1927,6 +2000,7 @@ pub const NIST_PARAMS_P32_SNS_FGLWE: DKGParams = DKGParams {
         rerand_configuration: Some(
             tfhe::shortint::parameters::ReRandomizationConfiguration::LegacyDedicatedCompactPublicKeyWithKeySwitch,
         ),
+        transciphering_parameters: None,
     },
     secret_key_deviations: Some(SecretKeyDeviations {
         log2_failure_proba: -80,
@@ -2007,6 +2081,7 @@ mod tests {
                     + p.num_needed_noise_ksk().num_bits_needed()
                     + p.num_needed_noise_bk().num_bits_needed()
                     + p.num_needed_noise_bk().num_bits_needed() // dedicated OPRF bk
+                    + p.num_needed_noise_transciphering_bk().num_bits_needed()
                     + p.num_needed_noise_pksk().num_bits_needed()
                     + p.num_needed_noise_compression_key().num_bits_needed()
                     + p.num_needed_noise_msnrk().num_bits_needed()

--- a/core/threshold-execution/src/tfhe_internals/parameters.rs
+++ b/core/threshold-execution/src/tfhe_internals/parameters.rs
@@ -1571,7 +1571,7 @@ impl DkgParamsAvailable {
 pub const BC_PARAMS_SNS: DKGParams = DKGParams {
     dkg_mode: DkgMode::Z128,
     sec: 128,
-    meta: tfhe::shortint::parameters::v1_7::meta::cpu::V1_7_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
+    meta: tfhe::shortint::parameters::v1_8::meta::cpu::V1_8_META_PARAM_CPU_2_2_KS_PBS_PKE_TO_SMALL_ZKV2_TUNIFORM_2M128,
     secret_key_deviations: None,
 };
 

--- a/core/threshold-execution/src/tfhe_internals/private_keysets.rs
+++ b/core/threshold-execution/src/tfhe_internals/private_keysets.rs
@@ -25,6 +25,9 @@ pub(crate) struct GenericPrivateKeySet<Z: Clone, const EXTENSION_DEGREE: usize> 
     pub lwe_encryption_secret_key_share: LweSecretKeyShare<Z, EXTENSION_DEGREE>,
     pub lwe_secret_key_share: LweSecretKeyShare<Z, EXTENSION_DEGREE>,
     pub oprf_secret_key_share: Option<LweSecretKeyShare<Z, EXTENSION_DEGREE>>,
+    /// Sampled independently of `oprf_secret_key_share`: the transciphering key material is
+    /// handed out to clients, so it must not derive from the general-purpose OPRF key.
+    pub transciphering_secret_key_share: Option<LweSecretKeyShare<Z, EXTENSION_DEGREE>>,
     pub glwe_secret_key_share: GlweSecretKeyShare<Z, EXTENSION_DEGREE>,
     pub glwe_secret_key_share_sns: Option<GlweSecretKeyShare<Z, EXTENSION_DEGREE>>,
     pub glwe_secret_key_share_compression: Option<CompressionPrivateKeyShares<Z, EXTENSION_DEGREE>>,
@@ -39,7 +42,10 @@ pub enum PrivateKeySetVersions<const EXTENSION_DEGREE: usize> {
     // V1 is the same as V0 with the addition of glwe_sns_compression_key
     V1(PrivateKeySetV1<EXTENSION_DEGREE>),
     V2(PrivateKeySetV2<EXTENSION_DEGREE>),
-    V3(PrivateKeySet<EXTENSION_DEGREE>),
+    // V3 is the same as V2 with the addition of oprf_secret_key_share
+    V3(PrivateKeySetV3<EXTENSION_DEGREE>),
+    // V4 is the same as V3 with the addition of transciphering_secret_key_share
+    V4(PrivateKeySet<EXTENSION_DEGREE>),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Versionize)]
@@ -61,6 +67,11 @@ pub struct PrivateKeySet<const EXTENSION_DEGREE: usize> {
     pub lwe_encryption_secret_key_share: LweSecretKeyShareEnum<EXTENSION_DEGREE>,
     pub lwe_compute_secret_key_share: LweSecretKeyShareEnum<EXTENSION_DEGREE>,
     pub oprf_secret_key_share: Option<LweSecretKeyShareEnum<EXTENSION_DEGREE>>,
+    /// Sampled independently of `oprf_secret_key_share`: the transciphering key material is
+    /// handed out to clients, so it must not derive from the general-purpose OPRF key.
+    /// `None` for keysets generated before transciphering existed, and for parameter sets that
+    /// do not enable it (see `DKGParams::transciphering_params`).
+    pub transciphering_secret_key_share: Option<LweSecretKeyShareEnum<EXTENSION_DEGREE>>,
     pub glwe_secret_key_share: GlweSecretKeyShareEnum<EXTENSION_DEGREE>,
     pub glwe_secret_key_share_sns_as_lwe: Option<LweSecretKeyShare<Z128, EXTENSION_DEGREE>>,
     pub glwe_secret_key_share_compression:
@@ -75,6 +86,7 @@ impl<const EXTENSION_DEGREE: usize> PrivateKeySet<EXTENSION_DEGREE> {
             lwe_encryption_secret_key_share,
             lwe_compute_secret_key_share,
             oprf_secret_key_share,
+            transciphering_secret_key_share,
             glwe_secret_key_share,
             glwe_secret_key_share_sns_as_lwe: _,
             glwe_secret_key_share_compression,
@@ -93,6 +105,10 @@ impl<const EXTENSION_DEGREE: usize> PrivateKeySet<EXTENSION_DEGREE> {
         }
 
         if let Some(LweSecretKeyShareEnum::Z64(key)) = oprf_secret_key_share {
+            count += key.data.len();
+        }
+
+        if let Some(LweSecretKeyShareEnum::Z64(key)) = transciphering_secret_key_share {
             count += key.data.len();
         }
 
@@ -121,6 +137,9 @@ impl<const EXTENSION_DEGREE: usize> PrivateKeySet<EXTENSION_DEGREE> {
             ),
             oprf_secret_key_share: self
                 .oprf_secret_key_share
+                .map(|key| LweSecretKeyShareEnum::Z64(key.convert_to_z64())),
+            transciphering_secret_key_share: self
+                .transciphering_secret_key_share
                 .map(|key| LweSecretKeyShareEnum::Z64(key.convert_to_z64())),
             glwe_secret_key_share: GlweSecretKeyShareEnum::Z64(
                 self.glwe_secret_key_share.convert_to_z64(),
@@ -216,6 +235,13 @@ impl<const EXTENSION_DEGREE: usize> PrivateKeySet<EXTENSION_DEGREE> {
             }));
         }
 
+        if let Some(LweSecretKeyShareEnum::Z64(key)) = self.transciphering_secret_key_share {
+            self.transciphering_secret_key_share =
+                Some(LweSecretKeyShareEnum::Z128(LweSecretKeyShare {
+                    data: SecureBitLift::execute(key.data, preproc, session).await?,
+                }));
+        }
+
         if let GlweSecretKeyShareEnum::Z64(key) = self.glwe_secret_key_share {
             self.glwe_secret_key_share = GlweSecretKeyShareEnum::Z128(GlweSecretKeyShare {
                 data: SecureBitLift::execute(key.data, preproc, session).await?,
@@ -275,6 +301,21 @@ pub struct PrivateKeySetV2<const EXTENSION_DEGREE: usize> {
     pub parameters: ClassicPBSParameters,
 }
 
+/// V3: private key set before adding the transciphering secret-key share.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Version)]
+pub struct PrivateKeySetV3<const EXTENSION_DEGREE: usize> {
+    //The two Lwe keys are the same if there's no dedicated pk parameters
+    pub lwe_encryption_secret_key_share: LweSecretKeyShareEnum<EXTENSION_DEGREE>,
+    pub lwe_compute_secret_key_share: LweSecretKeyShareEnum<EXTENSION_DEGREE>,
+    pub oprf_secret_key_share: Option<LweSecretKeyShareEnum<EXTENSION_DEGREE>>,
+    pub glwe_secret_key_share: GlweSecretKeyShareEnum<EXTENSION_DEGREE>,
+    pub glwe_secret_key_share_sns_as_lwe: Option<LweSecretKeyShare<Z128, EXTENSION_DEGREE>>,
+    pub glwe_secret_key_share_compression:
+        Option<CompressionPrivateKeySharesEnum<EXTENSION_DEGREE>>,
+    pub glwe_sns_compression_key_as_lwe: Option<LweSecretKeyShare<Z128, EXTENSION_DEGREE>>,
+    pub parameters: ClassicPBSParameters,
+}
+
 #[cfg(any(test, feature = "testing"))]
 impl<const EXTENSION_DEGREE: usize> PrivateKeySet<EXTENSION_DEGREE> {
     pub fn init_dummy(param: DKGParams) -> Self {
@@ -283,6 +324,9 @@ impl<const EXTENSION_DEGREE: usize> PrivateKeySet<EXTENSION_DEGREE> {
                 data: vec![],
             }),
             oprf_secret_key_share: Some(LweSecretKeyShareEnum::Z128(LweSecretKeyShare {
+                data: vec![],
+            })),
+            transciphering_secret_key_share: Some(LweSecretKeyShareEnum::Z128(LweSecretKeyShare {
                 data: vec![],
             })),
             lwe_encryption_secret_key_share: LweSecretKeyShareEnum::Z128(LweSecretKeyShare {
@@ -352,8 +396,27 @@ impl<const EXTENSION_DEGREE: usize> Upgrade<PrivateKeySetV2<EXTENSION_DEGREE>>
     }
 }
 
-impl<const EXTENSION_DEGREE: usize> Upgrade<PrivateKeySet<EXTENSION_DEGREE>>
+impl<const EXTENSION_DEGREE: usize> Upgrade<PrivateKeySetV3<EXTENSION_DEGREE>>
     for PrivateKeySetV2<EXTENSION_DEGREE>
+{
+    type Error = std::convert::Infallible;
+
+    fn upgrade(self) -> Result<PrivateKeySetV3<EXTENSION_DEGREE>, Self::Error> {
+        Ok(PrivateKeySetV3 {
+            lwe_encryption_secret_key_share: self.lwe_encryption_secret_key_share,
+            lwe_compute_secret_key_share: self.lwe_compute_secret_key_share,
+            oprf_secret_key_share: None,
+            glwe_secret_key_share: self.glwe_secret_key_share,
+            glwe_secret_key_share_sns_as_lwe: self.glwe_secret_key_share_sns_as_lwe,
+            glwe_secret_key_share_compression: self.glwe_secret_key_share_compression,
+            glwe_sns_compression_key_as_lwe: self.glwe_sns_compression_key_as_lwe,
+            parameters: self.parameters,
+        })
+    }
+}
+
+impl<const EXTENSION_DEGREE: usize> Upgrade<PrivateKeySet<EXTENSION_DEGREE>>
+    for PrivateKeySetV3<EXTENSION_DEGREE>
 {
     type Error = std::convert::Infallible;
 
@@ -361,7 +424,8 @@ impl<const EXTENSION_DEGREE: usize> Upgrade<PrivateKeySet<EXTENSION_DEGREE>>
         Ok(PrivateKeySet {
             lwe_encryption_secret_key_share: self.lwe_encryption_secret_key_share,
             lwe_compute_secret_key_share: self.lwe_compute_secret_key_share,
-            oprf_secret_key_share: None,
+            oprf_secret_key_share: self.oprf_secret_key_share,
+            transciphering_secret_key_share: None,
             glwe_secret_key_share: self.glwe_secret_key_share,
             glwe_secret_key_share_sns_as_lwe: self.glwe_secret_key_share_sns_as_lwe,
             glwe_secret_key_share_compression: self.glwe_secret_key_share_compression,
@@ -614,6 +678,21 @@ where
             })
             .transpose()?;
 
+        let transciphering_secret_key_share = self
+            .transciphering_secret_key_share
+            .as_ref()
+            .map(|key| -> anyhow::Result<_> {
+                match key {
+                    LweSecretKeyShareEnum::Z128(key) => Ok(key.clone()),
+                    LweSecretKeyShareEnum::Z64(_) => {
+                        anyhow::bail!(
+                            "Expected Z128 transciphering_secret_key_share, got Z64. Keys must be lifted to Z128 before calling to_generic."
+                        )
+                    }
+                }
+            })
+            .transpose()?;
+
         let glwe_secret_key_share = match &self.glwe_secret_key_share {
             GlweSecretKeyShareEnum::Z128(key) => key.clone(),
             GlweSecretKeyShareEnum::Z64(_) => {
@@ -673,6 +752,7 @@ where
             lwe_encryption_secret_key_share,
             lwe_secret_key_share,
             oprf_secret_key_share,
+            transciphering_secret_key_share,
             glwe_secret_key_share,
             glwe_secret_key_share_sns,
             glwe_secret_key_share_compression,
@@ -709,6 +789,14 @@ where
             None => None,
         };
 
+        let transciphering_secret_key_share = match lifted.transciphering_secret_key_share {
+            Some(LweSecretKeyShareEnum::Z64(key)) => Some(key),
+            Some(_) => {
+                unreachable!("lift_to_z64 should have converted transciphering key to Z64")
+            }
+            None => None,
+        };
+
         let glwe_secret_key_share = match lifted.glwe_secret_key_share {
             GlweSecretKeyShareEnum::Z64(key) => key,
             _ => unreachable!("lift_to_z64 should have converted to Z64"),
@@ -732,6 +820,7 @@ where
             lwe_encryption_secret_key_share,
             lwe_secret_key_share,
             oprf_secret_key_share,
+            transciphering_secret_key_share,
             glwe_secret_key_share,
             glwe_secret_key_share_sns: None,
             glwe_secret_key_share_compression,
@@ -764,6 +853,9 @@ where
             ),
             lwe_compute_secret_key_share: LweSecretKeyShareEnum::Z128(self.lwe_secret_key_share),
             oprf_secret_key_share: self.oprf_secret_key_share.map(LweSecretKeyShareEnum::Z128),
+            transciphering_secret_key_share: self
+                .transciphering_secret_key_share
+                .map(LweSecretKeyShareEnum::Z128),
             glwe_secret_key_share: GlweSecretKeyShareEnum::Z128(self.glwe_secret_key_share),
             glwe_secret_key_share_sns_as_lwe,
             glwe_secret_key_share_compression: self
@@ -788,6 +880,9 @@ impl<const EXTENSION_DEGREE: usize> GenericPrivateKeySet<Z64, EXTENSION_DEGREE> 
             ),
             lwe_compute_secret_key_share: LweSecretKeyShareEnum::Z64(self.lwe_secret_key_share),
             oprf_secret_key_share: self.oprf_secret_key_share.map(LweSecretKeyShareEnum::Z64),
+            transciphering_secret_key_share: self
+                .transciphering_secret_key_share
+                .map(LweSecretKeyShareEnum::Z64),
             glwe_secret_key_share: GlweSecretKeyShareEnum::Z64(self.glwe_secret_key_share),
             glwe_secret_key_share_sns_as_lwe: None,
             glwe_secret_key_share_compression: self
@@ -850,6 +945,7 @@ mod test {
             lwe_encryption_secret_key_share,
             lwe_compute_secret_key_share,
             oprf_secret_key_share,
+            transciphering_secret_key_share,
             glwe_secret_key_share,
             glwe_secret_key_share_sns_as_lwe,
             glwe_secret_key_share_compression,
@@ -874,6 +970,14 @@ mod test {
                 z64_vec.extend(oprf_key.data);
             } else if let LweSecretKeyShareEnum::Z128(oprf_key) = oprf_key {
                 z128_vec.extend(oprf_key.data);
+            }
+        }
+
+        if let Some(transciphering_key) = transciphering_secret_key_share {
+            if let LweSecretKeyShareEnum::Z64(transciphering_key) = transciphering_key {
+                z64_vec.extend(transciphering_key.data);
+            } else if let LweSecretKeyShareEnum::Z128(transciphering_key) = transciphering_key {
+                z128_vec.extend(transciphering_key.data);
             }
         }
 
@@ -1075,6 +1179,7 @@ mod test {
                 }),
                 glwe_secret_key_share_sns_as_lwe: None,
                 oprf_secret_key_share: None,
+                transciphering_secret_key_share: None,
                 glwe_secret_key_share_compression: None,
                 glwe_sns_compression_key_as_lwe: None,
                 parameters: params.classic_pbs(),
@@ -1177,6 +1282,9 @@ mod test {
                 oprf_secret_key_share: Some(LweSecretKeyShareEnum::Z128(LweSecretKeyShare {
                     data: vec![share],
                 })),
+                transciphering_secret_key_share: Some(LweSecretKeyShareEnum::Z128(
+                    LweSecretKeyShare { data: vec![share] },
+                )),
                 glwe_secret_key_share_compression: None,
                 glwe_sns_compression_key_as_lwe: None,
                 parameters: params.classic_pbs(),

--- a/core/threshold-execution/src/tfhe_internals/public_keysets.rs
+++ b/core/threshold-execution/src/tfhe_internals/public_keysets.rs
@@ -19,6 +19,7 @@ use tfhe::shortint::oprf::CompressedOprfServerKey;
 use tfhe::shortint::server_key::{
     CompressedModulusSwitchConfiguration, ShortintCompressedBootstrappingKey,
 };
+use tfhe::transciphering::CompressedTranscipheringServerKey;
 use tfhe::{
     XofSeed,
     shortint::ciphertext::{MaxDegree, MaxNoiseLevel},
@@ -71,6 +72,9 @@ pub(crate) struct RawCompressedPubKeySet {
     pub sns_compression_key: Option<CompressedNoiseSquashingCompressionKey>,
     pub cpk_re_randomization: Option<CompressedReRandomizationRawKey>,
     pub oprf_key: Option<CompressedOprfServerKey>,
+    /// Dedicated bootstrap key of the transciphering subsystem, present only when the parameter
+    /// set enables transciphering. Independent of `oprf_key`.
+    pub transciphering_key: Option<CompressedTranscipheringServerKey>,
     pub seed: u128,
 }
 
@@ -221,6 +225,7 @@ CompressedAtomicPatternNoiseSquashingKey::Standard(CompressedStandardAtomicPatte
             self.oprf_key.as_ref().map(|oprf_key| {
                 tfhe::integer::oprf::CompressedOprfServerKey::from_raw_parts(oprf_key.clone())
             }),
+            self.transciphering_key.clone(),
             tag,
         )
     }

--- a/core/threshold-execution/src/tfhe_internals/test_feature.rs
+++ b/core/threshold-execution/src/tfhe_internals/test_feature.rs
@@ -85,7 +85,7 @@ impl<'a> ClientKeyView<'a> {
     }
 
     pub fn raw_lwe_client_key(&self) -> LweSecretKey<Vec<u64>> {
-        let (inner_client_key, _, _, _, _, _, _, _) = self.ck.clone().into_raw_parts();
+        let (inner_client_key, _, _, _, _, _, _, _, _) = self.ck.clone().into_raw_parts();
         match inner_client_key.into_raw_parts().atomic_pattern {
             shortint::client_key::atomic_pattern::AtomicPatternClientKey::Standard(
                 standard_atomic_pattern_client_key,
@@ -102,11 +102,25 @@ impl<'a> ClientKeyView<'a> {
     /// Returns the dedicated OPRF private LWE secret key embedded in the
     /// `ClientKey`, or `None` if the keyset was generated without one.
     pub fn raw_oprf_client_key(&self) -> Option<LweSecretKey<Vec<u64>>> {
-        let (_, _, _, _, _, _, oprf_private_key, _) = self.ck.clone().into_raw_parts();
+        let (_, _, _, _, _, _, oprf_private_key, _, _) = self.ck.clone().into_raw_parts();
         oprf_private_key.map(|sk| match sk.into_raw_parts().into_raw_parts() {
             tfhe::shortint::oprf::AtomicPatternOprfPrivateKey::Standard(lwe) => lwe,
             tfhe::shortint::oprf::AtomicPatternOprfPrivateKey::KeySwitch32(_) => {
                 panic!("KeySwitch32 OPRF private key not supported")
+            }
+        })
+    }
+
+    /// Returns the transciphering private LWE secret key embedded in the `ClientKey`, or `None`
+    /// if the keyset was generated without transciphering.
+    ///
+    /// Independent of [`Self::raw_oprf_client_key`], even though both are OPRF-shaped keys.
+    pub fn raw_transciphering_client_key(&self) -> Option<LweSecretKey<Vec<u64>>> {
+        let (_, _, _, _, _, _, _, transciphering_private_key, _) = self.ck.clone().into_raw_parts();
+        transciphering_private_key.map(|sk| match sk.into_raw_parts().0.into_raw_parts() {
+            tfhe::shortint::oprf::AtomicPatternOprfPrivateKey::Standard(lwe) => lwe,
+            tfhe::shortint::oprf::AtomicPatternOprfPrivateKey::KeySwitch32(_) => {
+                panic!("KeySwitch32 transciphering private key not supported")
             }
         })
     }
@@ -117,7 +131,7 @@ impl<'a> ClientKeyView<'a> {
         // In the normal DKG the shares that correspond to the lwe private key
         // is copied to the encryption private key if the compact PKE parameters
         // don't exist.
-        let (_, compact_private_key, _, _, _, _, _, _) = self.ck.clone().into_raw_parts();
+        let (_, compact_private_key, _, _, _, _, _, _, _) = self.ck.clone().into_raw_parts();
         if let Some(inner) = compact_private_key {
             let raw_parts = inner.0.into_raw_parts();
             raw_parts.into_raw_parts().0
@@ -129,7 +143,7 @@ impl<'a> ClientKeyView<'a> {
     pub fn raw_compression_client_key_and_params(
         &self,
     ) -> Option<(GlweSecretKey<Vec<u64>>, CompressionParameters)> {
-        let (_, _, compression_sk, _, _, _, _, _) = self.ck.clone().into_raw_parts();
+        let (_, _, compression_sk, _, _, _, _, _, _) = self.ck.clone().into_raw_parts();
         compression_sk.map(|inner| {
             let raw_parts = inner.into_raw_parts();
             (raw_parts.post_packing_ks_key, raw_parts.params)
@@ -137,7 +151,7 @@ impl<'a> ClientKeyView<'a> {
     }
 
     pub fn raw_glwe_client_key(&self) -> GlweSecretKey<Vec<u64>> {
-        let (inner_client_key, _, _, _, _, _, _, _) = self.ck.clone().into_raw_parts();
+        let (inner_client_key, _, _, _, _, _, _, _, _) = self.ck.clone().into_raw_parts();
         match inner_client_key.into_raw_parts().atomic_pattern {
             shortint::client_key::atomic_pattern::AtomicPatternClientKey::Standard(
                 standard_atomic_pattern_client_key,
@@ -152,12 +166,12 @@ impl<'a> ClientKeyView<'a> {
     }
 
     pub fn raw_glwe_client_sns_key(&self) -> Option<GlweSecretKey<Vec<u128>>> {
-        let (_, _, _, noise_squashing_key, _, _, _, _) = self.ck.clone().into_raw_parts();
+        let (_, _, _, noise_squashing_key, _, _, _, _, _) = self.ck.clone().into_raw_parts();
         noise_squashing_key.map(|sns_key| sns_key.into_raw_parts().into_raw_parts().0)
     }
 
     pub fn raw_sns_compression_client_key(&self) -> Option<GlweSecretKey<Vec<u128>>> {
-        let (_, _, _, _, sns_compression_key, _, _, _) = self.ck.clone().into_raw_parts();
+        let (_, _, _, _, sns_compression_key, _, _, _, _) = self.ck.clone().into_raw_parts();
         sns_compression_key
             .map(|sns_compression_key| sns_compression_key.into_raw_parts().into_raw_parts().0)
     }
@@ -413,6 +427,8 @@ struct RawKeyContainers {
     sns_sk_container128: Option<Vec<u128>>,
     sns_compression_sk_container128: Option<Vec<u128>>,
     oprf_sk_container64: Vec<u64>,
+    /// `None` when the parameter set does not enable transciphering.
+    transciphering_sk_container64: Option<Vec<u64>>,
 }
 
 /// Extract raw key containers from a KeySet or create zero-filled placeholders.
@@ -503,6 +519,17 @@ fn extract_key_containers(
         .and_then(|ck| ck.raw_oprf_client_key().map(|k| k.into_container()))
         .unwrap_or_else(|| vec![Numeric::ZERO; params.lwe_dimension().0]);
 
+    let transciphering_sk_container64: Option<Vec<u64>> =
+        params.transciphering_params().map(|_| {
+            client_key
+                .as_ref()
+                .and_then(|ck| {
+                    ck.raw_transciphering_client_key()
+                        .map(|k| k.into_container())
+                })
+                .unwrap_or_else(|| vec![Numeric::ZERO; params.lwe_dimension().0])
+        });
+
     Ok(RawKeyContainers {
         lwe_sk_container64,
         lwe_encryption_sk_container64,
@@ -511,6 +538,7 @@ fn extract_key_containers(
         sns_sk_container128,
         sns_compression_sk_container128,
         oprf_sk_container64,
+        transciphering_sk_container64,
     })
 }
 
@@ -590,6 +618,33 @@ where
         None
     };
     let oprf_key_shares64 = robust_input(session, &secrets, &own_role, INPUT_PARTY_ID).await?;
+
+    // Share the transciphering LWE secret key, when the parameters call for one. Every party
+    // agrees on whether to run this round because it is decided by `params`, not by the key
+    // material, so the non-input parties stay in lockstep with the input party.
+    let transciphering_key_shares64 = match raw_keys.transciphering_sk_container64.as_ref() {
+        Some(container) => {
+            tracing::debug!(
+                "I'm {:?}, Sharing transciphering key64 to be sent: len {}",
+                session.my_role(),
+                container.len()
+            );
+            let secrets = if is_input_party {
+                Some(
+                    container
+                        .iter()
+                        .map(|cur| {
+                            ResiduePoly::<_, EXTENSION_DEGREE>::from_scalar(Wrapping::<u64>(*cur))
+                        })
+                        .collect_vec(),
+                )
+            } else {
+                None
+            };
+            Some(robust_input(session, &secrets, &own_role, INPUT_PARTY_ID).await?)
+        }
+        None => None,
+    };
 
     // Share glwe_sk
     tracing::debug!(
@@ -729,6 +784,8 @@ where
         oprf_secret_key_share: Some(LweSecretKeyShareEnum::Z64(LweSecretKeyShare {
             data: oprf_key_shares64,
         })),
+        transciphering_secret_key_share: transciphering_key_shares64
+            .map(|data| LweSecretKeyShareEnum::Z64(LweSecretKeyShare { data })),
         glwe_secret_key_share: GlweSecretKeyShareEnum::Z128(GlweSecretKeyShare {
             data: glwe_key_shares128,
             polynomial_size: params.polynomial_size(),
@@ -1050,6 +1107,10 @@ where
         Some(share) => insecure_open_lwe_enum_to(session, share, &output_party).await?,
         None => None,
     };
+    let transciphering_bits = match &existing.transciphering_secret_key_share {
+        Some(share) => insecure_open_lwe_enum_to(session, share, &output_party).await?,
+        None => None,
+    };
     let glwe_bits =
         insecure_open_glwe_enum_to(session, &existing.glwe_secret_key_share, &output_party).await?;
     let compression_bits = match &existing.glwe_secret_key_share_compression {
@@ -1127,6 +1188,21 @@ where
         }
     });
 
+    // Same back-fill as above, for the transciphering key (see
+    // `ensure_transciphering_secret_key_share_z128`). Only done when the parameters call for the
+    // key, since otherwise no transciphering material is generated at all.
+    let transciphering_private_lwe_sk =
+        params
+            .transciphering_params()
+            .map(|_| match transciphering_bits {
+                Some(bits) => LweSecretKeyOwned::from_container(bits),
+                None => {
+                    let seed: u128 = session.rng().r#gen();
+                    let mut secret_generator = secret_rng_from_seed(seed);
+                    LweSecretKey::generate_new_binary(params.lwe_dimension(), &mut secret_generator)
+                }
+            });
+
     let client_key = to_hl_client_key(
         &params,
         tag,
@@ -1137,6 +1213,7 @@ where
         sns_secret_key,
         sns_compression_secret_key,
         oprf_private_lwe_sk,
+        transciphering_private_lwe_sk,
     )?;
 
     Ok(Some(client_key))
@@ -1293,6 +1370,7 @@ pub fn to_hl_client_key(
     sns_secret_key: Option<GlweSecretKey<Vec<u128>>>,
     sns_compression_secret_key: Option<NoiseSquashingCompressionPrivateKey>,
     oprf_private_lwe_sk: Option<LweSecretKey<Vec<u64>>>,
+    transciphering_private_lwe_sk: Option<LweSecretKey<Vec<u64>>>,
 ) -> anyhow::Result<tfhe::ClientKey> {
     let ciphertext_params = params.classic_pbs();
 
@@ -1374,6 +1452,26 @@ pub fn to_hl_client_key(
         )
     });
 
+    // The transciphering private key carries its own parameters, so it can only be rebuilt when
+    // the parameter set enables transciphering.
+    let transciphering_private_key = match (
+        transciphering_private_lwe_sk,
+        params.transciphering_params(),
+    ) {
+        (None, _) => None,
+        (Some(_), None) => {
+            anyhow::bail!("missing transciphering parameters")
+        }
+        (Some(lwe_sk), Some(transciphering_params)) => Some(
+            tfhe::transciphering::TranscipheringPrivateKey::from_raw_parts(
+                tfhe::shortint::oprf::OprfPrivateKey::from_raw_parts(
+                    tfhe::shortint::oprf::AtomicPatternOprfPrivateKey::Standard(lwe_sk),
+                ),
+                transciphering_params,
+            ),
+        ),
+    };
+
     Ok(ClientKey::from_raw_parts(
         sck.into(),
         dedicated_compact_private_key,
@@ -1382,6 +1480,7 @@ pub fn to_hl_client_key(
         sns_compression_key,
         params.meta.rerandomization_parameters(),
         oprf_private_key,
+        transciphering_private_key,
         tag,
     ))
 }
@@ -1441,6 +1540,7 @@ where
     let glwe_secret_key_sns_as_lwe = client_key.raw_glwe_client_sns_key_as_lwe().unwrap();
     let glwe_secret_key_sns_compression_as_lwe = client_key.raw_sns_compression_client_key_as_lwe();
     let oprf_secret_key = client_key.raw_oprf_client_key();
+    let transciphering_secret_key = client_key.raw_transciphering_client_key();
     keygen_all_party_shares(
         lwe_secret_key,
         lwe_encryption_secret_key,
@@ -1449,6 +1549,7 @@ where
         glwe_secret_key_sns_as_lwe,
         glwe_secret_key_sns_compression_as_lwe,
         oprf_secret_key,
+        transciphering_secret_key,
         parameters,
         rng,
         num_parties,
@@ -1465,6 +1566,7 @@ fn keygen_all_party_shares<R: Rng + CryptoRng, const EXTENSION_DEGREE: usize>(
     glwe_secret_key_sns_as_lwe: LweSecretKey<Vec<u128>>,
     glwe_secreet_key_sns_compression_as_lwe: Option<LweSecretKey<Vec<u128>>>,
     oprf_secret_key: Option<LweSecretKey<Vec<u64>>>,
+    transciphering_secret_key: Option<LweSecretKey<Vec<u64>>>,
     parameters: ClassicPBSParameters,
     rng: &mut R,
     num_parties: usize,
@@ -1498,6 +1600,18 @@ where
     // share the dedicated OPRF LWE key (if provided)
     let vv128_oprf_key: Option<Vec<Vec<Share<ResiduePoly<Z128, EXTENSION_DEGREE>>>>> =
         match oprf_secret_key {
+            Some(sk) => Some(secret_share_key_shares(
+                sk.into_container(),
+                num_parties,
+                threshold,
+                rng,
+            )?),
+            None => None,
+        };
+
+    // share the transciphering LWE key (if provided)
+    let vv128_transciphering_key: Option<Vec<Vec<Share<ResiduePoly<Z128, EXTENSION_DEGREE>>>>> =
+        match transciphering_secret_key {
             Some(sk) => Some(secret_share_key_shares(
                 sk.into_container(),
                 num_parties,
@@ -1553,6 +1667,9 @@ where
             oprf_secret_key_share: vv128_oprf_key
                 .as_ref()
                 .map(|x| LweSecretKeyShareEnum::Z128(LweSecretKeyShare { data: x[p].clone() })),
+            transciphering_secret_key_share: vv128_transciphering_key
+                .as_ref()
+                .map(|x| LweSecretKeyShareEnum::Z128(LweSecretKeyShare { data: x[p].clone() })),
             glwe_secret_key_share: GlweSecretKeyShareEnum::Z128(GlweSecretKeyShare {
                 data: vv128_glwe_key[p].clone(),
                 polynomial_size: glwe_poly_size,
@@ -1590,7 +1707,7 @@ impl PartialEq for FhePubKeySet {
             pk.into_raw_parts() == other_pk.into_raw_parts() && tag == other_tag
         };
 
-        let (sks, ksk, comp, decomp, sns, _sns_comp, _rerand_key, _oprf, tag) =
+        let (sks, ksk, comp, decomp, sns, _sns_comp, _rerand_key, _oprf, _transciphering, tag) =
             self.server_key.clone().into_raw_parts();
         let (
             other_sks,
@@ -1601,6 +1718,7 @@ impl PartialEq for FhePubKeySet {
             _other_sns_comp,
             _other_rerand_key,
             _other_oprf,
+            _other_transciphering,
             other_tag,
         ) = other.server_key.clone().into_raw_parts();
 
@@ -1627,7 +1745,7 @@ pub fn run_decompression_test(
         Some(inner) => inner,
         None => &keyset1_client_key.generate_server_key(),
     };
-    let (_, _, _, decompression_key1, _, _, _, _, _) = server_key1.clone().into_raw_parts();
+    let (_, _, _, decompression_key1, _, _, _, _, _, _) = server_key1.clone().into_raw_parts();
     let decompression_key1 = decompression_key1.unwrap().into_raw_parts();
 
     assert_eq!(
@@ -1726,6 +1844,7 @@ pub fn combine_and_run_sns_compression_test(
         client_key_parts.5,
         client_key_parts.6,
         client_key_parts.7,
+        client_key_parts.8,
     );
 
     let server_key = match server_key {
@@ -1753,6 +1872,7 @@ pub fn combine_and_run_sns_compression_test(
         server_key_parts.6,
         server_key_parts.7,
         server_key_parts.8,
+        server_key_parts.9,
     );
 
     run_sns_compression_test(new_client_key, new_server_key);

--- a/core/threshold-execution/src/zk/ceremony.rs
+++ b/core/threshold-execution/src/zk/ceremony.rs
@@ -1126,6 +1126,11 @@ mod tests {
         }
     }
 
+    // `proofs::range` is deprecated upstream (only `proofs::pke` / `proofs::pke_v2` are
+    // maintained), but it is deliberately what this test uses: it exercises the CRS produced by
+    // the ceremony with the cheapest proof system to set up, and swapping it for pke/pke_v2 is a
+    // separate change.
+    #[allow(deprecated)]
     fn test_honest_crs_ceremony<F, C>(ceremony_f: F)
     where
         F: Fn() -> C,

--- a/core/threshold-networking/src/sending_service/service.rs
+++ b/core/threshold-networking/src/sending_service/service.rs
@@ -161,6 +161,17 @@ impl GrpcSendingService {
                 // then this should be changed
                 let endpoint = Channel::builder(endpoint)
                     .http2_adaptive_window(true)
+                    // Large HTTP/2 flow-control windows so per-stream throughput
+                    // is not capped at 64KiB/RTT over the added-latency vsock
+                    // tunnel (tonic default is 65535B stream + connection).
+                    // adaptive_window can still grow beyond this floor.
+                    .initial_stream_window_size(4u32 * 1024 * 1024)
+                    .initial_connection_window_size(32u32 * 1024 * 1024)
+                    // Keep idle P2P connections alive so the tunnel/NAT does not
+                    // silently drop them (a drop = full TCP+TLS re-handshake mid-DKG).
+                    .http2_keep_alive_interval(Duration::from_secs(20))
+                    .keep_alive_timeout(Duration::from_secs(10))
+                    .keep_alive_while_idle(true)
                     .tcp_nodelay(true);
                 // we have to pass a custom TLS connector to
                 // tonic::transport::Channel to be able to use a custom rustls
@@ -181,6 +192,13 @@ impl GrpcSendingService {
                 // then this should be changed
                 Channel::builder(endpoint)
                     .http2_adaptive_window(true)
+                    // See TLS branch above: large windows + keepalive to tolerate
+                    // the added-latency tunnel.
+                    .initial_stream_window_size(4u32 * 1024 * 1024)
+                    .initial_connection_window_size(32u32 * 1024 * 1024)
+                    .http2_keep_alive_interval(Duration::from_secs(20))
+                    .keep_alive_timeout(Duration::from_secs(10))
+                    .keep_alive_while_idle(true)
                     .tcp_nodelay(true)
                     .connect_lazy()
             }

--- a/docker/core/service/init_enclave.sh
+++ b/docker/core/service/init_enclave.sh
@@ -10,7 +10,12 @@ TUN_IF=vsocktun
 LOG_PORT=3000
 CONFIG_PORT=4000
 NETWORK_TUNNEL_PORT=2100
-TUN_TOKIO_WORKER_THREADS=4
+TUN_TOKIO_WORKER_THREADS=8
+# Jumbo MTU on the TUN cuts fragmentation of large MPC messages across the vsock
+# relay (fewer packets => fewer userspace relay hops). MUST match the parent-side
+# TUN MTU (charts/kms-core/values.yaml kmsCore.nitroEnclave.networkTunnel.mtu).
+# 8500 stays under the AWS VPC 9001 jumbo ceiling for the parent eth0 hop.
+TUN_MTU=8500
 
 KMS_SERVER_CONFIG_FILE="config.toml"
 AWS_WEB_IDENTITY_TOKEN_FILE="token"
@@ -80,6 +85,9 @@ do
     sleep 1
 done
 ifconfig "$TUN_IF" |& logger || fail "cannot setup tunnel interface"
+# Non-fatal: if MTU can't be raised, fall back to the default rather than
+# bringing the enclave down (but latency benefit is lost).
+ifconfig "$TUN_IF" mtu "$TUN_MTU" |& logger || log "warning: could not set MTU $TUN_MTU on $TUN_IF"
 log "enclave /etc/resolv.conf from vsocktun bootstrap:"
 cat /etc/resolv.conf |& logger
 

--- a/docker/kms-binaries/Dockerfile
+++ b/docker/kms-binaries/Dockerfile
@@ -7,6 +7,13 @@ FROM --platform=$BUILDPLATFORM ${RUST_GOLDEN_IMAGE} AS builder
 # Cargo profile to build with.
 # Use --build-arg LTO_RELEASE=release-lto-off for faster local linking.
 ARG LTO_RELEASE=release-lto-thin
+# Baseline CPU to generate code for. `x86-64-v3` (AVX2, FMA, BMI1/2, LZCNT)
+# is supported by every Haswell-or-later x86 host, which covers the CI
+# runners, the Kind clusters and the c7a enclave nodes, and it lets the
+# threshold arithmetic and non-tfhe hot paths use instructions the generic
+# `x86-64` baseline has to emulate. Pass `--build-arg TARGET_CPU=` to fall
+# back to the generic baseline.
+ARG TARGET_CPU=x86-64-v3
 ARG SCCACHE_BUCKET
 ARG SCCACHE_REGION=eu-west-3
 ARG SCCACHE_S3_PREFIX
@@ -15,6 +22,10 @@ ARG SCCACHE_S3_PREFIX
 # unset, so RUSTC_WRAPPER stays empty and the build compiles without the remote
 # cache instead of failing to authenticate to S3.
 ENV RUSTC_WRAPPER=${SCCACHE_BUCKET:+sccache}
+# Append to (not replace) the golden image's RUSTFLAGS, which carries
+# `-C target-feature=-crt-static`. RUSTFLAGS is part of the sccache cache key,
+# so the first build after changing TARGET_CPU is a full cache miss.
+ENV RUSTFLAGS="${RUSTFLAGS}${TARGET_CPU:+ -C target-cpu=${TARGET_CPU}}"
 ENV SCCACHE_IDLE_TIMEOUT=0
 ENV SCCACHE_BUCKET=${SCCACHE_BUCKET}
 ENV SCCACHE_REGION=${SCCACHE_REGION}


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->
Oops branch name is wrong should be dkg and ddec (but it wont be merged so no big deal)

### Conclusion
The DKG preprocessing should run in about 10-11hours inside the enclave (note that there's is at least a 2x performance degradation compared to running it outside the enclave).
The system still seems to be able to handle decryptions requests whilst doing the preprocessing, however it may responds with a (big) increased latency -- I have seen up to `2s` on the kms-core side to answer the request (which is usually answered in a couple `ms`). It is likely dependant on when the request hit and how it is scheduled on the different thread pools.
If such a latency increase is not acceptable, then the work of Frederic on spawning the 2 shards on the same host might resolve the issue as it'd then be easier to configure how many CPUs each enclave, and my guess is that if we give e.g. 40 cores to the preproc enclave and 4 cores to the ddec enclave, we should be able to handle ddec with the usual latency (assuming ofc we get a reasonable amount of ddec requests).


<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
