### PR TITLE
chore: store domain for verification

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -328,13 +328,17 @@ the **raw stored bytes**, never over a serialization of a decoded value: a tfhe 
 since the material was generated would alter the bytes and report intact material as corrupt.
 Legacy metadata has no digest, so its public objects receive a raw presence check only.
 
-Two limits are worth knowing. `external_signature`, and the ECDSA entry of `signatures`, sign
-an EIP-712 hash whose `Eip712Domain` arrives on the originating gRPC request and is never
-persisted, so those signatures cannot be reconstructed at boot and are skipped — and since
-`signatures` defaults to empty, the signature check is a no-op for material generated without
-an explicitly requested post-quantum or Ed25519 scheme. And `PubDataType::DecompressionKey`
-has no private-storage counterpart at all (`write_decompression_key` persists no private
-data), so a published decompression key cannot be verified.
+`external_signature` and the ECDSA entry of `signatures` sign an EIP-712 hash built from an
+`Eip712Domain` that arrives from a gRPC request. Current key and CRS metadata therefore persists
+the domain so the signatures can be re-checked later; nothing reads it back yet, which is part of
+[issue 3178](https://github.com/zama-ai/kms-internal/issues/3178). Older metadata versions upgrade
+with no domain and stay unverifiable. The signed Solidity schema is inferred from the metadata
+kind: CRS metadata uses `CrsgenVerification`, decompression-key metadata uses
+`FheDecompressionUpgradeKey`, and other key metadata uses `KeygenVerification`.
+
+`PubDataType::DecompressionKey` has no private-storage counterpart at all
+(`write_decompression_key` persists no private data), so a published decompression key cannot be
+verified at startup.
 
 ## Backward compatibility
 

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -83,7 +83,7 @@ The service crate is the main surface area. Key subdirectories under
   [material_integrity.rs](core/service/src/engine/material_integrity.rs) (digest
   primitives over raw stored bytes, depended on by both the storage layer and the
   startup checks) and
-  [public_material_verification.rs](core/service/src/engine/public_material_verification.rs)
+  [storage_material_verification.rs](core/service/src/engine/storage_material_verification.rs)
   (the startup orchestration built on top of them — see
   [Boot-time storage verification](#boot-time-storage-verification)),
   [validation_non_wasm.rs](core/service/src/engine/validation_non_wasm.rs) and
@@ -295,8 +295,8 @@ so it is the reference.
 The code is split by level. [material_integrity.rs](core/service/src/engine/material_integrity.rs)
 holds the digest primitives — pure functions over raw stored bytes, with no storage or
 orchestration — so the vault layer can reuse them without depending on startup logic.
-[public_material_verification.rs](core/service/src/engine/public_material_verification.rs)
-sits above it and owns the startup orchestration, entered through `verify_public_material`.
+[storage_material_verification.rs](core/service/src/engine/storage_material_verification.rs)
+sits above it and owns the startup orchestration, entered through `verify_storage_material`.
 The checks follow three rules:
 
 1. **Private storage is the reference.** Iteration is always "for each entry in private

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -314,6 +314,7 @@ What it verifies, and how failures are treated:
 | Check | On failure |
 |---|---|
 | Published keysets and CRSes are present, and their raw stored bytes hash to the digests in `KeyGenMetadata` / `CrsGenMetadata` | boot fails |
+| Current private keygen and CRS metadata with a stored domain reconstruct a valid EIP-712 signature from the node's signing key | boot fails |
 | `VerfKey` and `VerfAddress` at `SIGNING_KEY_ID` match the key derived from the private `SigningKey` | boot fails |
 
 Custodian backup readiness is deliberately *not* part of this. It is a property of the vault's
@@ -329,12 +330,9 @@ since the material was generated would alter the bytes and report intact materia
 Legacy metadata has no digest, so its public objects receive a raw presence check only.
 
 `external_signature` and the ECDSA entry of `signatures` sign an EIP-712 hash built from an
-`Eip712Domain` that arrives from a gRPC request. Current key and CRS metadata therefore persists
-the domain so the signatures can be re-checked later; nothing reads it back yet, which is part of
-[issue 3178](https://github.com/zama-ai/kms-internal/issues/3178). Older metadata versions upgrade
-with no domain and stay unverifiable. The signed Solidity schema is inferred from the metadata
-kind: CRS metadata uses `CrsgenVerification`, decompression-key metadata uses
-`FheDecompressionUpgradeKey`, and other key metadata uses `KeygenVerification`.
+`Eip712Domain` that arrives from a gRPC request. At boot, current private keygen and CRS metadata
+with a stored domain reconstruct their signed Solidity payload and must recover the node's
+signing address. Older metadata versions upgrade with no domain and stay unverifiable.
 
 `PubDataType::DecompressionKey` has no private-storage counterpart at all
 (`write_decompression_key` persists no private data), so a published decompression key cannot be

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -281,6 +281,9 @@ and
 
 Every node checks its storage during service construction, before it serves any request.
 Two independent things happen.
+Boot-time verification lets us ensure the public and private storage are
+consistent, and detect any malicious behaviour and/or misconfiguration before
+the the KMS party boots up.
 
 **The backup vault is repaired.** `update_backup_vault(false, OP_BOOT)` copies anything
 present in private storage but missing from the backup vault, so a vault that moved or lost

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -283,7 +283,7 @@ Every node checks its storage during service construction, before it serves any 
 Two independent things happen.
 Boot-time verification lets us ensure the public and private storage are
 consistent, and detect any malicious behaviour and/or misconfiguration before
-the the KMS party boots up.
+the KMS party boots up.
 
 **The backup vault is repaired.** `update_backup_vault(false, OP_BOOT)` copies anything
 present in private storage but missing from the backup vault, so a vault that moved or lost

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -76,8 +76,7 @@ pub static INSECURE_PREPROCESSING_ID: LazyLock<RequestId> =
     LazyLock::new(|| crate::engine::base::derive_request_id("INSECURE_PREPROCESSING_ID").unwrap());
 
 #[derive(Clone, Serialize, Deserialize, VersionsDispatch)]
-// Boxing a version variant would change the persisted representation.
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum KmsFheKeyHandlesVersions {
     V0(KmsFheKeyHandlesV0),
     V1(KmsFheKeyHandles),
@@ -1389,7 +1388,6 @@ pub struct KeyGenMetadataInner {
 }
 
 #[derive(Clone, Serialize, Deserialize, Version)]
-/// Previous current key metadata layout, before retaining the EIP-712 domain.
 pub struct KeyGenMetadataInnerV3 {
     pub key_id: RequestId,
     pub preprocessing_id: RequestId,
@@ -1495,8 +1493,7 @@ pub enum KeyGenMetadataVersions {
 // Values that need to be stored temporarily as part of an async key generation call.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Versionize)]
 #[versionize(KeyGenMetadataVersions)]
-// Boxing a variant would change the persisted representation.
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum KeyGenMetadata {
     Current(KeyGenMetadataInner),
     LegacyV0(HashMap<PubDataType, SignedPubDataHandleInternal>),
@@ -1665,8 +1662,7 @@ pub struct CrsGenMetadataInnerV0 {
 }
 
 #[derive(Clone, Serialize, Deserialize, VersionsDispatch)]
-// Boxing a version variant would change the persisted representation.
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum CrsGenMetadataVersions {
     V0(CrsGenMetadataV0),
     V1(CrsGenMetadata),
@@ -1674,8 +1670,7 @@ pub enum CrsGenMetadataVersions {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Versionize)]
 #[versionize(CrsGenMetadataVersions)]
-// Boxing a variant would change the persisted representation.
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum CrsGenMetadata {
     Current(CrsGenMetadataInner),
     LegacyV0(SignedPubDataHandleInternal),

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -386,6 +386,98 @@ pub(crate) fn crs_payload_bytes(
     })
 }
 
+pub(crate) const ERR_INVALID_CURRENT_PUBLIC_KEY_SHAPE: &str =
+    "Invalid current public key metadata shape";
+
+#[derive(Clone, Copy)]
+pub(crate) enum CurrentPublicMaterialLayout {
+    Standard,
+    Compressed,
+}
+
+/// Classify the supported current keygen metadata layouts.
+pub(crate) fn classify_current_public_material(
+    key_digest_map: &BTreeMap<PubDataType, Vec<u8>>,
+) -> anyhow::Result<CurrentPublicMaterialLayout> {
+    let has_public_key = key_digest_map.contains_key(&PubDataType::PublicKey);
+    let has_server_key = key_digest_map.contains_key(&PubDataType::ServerKey);
+    let has_compressed_keyset = key_digest_map.contains_key(&PubDataType::CompressedXofKeySet);
+
+    match (
+        has_public_key,
+        has_server_key,
+        has_compressed_keyset,
+        key_digest_map.len(),
+    ) {
+        (true, true, false, 2) => Ok(CurrentPublicMaterialLayout::Standard),
+        (true, false, true, 2) => Ok(CurrentPublicMaterialLayout::Compressed),
+        _ => anyhow::bail!(
+            "{ERR_INVALID_CURRENT_PUBLIC_KEY_SHAPE}: expected either \
+             {{PublicKey, ServerKey}} or {{PublicKey, CompressedXofKeySet}}, got {:?}",
+            key_digest_map.keys().collect::<Vec<_>>()
+        ),
+    }
+}
+
+/// Build the EIP-712 struct signed for a keygen result.
+///
+/// Shared between signing and after-the-fact verification so there is exactly one definition of
+/// the message represented by keygen metadata.
+///
+/// `layout` decides which of the two messages is built. Signing sites pass the layout they are
+/// generating for, so the choice stays static there; verification has only the stored metadata
+/// to go on and derives it with [`classify_current_public_material`].
+pub(crate) fn keygen_sol_type(
+    layout: CurrentPublicMaterialLayout,
+    prep_id: &RequestId,
+    key_id: &RequestId,
+    key_digest_map: &BTreeMap<PubDataType, Vec<u8>>,
+    extra_data: &[u8],
+) -> anyhow::Result<KeygenVerification> {
+    let digest = |data_type: PubDataType| {
+        key_digest_map
+            .get(&data_type)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("missing {data_type} digest"))
+    };
+    let public_key_digest = digest(PubDataType::PublicKey)?;
+
+    Ok(match layout {
+        CurrentPublicMaterialLayout::Standard => KeygenVerification::new_uncompressed(
+            prep_id,
+            key_id,
+            digest(PubDataType::ServerKey)?,
+            public_key_digest,
+            extra_data.to_vec(),
+        ),
+        CurrentPublicMaterialLayout::Compressed => KeygenVerification::new_compressed(
+            prep_id,
+            key_id,
+            digest(PubDataType::CompressedXofKeySet)?,
+            public_key_digest,
+            extra_data.to_vec(),
+        ),
+    })
+}
+
+/// Build the EIP-712 struct signed for a CRS result.
+///
+/// Shared between signing and after-the-fact verification so there is exactly one definition of
+/// the message represented by CRS metadata.
+pub(crate) fn crs_sol_type(
+    crs_id: &RequestId,
+    crs_digest: &[u8],
+    max_num_bits: u32,
+    extra_data: &[u8],
+) -> CrsgenVerification {
+    CrsgenVerification::new(
+        crs_id,
+        max_num_bits as usize,
+        crs_digest.to_vec(),
+        extra_data.to_vec(),
+    )
+}
+
 /// Convert stored per-scheme signatures into their gRPC representation.
 pub(crate) fn stored_scheme_signatures_to_proto(
     signatures: &[StoredTypedSignature],
@@ -516,8 +608,7 @@ pub(crate) fn compute_info_crs_from_digest(
     domain: &alloy_sol_types::Eip712Domain,
     extra_data: Vec<u8>,
 ) -> anyhow::Result<CrsGenMetadata> {
-    let sol_type =
-        CrsgenVerification::new(crs_id, max_num_bits, crs_digest.clone(), extra_data.clone());
+    let sol_type = crs_sol_type(crs_id, &crs_digest, max_num_bits as u32, &extra_data);
     let payload_bytes = crs_payload_bytes(crs_id, max_num_bits as u32, &crs_digest, &extra_data)?;
     let (external_signature, signatures) = sign_result(
         sk,
@@ -617,17 +708,17 @@ pub(crate) fn compute_info_standard_keygen_from_digests(
     domain: &alloy_sol_types::Eip712Domain,
     extra_data: Vec<u8>,
 ) -> anyhow::Result<KeyGenMetadata> {
-    let sol_type = KeygenVerification::new_uncompressed(
-        prep_id,
-        key_id,
-        server_key_digest.clone(),
-        public_key_digest.clone(),
-        extra_data.clone(),
-    );
     let key_digests = BTreeMap::from([
         (PubDataType::ServerKey, server_key_digest),
         (PubDataType::PublicKey, public_key_digest),
     ]);
+    let sol_type = keygen_sol_type(
+        CurrentPublicMaterialLayout::Standard,
+        prep_id,
+        key_id,
+        &key_digests,
+        &extra_data,
+    )?;
     let payload_bytes = keygen_payload_bytes(prep_id, key_id, &key_digests, &extra_data)?;
     let (external_signature, signatures) = sign_result(
         sk,
@@ -734,17 +825,17 @@ pub(crate) fn compute_info_compressed_keygen_from_digests(
         hex::encode(&public_key_digest),
     );
 
-    let sol_type = KeygenVerification::new_compressed(
-        prep_id,
-        key_id,
-        compressed_keyset_digest.clone(),
-        public_key_digest.clone(),
-        extra_data.clone(),
-    );
     let key_digests = BTreeMap::from([
         (PubDataType::CompressedXofKeySet, compressed_keyset_digest),
         (PubDataType::PublicKey, public_key_digest),
     ]);
+    let sol_type = keygen_sol_type(
+        CurrentPublicMaterialLayout::Compressed,
+        prep_id,
+        key_id,
+        &key_digests,
+        &extra_data,
+    )?;
     let payload_bytes = keygen_payload_bytes(prep_id, key_id, &key_digests, &extra_data)?;
     let (external_signature, signatures) = sign_result(
         sk,

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -351,7 +351,7 @@ where
 /// The canonical bytes a non-ECDSA scheme signs for a keygen result.
 ///
 /// Shared between signing and after-the-fact verification (see
-/// [`crate::engine::public_material_verification`]) so there is exactly one definition of
+/// [`crate::engine::storage_material_verification`]) so there is exactly one definition of
 /// what was signed.
 pub(crate) fn keygen_payload_bytes(
     prep_id: &RequestId,
@@ -370,7 +370,7 @@ pub(crate) fn keygen_payload_bytes(
 /// The canonical bytes a non-ECDSA scheme signs for a CRS result.
 ///
 /// Shared between signing and after-the-fact verification (see
-/// [`crate::engine::public_material_verification`]) so there is exactly one definition of
+/// [`crate::engine::storage_material_verification`]) so there is exactly one definition of
 /// what was signed.
 pub(crate) fn crs_payload_bytes(
     crs_id: &RequestId,

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -11,7 +11,7 @@ use crate::util::key_setup::FhePrivateKey;
 use aes_prng::AesRng;
 use alloy_dyn_abi::DynSolValue;
 use alloy_primitives::U256;
-use alloy_primitives::{Bytes, FixedBytes, Uint};
+use alloy_primitives::{Address, B256, Bytes, FixedBytes, Uint};
 use alloy_sol_types::Eip712Domain;
 use alloy_sol_types::SolStruct;
 use hashing::{DomainSep, hash_element, hash_versioned, serialize_hash_element};
@@ -76,6 +76,8 @@ pub static INSECURE_PREPROCESSING_ID: LazyLock<RequestId> =
     LazyLock::new(|| crate::engine::base::derive_request_id("INSECURE_PREPROCESSING_ID").unwrap());
 
 #[derive(Clone, Serialize, Deserialize, VersionsDispatch)]
+// Boxing a version variant would change the persisted representation.
+#[allow(clippy::large_enum_variant)]
 pub enum KmsFheKeyHandlesVersions {
     V0(KmsFheKeyHandlesV0),
     V1(KmsFheKeyHandles),
@@ -531,6 +533,7 @@ pub(crate) fn compute_info_crs_from_digest(
         *crs_id,
         crs_digest,
         max_num_bits as u32,
+        domain,
         external_signature,
         signatures,
         extra_data,
@@ -640,6 +643,7 @@ pub(crate) fn compute_info_standard_keygen_from_digests(
         *key_id,
         *prep_id,
         key_digests,
+        domain,
         external_signature,
         signatures,
         extra_data,
@@ -678,6 +682,7 @@ pub(crate) fn compute_info_decompression_keygen(
         *key_id,
         *prep_id,
         key_digests,
+        domain,
         external_signature,
         signatures,
         extra_data,
@@ -755,6 +760,7 @@ pub(crate) fn compute_info_compressed_keygen_from_digests(
         *key_id,
         *prep_id,
         key_digests,
+        domain,
         external_signature,
         signatures,
         extra_data,
@@ -1314,17 +1320,77 @@ pub(crate) fn retrieve_parameters(fhe_parameter: Option<i32>) -> Result<DKGParam
     Ok(params)
 }
 
+/// Version dispatch for [`StoredEip712Domain`].
+#[derive(Clone, Serialize, Deserialize, VersionsDispatch)]
+pub enum StoredEip712DomainVersions {
+    /// Initial canonical domain representation.
+    V0(StoredEip712Domain),
+}
+
+/// Canonical persisted representation of an EIP-712 domain.
+///
+/// Alloy and protobuf domain types are kept out of persisted metadata so dependency or wire
+/// representation changes cannot silently alter the on-disk format.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Versionize)]
+#[versionize(StoredEip712DomainVersions)]
+pub struct StoredEip712Domain {
+    name: Option<String>,
+    version: Option<String>,
+    chain_id: Option<[u8; 32]>,
+    verifying_contract: Option<[u8; 20]>,
+    salt: Option<[u8; 32]>,
+}
+
+impl From<&Eip712Domain> for StoredEip712Domain {
+    fn from(domain: &Eip712Domain) -> Self {
+        Self {
+            name: domain.name.as_ref().map(ToString::to_string),
+            version: domain.version.as_ref().map(ToString::to_string),
+            chain_id: domain.chain_id.map(|chain_id| chain_id.to_be_bytes()),
+            verifying_contract: domain
+                .verifying_contract
+                .map(alloy_primitives::Address::into_array),
+            salt: domain.salt.map(|salt| salt.0),
+        }
+    }
+}
+
+impl From<&StoredEip712Domain> for Eip712Domain {
+    fn from(domain: &StoredEip712Domain) -> Self {
+        Eip712Domain::new(
+            domain.name.clone().map(Into::into),
+            domain.version.clone().map(Into::into),
+            domain.chain_id.map(U256::from_be_bytes),
+            domain.verifying_contract.map(Address::from),
+            domain.salt.map(B256::from),
+        )
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, VersionsDispatch)]
 pub enum KeyGenMetadataInnerVersions {
     V0(KeyGenMetadataInnerV0),
     V1(KeyGenMetadataInnerV1),
     V2(KeyGenMetadataInnerV2),
-    V3(KeyGenMetadataInner),
+    V3(KeyGenMetadataInnerV3),
+    V4(KeyGenMetadataInner),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Versionize)]
 #[versionize(KeyGenMetadataInnerVersions)]
 pub struct KeyGenMetadataInner {
+    pub key_id: RequestId,
+    pub preprocessing_id: RequestId,
+    pub key_digest_map: BTreeMap<PubDataType, Vec<u8>>,
+    pub extra_data: Option<Vec<u8>>,
+    pub eip712_domain: Option<StoredEip712Domain>,
+    pub external_signature: Vec<u8>,
+    pub signatures: Vec<StoredTypedSignature>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Version)]
+/// Previous current key metadata layout, before retaining the EIP-712 domain.
+pub struct KeyGenMetadataInnerV3 {
     pub key_id: RequestId,
     pub preprocessing_id: RequestId,
     pub key_digest_map: BTreeMap<PubDataType, Vec<u8>>,
@@ -1379,11 +1445,11 @@ impl Upgrade<KeyGenMetadataInnerV2> for KeyGenMetadataInnerV1 {
     }
 }
 
-impl Upgrade<KeyGenMetadataInner> for KeyGenMetadataInnerV2 {
+impl Upgrade<KeyGenMetadataInnerV3> for KeyGenMetadataInnerV2 {
     type Error = std::convert::Infallible;
 
-    fn upgrade(self) -> Result<KeyGenMetadataInner, Self::Error> {
-        Ok(KeyGenMetadataInner {
+    fn upgrade(self) -> Result<KeyGenMetadataInnerV3, Self::Error> {
+        Ok(KeyGenMetadataInnerV3 {
             key_id: self.key_id,
             preprocessing_id: self.preprocessing_id,
             key_digest_map: self.key_digest_map,
@@ -1392,6 +1458,22 @@ impl Upgrade<KeyGenMetadataInner> for KeyGenMetadataInnerV2 {
             // `signatures` is an opt-in per-scheme, so stays empty here.
             external_signature: self.external_signature,
             signatures: Vec::new(),
+        })
+    }
+}
+
+impl Upgrade<KeyGenMetadataInner> for KeyGenMetadataInnerV3 {
+    type Error = std::convert::Infallible;
+
+    fn upgrade(self) -> Result<KeyGenMetadataInner, Self::Error> {
+        Ok(KeyGenMetadataInner {
+            key_id: self.key_id,
+            preprocessing_id: self.preprocessing_id,
+            key_digest_map: self.key_digest_map,
+            extra_data: self.extra_data,
+            eip712_domain: None,
+            external_signature: self.external_signature,
+            signatures: self.signatures,
         })
     }
 }
@@ -1413,6 +1495,8 @@ pub enum KeyGenMetadataVersions {
 // Values that need to be stored temporarily as part of an async key generation call.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Versionize)]
 #[versionize(KeyGenMetadataVersions)]
+// Boxing a variant would change the persisted representation.
+#[allow(clippy::large_enum_variant)]
 pub enum KeyGenMetadata {
     Current(KeyGenMetadataInner),
     LegacyV0(HashMap<PubDataType, SignedPubDataHandleInternal>),
@@ -1424,11 +1508,12 @@ impl Named for KeyGenMetadata {
 }
 
 impl KeyGenMetadata {
-    /// Create a new KeyGenMetadata instance with the provided parameters.
+    /// Create a new KeyGenMetadata instance with the provided parameters and EIP-712 domain.
     pub fn new(
         key_id: RequestId,
         preprocessing_id: RequestId,
         key_digest_map: BTreeMap<PubDataType, Vec<u8>>,
+        eip712_domain: &Eip712Domain,
         external_signature: Vec<u8>,
         signatures: Vec<StoredTypedSignature>,
         extra_data: Vec<u8>,
@@ -1442,6 +1527,7 @@ impl KeyGenMetadata {
             key_id,
             preprocessing_id,
             key_digest_map,
+            eip712_domain: Some(eip712_domain.into()),
             external_signature,
             signatures,
             extra_data: parsed_extra_data,
@@ -1486,7 +1572,8 @@ impl KeyGenMetadata {
 pub enum CrsGenMetadataInnerVersions {
     V0(CrsGenMetadataInnerV0),
     V1(CrsGenMetadataInnerV1),
-    V2(CrsGenMetadataInner),
+    V2(CrsGenMetadataInnerV2),
+    V3(CrsGenMetadataInner),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Versionize)]
@@ -1496,8 +1583,20 @@ pub struct CrsGenMetadataInner {
     pub(crate) crs_digest: Vec<u8>,
     pub(crate) max_num_bits: u32,
     pub(crate) extra_data: Option<Vec<u8>>,
+    pub(crate) eip712_domain: Option<StoredEip712Domain>,
     pub(crate) external_signature: Vec<u8>,
     pub(crate) signatures: Vec<StoredTypedSignature>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Version)]
+/// Previous current CRS metadata layout, before retaining the EIP-712 domain.
+pub struct CrsGenMetadataInnerV2 {
+    pub crs_id: RequestId,
+    pub crs_digest: Vec<u8>,
+    pub max_num_bits: u32,
+    pub extra_data: Option<Vec<u8>>,
+    pub external_signature: Vec<u8>,
+    pub signatures: Vec<StoredTypedSignature>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Version)]
@@ -1523,11 +1622,11 @@ impl Upgrade<CrsGenMetadataInnerV1> for CrsGenMetadataInnerV0 {
     }
 }
 
-impl Upgrade<CrsGenMetadataInner> for CrsGenMetadataInnerV1 {
+impl Upgrade<CrsGenMetadataInnerV2> for CrsGenMetadataInnerV1 {
     type Error = std::convert::Infallible;
 
-    fn upgrade(self) -> Result<CrsGenMetadataInner, Self::Error> {
-        Ok(CrsGenMetadataInner {
+    fn upgrade(self) -> Result<CrsGenMetadataInnerV2, Self::Error> {
+        Ok(CrsGenMetadataInnerV2 {
             crs_id: self.crs_id,
             crs_digest: self.crs_digest,
             max_num_bits: self.max_num_bits,
@@ -1541,6 +1640,22 @@ impl Upgrade<CrsGenMetadataInner> for CrsGenMetadataInnerV1 {
     }
 }
 
+impl Upgrade<CrsGenMetadataInner> for CrsGenMetadataInnerV2 {
+    type Error = std::convert::Infallible;
+
+    fn upgrade(self) -> Result<CrsGenMetadataInner, Self::Error> {
+        Ok(CrsGenMetadataInner {
+            crs_id: self.crs_id,
+            crs_digest: self.crs_digest,
+            max_num_bits: self.max_num_bits,
+            extra_data: self.extra_data,
+            eip712_domain: None,
+            external_signature: self.external_signature,
+            signatures: self.signatures,
+        })
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Version)]
 pub struct CrsGenMetadataInnerV0 {
     pub crs_id: RequestId,
@@ -1550,6 +1665,8 @@ pub struct CrsGenMetadataInnerV0 {
 }
 
 #[derive(Clone, Serialize, Deserialize, VersionsDispatch)]
+// Boxing a version variant would change the persisted representation.
+#[allow(clippy::large_enum_variant)]
 pub enum CrsGenMetadataVersions {
     V0(CrsGenMetadataV0),
     V1(CrsGenMetadata),
@@ -1557,6 +1674,8 @@ pub enum CrsGenMetadataVersions {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Versionize)]
 #[versionize(CrsGenMetadataVersions)]
+// Boxing a variant would change the persisted representation.
+#[allow(clippy::large_enum_variant)]
 pub enum CrsGenMetadata {
     Current(CrsGenMetadataInner),
     LegacyV0(SignedPubDataHandleInternal),
@@ -1570,10 +1689,12 @@ impl Upgrade<CrsGenMetadata> for CrsGenMetadataV0 {
 }
 
 impl CrsGenMetadata {
+    /// Create a new CRS metadata value with the provided EIP-712 domain.
     pub fn new(
         crs_id: RequestId,
         crs_digest: Vec<u8>,
         max_num_bits: u32,
+        eip712_domain: &Eip712Domain,
         external_signature: Vec<u8>,
         signatures: Vec<StoredTypedSignature>,
         extra_data: Vec<u8>,
@@ -1588,6 +1709,7 @@ impl CrsGenMetadata {
             crs_digest,
             max_num_bits,
             extra_data: parsed_extra_data,
+            eip712_domain: Some(eip712_domain.into()),
             external_signature,
             signatures,
         })
@@ -1642,8 +1764,8 @@ pub type UserDecryptCallValues = DecryptionCallValues<UserDecryptionResponsePayl
 #[cfg(test)]
 pub(crate) mod tests {
     use super::{
-        CrsGenMetadataInner, CrsGenMetadataInnerV0, KeyGenMetadata, KeyGenMetadataInner,
-        KeyGenMetadataInnerV0, KeyGenMetadataInnerV1,
+        CrsGenMetadata, CrsGenMetadataInner, CrsGenMetadataInnerV0, KeyGenMetadata,
+        KeyGenMetadataInner, KeyGenMetadataInnerV0, KeyGenMetadataInnerV1, StoredEip712Domain,
     };
     use super::{TypedPlaintext, deserialize_to_low_level};
     use crate::cryptography::signatures::compute_eip712_signature;
@@ -1680,11 +1802,33 @@ pub(crate) mod tests {
     use tfhe::{
         FheTypes, FheUint32, Seed, prelude::SquashNoise, safe_serialization::safe_serialize,
     };
-    use tfhe_versionable::Upgrade;
+    use tfhe_versionable::{Unversionize, Upgrade, VersionizeOwned};
     use threshold_execution::{
         keyset_config::StandardKeySetConfig,
         tfhe_internals::{public_keysets::FhePubKeySet, utils::expanded_encrypt},
     };
+
+    #[test]
+    fn stored_eip712_domain_roundtrip_preserves_all_fields() {
+        let domain = alloy_sol_types::Eip712Domain::new(
+            Some("KMS domain".to_owned().into()),
+            Some("42".to_owned().into()),
+            Some(alloy_primitives::U256::from(8006)),
+            Some(alloy_primitives::address!(
+                "66f9664f97F2b50F62D13eA064982f936dE76657"
+            )),
+            Some(alloy_primitives::B256::from([0xA5; 32])),
+        );
+        let stored = StoredEip712Domain::from(&domain);
+        let versioned = stored.clone().versionize_owned();
+        let bytes = bc2wrap::serialize(&versioned).unwrap();
+        let decoded_versioned: <StoredEip712Domain as VersionizeOwned>::VersionedOwned =
+            bc2wrap::deserialize_slice(&bytes).unwrap();
+        let decoded = StoredEip712Domain::unversionize(decoded_versioned).unwrap();
+
+        assert_eq!(decoded, stored);
+        assert_eq!(alloy_sol_types::Eip712Domain::from(&decoded), domain);
+    }
 
     /// Round-trip test for every signature on a decryption response, as the
     /// async decryption job produces them:
@@ -2914,22 +3058,30 @@ pub(crate) mod tests {
             q126.external_signature
         );
 
-        // V1 -> V2 -> V3: the HashMap is converted to a BTreeMap (V2) and the
-        // per-scheme `signatures` list is added (V3) and upgrades to empty.
+        // V1 -> V2 -> V3 -> V4: the HashMap is converted to a BTreeMap (V2), the
+        // per-scheme `signatures` list is added (V3), and the optional EIP-712 domain is
+        // added (V4).
         // Field-by-field structural equality remains, modulo container type.
-        let upgraded_v3: KeyGenMetadataInner = upgraded.upgrade().unwrap().upgrade().unwrap();
-        assert_eq!(upgraded_v3.extra_data, None);
-        assert_eq!(upgraded_v3.key_id, q126.key_id);
-        assert_eq!(upgraded_v3.preprocessing_id, q126.preprocessing_id);
+        let upgraded_v4: KeyGenMetadataInner = upgraded
+            .upgrade()
+            .unwrap()
+            .upgrade()
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        assert_eq!(upgraded_v4.extra_data, None);
+        assert_eq!(upgraded_v4.key_id, q126.key_id);
+        assert_eq!(upgraded_v4.preprocessing_id, q126.preprocessing_id);
         assert_eq!(
-            upgraded_v3.key_digest_map,
+            upgraded_v4.key_digest_map,
             q126.key_digest_map
                 .iter()
                 .map(|(k, v)| (*k, v.clone()))
                 .collect::<BTreeMap<_, _>>(),
         );
-        assert_eq!(upgraded_v3.external_signature, q126.external_signature);
-        assert!(upgraded_v3.signatures.is_empty());
+        assert_eq!(upgraded_v4.external_signature, q126.external_signature);
+        assert!(upgraded_v4.signatures.is_empty());
+        assert_eq!(upgraded_v4.eip712_domain, None);
     }
 
     #[test]
@@ -2937,16 +3089,29 @@ pub(crate) mod tests {
         let mut rng = AesRng::seed_from_u64(890);
         let key_id = RequestId::new_random(&mut rng);
         let preprocessing_id = RequestId::new_random(&mut rng);
+        let domain = dummy_domain();
+        let expected_domain = StoredEip712Domain::from(&domain);
 
         let current = KeyGenMetadata::new(
             key_id,
             preprocessing_id,
             BTreeMap::new(),
+            &domain,
             vec![],
             vec![],
             vec![],
         );
         assert_eq!(current.preprocessing_id(), Some(&preprocessing_id));
+        let KeyGenMetadata::Current(current_inner) = &current else {
+            panic!("KeyGenMetadata::new must produce current metadata");
+        };
+        assert_eq!(current_inner.eip712_domain.as_ref(), Some(&expected_domain));
+
+        let crs = CrsGenMetadata::new(key_id, vec![], 64, &domain, vec![], vec![], vec![]);
+        let CrsGenMetadata::Current(crs_inner) = &crs else {
+            panic!("CrsGenMetadata::new must produce current metadata");
+        };
+        assert_eq!(crs_inner.eip712_domain.as_ref(), Some(&expected_domain));
 
         // Legacy metadata predates the field, so there is nothing to report.
         let legacy = KeyGenMetadata::LegacyV0(HashMap::new());
@@ -2974,12 +3139,19 @@ pub(crate) mod tests {
             external_signature: external_signature.clone(),
         };
 
-        // Verify upgrade (V0 -> V1 -> V2) sets extra_data as None; `signatures`
-        // is opt-in, so it upgrades to empty (the ECDSA/EIP-712 signature stays
-        // in `external_signature`).
-        let upgraded: CrsGenMetadataInner = q126.clone().upgrade().unwrap().upgrade().unwrap();
+        // Verify upgrade (V0 -> V1 -> V2 -> V3) sets extra_data as None; `signatures`
+        // is opt-in, so it upgrades to empty, and the EIP-712 domain is unavailable.
+        let upgraded: CrsGenMetadataInner = q126
+            .clone()
+            .upgrade()
+            .unwrap()
+            .upgrade()
+            .unwrap()
+            .upgrade()
+            .unwrap();
         assert_eq!(upgraded.extra_data, None);
         assert!(upgraded.signatures.is_empty());
+        assert_eq!(upgraded.eip712_domain, None);
         // Upgraded serialization
         let upgraded_bytes = bc2wrap::serialize(&upgraded).unwrap();
 

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -1581,7 +1581,9 @@ pub enum KeyGenMetadataVersions {
     V0(KeyGenMetadata),
 }
 
-// Values that need to be stored temporarily as part of an async key generation call.
+/// Values that need to be stored temporarily as part of an async key generation call.
+// We marked it as a large enum variant because the LegacyV0 variant (~48 B) is
+// much smaller than the Current variant (nearly 300 B) at the time of writing.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Versionize)]
 #[versionize(KeyGenMetadataVersions)]
 #[expect(clippy::large_enum_variant)]

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -1662,7 +1662,6 @@ pub struct CrsGenMetadataInnerV0 {
 }
 
 #[derive(Clone, Serialize, Deserialize, VersionsDispatch)]
-#[expect(clippy::large_enum_variant)]
 pub enum CrsGenMetadataVersions {
     V0(CrsGenMetadataV0),
     V1(CrsGenMetadata),
@@ -1670,7 +1669,6 @@ pub enum CrsGenMetadataVersions {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Versionize)]
 #[versionize(CrsGenMetadataVersions)]
-#[expect(clippy::large_enum_variant)]
 pub enum CrsGenMetadata {
     Current(CrsGenMetadataInner),
     LegacyV0(SignedPubDataHandleInternal),

--- a/core/service/src/engine/centralized/central_kms.rs
+++ b/core/service/src/engine/centralized/central_kms.rs
@@ -20,7 +20,7 @@ use crate::engine::base::{BaseKmsStruct, KmsFheKeyHandles};
 use crate::engine::base::{KeyGenMetadata, PubDecCallValues, UserDecryptCallValues};
 use crate::engine::context_manager::CentralizedContextManager;
 #[cfg(feature = "non-wasm")]
-use crate::engine::public_material_verification::verify_storage_material;
+use crate::engine::storage_material_verification::verify_storage_material;
 use crate::engine::traits::{BackupOperator, ContextManager};
 use crate::engine::traits::{BaseKms, Kms};
 use crate::engine::validation::DSEP_USER_DECRYPTION;

--- a/core/service/src/engine/centralized/central_kms.rs
+++ b/core/service/src/engine/centralized/central_kms.rs
@@ -20,7 +20,7 @@ use crate::engine::base::{BaseKmsStruct, KmsFheKeyHandles};
 use crate::engine::base::{KeyGenMetadata, PubDecCallValues, UserDecryptCallValues};
 use crate::engine::context_manager::CentralizedContextManager;
 #[cfg(feature = "non-wasm")]
-use crate::engine::public_material_verification::verify_public_storage_material;
+use crate::engine::public_material_verification::verify_storage_material;
 use crate::engine::traits::{BackupOperator, ContextManager};
 use crate::engine::traits::{BaseKms, Kms};
 use crate::engine::validation::DSEP_USER_DECRYPTION;
@@ -957,7 +957,7 @@ impl<
         // Verify that public storage holds exactly what private storage says it should, and
         // that it is intact. Private storage is the reference; extra material in public
         // storage is ignored.
-        verify_public_storage_material(
+        verify_storage_material(
             &public_storage,
             &entries,
             &crs_info,

--- a/core/service/src/engine/material_integrity.rs
+++ b/core/service/src/engine/material_integrity.rs
@@ -3,7 +3,7 @@
 //! These are the lowest-level building blocks of material integrity: pure functions over raw
 //! bytes with no storage, no key metadata and no orchestration. They live below both the
 //! storage layer and the startup checks in
-//! [`crate::engine::public_material_verification`], so either can call them without depending
+//! [`crate::engine::storage_material_verification`], so either can call them without depending
 //! on boot logic.
 //!
 //! Every function takes the **raw bytes as they were stored** rather than a deserialized value.

--- a/core/service/src/engine/mod.rs
+++ b/core/service/src/engine/mod.rs
@@ -20,7 +20,7 @@ pub mod material_integrity;
 #[cfg(feature = "non-wasm")]
 pub mod migration;
 #[cfg(feature = "non-wasm")]
-pub(crate) mod public_material_verification;
+pub(crate) mod storage_material_verification;
 #[cfg(feature = "non-wasm")]
 pub mod threshold;
 #[cfg(feature = "non-wasm")]

--- a/core/service/src/engine/public_material_verification.rs
+++ b/core/service/src/engine/public_material_verification.rs
@@ -25,15 +25,22 @@
 
 use crate::backup::operator::RecoveryValidationMaterial;
 use crate::consts::SIGNING_KEY_ID;
+use crate::cryptography::signatures::recover_address_from_ext_signature;
 use crate::cryptography::signing::ecdsa::{PrivateSigKey, PublicSigKey};
-use crate::engine::base::{CrsGenMetadata, DSEP_PUBDATA_KEY, KeyGenMetadata};
+use crate::engine::base::{
+    CrsGenMetadata, CrsGenMetadataInner, DSEP_PUBDATA_KEY, KeyGenMetadata, KeyGenMetadataInner,
+    StoredEip712Domain,
+};
 use crate::engine::material_integrity::{
     verify_compressed_key_digest_from_bytes, verify_crs_digest_from_bytes,
     verify_public_key_digest_from_bytes, verify_server_key_digest_from_bytes,
 };
 use crate::vault::storage::{StorageReader, read_text_at_request_id};
+use alloy_primitives::Address;
+use alloy_sol_types::{Eip712Domain, SolStruct};
 use kms_grpc::RequestId;
 use kms_grpc::rpc_types::PubDataType;
+use kms_grpc::solidity_types::{CrsgenVerification, KeygenVerification};
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 use strum::IntoEnumIterator;
@@ -240,8 +247,10 @@ fn verify_recovery_material(
     Ok(())
 }
 
-/// Verify public storage material against private storage and verify recovery validation material.
-pub async fn verify_public_storage_material<S>(
+/// Verify the consistency of private storage and then verify the public storage
+/// material against private storage, as well as the recovery validation
+/// material.
+pub async fn verify_storage_material<S>(
     public_storage: &S,
     key_entries: &[(RequestId, KeyGenMetadata)],
     crs_entries: &HashMap<RequestId, CrsGenMetadata>,
@@ -261,7 +270,8 @@ where
         ensure_crs_metadata_id_matches(crs_id, metadata)?;
     }
 
-    // TODO(github.com/zama-ai/kms-internal/issues/3178) private storage validation will come later
+    let expected_address = PublicSigKey::from_sk(signing_key).address();
+    verify_private_metadata(key_entries, crs_entries, expected_address)?;
 
     for data_type in PubDataType::iter() {
         match data_type {
@@ -311,12 +321,186 @@ where
     Ok(())
 }
 
-/// Check that keyset metadata declares the same key ID it is stored under.
+/// Verify the signatures that authenticate current metadata in private storage.
 ///
-/// The published bytes are loaded under the storage ID, while the digests and signatures cover
-/// `inner.key_id`. If those disagree, every other check is describing a different key and none
-/// of their results mean anything — so this runs before them, and needs no signing key.
-/// `LegacyV0` metadata declares no ID, so there is nothing to compare.
+/// We cannot authenticate the signatures for oldre metadata since the EIP-712
+/// domain was not persisted. So those entries remain usable for backward
+/// compatibility. All newly written current metadata must carry a domain and a
+/// valid signature from this node.
+///
+/// Assumes every entry has already been checked against the ID it is stored under; see
+/// [`verify_keygen_metadata_signature`] for why that ordering matters.
+fn verify_private_metadata(
+    key_entries: &[(RequestId, KeyGenMetadata)],
+    crs_entries: &HashMap<RequestId, CrsGenMetadata>,
+    expected_address: Address,
+) -> anyhow::Result<()> {
+    for (key_id, metadata) in key_entries {
+        match metadata {
+            KeyGenMetadata::Current(inner) => {
+                verify_keygen_metadata_signature(key_id, inner, expected_address)?;
+            }
+            KeyGenMetadata::LegacyV0(_) => {
+                tracing::info!(
+                    "Legacy keygen metadata for id={key_id} has no stored EIP-712 domain; skipping signature verification"
+                );
+            }
+        }
+    }
+
+    for (crs_id, metadata) in crs_entries {
+        match metadata {
+            CrsGenMetadata::Current(inner) => {
+                verify_crs_metadata_signature(crs_id, inner, expected_address)?;
+            }
+            CrsGenMetadata::LegacyV0(_) => {
+                tracing::info!(
+                    "Legacy CRS metadata for id={crs_id} has no stored EIP-712 domain; skipping signature verification"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Verify the EIP-712 `external_signature` on one current keygen metadata record.
+///
+/// Callers must run [`ensure_keygen_metadata_id_matches`] first. Without it,
+/// metadata stored under the wrong ID would verify happily against the ID it
+/// declares and the mismatch would go unnoticed here.
+fn verify_keygen_metadata_signature(
+    key_id: &RequestId,
+    metadata: &KeyGenMetadataInner,
+    expected_address: Address,
+) -> anyhow::Result<()> {
+    let Some(stored_domain) = metadata.eip712_domain.as_ref() else {
+        tracing::info!(
+            "Current keygen metadata for id={key_id} has no stored EIP-712 domain; skipping signature verification"
+        );
+        return Ok(());
+    };
+
+    let extra_data = metadata.extra_data.clone().unwrap_or_default();
+
+    match classify_current_public_material(&metadata.key_digest_map)? {
+        CurrentPublicMaterialLayout::Standard => {
+            let server_key_digest = metadata
+                .key_digest_map
+                .get(&PubDataType::ServerKey)
+                .ok_or_else(|| anyhow::anyhow!("Missing server-key digest for id={key_id}"))?;
+            let public_key_digest = metadata
+                .key_digest_map
+                .get(&PubDataType::PublicKey)
+                .ok_or_else(|| anyhow::anyhow!("Missing public-key digest for id={key_id}"))?;
+            let sol_type = KeygenVerification::new_uncompressed(
+                &metadata.preprocessing_id,
+                &metadata.key_id,
+                server_key_digest.clone(),
+                public_key_digest.clone(),
+                extra_data,
+            );
+            verify_eip712_metadata_signature(
+                "keygen",
+                key_id,
+                &sol_type,
+                stored_domain,
+                &metadata.external_signature,
+                expected_address,
+            )?;
+        }
+        CurrentPublicMaterialLayout::Compressed => {
+            let compressed_keyset_digest = metadata
+                .key_digest_map
+                .get(&PubDataType::CompressedXofKeySet)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Missing compressed-keyset digest for id={key_id}")
+                })?;
+            let public_key_digest = metadata
+                .key_digest_map
+                .get(&PubDataType::PublicKey)
+                .ok_or_else(|| anyhow::anyhow!("Missing public-key digest for id={key_id}"))?;
+            let sol_type = KeygenVerification::new_compressed(
+                &metadata.preprocessing_id,
+                &metadata.key_id,
+                compressed_keyset_digest.clone(),
+                public_key_digest.clone(),
+                extra_data,
+            );
+            verify_eip712_metadata_signature(
+                "compressed keygen",
+                key_id,
+                &sol_type,
+                stored_domain,
+                &metadata.external_signature,
+                expected_address,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Verify the EIP-712 `external_signature` on one current CRS metadata record.
+///
+/// Carries the same precondition as [`verify_keygen_metadata_signature`]: the signed message is
+/// rebuilt from the metadata's own `crs_id`, so [`ensure_crs_metadata_id_matches`] must have run
+/// over this entry first.
+fn verify_crs_metadata_signature(
+    crs_id: &RequestId,
+    metadata: &CrsGenMetadataInner,
+    expected_address: Address,
+) -> anyhow::Result<()> {
+    let Some(stored_domain) = metadata.eip712_domain.as_ref() else {
+        tracing::info!(
+            "Current CRS metadata for id={crs_id} has no stored EIP-712 domain; skipping signature verification"
+        );
+        return Ok(());
+    };
+
+    let sol_type = CrsgenVerification::new(
+        &metadata.crs_id,
+        metadata.max_num_bits as usize,
+        metadata.crs_digest.clone(),
+        metadata.extra_data.clone().unwrap_or_default(),
+    );
+    verify_eip712_metadata_signature(
+        "CRS",
+        crs_id,
+        &sol_type,
+        stored_domain,
+        &metadata.external_signature,
+        expected_address,
+    )
+}
+
+fn verify_eip712_metadata_signature<T: SolStruct>(
+    metadata_kind: &str,
+    metadata_id: &RequestId,
+    sol_type: &T,
+    stored_domain: &StoredEip712Domain,
+    external_signature: &[u8],
+    expected_address: Address,
+) -> anyhow::Result<()> {
+    let domain = Eip712Domain::from(stored_domain);
+    let recovered_address = recover_address_from_ext_signature(sol_type, &domain, external_signature)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Invalid EIP-712 signature in private {metadata_kind} metadata for id={metadata_id}: {e}"
+            )
+        })?;
+    if recovered_address != expected_address {
+        anyhow::bail!(
+            "Invalid EIP-712 signature in private {metadata_kind} metadata for id={metadata_id}: recovered signer {recovered_address}, expected {expected_address}"
+        );
+    }
+
+    // TODO(https://github.com/zama-ai/kms-internal/issues/3078): verify the optional
+    // per-scheme signatures stored in the metadata, including PQ signatures.
+    Ok(())
+}
+
+/// Check that keyset metadata declares the same key ID it is stored under.
 fn ensure_keygen_metadata_id_matches(
     key_id: &RequestId,
     metadata: &KeyGenMetadata,
@@ -752,15 +936,10 @@ mod tests {
             .await
             .expect("the digests match, so the digest checks alone cannot catch this");
 
-        let err = verify_public_storage_material(
-            &storage,
-            &entries,
-            &HashMap::new(),
-            &HashMap::new(),
-            &sk,
-        )
-        .await
-        .unwrap_err();
+        let err =
+            verify_storage_material(&storage, &entries, &HashMap::new(), &HashMap::new(), &sk)
+                .await
+                .unwrap_err();
         assert!(
             err.to_string().contains(ERR_METADATA_ID_MISMATCH),
             "expected an ID mismatch before public storage verification, got: {err}"
@@ -796,7 +975,7 @@ mod tests {
         let (_pk, sk) = gen_sig_keys(&mut AesRng::seed_from_u64(124));
 
         let entries = HashMap::from([(other_id, metadata)]);
-        let err = verify_public_storage_material(&storage, &[], &entries, &HashMap::new(), &sk)
+        let err = verify_storage_material(&storage, &[], &entries, &HashMap::new(), &sk)
             .await
             .unwrap_err();
         assert!(
@@ -964,7 +1143,7 @@ mod tests {
         let orphan_crs_id = RequestId::new_random(&mut rng);
         let _orphan_crs = setup_crs(&mut storage, &orphan_crs_id).await;
 
-        verify_public_storage_material(&storage, &[], &HashMap::new(), &HashMap::new(), &sk)
+        verify_storage_material(&storage, &[], &HashMap::new(), &HashMap::new(), &sk)
             .await
             .expect("material with no private counterpart must be ignored");
     }
@@ -997,6 +1176,82 @@ mod tests {
         );
     }
 
+    #[test]
+    fn private_compressed_keygen_metadata_signature_verifies_with_stored_domain() {
+        let mut rng = AesRng::seed_from_u64(174);
+        let (_verf_key, signing_key) = gen_sig_keys(&mut rng);
+        let domain = crate::dummy_domain();
+        let prep_id = RequestId::new_random(&mut rng);
+        let key_id = RequestId::new_random(&mut rng);
+        let metadata = crate::engine::base::compute_info_compressed_keygen_from_digests(
+            &signing_key,
+            &[],
+            &prep_id,
+            &key_id,
+            vec![0x11; 32],
+            vec![0x22; 32],
+            &domain,
+            vec![0x03],
+        )
+        .expect("compressed keygen metadata construction must succeed");
+
+        let KeyGenMetadata::Current(inner) = &metadata else {
+            panic!("metadata construction must produce current metadata");
+        };
+        verify_keygen_metadata_signature(
+            &key_id,
+            inner,
+            PublicSigKey::from_sk(&signing_key).address(),
+        )
+        .expect("the stored domain must verify the compressed keygen signature");
+
+        let wrong_domain = alloy_sol_types::eip712_domain!(
+            name: "wrong domain",
+            version: "1",
+            chain_id: 8006,
+            verifying_contract: alloy_primitives::address!("66f9664f97F2b50F62D13eA064982f936dE76657"),
+        );
+        let mut tampered_inner = inner.clone();
+        tampered_inner.eip712_domain = Some((&wrong_domain).into());
+        let err = verify_keygen_metadata_signature(
+            &key_id,
+            &tampered_inner,
+            PublicSigKey::from_sk(&signing_key).address(),
+        )
+        .expect_err("a changed stored domain must invalidate the signature");
+        assert!(
+            err.to_string().contains("Invalid EIP-712 signature"),
+            "expected a signature verification error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn private_crs_metadata_signature_verifies_with_stored_domain() {
+        let mut rng = AesRng::seed_from_u64(175);
+        let (_verf_key, signing_key) = gen_sig_keys(&mut rng);
+        let crs_id = RequestId::new_random(&mut rng);
+        let metadata = crate::engine::base::compute_info_crs_from_digest(
+            &signing_key,
+            &[],
+            &crs_id,
+            vec![0x33; 32],
+            64,
+            &crate::dummy_domain(),
+            vec![0x04],
+        )
+        .expect("CRS metadata construction must succeed");
+
+        let CrsGenMetadata::Current(inner) = &metadata else {
+            panic!("metadata construction must produce current metadata");
+        };
+        verify_crs_metadata_signature(
+            &crs_id,
+            inner,
+            PublicSigKey::from_sk(&signing_key).address(),
+        )
+        .expect("the stored domain must verify the CRS signature");
+    }
+
     // === End to end ===
 
     #[tokio::test]
@@ -1004,20 +1259,48 @@ mod tests {
         let mut storage = RamStorage::new();
         let mut rng = AesRng::seed_from_u64(160);
         let material = setup_standard_keys(&mut storage, 161).await;
-        let metadata = material.current_metadata();
         let (_pk, sk) = gen_sig_keys(&mut AesRng::seed_from_u64(161));
         store_signing_key_material(&mut storage, &sk, None).await;
+        let domain = crate::dummy_domain();
+        let metadata = crate::engine::base::compute_info_standard_keygen_from_digests(
+            &sk,
+            &[],
+            &material.preproc_id,
+            &material.key_id,
+            material
+                .key_digest_map
+                .get(&PubDataType::ServerKey)
+                .cloned()
+                .expect("test material must contain a server-key digest"),
+            material
+                .key_digest_map
+                .get(&PubDataType::PublicKey)
+                .cloned()
+                .expect("test material must contain a public-key digest"),
+            &domain,
+            vec![],
+        )
+        .expect("signed keygen metadata construction must succeed");
 
         let crs_id = RequestId::new_random(&mut rng);
         let crs_digest = setup_crs(&mut storage, &crs_id).await;
-        let crs_metadata = current_crs_metadata(crs_id, crs_digest);
+        let crs_metadata = crate::engine::base::compute_info_crs_from_digest(
+            &sk,
+            &[],
+            &crs_id,
+            crs_digest,
+            64,
+            &domain,
+            vec![],
+        )
+        .expect("signed CRS metadata construction must succeed");
 
         let entries = vec![(material.key_id, metadata)];
         let crs_entries = HashMap::from_iter([(crs_id, crs_metadata)]);
         let recovery_material = test_recovery_material(&sk);
         let context_id = recovery_material.custodian_context().context_id;
         let recovery_material = HashMap::from([(context_id, recovery_material)]);
-        verify_public_storage_material(&storage, &entries, &crs_entries, &recovery_material, &sk)
+        verify_storage_material(&storage, &entries, &crs_entries, &recovery_material, &sk)
             .await
             .expect("consistent public storage must verify");
     }

--- a/core/service/src/engine/public_material_verification.rs
+++ b/core/service/src/engine/public_material_verification.rs
@@ -459,6 +459,7 @@ mod tests {
                 key_id: self.key_id,
                 preprocessing_id: self.preproc_id,
                 key_digest_map: self.key_digest_map.clone(),
+                eip712_domain: None,
                 external_signature: vec![],
                 extra_data: None,
             })
@@ -483,6 +484,7 @@ mod tests {
                 key_id: self.key_id,
                 preprocessing_id: self.preproc_id,
                 key_digest_map,
+                eip712_domain: None,
                 external_signature: vec![],
                 extra_data: None,
             })
@@ -1092,6 +1094,7 @@ mod tests {
             crs_digest,
             max_num_bits: 64,
             extra_data: None,
+            eip712_domain: None,
             external_signature: vec![],
             signatures: vec![],
         })

--- a/core/service/src/engine/storage_material_verification.rs
+++ b/core/service/src/engine/storage_material_verification.rs
@@ -344,6 +344,10 @@ fn verify_keygen_metadata_signature(
     metadata: &KeyGenMetadataInner,
     expected_address: Address,
 ) -> anyhow::Result<()> {
+    // TODO(github.com/zama-ai/kms-internal#3201)
+    // After we upgrade to 0.16 (and have migrated keys in 0.15),
+    // or after we retire the default epoch, then remove the backward compatibility support.
+    // That is, we should always have a domain in the metadata that we can use to verify the signature.
     let Some(stored_domain) = metadata.eip712_domain.as_ref() else {
         tracing::info!(
             "Current keygen metadata for id={key_id} has no stored EIP-712 domain; skipping signature verification"
@@ -386,6 +390,10 @@ fn verify_crs_metadata_signature(
     metadata: &CrsGenMetadataInner,
     expected_address: Address,
 ) -> anyhow::Result<()> {
+    // TODO(github.com/zama-ai/kms-internal#3201)
+    // After we can retire the default epoch, we can remove the backward compatibility support
+    // since new epochs will be re-signed using the more recent format.
+    // That is, we should always have a domain in the metadata that we can use to verify the signature.
     let Some(stored_domain) = metadata.eip712_domain.as_ref() else {
         tracing::info!(
             "Current CRS metadata for id={crs_id} has no stored EIP-712 domain; skipping signature verification"

--- a/core/service/src/engine/storage_material_verification.rs
+++ b/core/service/src/engine/storage_material_verification.rs
@@ -28,8 +28,9 @@ use crate::consts::SIGNING_KEY_ID;
 use crate::cryptography::signatures::recover_address_from_ext_signature;
 use crate::cryptography::signing::ecdsa::{PrivateSigKey, PublicSigKey};
 use crate::engine::base::{
-    CrsGenMetadata, CrsGenMetadataInner, DSEP_PUBDATA_KEY, KeyGenMetadata, KeyGenMetadataInner,
-    StoredEip712Domain,
+    CrsGenMetadata, CrsGenMetadataInner, CurrentPublicMaterialLayout, DSEP_PUBDATA_KEY,
+    KeyGenMetadata, KeyGenMetadataInner, StoredEip712Domain, classify_current_public_material,
+    crs_sol_type, keygen_sol_type,
 };
 use crate::engine::material_integrity::{
     verify_compressed_key_digest_from_bytes, verify_crs_digest_from_bytes,
@@ -40,12 +41,10 @@ use alloy_primitives::Address;
 use alloy_sol_types::{Eip712Domain, SolStruct};
 use kms_grpc::RequestId;
 use kms_grpc::rpc_types::PubDataType;
-use kms_grpc::solidity_types::{CrsgenVerification, KeygenVerification};
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 
-const ERR_INVALID_CURRENT_PUBLIC_KEY_SHAPE: &str = "Invalid current public key metadata shape";
 const ERR_INVALID_LEGACY_PUBLIC_KEY_SHAPE: &str = "Invalid legacy public key metadata shape";
 pub(crate) const ERR_METADATA_ID_MISMATCH: &str =
     "Result metadata is stored under a different ID than it declares";
@@ -53,35 +52,6 @@ pub(crate) const ERR_VERF_KEY_MISMATCH: &str =
     "Verification key in public storage does not match the private signing key";
 pub(crate) const ERR_VERF_ADDRESS_MISMATCH: &str =
     "Verification address in public storage does not match the private signing key";
-
-#[derive(Clone, Copy)]
-enum CurrentPublicMaterialLayout {
-    Standard,
-    Compressed,
-}
-
-fn classify_current_public_material(
-    key_digest_map: &BTreeMap<PubDataType, Vec<u8>>,
-) -> anyhow::Result<CurrentPublicMaterialLayout> {
-    let has_public_key = key_digest_map.contains_key(&PubDataType::PublicKey);
-    let has_server_key = key_digest_map.contains_key(&PubDataType::ServerKey);
-    let has_compressed_keyset = key_digest_map.contains_key(&PubDataType::CompressedXofKeySet);
-
-    match (
-        has_public_key,
-        has_server_key,
-        has_compressed_keyset,
-        key_digest_map.len(),
-    ) {
-        (true, true, false, 2) => Ok(CurrentPublicMaterialLayout::Standard),
-        (true, false, true, 2) => Ok(CurrentPublicMaterialLayout::Compressed),
-        _ => anyhow::bail!(
-            "{ERR_INVALID_CURRENT_PUBLIC_KEY_SHAPE}: expected either \
-             {{PublicKey, ServerKey}} or {{PublicKey, CompressedXofKeySet}}, got {:?}",
-            key_digest_map.keys().collect::<Vec<_>>()
-        ),
-    }
-}
 
 fn validate_legacy_public_material_shape<T>(
     public_materials: &HashMap<PubDataType, T>,
@@ -323,7 +293,7 @@ where
 
 /// Verify the signatures that authenticate current metadata in private storage.
 ///
-/// We cannot authenticate the signatures for oldre metadata since the EIP-712
+/// We cannot authenticate the signatures for older metadata since the EIP-712
 /// domain was not persisted. So those entries remain usable for backward
 /// compatibility. All newly written current metadata must carry a domain and a
 /// valid signature from this node.
@@ -381,62 +351,27 @@ fn verify_keygen_metadata_signature(
         return Ok(());
     };
 
-    let extra_data = metadata.extra_data.clone().unwrap_or_default();
-
-    match classify_current_public_material(&metadata.key_digest_map)? {
-        CurrentPublicMaterialLayout::Standard => {
-            let server_key_digest = metadata
-                .key_digest_map
-                .get(&PubDataType::ServerKey)
-                .ok_or_else(|| anyhow::anyhow!("Missing server-key digest for id={key_id}"))?;
-            let public_key_digest = metadata
-                .key_digest_map
-                .get(&PubDataType::PublicKey)
-                .ok_or_else(|| anyhow::anyhow!("Missing public-key digest for id={key_id}"))?;
-            let sol_type = KeygenVerification::new_uncompressed(
+    // Signing sites know their layout statically; here it can only be read back off the
+    // stored digest map.
+    let sol_type = classify_current_public_material(&metadata.key_digest_map)
+        .and_then(|layout| {
+            keygen_sol_type(
+                layout,
                 &metadata.preprocessing_id,
                 &metadata.key_id,
-                server_key_digest.clone(),
-                public_key_digest.clone(),
-                extra_data,
-            );
-            verify_eip712_metadata_signature(
-                "keygen",
-                key_id,
-                &sol_type,
-                stored_domain,
-                &metadata.external_signature,
-                expected_address,
-            )?;
-        }
-        CurrentPublicMaterialLayout::Compressed => {
-            let compressed_keyset_digest = metadata
-                .key_digest_map
-                .get(&PubDataType::CompressedXofKeySet)
-                .ok_or_else(|| {
-                    anyhow::anyhow!("Missing compressed-keyset digest for id={key_id}")
-                })?;
-            let public_key_digest = metadata
-                .key_digest_map
-                .get(&PubDataType::PublicKey)
-                .ok_or_else(|| anyhow::anyhow!("Missing public-key digest for id={key_id}"))?;
-            let sol_type = KeygenVerification::new_compressed(
-                &metadata.preprocessing_id,
-                &metadata.key_id,
-                compressed_keyset_digest.clone(),
-                public_key_digest.clone(),
-                extra_data,
-            );
-            verify_eip712_metadata_signature(
-                "compressed keygen",
-                key_id,
-                &sol_type,
-                stored_domain,
-                &metadata.external_signature,
-                expected_address,
-            )?;
-        }
-    }
+                &metadata.key_digest_map,
+                metadata.extra_data.as_deref().unwrap_or_default(),
+            )
+        })
+        .map_err(|e| anyhow::anyhow!("Invalid private keygen metadata for id={key_id}: {e}"))?;
+    verify_eip712_metadata_signature(
+        "keygen",
+        key_id,
+        &sol_type,
+        stored_domain,
+        &metadata.external_signature,
+        expected_address,
+    )?;
 
     Ok(())
 }
@@ -458,11 +393,11 @@ fn verify_crs_metadata_signature(
         return Ok(());
     };
 
-    let sol_type = CrsgenVerification::new(
+    let sol_type = crs_sol_type(
         &metadata.crs_id,
-        metadata.max_num_bits as usize,
-        metadata.crs_digest.clone(),
-        metadata.extra_data.clone().unwrap_or_default(),
+        &metadata.crs_digest,
+        metadata.max_num_bits,
+        metadata.extra_data.as_deref().unwrap_or_default(),
     );
     verify_eip712_metadata_signature(
         "CRS",
@@ -608,8 +543,8 @@ mod tests {
     use crate::consts::DEFAULT_MPC_CONTEXT;
     use crate::cryptography::encryption::{Encryption, PkeScheme, PkeSchemeType};
     use crate::cryptography::signatures::gen_sig_keys;
-    use crate::engine::base::DSEP_PUBDATA_CRS;
     use crate::engine::base::KeyGenMetadataInner;
+    use crate::engine::base::{DSEP_PUBDATA_CRS, ERR_INVALID_CURRENT_PUBLIC_KEY_SHAPE};
     use crate::engine::material_integrity::{
         ERR_COMPRESSED_KEYSET_DIGEST_MISMATCH, ERR_CRS_DIGEST_MISMATCH,
         ERR_PUBLIC_KEY_DIGEST_MISMATCH, ERR_SERVER_KEY_DIGEST_MISMATCH,
@@ -1177,6 +1112,53 @@ mod tests {
     }
 
     #[test]
+    fn private_standard_keygen_metadata_signature_verifies_with_stored_domain() {
+        let mut rng = AesRng::seed_from_u64(176);
+        let (_verf_key, signing_key) = gen_sig_keys(&mut rng);
+        let domain = crate::dummy_domain();
+        let prep_id = RequestId::new_random(&mut rng);
+        let key_id = RequestId::new_random(&mut rng);
+        let metadata = crate::engine::base::compute_info_standard_keygen_from_digests(
+            &signing_key,
+            &[],
+            &prep_id,
+            &key_id,
+            vec![0x11; 32],
+            vec![0x22; 32],
+            &domain,
+            vec![0x03],
+        )
+        .expect("standard keygen metadata construction must succeed");
+
+        let KeyGenMetadata::Current(inner) = &metadata else {
+            panic!("metadata construction must produce current metadata");
+        };
+        verify_keygen_metadata_signature(
+            &key_id,
+            inner,
+            PublicSigKey::from_sk(&signing_key).address(),
+        )
+        .expect("the stored domain must verify the standard keygen signature");
+
+        // The server-key digest is the field that separates the standard signed message from
+        // the compressed one, so changing it must invalidate the signature.
+        let mut tampered_inner = inner.clone();
+        tampered_inner
+            .key_digest_map
+            .insert(PubDataType::ServerKey, vec![0x44; 32]);
+        let err = verify_keygen_metadata_signature(
+            &key_id,
+            &tampered_inner,
+            PublicSigKey::from_sk(&signing_key).address(),
+        )
+        .expect_err("a changed server-key digest must invalidate the signature");
+        assert!(
+            err.to_string().contains("Invalid EIP-712 signature"),
+            "expected a signature verification error, got: {err}"
+        );
+    }
+
+    #[test]
     fn private_compressed_keygen_metadata_signature_verifies_with_stored_domain() {
         let mut rng = AesRng::seed_from_u64(174);
         let (_verf_key, signing_key) = gen_sig_keys(&mut rng);
@@ -1256,14 +1238,111 @@ mod tests {
 
     #[tokio::test]
     async fn verify_storage_material_accepts_consistent_storage() {
-        let mut storage = RamStorage::new();
-        let mut rng = AesRng::seed_from_u64(160);
-        let material = setup_standard_keys(&mut storage, 161).await;
         let (_pk, sk) = gen_sig_keys(&mut AesRng::seed_from_u64(161));
-        store_signing_key_material(&mut storage, &sk, None).await;
-        let domain = crate::dummy_domain();
-        let metadata = crate::engine::base::compute_info_standard_keygen_from_digests(
+        let (storage, entries, crs_entries) = setup_consistent_material(160, &sk, &sk).await;
+
+        verify_storage_material(
+            &storage,
+            &entries,
+            &crs_entries,
+            &recovery_material_for(&sk),
             &sk,
+        )
+        .await
+        .expect("consistent public storage must verify");
+    }
+
+    #[tokio::test]
+    async fn verify_storage_material_rejects_metadata_signed_by_another_key() {
+        let mut rng = AesRng::seed_from_u64(162);
+        let (_pk, sk) = gen_sig_keys(&mut rng);
+        let (other_pk, other_sk) = gen_sig_keys(&mut rng);
+        // Everything public storage holds is this node's own and internally consistent; only
+        // the private metadata was signed by another node's key. Material replicated from a
+        // peer and then filed as ours would look exactly like this.
+        let (storage, entries, _crs_entries) = setup_consistent_material(163, &other_sk, &sk).await;
+
+        let err = verify_storage_material(
+            &storage,
+            &entries,
+            &HashMap::new(),
+            &recovery_material_for(&sk),
+            &sk,
+        )
+        .await
+        .expect_err("metadata signed by another key must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Invalid EIP-712 signature")
+                && msg.contains(&other_pk.address().to_string())
+                && msg.contains(&PublicSigKey::from_sk(&sk).address().to_string()),
+            "error should name both the recovered and the expected signer, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_storage_material_accepts_current_metadata_without_stored_domain() {
+        let mut rng = AesRng::seed_from_u64(164);
+        let mut storage = RamStorage::new();
+        let (_pk, sk) = gen_sig_keys(&mut rng);
+        store_signing_key_material(&mut storage, &sk, None).await;
+
+        // Metadata written before the EIP-712 domain was persisted: current format, but with
+        // no domain and therefore no signature that can be rebuilt. Every already-deployed
+        // node holds only entries of this shape, so startup must keep accepting them.
+        let material = setup_standard_keys(&mut storage, 165).await;
+        let metadata = material.current_metadata();
+        assert!(
+            matches!(&metadata, KeyGenMetadata::Current(inner) if inner.eip712_domain.is_none()),
+            "this test is only meaningful for current metadata with no stored domain"
+        );
+        let entries = vec![(material.key_id, metadata)];
+
+        let crs_id = RequestId::new_random(&mut rng);
+        let crs_digest = setup_crs(&mut storage, &crs_id).await;
+        let crs_metadata = current_crs_metadata(crs_id, crs_digest);
+        assert!(
+            matches!(&crs_metadata, CrsGenMetadata::Current(inner) if inner.eip712_domain.is_none()),
+            "this test is only meaningful for current CRS metadata with no stored domain"
+        );
+        let crs_entries = HashMap::from_iter([(crs_id, crs_metadata)]);
+
+        verify_storage_material(
+            &storage,
+            &entries,
+            &crs_entries,
+            &recovery_material_for(&sk),
+            &sk,
+        )
+        .await
+        .expect("current metadata without a stored domain must still verify");
+    }
+
+    // === Helpers ===
+
+    /// Public storage that is consistent by construction — matching key and CRS digests plus a
+    /// published verification key and address — together with the private metadata describing
+    /// it.
+    ///
+    /// `metadata_sk` signs the metadata and `node_sk` is the key the node boots with. Passing
+    /// two different keys yields storage whose only defect is the metadata signature.
+    async fn setup_consistent_material(
+        seed: u64,
+        metadata_sk: &PrivateSigKey,
+        node_sk: &PrivateSigKey,
+    ) -> (
+        RamStorage,
+        Vec<(RequestId, KeyGenMetadata)>,
+        HashMap<RequestId, CrsGenMetadata>,
+    ) {
+        let mut rng = AesRng::seed_from_u64(seed);
+        let mut storage = RamStorage::new();
+        let material = setup_standard_keys(&mut storage, seed + 1).await;
+        store_signing_key_material(&mut storage, node_sk, None).await;
+        let domain = crate::dummy_domain();
+
+        let key_metadata = crate::engine::base::compute_info_standard_keygen_from_digests(
+            metadata_sk,
             &[],
             &material.preproc_id,
             &material.key_id,
@@ -1285,7 +1364,7 @@ mod tests {
         let crs_id = RequestId::new_random(&mut rng);
         let crs_digest = setup_crs(&mut storage, &crs_id).await;
         let crs_metadata = crate::engine::base::compute_info_crs_from_digest(
-            &sk,
+            metadata_sk,
             &[],
             &crs_id,
             crs_digest,
@@ -1295,17 +1374,22 @@ mod tests {
         )
         .expect("signed CRS metadata construction must succeed");
 
-        let entries = vec![(material.key_id, metadata)];
-        let crs_entries = HashMap::from_iter([(crs_id, crs_metadata)]);
-        let recovery_material = test_recovery_material(&sk);
-        let context_id = recovery_material.custodian_context().context_id;
-        let recovery_material = HashMap::from([(context_id, recovery_material)]);
-        verify_storage_material(&storage, &entries, &crs_entries, &recovery_material, &sk)
-            .await
-            .expect("consistent public storage must verify");
+        (
+            storage,
+            vec![(material.key_id, key_metadata)],
+            HashMap::from_iter([(crs_id, crs_metadata)]),
+        )
     }
 
-    // === Helpers ===
+    /// Recovery validation material signed by `signing_key`, keyed by its own context ID, so
+    /// end-to-end tests can pass the recovery check and isolate what they are actually testing.
+    fn recovery_material_for(
+        signing_key: &PrivateSigKey,
+    ) -> HashMap<RequestId, RecoveryValidationMaterial> {
+        let material = test_recovery_material(signing_key);
+        let context_id = material.custodian_context().context_id;
+        HashMap::from([(context_id, material)])
+    }
 
     fn test_recovery_material(signing_key: &PrivateSigKey) -> RecoveryValidationMaterial {
         let mut rng = AesRng::seed_from_u64(173);

--- a/core/service/src/engine/storage_material_verification.rs
+++ b/core/service/src/engine/storage_material_verification.rs
@@ -1,4 +1,4 @@
-//! Verification of the material published in public storage.
+//! Verification of material in private and public storage.
 //!
 //! Public storage may deviate from a consistent state: a misconfigured bucket or prefix can
 //! point a node at the wrong material, and writes are not atomic, so a crash part-way through
@@ -312,7 +312,7 @@ where
     }
 
     tracing::info!(
-        "Verified public storage material in storage \"{}\": {} keyset(s), {} CRS(es), {} recovery validation material item(s)",
+        "Verified storage material in storage \"{}\": {} keyset(s), {} CRS(es), {} recovery validation material item(s)",
         public_storage.info(),
         key_entries.len(),
         crs_entries.len(),
@@ -1255,7 +1255,7 @@ mod tests {
     // === End to end ===
 
     #[tokio::test]
-    async fn verify_public_storage_material_accepts_consistent_storage() {
+    async fn verify_storage_material_accepts_consistent_storage() {
         let mut storage = RamStorage::new();
         let mut rng = AesRng::seed_from_u64(160);
         let material = setup_standard_keys(&mut storage, 161).await;

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -2494,6 +2494,7 @@ pub(crate) mod tests {
                 *key_id,
                 *preproc_id,
                 std::collections::BTreeMap::new(),
+                &crate::dummy_domain(),
                 vec![],
                 vec![],
                 vec![],

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -1025,6 +1025,8 @@ mod tests {
         }
 
         #[derive(Clone, Serialize, Deserialize, VersionsDispatch)]
+        // Boxing a version variant would change the serialized test fixture.
+        #[allow(clippy::large_enum_variant)]
         pub enum ThresholdFheKeysVersions {
             V0(PlaceholderV0),
             V1(PlaceholderV1),
@@ -1092,6 +1094,7 @@ mod tests {
                     RequestId::zeros(),
                     RequestId::zeros(),
                     BTreeMap::new(),
+                    &crate::dummy_domain(),
                     vec![],
                     vec![],
                     vec![],
@@ -1141,6 +1144,7 @@ mod tests {
                 RequestId::zeros(),
                 RequestId::zeros(),
                 BTreeMap::new(),
+                &crate::dummy_domain(),
                 vec![],
                 vec![],
                 vec![],
@@ -1216,6 +1220,7 @@ mod tests {
                 RequestId::zeros(),
                 RequestId::zeros(),
                 BTreeMap::new(),
+                &crate::dummy_domain(),
                 vec![],
                 vec![],
                 vec![],

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -73,7 +73,7 @@ use crate::{
         },
         context_manager::{ThresholdContextManager, ensure_default_threshold_context_in_storage},
         prepare_shutdown_signals,
-        public_material_verification::verify_public_storage_material,
+        public_material_verification::verify_storage_material,
         threshold::{
             service::{
                 public_decryptor::SecureNoiseFloodDecryptor,
@@ -573,7 +573,7 @@ where
     // Private storage is the reference; extra material in public storage is ignored.
     match base_kms.sig_key() {
         Ok(signing_key) => {
-            verify_public_storage_material(
+            verify_storage_material(
                 &public_storage,
                 &key_info,
                 &crs_info,
@@ -1025,8 +1025,7 @@ mod tests {
         }
 
         #[derive(Clone, Serialize, Deserialize, VersionsDispatch)]
-        // Boxing a version variant would change the serialized test fixture.
-        #[allow(clippy::large_enum_variant)]
+        #[expect(clippy::large_enum_variant)]
         pub enum ThresholdFheKeysVersions {
             V0(PlaceholderV0),
             V1(PlaceholderV1),

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -73,7 +73,7 @@ use crate::{
         },
         context_manager::{ThresholdContextManager, ensure_default_threshold_context_in_storage},
         prepare_shutdown_signals,
-        public_material_verification::verify_storage_material,
+        storage_material_verification::verify_storage_material,
         threshold::{
             service::{
                 public_decryptor::SecureNoiseFloodDecryptor,

--- a/core/service/src/vault/storage/crypto_material/tests.rs
+++ b/core/service/src/vault/storage/crypto_material/tests.rs
@@ -77,7 +77,15 @@ where
 
 fn dummy_info() -> KeyGenMetadata {
     let req_id = derive_request_id("dummy_info").unwrap();
-    KeyGenMetadata::new(req_id, req_id, BTreeMap::new(), vec![], vec![], vec![])
+    KeyGenMetadata::new(
+        req_id,
+        req_id,
+        BTreeMap::new(),
+        &crate::dummy_domain(),
+        vec![],
+        vec![],
+        vec![],
+    )
 }
 
 fn ram_threshold_storage(
@@ -842,6 +850,7 @@ fn dummy_crs_metadata(seed: u8) -> CrsGenMetadata {
         crs_id,
         vec![seed; 32],
         128,
+        &crate::dummy_domain(),
         vec![seed; 8],
         vec![],
         format!("extra-{seed}").into_bytes(),

--- a/core/service/src/vault/storage/crypto_material/tests/migration.rs
+++ b/core/service/src/vault/storage/crypto_material/tests/migration.rs
@@ -663,7 +663,15 @@ async fn test_copy_compressed_key_validation_failure_is_atomic() {
     let bad_fhe_keys = ThresholdFheKeys::new(
         old_fhe_keys.private_keys.clone(),
         PublicKeyMaterial::new(compressed_keyset.clone()),
-        KeyGenMetadata::new(new_key_id, prep_id, BTreeMap::new(), vec![], vec![], vec![]),
+        KeyGenMetadata::new(
+            new_key_id,
+            prep_id,
+            BTreeMap::new(),
+            &domain,
+            vec![],
+            vec![],
+            vec![],
+        ),
     );
     store_migrated_compressed_material(
         &crypto_storage,

--- a/core/service/src/vault/storage/crypto_material/threshold.rs
+++ b/core/service/src/vault/storage/crypto_material/threshold.rs
@@ -395,6 +395,7 @@ impl<PubS: Storage + Send + Sync + 'static, PrivS: StorageExt + Send + Sync + 's
                     *old_key_id,
                     migrated_inner.preprocessing_id,
                     migrated_inner.key_digest_map.clone(),
+                    eip712_domain,
                     new_signature,
                     Vec::new(),
                     extra_data,

--- a/core/service/tests/backward_compatibility_determinism.rs
+++ b/core/service/tests/backward_compatibility_determinism.rs
@@ -21,6 +21,15 @@ use threshold_types::role::Role;
 const REPEATS: usize = 10;
 const SEED: u64 = 0xdeadbeef;
 
+fn dummy_domain() -> alloy_sol_types::Eip712Domain {
+    alloy_sol_types::eip712_domain!(
+        name: "Authorization token",
+        version: "1",
+        chain_id: 8006,
+        verifying_contract: alloy_primitives::address!("66f9664f97F2b50F62D13eA064982f936dE76657"),
+    )
+}
+
 fn encode_versioned<T: Versionize>(value: &T) -> Vec<u8> {
     // Mirror backward-compatibility/generate-vX.Y.Z/src/generate.rs::save_bcode.
     let versioned = value.versionize();
@@ -58,6 +67,7 @@ fn build_key_gen_metadata_inner() -> KeyGenMetadataInner {
         key_id,
         preprocessing_id,
         digest_map,
+        &dummy_domain(),
         vec![0xEE; 64],
         Vec::new(),
         b"extra".to_vec(),

--- a/core/service/tests/backward_compatibility_kms.rs
+++ b/core/service/tests/backward_compatibility_kms.rs
@@ -58,8 +58,9 @@ use kms_lib::{
     },
     engine::{
         base::{
-            CrsGenMetadata, CrsSignedPayload, KeyGenMetadata, KeyGenMetadataInner,
-            KeygenSignedPayload, KmsFheKeyHandles, PrepKeygenSignedPayload, StoredTypedSignature,
+            CrsGenMetadata, CrsGenMetadataInner, CrsGenMetadataInnerV2, CrsSignedPayload,
+            KeyGenMetadata, KeyGenMetadataInner, KeygenSignedPayload, KmsFheKeyHandles,
+            PrepKeygenSignedPayload, StoredTypedSignature,
         },
         context::{ContextInfo, NodeInfo, SchemeDigests, SignerAddress, SoftwareVersion},
         threshold::service::{
@@ -79,6 +80,7 @@ use std::{
 };
 use strum::IntoEnumIterator;
 use tfhe::integer::compression_keys::DecompressionKey;
+use tfhe_versionable::Upgrade;
 use threshold_execution::{
     small_execution::prss::PRSSSetup, tfhe_internals::public_keysets::FhePubKeySet,
 };
@@ -240,6 +242,7 @@ fn test_key_gen_metadata(
         key_id,
         preprocessing_id,
         key_digest_map,
+        eip712_domain: None,
         external_signature,
         extra_data: None, // Legacy approach
     };
@@ -291,14 +294,17 @@ fn test_crs_gen_metadata(
                 format,
             )
         })?;
-    let new_current = CrsGenMetadata::new(
+    let new_inner: CrsGenMetadataInner = CrsGenMetadataInnerV2 {
         crs_id,
-        digest,
+        crs_digest: digest,
         max_num_bits,
-        external_signature.clone(),
-        vec![],
-        vec![],
-    );
+        extra_data: None,
+        external_signature: external_signature.clone(),
+        signatures: vec![],
+    }
+    .upgrade()
+    .unwrap();
+    let new_current = CrsGenMetadata::Current(new_inner);
     match &new_current {
         CrsGenMetadata::LegacyV0(_) => {
             return Err(test.failure(
@@ -382,6 +388,7 @@ fn test_key_gen_metadata_with_extra_data(
         key_id,
         preprocessing_id,
         key_digest_map,
+        eip712_domain: None,
         external_signature,
         extra_data: Some(extra_data),
     };
@@ -425,14 +432,17 @@ fn test_crs_gen_metadata_with_extra_data(
                 format,
             )
         })?;
-    let new_current = CrsGenMetadata::new(
+    let new_inner: CrsGenMetadataInner = CrsGenMetadataInnerV2 {
         crs_id,
-        digest,
+        crs_digest: digest,
         max_num_bits,
-        external_signature.clone(),
-        vec![],
-        extra_data,
-    );
+        extra_data: Some(extra_data),
+        external_signature: external_signature.clone(),
+        signatures: vec![],
+    }
+    .upgrade()
+    .unwrap();
+    let new_current = CrsGenMetadata::Current(new_inner);
     match &new_current {
         CrsGenMetadata::LegacyV0(_) => {
             return Err(test.failure(

--- a/core/service/tests/versioned_enum_coverage.rs
+++ b/core/service/tests/versioned_enum_coverage.rs
@@ -79,7 +79,7 @@ const ALLOW_UNCOVERED: &[&str] = &[
     // Covered via CrsGenMetadataTest.
     "CrsGenMetadataInner",
     // Field of KeyGenMetadataInner.eip712_domain.
-    // Covered via KeyGenMetadataTest and current-format metadata roundtrip tests.
+    // TODO(github.com/zama-ai/kms-internal/issues/3200)
     "StoredEip712Domain",
     // Field of Share.
     // Covered via ShareTest.

--- a/core/service/tests/versioned_enum_coverage.rs
+++ b/core/service/tests/versioned_enum_coverage.rs
@@ -78,6 +78,9 @@ const ALLOW_UNCOVERED: &[&str] = &[
     // Variant payload of CrsGenMetadata::Current.
     // Covered via CrsGenMetadataTest.
     "CrsGenMetadataInner",
+    // Field of KeyGenMetadataInner.eip712_domain.
+    // Covered via KeyGenMetadataTest and current-format metadata roundtrip tests.
+    "StoredEip712Domain",
     // Field of Share.
     // Covered via ShareTest.
     "Role",


### PR DESCRIPTION
## Description

We want to have a way to verify signatures in key/crs metadata, but this verification needs the domain. So this PR
- introduces a way to store a domain so that verification can happen
- perform the verification on the key/crs metadata in private storage

### Related issue(s)

Closes zama-ai/kms-internal#3172
Closes zama-ai/kms-internal#3178

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
