### PR TITLE
chore: bump amazon EKS AMI to 1.34.9-20260810

### DIFF
--- a/ci/perf-testing/centralizedWithEnclave/kms-ci/tkms-infra/values-kms-enclave-ci.yaml
+++ b/ci/perf-testing/centralizedWithEnclave/kms-ci/tkms-infra/values-kms-enclave-ci.yaml
@@ -66,8 +66,8 @@ kmsParties:
       cpuAllocatable: 48
       memoryAllocatableInGiB: 96
     # Find the release version here: https://github.com/awslabs/amazon-eks-ami/releases
-    releaseVersion: "1.32.3-20250620"
-    version: "1.32"
+    releaseVersion: "1.34.9-20260810"
+    version: "1.34"
     additionalManagedPolicyArns:
       - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
     taint:

--- a/ci/perf-testing/thresholdWithEnclave/kms-ci/tkms-infra/values-kms-enclave-ci.yaml
+++ b/ci/perf-testing/thresholdWithEnclave/kms-ci/tkms-infra/values-kms-enclave-ci.yaml
@@ -65,8 +65,8 @@ kmsParties:
       cpuAllocatable: 48
       memoryAllocatableInGiB: 96
     # Find the release version here: https://github.com/awslabs/amazon-eks-ami/releases
-    releaseVersion: "1.32.3-20250620"
-    version: "1.32"
+    releaseVersion: "1.34.9-20260810"
+    version: "1.34"
     additionalManagedPolicyArns:
       - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
     taint:

--- a/ci/pr-preview/centralizedWithEnclave/tkms-infra/values-kms-ci.yaml
+++ b/ci/pr-preview/centralizedWithEnclave/tkms-infra/values-kms-ci.yaml
@@ -66,8 +66,8 @@ kmsParties:
       cpuAllocatable: 48
       memoryAllocatableInGiB: 96
     # Find the release version here: https://github.com/awslabs/amazon-eks-ami/releases
-    releaseVersion: "1.32.3-20250620"
-    version: "1.32"
+    releaseVersion: "1.34.9-20260810"
+    version: "1.34"
     additionalManagedPolicyArns:
       - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
     taint:

--- a/ci/pr-preview/thresholdWithEnclave/tkms-infra/values-kms-ci.yaml
+++ b/ci/pr-preview/thresholdWithEnclave/tkms-infra/values-kms-ci.yaml
@@ -65,8 +65,8 @@ kmsParties:
       cpuAllocatable: 48
       memoryAllocatableInGiB: 96
     # Find the release version here: https://github.com/awslabs/amazon-eks-ami/releases
-    releaseVersion: "1.32.3-20250620"
-    version: "1.32"
+    releaseVersion: "1.34.9-20260810"
+    version: "1.34"
     additionalManagedPolicyArns:
       - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
     taint:

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -30,7 +30,7 @@ This documentation is designed for:
 ## Critical Requirements
 
 ### **Production Requirements**
-- **AWS Instance**: `c7a.16xlarge` with AMI `1.32.3-20250620` (Nitro Enclaves)
+- **AWS Instance**: `c7a.16xlarge` with AMI `1.34.9-20260810` (Nitro Enclaves)
 - **Memory**: 32Gi minimum for production operations (96Gi allocated to Nitro Enclaves)
 - **Network**: PrivateLink connections to other 12 parties required
 - **Ports**: <GRPC_PORT> (gRPC, default: 50100), <P2P_PORT> (P2P - varies by party ID, default: 50001), <METRICS_PORT> (metrics, default: 9646)
@@ -40,7 +40,7 @@ This documentation is designed for:
 ## Getting Help
 
 1. **Emergency** - Use [Emergency Procedures](emergency-procedures.md) for immediate fixes
