### PR TITLE
chore: make all udec tests use BigCompressed

### DIFF
--- a/core/service/src/client/tests/centralized/nightly_tests.rs
+++ b/core/service/src/client/tests/centralized/nightly_tests.rs
@@ -108,7 +108,7 @@ async fn default_user_decryption_centralized(
         msg,
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         parallelism,
         secure,

--- a/core/service/src/client/tests/centralized/user_decryption_tests.rs
+++ b/core/service/src/client/tests/centralized/user_decryption_tests.rs
@@ -33,7 +33,7 @@ async fn test_user_decryption_centralized(#[values(true, false)] secure: bool) -
         TestingPlaintext::U8(48),
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         4,
         secure,
@@ -121,7 +121,7 @@ async fn default_user_decryption_centralized(#[values(true, false)] secure: bool
         msg,
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         parallelism,
         secure,

--- a/core/service/src/client/tests/threshold/nightly_tests.rs
+++ b/core/service/src/client/tests/threshold/nightly_tests.rs
@@ -105,7 +105,7 @@ async fn default_user_decryption_threshold(
         msg,
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         parallelism,
         secure,
@@ -186,7 +186,7 @@ async fn default_user_decryption_threshold_with_crash(
         msg,
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         parallelism,
         secure,

--- a/core/service/src/client/tests/threshold/user_decryption_tests.rs
+++ b/core/service/src/client/tests/threshold/user_decryption_tests.rs
@@ -55,7 +55,8 @@ async fn test_user_decryption_threshold(
         pt,
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            // BitDecSmall explicitly exercises the small-ciphertext path.
+            precompute_sns: !matches!(decryption_mode, DecryptionMode::BitDecSmall),
         },
         1,
         secure,
@@ -83,7 +84,7 @@ async fn test_user_decryption_threshold_malicious(
         pt,
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         1,    // parallelism
         true, // secure
@@ -106,7 +107,7 @@ async fn test_user_decryption_threshold_malicious_failure() {
         TestingPlaintext::U32(u32::MAX),
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         1,    // parallelism
         true, // secure
@@ -134,7 +135,7 @@ async fn test_user_decryption_threshold_all_malicious_failure() {
         TestingPlaintext::U16(u16::MAX),
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         1,    // parallelism
         true, // secure
@@ -197,7 +198,7 @@ async fn test_user_decryption_threshold_and_write_transcript(
         TestingPlaintext::U8(42),
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         1,
         secure,
@@ -227,7 +228,7 @@ async fn default_user_decryption_threshold_and_write_transcript(
         msg,
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         1, // wasm tests are single-threaded
         secure,
@@ -257,7 +258,7 @@ async fn default_user_decryption_threshold(
         msg,
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         parallelism,
         secure,
@@ -316,7 +317,7 @@ async fn default_user_decryption_threshold_with_crash(
         msg,
         EncryptionConfig {
             compression: true,
-            precompute_sns: false,
+            precompute_sns: true,
         },
         parallelism,
         secure,


### PR DESCRIPTION
chore: make all udec tests use BigCompressed format (prod default), unless the test explicitly exercise a different format. This is similar to PR #701, but for udec.

Closes https://github.com/zama-ai/kms-internal/issues/3100
