### PR TITLE
fix: bcast fix port

### DIFF
--- a/core/threshold-execution/src/communication/broadcast.rs
+++ b/core/threshold-execution/src/communication/broadcast.rs
@@ -628,7 +628,8 @@ impl Broadcast for SyncReliableBroadcast {
 mod tests {
     use super::*;
     use crate::malicious_execution::communication::malicious_broadcast::{
-        MaliciousBroadcastDrop, MaliciousBroadcastSender, MaliciousBroadcastSenderEcho,
+        MaliciousBroadcastDoubleVote, MaliciousBroadcastDrop, MaliciousBroadcastSender,
+        MaliciousBroadcastSenderEcho,
     };
     use crate::runtime::sessions::base_session::GenericBaseSessionHandles;
     use crate::runtime::sessions::small_session::SmallSession;
@@ -920,6 +921,58 @@ mod tests {
             { ResiduePolyF4Z128::EXTENSION_DEGREE },
             _,
         >(params, malicious_strategy)
+        .await;
+    }
+
+    /// Regression test
+    /// Two colluding parties (P6, P7) equivocate on their own
+    /// slots and re-send a vote for a phantom value in every voting round. With
+    /// `n = 7, t = 2` that is `t * (t + 1) = 6 >= n - t = 5` counted votes, so
+    /// honest parties deliver the phantom for the equivocating slots instead of
+    /// `Bot`. The equivocators evade corruption detection, so the harness's
+    /// `should_be_detected = true` assertion blows up.
+    ///
+    /// Once vote counting deduplicates per voter, the phantom gets only 2 distinct
+    /// votes (< 5), the equivocators are detected, and this test passes — remove
+    /// the `#[should_panic]` at that point.
+    #[tokio::test]
+    #[should_panic]
+    async fn test_broadcast_double_vote_evades_detection() {
+        let strategy = MaliciousBroadcastDoubleVote {
+            targets: HashSet::from([Role::indexed_from_one(6), Role::indexed_from_one(7)]),
+            flood: true,
+        };
+        // P6, P7 malicious (zero-based indices 5, 6); they equivocate, so a correct
+        // protocol must detect them.
+        let params = TestingParameters::init(7, 2, &[5, 6], &[], &[], true, None);
+
+        test_broadcast_from_all_w_corrupt_set_update_strategies::<
+            ResiduePolyF4Z128,
+            { ResiduePolyF4Z128::EXTENSION_DEGREE },
+            _,
+        >(params, strategy)
+        .await;
+    }
+
+    /// Control: the *same* strategy voting only ONCE (`flood = false`). That is 2
+    /// votes for the phantom (< n - t = 5) — exactly what correct distinct-voter
+    /// counting sees — so the phantom is ignored, the equivocating senders are
+    /// correctly detected, and the harness's assertions pass on the current code.
+    /// This isolates the *duplication* (not the mere presence of the malicious
+    /// votes) as the root cause of the break.
+    #[tokio::test]
+    async fn test_broadcast_single_vote_is_detected() {
+        let strategy = MaliciousBroadcastDoubleVote {
+            targets: HashSet::from([Role::indexed_from_one(6), Role::indexed_from_one(7)]),
+            flood: false,
+        };
+        let params = TestingParameters::init(7, 2, &[5, 6], &[], &[], true, None);
+
+        test_broadcast_from_all_w_corrupt_set_update_strategies::<
+            ResiduePolyF4Z128,
+            { ResiduePolyF4Z128::EXTENSION_DEGREE },
+            _,
+        >(params, strategy)
         .await;
     }
 }

--- a/core/threshold-execution/src/communication/broadcast.rs
+++ b/core/threshold-execution/src/communication/broadcast.rs
@@ -161,16 +161,15 @@ impl ProtocolDescription for SyncReliableBroadcast {
 pub(crate) async fn receive_contribution_from_all_senders<Z: Ring, B: BaseSessionHandles>(
     round1_data: &mut RoleValueMap<Z>,
     session: &B,
-    receiver: &Role,
     senders: &HashSet<Role>,
     non_answering_parties: &mut HashSet<Role>,
 ) -> anyhow::Result<()> {
     let mut jobs = JoinSet::<Result<(Role, anyhow::Result<BroadcastValue<Z>>), Elapsed>>::new();
+    let my_role = session.my_role();
     // The error we propagate here is if sender IDs and roles cannot be tied together.
     generic_receive_from_all_senders(
         &mut jobs,
         session,
-        receiver,
         senders,
         Some(non_answering_parties),
         |msg, id| match msg {
@@ -196,7 +195,7 @@ pub(crate) async fn receive_contribution_from_all_senders<Z: Ring, B: BaseSessio
                 answering_parties.insert(party_id);
                 if let Err(e) = data {
                     tracing::warn!(
-                        "(Bcast Round 1) I am {receiver}, received wrong type from {party_id} {:?}",
+                        "(Bcast Round 1) I am {my_role}, received wrong type from {party_id} {:?}",
                         e
                     );
                 } else {
@@ -206,9 +205,9 @@ pub(crate) async fn receive_contribution_from_all_senders<Z: Ring, B: BaseSessio
         }
     }
     for party_id in senders {
-        if !answering_parties.contains(party_id) && party_id != receiver {
+        if !answering_parties.contains(party_id) && party_id != &my_role {
             non_answering_parties.insert(*party_id);
-            tracing::warn!("(Bcast Round1) I am {receiver}, haven't heard from {party_id}");
+            tracing::warn!("(Bcast Round1) I am {my_role}, haven't heard from {party_id}");
         }
     }
     Ok(())
@@ -227,11 +226,10 @@ pub(crate) async fn receive_contribution_from_all_senders<Z: Ring, B: BaseSessio
 /// - a Map from (Role, Hash(contribution)) to contribution for all the contributions we received
 pub(crate) async fn receive_echos_from_all_batched<Z: Ring, B: BaseSessionHandles>(
     session: &B,
-    receiver: &Role,
     non_answering_parties: &mut HashSet<Role>,
-    echoed_data: HashMap<(Role, BroadcastValue<Z>), u32>,
+    echoed_data: HashMap<(Role, BroadcastValue<Z>), HashSet<Role>>,
 ) -> anyhow::Result<(
-    HashMap<(Role, BcastHash), u32>,
+    HashMap<(Role, BcastHash), HashSet<Role>>,
     HashMap<(Role, BcastHash), BroadcastValue<Z>>,
 )> {
     //Receiving from every parties as everyone can send an echo
@@ -239,7 +237,6 @@ pub(crate) async fn receive_echos_from_all_batched<Z: Ring, B: BaseSessionHandle
     generic_receive_from_all(
         &mut jobs,
         session,
-        receiver,
         Some(non_answering_parties),
         |msg, id| match msg {
             NetworkValue::EchoBatch(v) => Ok(v),
@@ -253,7 +250,7 @@ pub(crate) async fn receive_echos_from_all_batched<Z: Ring, B: BaseSessionHandle
 
     //Process all the messages we just received, looking for values we can vote for
     process_echos(
-        receiver,
+        session.my_role(),
         &mut jobs,
         echoed_data,
         session.num_parties(),
@@ -274,13 +271,11 @@ pub(crate) async fn receive_echos_from_all_batched<Z: Ring, B: BaseSessionHandle
 async fn receive_from_all_votes<Z: Ring, B: BaseSessionHandles>(
     jobs: &mut JoinSet<Result<VoteJobType, Elapsed>>,
     session: &B,
-    receiver: &Role,
     non_answering_parties: &HashSet<Role>,
 ) {
     generic_receive_from_all(
         jobs,
         session,
-        receiver,
         Some(non_answering_parties),
         |msg: NetworkValue<Z>, id| match msg {
             NetworkValue::VoteBatch(v) => Ok(v),
@@ -295,9 +290,9 @@ async fn receive_from_all_votes<Z: Ring, B: BaseSessionHandles>(
 
 ///Update the vote counts for each (sender, value) by processing the echos or votes from all the other parties
 async fn internal_process_echos_or_votes<T>(
-    receiver: &Role,
+    my_role: &Role,
     rcv_tasks: &mut GenericEchoVoteJob<T>,
-    map_data: &mut HashMap<(Role, T), u32>,
+    map_data: &mut HashMap<(Role, T), HashSet<Role>>,
     num_parties: usize,
     non_answering_parties: &mut HashSet<Role>,
 ) -> anyhow::Result<()>
@@ -316,12 +311,12 @@ where
                 debug_assert!(rcv_vote_or_echo.len() <= num_parties);
                 // iterate through the echo batched message and check the frequency of each message
                 rcv_vote_or_echo.into_iter().for_each(|(role, m)| {
-                    let entry = map_data.entry((role, m)).or_insert(0);
-                    *entry += 1;
+                    let entry = map_data.entry((role, m)).or_default();
+                    entry.insert(from_party);
                 });
             } else {
                 tracing::warn!(
-                    "(Process echos) I am {receiver}, received wrong type from {}: {:?}",
+                    "(Process echos) I am {my_role}, received wrong type from {}: {:?}",
                     from_party.clone(),
                     data
                 );
@@ -331,10 +326,10 @@ where
     //Log timeouts
     for party_id in 1..=num_parties {
         if !answering_parties.contains(&Role::indexed_from_one(party_id))
-            && party_id != receiver.one_based()
+            && party_id != my_role.one_based()
         {
             non_answering_parties.insert(Role::indexed_from_one(party_id));
-            tracing::warn!("(Process echos) I am {receiver} haven't heard from {party_id}");
+            tracing::warn!("(Process echos) I am {my_role} haven't heard from {party_id}");
         }
     }
     Ok(())
@@ -343,18 +338,18 @@ where
 /// Process Echo messages one by one, starting with the own echoed_data
 /// If enough echoes >=(N-T) then party can cast a vote
 async fn process_echos<Z: Ring>(
-    receiver: &Role,
+    my_role: Role,
     echo_recv_tasks: &mut JoinSet<Result<SendEchoJobType<Z>, Elapsed>>,
-    mut echoed_data: HashMap<(Role, BroadcastValue<Z>), u32>,
+    mut echoed_data: HashMap<(Role, BroadcastValue<Z>), HashSet<Role>>,
     num_parties: usize,
     threshold: usize,
     non_answering_parties: &mut HashSet<Role>,
 ) -> anyhow::Result<(
-    HashMap<(Role, BcastHash), u32>,
+    HashMap<(Role, BcastHash), HashSet<Role>>,
     HashMap<(Role, BcastHash), BroadcastValue<Z>>,
 )> {
     internal_process_echos_or_votes(
-        receiver,
+        &my_role,
         echo_recv_tasks,
         &mut echoed_data,
         num_parties,
@@ -366,13 +361,13 @@ async fn process_echos<Z: Ring>(
         let mut registered_votes = HashMap::new();
         let mut map_hash_to_value = HashMap::new();
         //Any entry with at least N-t times is good for a vote
-        for ((role, m), num_entries) in echoed_data.into_iter() {
+        for ((role, m), from_parties) in echoed_data.into_iter() {
             let hash = m.to_bcast_hash().map_err(|e| {
                 anyhow::anyhow!("Failed to compute broadcast hash for role {}: {}", role, e)
             })?;
             map_hash_to_value.insert((role, hash), m);
-            if num_entries >= ((num_parties - threshold) as u32) {
-                registered_votes.insert((role, hash), 1);
+            if from_parties.len() >= (num_parties - threshold) {
+                registered_votes.insert((role, hash), HashSet::from([my_role]));
             }
         }
         Ok::<_, anyhow::Error>((registered_votes, map_hash_to_value))
@@ -386,14 +381,13 @@ async fn process_echos<Z: Ring>(
 /// __NOTE__:  We vote using the Hash of the broadcast value
 pub(crate) async fn cast_threshold_vote<Z: Ring, B: BaseSessionHandles>(
     session: &B,
-    sender: &Role,
-    registered_votes: &HashMap<(Role, BcastHash), u32>,
-    threshold: u32,
+    registered_votes: &HashMap<(Role, BcastHash), HashSet<Role>>,
+    threshold: usize,
 ) -> anyhow::Result<()> {
     let vote_data: HashMap<Role, BcastHash> = registered_votes
         .iter()
         .filter_map(|(k, f)| {
-            if *f >= threshold {
+            if f.len() >= threshold {
                 Some((k.0, k.1))
             } else {
                 None
@@ -402,10 +396,10 @@ pub(crate) async fn cast_threshold_vote<Z: Ring, B: BaseSessionHandles>(
         .collect();
     //Send empty msg to avoid waiting on timeouts on rcver side
     if vote_data.is_empty() {
-        tracing::debug!("I am {sender}, sending an empty message");
-        send_to_all(session, sender, NetworkValue::<Z>::Empty).await?;
+        tracing::debug!("I am {}, sending an empty message", session.my_role());
+        send_to_all(session, NetworkValue::<Z>::Empty).await?;
     } else {
-        send_to_all(session, sender, NetworkValue::<Z>::VoteBatch(vote_data)).await?;
+        send_to_all(session, NetworkValue::<Z>::VoteBatch(vote_data)).await?;
     }
     Ok(())
 }
@@ -415,28 +409,22 @@ pub(crate) async fn cast_threshold_vote<Z: Ring, B: BaseSessionHandles>(
 /// If enough votes >=(T+R) and sender hasn't voted then vote
 pub(crate) async fn gather_votes<Z: Ring, B: BaseSessionHandles>(
     session: &B,
-    sender: &Role,
-    registered_votes: &mut HashMap<(Role, BcastHash), u32>,
+    registered_votes: &mut HashMap<(Role, BcastHash), HashSet<Role>>,
     casted: &mut HashMap<Role, bool>,
     non_answering_parties: &mut HashSet<Role>,
 ) -> anyhow::Result<()> {
     let num_parties = session.num_parties();
     let threshold = session.threshold() as usize;
+    let my_role = session.my_role();
 
     // wait for other parties' incoming vote
     for round in 1..=threshold + 1 {
         let mut vote_recv_tasks = JoinSet::new();
 
         // The error we propagate here is if sender IDs and roles cannot be tied together.
-        receive_from_all_votes::<Z, B>(
-            &mut vote_recv_tasks,
-            session,
-            sender,
-            non_answering_parties,
-        )
-        .await;
+        receive_from_all_votes::<Z, B>(&mut vote_recv_tasks, session, non_answering_parties).await;
         internal_process_echos_or_votes(
-            sender,
+            &my_role,
             &mut vote_recv_tasks,
             registered_votes,
             num_parties,
@@ -451,29 +439,23 @@ pub(crate) async fn gather_votes<Z: Ring, B: BaseSessionHandles>(
 
         //Here propagate error if my own casted hashmap does not contain the expected party's id
         let mut round_registered_votes = HashMap::new();
-        for ((role, m), num_votes) in registered_votes.iter_mut() {
-            if *num_votes as usize >= (threshold + round)
+        for ((role, m), from_parties) in registered_votes.iter_mut() {
+            if from_parties.len() >= (threshold + round)
                 && !*(casted.get(role).ok_or_else(|| {
                     anyhow_error_and_log("Cant retrieve whether I casted a vote".to_string())
                 })?)
             {
-                round_registered_votes.insert((*role, *m), *num_votes);
+                round_registered_votes.insert((*role, *m), from_parties.clone());
                 //Remember I casted a vote
                 let casted_vote_role = casted.get_mut(role).ok_or_else(|| {
                     anyhow_error_and_log("Can't retrieve whether I casted a vote".to_string())
                 })?;
                 *casted_vote_role = true;
                 //Also add a vote in my own data struct
-                *num_votes += 1;
+                from_parties.insert(my_role);
             }
         }
-        cast_threshold_vote::<Z, B>(
-            session,
-            sender,
-            &round_registered_votes,
-            (threshold + round) as u32,
-        )
-        .await?;
+        cast_threshold_vote::<Z, B>(session, &round_registered_votes, threshold + round).await?;
     }
     Ok(())
 }
@@ -500,7 +482,7 @@ impl Broadcast for SyncReliableBroadcast {
                 "The number of parties {num_parties} is less or equal to the threshold {threshold}"
             )));
         }
-        let min_honest_nodes = num_parties as u32 - threshold as u32;
+        let min_honest_nodes = num_parties - threshold;
 
         let my_role = session.my_role();
         let is_sender = senders.contains(&my_role);
@@ -519,7 +501,7 @@ impl Broadcast for SyncReliableBroadcast {
             (Some(my_message), true) => {
                 bcast_data.insert(my_role, my_message.clone());
                 let msg = NetworkValue::Send(my_message);
-                send_to_all(session, &my_role, &msg).await?;
+                send_to_all(session, &msg).await?;
                 let msg = match msg {
                     NetworkValue::Send(v) => v,
                     _ => panic!("Bug here, we just wrapped send into Send"),
@@ -540,7 +522,6 @@ impl Broadcast for SyncReliableBroadcast {
         receive_contribution_from_all_senders(
             &mut round1_contributions,
             session,
-            &my_role,
             senders,
             &mut non_answering_parties,
         )
@@ -549,7 +530,7 @@ impl Broadcast for SyncReliableBroadcast {
         // Communication round 2
         // Parties send Echo to the other parties
         let to_send = NetworkValue::EchoBatch(round1_contributions);
-        send_to_all(session, &my_role, &to_send).await?;
+        send_to_all(session, &to_send).await?;
         let round1_contributions = match to_send {
             NetworkValue::EchoBatch(v) => v,
             _ => panic!("Bug here, we just wrapped send into EchoBatch"),
@@ -558,19 +539,15 @@ impl Broadcast for SyncReliableBroadcast {
         // Parties receive Echo from others and process them,
         // if there are enough Echo messages then they will cast a vote in subsequent rounds
         // adding own echo to the map
-        let echos_count: HashMap<(Role, BroadcastValue<Z>), u32> = round1_contributions
+        let echos_count: HashMap<(Role, BroadcastValue<Z>), HashSet<Role>> = round1_contributions
             .into_iter()
-            .map(|(k, v)| ((k, v), 1))
+            .map(|(k, v)| ((k, v), HashSet::from([my_role])))
             .collect();
         // receive echos from all parties,
         // updates the echos_count and outputs the values I should vote for
-        let (mut registered_votes, mut map_hash_to_value) = receive_echos_from_all_batched(
-            session,
-            &my_role,
-            &mut non_answering_parties,
-            echos_count,
-        )
-        .await?;
+        let (mut registered_votes, mut map_hash_to_value) =
+            receive_echos_from_all_batched(session, &mut non_answering_parties, echos_count)
+                .await?;
 
         // Communication round 3 onward
         // We are only exchanging hashes at this point, so we use the tokio runtime for deserialization
@@ -581,7 +558,7 @@ impl Broadcast for SyncReliableBroadcast {
         let mut casted_vote: HashMap<Role, bool> =
             senders.iter().map(|role| (*role, false)).collect();
 
-        cast_threshold_vote::<Z, B>(session, &my_role, &registered_votes, 1).await?;
+        cast_threshold_vote::<Z, B>(session, &registered_votes, 1).await?;
 
         //Keep track of which instances of bcast we already voted for so we don't vote twice
         for (role, _) in registered_votes.keys() {
@@ -600,14 +577,13 @@ impl Broadcast for SyncReliableBroadcast {
         // then we know for sure that Pi has broadcasted message m
         gather_votes::<Z, B>(
             session,
-            &my_role,
             &mut registered_votes,
             &mut casted_vote,
             &mut non_answering_parties,
         )
         .await?;
         for ((role, hash), hits) in registered_votes.into_iter() {
-            if hits >= min_honest_nodes {
+            if hits.len() >= min_honest_nodes {
                 //Retrieve the actual data from the hash
                 let value = map_hash_to_value.remove(&(role, hash)).ok_or_else(|| {
                     anyhow_error_and_log(format!(
@@ -927,16 +903,9 @@ mod tests {
     /// Regression test
     /// Two colluding parties (P6, P7) equivocate on their own
     /// slots and re-send a vote for a phantom value in every voting round. With
-    /// `n = 7, t = 2` that is `t * (t + 1) = 6 >= n - t = 5` counted votes, so
-    /// honest parties deliver the phantom for the equivocating slots instead of
-    /// `Bot`. The equivocators evade corruption detection, so the harness's
-    /// `should_be_detected = true` assertion blows up.
-    ///
-    /// Once vote counting deduplicates per voter, the phantom gets only 2 distinct
-    /// votes (< 5), the equivocators are detected, and this test passes — remove
-    /// the `#[should_panic]` at that point.
+    /// `n = 7, t = 2` that is `t * (t + 1) = 6 >= n - t = 5` votes.
+    /// Honest parties correctly count only one vote, thus the phantom value is ignored and Bot is output for malicious contributors.
     #[tokio::test]
-    #[should_panic]
     async fn test_broadcast_double_vote_evades_detection() {
         let strategy = MaliciousBroadcastDoubleVote {
             targets: HashSet::from([Role::indexed_from_one(6), Role::indexed_from_one(7)]),

--- a/core/threshold-execution/src/communication/p2p.rs
+++ b/core/threshold-execution/src/communication/p2p.rs
@@ -206,7 +206,6 @@ async fn internal_receive_from_parties<'a, Z: Ring, B: BaseSessionHandles + 'a>(
 /// Send to all parties and automatically increase round counter
 pub async fn send_to_all<T, Z: Ring, B: BaseSessionHandles>(
     session: &B,
-    sender: &Role,
     msg: T,
 ) -> anyhow::Result<()>
 where
@@ -217,7 +216,7 @@ where
     session.network().increase_round_counter().await;
     for other_role in session.roles() {
         let networking = Arc::clone(session.network());
-        if *sender != *other_role {
+        if session.my_role() != *other_role {
             networking
                 .send(Arc::clone(&serialized_message), other_role)
                 .await?;
@@ -235,7 +234,6 @@ where
 /// from the inside enum.
 ///
 /// **NOTE: We do not try to receive any value from the non_answering_parties set.**
-#[expect(clippy::too_many_arguments)]
 pub(crate) async fn generic_receive_from_all_senders_with_role_transform<
     E,
     V,
@@ -246,7 +244,6 @@ pub(crate) async fn generic_receive_from_all_senders_with_role_transform<
 >(
     jobs: &mut JoinSet<Result<(S, anyhow::Result<V>), Elapsed>>,
     session: &B,
-    receiver: &R,
     senders: &HashSet<R>,
     non_answering_parties: Option<&HashSet<R>>,
     match_network_value_fn: fn(network_value: NetworkValue<Z>, id: &R) -> anyhow::Result<V>,
@@ -260,11 +257,11 @@ pub(crate) async fn generic_receive_from_all_senders_with_role_transform<
     let deserialization_runtime = session.get_deserialization_runtime();
     let binding = HashSet::new();
     let non_answering_parties = non_answering_parties.unwrap_or(&binding);
+    let my_role = session.my_role();
     for sender in senders {
-        if !non_answering_parties.contains(sender) && *receiver != *sender {
+        if !non_answering_parties.contains(sender) && my_role != *sender {
             let sender = *sender;
             let networking = Arc::clone(session.network());
-            let my_role = session.my_role();
             let timeout = session.network().get_timeout_current_round().await.into();
             let task = async move {
                 let stripped_message = timeout_at(timeout, networking.receive(&sender)).await;
@@ -309,7 +306,6 @@ pub async fn generic_receive_from_all_senders<
 >(
     jobs: &mut JoinSet<Result<(R, anyhow::Result<V>), Elapsed>>,
     session: &B,
-    receiver: &R,
     senders: &HashSet<R>,
     non_answering_parties: Option<&HashSet<R>>,
     match_network_value_fn: fn(network_value: NetworkValue<Z>, id: &R) -> anyhow::Result<V>,
@@ -319,7 +315,6 @@ pub async fn generic_receive_from_all_senders<
     generic_receive_from_all_senders_with_role_transform::<(), _, _, _, _, _>(
         jobs,
         session,
-        receiver,
         senders,
         non_answering_parties,
         match_network_value_fn,
@@ -333,7 +328,6 @@ pub async fn generic_receive_from_all_senders<
 pub async fn generic_receive_from_all<V, Z: Ring, B: BaseSessionHandles>(
     jobs: &mut JoinSet<Result<(Role, anyhow::Result<V>), Elapsed>>,
     session: &B,
-    receiver: &Role,
     non_answering_parties: Option<&HashSet<Role>>,
     match_network_value_fn: fn(network_value: NetworkValue<Z>, id: &Role) -> anyhow::Result<V>,
 ) where
@@ -342,7 +336,6 @@ pub async fn generic_receive_from_all<V, Z: Ring, B: BaseSessionHandles>(
     generic_receive_from_all_senders(
         jobs,
         session,
-        receiver,
         session.roles(),
         non_answering_parties,
         match_network_value_fn,

--- a/core/threshold-execution/src/large_execution/vss.rs
+++ b/core/threshold-execution/src/large_execution/vss.rs
@@ -185,7 +185,7 @@ impl Vss for DummyVss {
         send_to_parties(&values_to_send, session).await?;
         let mut jobs: JoinSet<Result<(Role, Result<Vec<Z>, anyhow::Error>), Elapsed>> =
             JoinSet::new();
-        generic_receive_from_all(&mut jobs, session, &own_role, None, |msg, _id| match msg {
+        generic_receive_from_all(&mut jobs, session, None, |msg, _id| match msg {
             NetworkValue::VecRingValue(v) => Ok(v),
             _ => Err(anyhow_error_and_log(
                 "Received something else, not a galois ring element".to_string(),
@@ -350,7 +350,7 @@ pub(crate) async fn round_1<Z: Ring, S: BaseSessionHandles>(
 
     let mut jobs = JoinSet::<ResultRound1<Z>>::new();
     // Receive data
-    vss_receive_round_1(session, &mut jobs, my_role).await;
+    vss_receive_round_1(session, &mut jobs).await;
 
     // Parse the result, making sure we receive the expected amount of data
     // if there is any inconsistency we default to 0
@@ -737,12 +737,10 @@ pub(crate) async fn round_4<
 async fn vss_receive_round_1<Z: Ring, S: BaseSessionHandles>(
     session: &S,
     jobs: &mut JoinSet<ResultRound1<Z>>,
-    my_role: Role,
 ) {
     generic_receive_from_all(
         jobs,
         session,
-        &my_role,
         Some(session.corrupt_roles()),
         |msg, _id| match msg {
             NetworkValue::Round1VSS(v) => Ok(v),

--- a/core/threshold-execution/src/malicious_execution/communication/malicious_broadcast.rs
+++ b/core/threshold-execution/src/malicious_execution/communication/malicious_broadcast.rs
@@ -445,3 +445,153 @@ impl Broadcast for MaliciousBroadcastRandomizer {
             .await
     }
 }
+
+/// Malicious implementation of the [`Broadcast`] protocol that exploits the
+/// missing *per-voter* deduplication in the vote-counting logic
+/// (`internal_process_echos_or_votes`).
+///
+/// Each colluding party equivocates on its own sender slot in round 1 (sending a
+/// different random value to every party, like [`MaliciousBroadcastSender`]) so
+/// that no honest value for that slot ever reaches the `n - t` echo threshold — a
+/// correct protocol therefore outputs `Bot` for it and flags the sender as
+/// corrupt. The coalition then *injects* a fixed `phantom` value into each
+/// `target` slot: it echoes the phantom (so honest parties learn its pre-image,
+/// but with only `t` echoes it is never *registered*), and, crucially, it
+/// re-broadcasts a vote for `(target, hash(phantom))` in *every* one of the
+/// `threshold + 1` voting rounds.
+///
+/// Because votes are tallied by `(sender, value)` with no record of *who* voted,
+/// every re-sent copy is counted: `t` colluding parties contribute up to
+/// `t * (t + 1)` votes for the phantom — enough to cross the `n - t` delivery
+/// threshold (for `t >= 2`, e.g. `n = 7, t = 2`). Honest parties then deliver the
+/// phantom for a slot that no honest party legitimately voted for, so the
+/// equivocating senders evade `Bot`/corruption detection and agreement is
+/// violated. Run through the standard harness, this makes the protocol's
+/// correctness assertion fail.
+///
+/// Set `flood = false` to send the injected votes only once. That is `t` votes,
+/// which correct (distinct-voter) counting keeps below `n - t`, so the phantom is
+/// ignored, the equivocating senders are correctly detected, and the protocol
+/// behaves as specified. This isolates the *duplication* — not the mere presence
+/// of the malicious votes — as the root cause.
+#[derive(Clone)]
+pub struct MaliciousBroadcastDoubleVote {
+    /// Sender slots to inject the phantom value into. In the coalition setting
+    /// these are the malicious parties' own (equivocated) slots.
+    pub targets: HashSet<Role>,
+    /// If `true`, re-send the injected votes in every voting round (the exploit).
+    /// If `false`, send them only once (honest-style single vote, the control).
+    pub flood: bool,
+}
+
+impl ProtocolDescription for MaliciousBroadcastDoubleVote {
+    fn protocol_desc(depth: usize) -> String {
+        let indent = Self::INDENT_STRING.repeat(depth);
+        format!("{indent}-MaliciousBroadcastDoubleVote")
+    }
+}
+
+#[async_trait]
+impl Broadcast for MaliciousBroadcastDoubleVote {
+    async fn execute<Z: Ring, B: BaseSessionHandles>(
+        &self,
+        session: &mut B,
+        senders: &HashSet<Role>,
+        my_message: Option<BroadcastValue<Z>>,
+    ) -> anyhow::Result<RoleValueMap<Z>> {
+        if senders.is_empty() {
+            return Err(anyhow_error_and_log(
+                "We expect at least one party as sender in reliable broadcast".to_string(),
+            ));
+        }
+        let threshold = session.threshold() as usize;
+        let my_role = session.my_role();
+        let is_sender = senders.contains(&my_role);
+        let mut non_answering_parties = HashSet::new();
+
+        // The value the coalition injects into every target slot: a fixed, non-Bot
+        // constant whose pre-image we make available through our Echo messages.
+        let phantom = BroadcastValue::from(Z::ONE);
+        assert_ne!(
+            my_message,
+            Some(phantom.clone()),
+            "The phantom must be distinct from the input for this strategy to be malicious"
+        );
+        let phantom_hash = phantom.to_bcast_hash()?;
+
+        // ---- Round 1 (Send): equivocate — send a different random value to each
+        // party, so no single value for our own slot reaches n - t echoes. We stay
+        // "answering", so honest parties keep counting our echoes and votes. ----
+        let mut round1_contributions = HashMap::<Role, BroadcastValue<Z>>::new();
+        session.network().increase_round_counter().await;
+        let mut rng = AesRng::from_random_seed();
+        match (my_message, is_sender) {
+            (Some(message), true) => {
+                round1_contributions.insert(my_role, message);
+                for other_role in session.roles().iter() {
+                    if my_role != *other_role {
+                        let malicious_msg =
+                            NetworkValue::Send(BroadcastValue::from(Z::sample(&mut rng)));
+                        session
+                            .network()
+                            .send(Arc::new(malicious_msg.to_network()), other_role)
+                            .await?;
+                    }
+                }
+            }
+            (None, false) => (),
+            (_, _) => {
+                return Err(anyhow_error_and_log(
+                    "A sender must have a value in reliable broadcast".to_string(),
+                ));
+            }
+        }
+        receive_contribution_from_all_senders(
+            &mut round1_contributions,
+            session,
+            &my_role,
+            senders,
+            &mut non_answering_parties,
+        )
+        .await?;
+
+        // ---- Round 2 (Echo): announce the phantom for every target slot so honest
+        // parties store its pre-image. Only the malicious coalition echoes it (< n - t), so it
+        // is never *registered* from echoes — it is forced through via votes. ----
+        let mut echo_batch = round1_contributions;
+        for target in self.targets.iter() {
+            echo_batch.insert(*target, phantom.clone());
+        }
+        let to_send = NetworkValue::EchoBatch(echo_batch);
+        send_to_all(session, &my_role, &to_send).await?;
+        let _ = receive_echos_from_all_batched::<Z, B>(
+            session,
+            &my_role,
+            &mut non_answering_parties,
+            HashMap::new(),
+        )
+        .await?;
+
+        // ---- Vote phase: THE EXPLOIT. ----
+        // Honest parties emit exactly `threshold + 1` vote messages (one initial
+        // cast + `threshold` amplification casts). We match that count exactly to
+        // stay in round-sync, but we re-send the same votes for every target slot
+        // every time (or just once, if `!flood`). With no per-voter dedup, each
+        // copy is counted, inflating the tally past `n - t`.
+        let mut inflated_vote = HashMap::new();
+        for target in self.targets.iter() {
+            inflated_vote.insert(*target, phantom_hash);
+        }
+        for round in 0..=threshold {
+            let msg: NetworkValue<Z> = if self.flood || round == 0 {
+                NetworkValue::VoteBatch(inflated_vote.clone())
+            } else {
+                NetworkValue::Empty
+            };
+            send_to_all(session, &my_role, &msg).await?;
+        }
+
+        // The attacker does not care about its own output.
+        Ok(RoleValueMap::new())
+    }
+}

--- a/core/threshold-execution/src/malicious_execution/communication/malicious_broadcast.rs
+++ b/core/threshold-execution/src/malicious_execution/communication/malicious_broadcast.rs
@@ -75,7 +75,7 @@ impl Broadcast for MaliciousBroadcastSender {
         let num_senders = senders.len();
 
         let threshold = session.threshold();
-        let min_honest_nodes = num_parties as u32 - threshold as u32;
+        let min_honest_nodes = num_parties - threshold as usize;
 
         let my_role = session.my_role();
         let is_sender = senders.contains(&my_role);
@@ -116,7 +116,6 @@ impl Broadcast for MaliciousBroadcastSender {
         receive_contribution_from_all_senders(
             &mut round1_data,
             session,
-            &my_role,
             senders,
             &mut non_answering_parties,
         )
@@ -126,25 +125,23 @@ impl Broadcast for MaliciousBroadcastSender {
         // Parties send Echo to the other parties
         // Parties receive Echo from others and process them, if there are enough Echo messages then they can cast a vote
         let msg = round1_data;
-        send_to_all(session, &my_role, NetworkValue::EchoBatch(msg.clone())).await?;
+        send_to_all(session, NetworkValue::EchoBatch(msg.clone())).await?;
         // adding own echo to the map
-        let echos_count: HashMap<(Role, BroadcastValue<Z>), u32> =
-            msg.iter().map(|(k, v)| ((*k, v.clone()), 1)).collect();
+        let echos_count: HashMap<(Role, BroadcastValue<Z>), HashSet<Role>> = msg
+            .iter()
+            .map(|(k, v)| ((*k, v.clone()), HashSet::from([session.my_role()])))
+            .collect();
         // retrieve echos from all parties
-        let (mut registered_votes, mut map_hash_to_value) = receive_echos_from_all_batched(
-            session,
-            &my_role,
-            &mut non_answering_parties,
-            echos_count,
-        )
-        .await?;
+        let (mut registered_votes, mut map_hash_to_value) =
+            receive_echos_from_all_batched(session, &mut non_answering_parties, echos_count)
+                .await?;
 
         // Communication round 3
         // Parties try to cast the vote if received enough Echo messages (i.e. can_vote is true)
         let mut casted_vote: HashMap<Role, bool> =
             senders.iter().map(|role| (*role, false)).collect();
 
-        cast_threshold_vote::<Z, B>(session, &my_role, &registered_votes, 1).await?;
+        cast_threshold_vote::<Z, B>(session, &registered_votes, 1).await?;
 
         //Keep track of which instances of bcast we already voted for so we don't vote twice
         for (role, _) in registered_votes.keys() {
@@ -163,14 +160,13 @@ impl Broadcast for MaliciousBroadcastSender {
         // then we know for sure that Pi has broadcasted message m
         gather_votes::<Z, B>(
             session,
-            &my_role,
             &mut registered_votes,
             &mut casted_vote,
             &mut non_answering_parties,
         )
         .await?;
         for ((role, value), hits) in registered_votes.into_iter() {
-            if hits >= min_honest_nodes {
+            if hits.len() >= min_honest_nodes {
                 //Retrieve the actual data from the hash
                 let value = map_hash_to_value.remove(&(role, value)).ok_or_else(|| {
                     anyhow_error_and_log(format!(
@@ -265,7 +261,6 @@ impl Broadcast for MaliciousBroadcastSenderEcho {
         receive_contribution_from_all_senders(
             &mut round1_data,
             session,
-            &my_role,
             senders,
             &mut non_answering_parties,
         )
@@ -294,12 +289,12 @@ impl Broadcast for MaliciousBroadcastSenderEcho {
         }
         let msg = msg_to_others;
         // adding own echo to the map
-        let echos: HashMap<(Role, BroadcastValue<Z>), u32> =
-            msg.iter().map(|(k, v)| ((*k, v.clone()), 1)).collect();
+        let echos: HashMap<(Role, BroadcastValue<Z>), HashSet<Role>> = msg
+            .iter()
+            .map(|(k, v)| ((*k, v.clone()), HashSet::from([my_role])))
+            .collect();
         // retrieve echos from all parties
-        let _ =
-            receive_echos_from_all_batched(session, &my_role, &mut non_answering_parties, echos)
-                .await?;
+        let _ = receive_echos_from_all_batched(session, &mut non_answering_parties, echos).await?;
 
         //Stop voting now
         Ok(round1_data)
@@ -549,7 +544,6 @@ impl Broadcast for MaliciousBroadcastDoubleVote {
         receive_contribution_from_all_senders(
             &mut round1_contributions,
             session,
-            &my_role,
             senders,
             &mut non_answering_parties,
         )
@@ -563,10 +557,9 @@ impl Broadcast for MaliciousBroadcastDoubleVote {
             echo_batch.insert(*target, phantom.clone());
         }
         let to_send = NetworkValue::EchoBatch(echo_batch);
-        send_to_all(session, &my_role, &to_send).await?;
+        send_to_all(session, &to_send).await?;
         let _ = receive_echos_from_all_batched::<Z, B>(
             session,
-            &my_role,
             &mut non_answering_parties,
             HashMap::new(),
         )
@@ -588,7 +581,7 @@ impl Broadcast for MaliciousBroadcastDoubleVote {
             } else {
                 NetworkValue::Empty
             };
-            send_to_all(session, &my_role, &msg).await?;
+            send_to_all(session, &msg).await?;
         }
 
         // The attacker does not care about its own output.

--- a/core/threshold-execution/src/online/reshare.rs
+++ b/core/threshold-execution/src/online/reshare.rs
@@ -718,7 +718,6 @@ where
         generic_receive_from_all_senders_with_role_transform(
             &mut jobs,
             two_sets_session,
-            &two_sets_session.my_role(),
             &parties_in_s1,
             Some(two_sets_session.corrupt_roles()),
             |msg, _id| match msg {

--- a/core/threshold-execution/src/sharing/open.rs
+++ b/core/threshold-execution/src/sharing/open.rs
@@ -238,7 +238,7 @@ impl RobustOpen for SecureRobustOpen {
                 // We do not need to explicitly increase the round counter here
                 // because send_to_all does it
                 let shares = NetworkValue::VecRingValue(shares);
-                send_to_all(session, &own_role, &shares).await?;
+                send_to_all(session, &shares).await?;
 
                 // Small hack to avoid cloning ,
                 // we just wrap and unwrap the shares into a NetworkValue
@@ -257,7 +257,6 @@ impl RobustOpen for SecureRobustOpen {
             generic_receive_from_all(
                 &mut jobs,
                 session,
-                &own_role,
                 Some(session.corrupt_roles()),
                 |msg, _id| match msg {
                     NetworkValue::VecRingValue(v) => Ok(v),
@@ -355,7 +354,6 @@ impl RobustOpen for SecureRobustOpen {
             generic_receive_from_all_senders_with_role_transform(
                 &mut jobs,
                 session,
-                &own_role,
                 &parties_to_receive_from,
                 Some(session.corrupt_roles()),
                 |msg, _id| match msg {


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->
https://github.com/zama-ai/kms-internal/pull/3170
### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