-2. **Diagnosis** - Follow the [Monitoring Guide](monitoring.md) health check procedures  
+2. **Diagnosis** - Follow the [Monitoring Guide](monitoring.md) health check procedures
 3. **Detailed Help** - Check [Advanced Documentation](advanced/) for comprehensive guides
 4. **Escalation** - Contact MPC development team for cryptographic issues
 

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -7,7 +7,7 @@
 This guide covers production deployment of **your party's KMS node** in a **13-party threshold network**:
 
 - **Infrastructure**: [Terraform MPC modules](https://github.com/zama-ai/terraform-mpc-modules) for your AWS EKS, S3, IAM, Nitro Enclaves
-- **Application**: Official KMS Helm charts (`charts/kms-core/`) for your StatefulSet deployment  
+- **Application**: Official KMS Helm charts (`charts/kms-core/`) for your StatefulSet deployment
 - **Security**: AWS Nitro Enclaves, IRSA, PrivateLink networking to other parties
 - **Architecture**: Your independent node in a decentralized 13-party threshold network
 
@@ -26,7 +26,7 @@ This guide covers production deployment of **your party's KMS node** in a **13-p
 │  YOUR    │  Other   │  Other   │  Other   │  Other   │  Other   │  Other   │
 │  PARTY   │  Party   │  Party   │  Party   │  Party   │  Party   │  Party   │
 └──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┘
-     ▲                                                                    
+     ▲
      │◄──────────── PrivateLink Connections ──────────────────────────────┤
      └─────────────── To All Other 12 Parties ──────────────────────────┘
 ```
@@ -53,7 +53,7 @@ You deploy and manage:
 
 ### Critical Requirements
 - **AWS Instance Type**: `c7a.16xlarge` (required for Nitro Enclaves)
-- **AMI Version**: `1.32.3-20250620` (specific version required)
+- **AMI Version**: `1.34.9-20260810` (specific version required)
 - **Memory**: Minimum 32Gi RAM per party (96Gi allocated to Nitro Enclaves)
 - **CPU**: Minimum 8 cores (16 cores recommended for production)
 - **Storage**: 100Gi+ for key material and logs
@@ -99,7 +99,7 @@ nodegroup_desired_size                   = 1
 nodegroup_disk_size                      = 100
 nodegroup_capacity_type                  = "ON_DEMAND"
 nodegroup_ami_type                       = "AL2023_x86_64_STANDARD"
-nodegroup_ami_release_version           = "1.32.3-20250620"
+nodegroup_ami_release_version           = "1.34.9-20260810"
 nodegroup_enable_nitro_enclaves         = true
 nodegroup_enable_ssm_managed_instance   = true
 
@@ -377,22 +377,22 @@ echo "Validating KMS threshold cluster..."
 for i in "${!PARTIES[@]}"; do
   party="${PARTIES[$i]}"
   namespace="${NAMESPACES[$i]}"
-  
+
   echo "Checking $party..."
-  
+
   # Check StatefulSet status
   if ! kubectl get statefulset kms-core -n "$namespace" | grep -q "1/1"; then
     echo "ERROR: $party StatefulSet not ready"
     exit 1
   fi
-  
+
   # Check pod health
   if ! kubectl exec -n "$namespace" kms-core-1 -- \
        kms-health-check live --endpoint localhost:<GRPC_PORT> | grep -q "Optimal\|Healthy"; then
     echo "ERROR: $party health check failed"
     exit 1
   fi
-  
+
   echo "SUCCESS: $party - OK"
 done
 
@@ -449,7 +449,7 @@ kubectl exec -n kms-threshold kms-core-1 -- \
 
 # This will show:
 # - FHE key IDs and counts
-# - CRS key availability  
+# - CRS key availability
 # - Preprocessing material status
 # - Storage backend information
 ```
@@ -550,7 +550,7 @@ kubectl exec -n kms-threshold kms-core-1 -- \
 
 **Success Criteria**: A fully operational, production-ready KMS threshold cluster deployed across 4 AWS accounts using official Terraform modules and Helm charts, with Nitro Enclaves security, comprehensive monitoring, and validated cryptographic operations.
 
-**Need Help?** 
+**Need Help?**
 - [Emergency Procedures](emergency-procedures.md) for emergency procedures
 - [Terraform MPC Modules](https://github.com/zama-ai/terraform-mpc-modules) for infrastructure
 - KMS Helm Charts (`charts/kms-core/`) for application deployment


### PR DESCRIPTION
## Description
The current EKS AMI was >1 year old, so we update it to the recent version `1.34.9-20260810`.
This also matches what infra is using in prod.


## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
