### PR TITLE
ci(deps): scope the RUSTSEC-2026-0258 ignore

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,7 +3,17 @@
 
 [advisories]
 # RUSTSEC-2023-0071 is not applicable in our use-case.
-ignore = ["RUSTSEC-2023-0071"]
+# RUSTSEC-2026-0258 (h2 unbounded empty DATA frames): the h2 0.4 line is patched
+# by the 0.4.16 bump in Cargo.lock. It also matches h2 0.3.27, which has no
+# patched release, but that one is test-only -- it enters solely through our
+# `testing` feature: aws-sdk-s3/test-util -> aws-smithy-runtime/test-util ->
+# legacy-test-util -> connector-hyper-0-14-x -> aws-smithy-http-client/hyper-014
+# -> dep:h2-0-3. Production builds never compile it (`cargo build -p kms --lib`
+# builds only h2 0.4.16), and dropping it would mean giving up aws-smithy-mocks'
+# `mock_client!`.
+# TODO: Drop this entry once aws-sdk-s3's test-util stops pulling the hyper-0.14.
+# See issue: https://github.com/zama-ai/kms-internal/issues/3173
+ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2026-0258"]
 informational_warnings = ["unmaintained"]
 severity_threshold = "medium"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,7 +1659,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "h2 0.3.27",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -3314,7 +3314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3789,9 +3789,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4065,7 +4065,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -4124,7 +4124,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4361,7 +4361,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6107,7 +6107,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6146,9 +6146,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6752,7 +6752,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6810,7 +6810,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8266,7 +8266,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -8927,7 +8927,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
temporarily ignore RUSTSEC-2026-0258 to unblock CI

### Related issue(s)
https://github.com/zama-ai/kms-internal/issues/3173

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

