### PR TITLE
perf: fix the "achieved rate" accounting (1/5)

### DIFF
--- a/ci/perf-testing/PERF_TEST_README.md
+++ b/ci/perf-testing/PERF_TEST_README.md
@@ -118,11 +118,15 @@ The Slack report and JSON artifacts use these fields.
 | Metric | Meaning |
 | --- | --- |
 | `offered` | Requests the rate generator scheduled. |
-| `completed` | Requests that collected enough KMS responses. |
+| `completed` | Requests that collected enough KMS responses |
+| `completed_in_window` | Requests completed during the configured measurement window. |
+| `completed_during_drain` | Requests completed after the measurement window while draining in-flight work. |
+| `measurement_elapsed_seconds` | Duration of the measurement window. |
+| `drain_elapsed_seconds` | Time spent draining in-flight work after the measurement window. |
 | `failed` | Requests that were sent but didn't collect enough responses in time. |
 | `shed` | Requests dropped before sending because `max_in_flight` was already reached. |
 | `saturated` | `true` if anything was shed, or the post-run drain timed out with requests still in flight. |
-| `achieved_rate` | `completed / collection_elapsed_seconds`. |
+| `achieved_rate` | `completed_in_window / measurement_elapsed_seconds`. |
 
 **Payload throughput** (protobuf-encoded body only — excludes gRPC/TLS/header
 overhead):
@@ -130,14 +134,16 @@ overhead):
 | Metric | Meaning |
 | --- | --- |
 | `request_payload_bytes` | Total request bytes submitted, counted once per core target. |
-| `request_payload_mib_per_sec` | Request bytes per second, in MiB/s. |
+| `request_payload_mib_per_sec` | Request bytes per measurement-window second, in MiB/s. |
 | `request_payload_avg_bytes` | Average encoded size of one request. |
 | `response_payload_bytes` | Total response bytes accepted for verification/reconstruction (excludes late/abandoned responses). |
-| `response_payload_mib_per_sec` | Response bytes per second, in MiB/s. |
+| `response_payload_bytes_in_window` | Response bytes accepted during the measurement window. |
+| `response_payload_mib_per_sec` | Measurement-window response bytes per second, in MiB/s. |
 | `response_payload_avg_bytes` | Average encoded size of one accepted response. |
 
 The `request_payload_messages` / `response_payload_messages` counters record how
-many payloads went into the corresponding `_bytes` totals.
+many payloads went into the corresponding `_bytes` totals;
+`response_payload_messages_in_window` is the same, counting inside the measurement-window.
 
 ## Reusing Docker image tags
 
@@ -206,10 +212,9 @@ Network diagnostics are printed directly in the GitHub Actions log. The output
 is intentionally terse: node placement, KMS core pod placement, and after-run
 `eth0` rx/tx deltas for each running KMS core pod plus a total.
 
-Each decrypt scenario also captures its own `eth0` rx/tx counters *inside* the
-Argo test pod, reported as `net_rx`/`net_tx` in Slack — the outer before/after
-diagnostics only include KMS core pods that are still running when the snapshot
-is taken.
+Each decrypt scenario also captures its own `eth0` rx/tx counters inside the
+Argo test pod. The core client samples them around the measurement window, and
+the resulting rates are reported as `net_rx`/`net_tx` in Slack.
 
 Pod-level `ethtool` can't see AWS ENA allowance counters; those need a
 privileged node-level probe.

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -487,59 +487,6 @@ spec:
           test_command="${command_name} from-args -d {{workflow.parameters.data-type}} -k ${key_id} -e ffffffffffffffff --batch-size {{workflow.parameters.batch-size}} --rate {{inputs.parameters.rate}} --duration {{inputs.parameters.duration}} --max-in-flight {{workflow.parameters.max-in-flight}}"
           mkdir -p /tmp/artifacts
 
-          capture_net_snapshot() {
-            local output="$1"
-            printf 'iface\trx_bytes\ttx_bytes\trx_packets\ttx_packets\trx_errors\ttx_errors\trx_dropped\ttx_dropped\tmtu\n' > "$output"
-            for iface_path in /sys/class/net/*; do
-              iface="${iface_path##*/}"
-              printf '%s\t' "$iface" >> "$output"
-              for stat in rx_bytes tx_bytes rx_packets tx_packets rx_errors tx_errors rx_dropped tx_dropped; do
-                tr -d '\n' < "${iface_path}/statistics/${stat}" >> "$output" 2>/dev/null || printf '0' >> "$output"
-                printf '\t' >> "$output"
-              done
-              tr -d '\n' < "${iface_path}/mtu" >> "$output" 2>/dev/null || printf '0' >> "$output"
-              printf '\n' >> "$output"
-            done
-          }
-
-          network_metrics_suffix() {
-            local sample_secs="$1"
-            awk -F '\t' -v sample_secs="$sample_secs" '
-              NR == FNR && FNR > 1 {
-                before[$1, "rx_bytes"] = $2 + 0
-                before[$1, "tx_bytes"] = $3 + 0
-                before[$1, "rx_packets"] = $4 + 0
-                before[$1, "tx_packets"] = $5 + 0
-                before[$1, "rx_errors"] = $6 + 0
-                before[$1, "tx_errors"] = $7 + 0
-                before[$1, "rx_dropped"] = $8 + 0
-                before[$1, "tx_dropped"] = $9 + 0
-                next
-              }
-              FNR > 1 && $1 == "eth0" {
-                rx_bytes = ($2 + 0) - before[$1, "rx_bytes"]
-                tx_bytes = ($3 + 0) - before[$1, "tx_bytes"]
-                rx_packets = ($4 + 0) - before[$1, "rx_packets"]
-                tx_packets = ($5 + 0) - before[$1, "tx_packets"]
-                rx_errors = ($6 + 0) - before[$1, "rx_errors"]
-                tx_errors = ($7 + 0) - before[$1, "tx_errors"]
-                rx_dropped = ($8 + 0) - before[$1, "rx_dropped"]
-                tx_dropped = ($9 + 0) - before[$1, "tx_dropped"]
-                mtu = $10 + 0
-                found = 1
-              }
-              END {
-                if (sample_secs <= 0) {
-                  sample_secs = 1
-                }
-                if (!found) {
-                  rx_bytes = tx_bytes = rx_packets = tx_packets = rx_errors = tx_errors = rx_dropped = tx_dropped = mtu = 0
-                }
-                printf ",\"network\":{\"iface\":\"eth0\",\"sample_secs\":%d,\"mtu\":%d,\"rx_bytes\":%.0f,\"tx_bytes\":%.0f,\"rx_packets\":%.0f,\"tx_packets\":%.0f,\"rx_errors\":%.0f,\"tx_errors\":%.0f,\"rx_dropped\":%.0f,\"tx_dropped\":%.0f,\"rx_mib_per_sec\":%.6f,\"tx_mib_per_sec\":%.6f,\"rx_gbps\":%.6f,\"tx_gbps\":%.6f}", sample_secs, mtu, rx_bytes, tx_bytes, rx_packets, tx_packets, rx_errors, tx_errors, rx_dropped, tx_dropped, rx_bytes / 1024 / 1024 / sample_secs, tx_bytes / 1024 / 1024 / sample_secs, rx_bytes * 8 / sample_secs / 1000000000, tx_bytes * 8 / sample_secs / 1000000000
-              }
-            ' /tmp/net-before.tsv /tmp/net-after.tsv
-          }
-
           parameter_set="maxfail={{inputs.parameters.maxfail}},maxshed={{inputs.parameters.maxshed}},pct={{inputs.parameters.pct}}"
           allowed_failure="{{inputs.parameters.allowfail}}"
 
@@ -582,7 +529,6 @@ spec:
             client_logs_arg="--logs"
           fi
           rate_timeout=$(({{inputs.parameters.duration}} + 300))
-          capture_net_snapshot /tmp/net-before.tsv
           start_time=$(date +%s)
           set +e
           if command -v timeout >/dev/null 2>&1; then
@@ -595,7 +541,6 @@ spec:
           set -e
           end_time=$(date +%s)
           duration=$((end_time - start_time))
-          capture_net_snapshot /tmp/net-after.tsv
 
           # Keep the last valid metrics line; normal logs may contain many JSON records.
           decrypt_metrics=""
@@ -628,7 +573,6 @@ spec:
             decrypt_metrics="{\"target_rate\":{{inputs.parameters.rate}},\"failed\":1,\"shed\":0,\"saturated\":true}"
             echo "ERROR: no valid $metrics_marker JSON with failed/shed/saturated found"
           fi
-          network_metrics="$(network_metrics_suffix "$duration")"
           maxfail="{{inputs.parameters.maxfail}}"
           maxshed="{{inputs.parameters.maxshed}}"
           pct="{{inputs.parameters.pct}}"
@@ -664,7 +608,7 @@ spec:
               }')
           # Escape the brace; ${var%}} does not trim the final JSON object brace in bash.
           limit_metrics=",\"parameter_set\":\"${parameter_set}\",\"within_parameter_set\":${within_parameter_set},\"allowed_failure\":${allowed_failure}"
-          decrypt_metrics="${decrypt_metrics%\}}${network_metrics}${limit_metrics}}"
+          decrypt_metrics="${decrypt_metrics%\}}${limit_metrics}}"
 
           # Task success means "measurement exists"; capacity-ok gates the next rung.
           if [ "$test_exit" -eq 0 ] && [ "$metrics_valid" = "true" ]; then

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -140,42 +140,101 @@ impl CollectedDecryptRateResult for CollectedPublicDecrypt {
 
 /// Accumulated responses and counters from a single rate-test run.
 struct DecryptRateCollection<T> {
+    /// Successful requests, including those completed during drain.
     collected: Vec<T>,
+    /// Total successful requests, including drain completions.
     completed: u64,
+    /// Successful requests completed before the measurement deadline.
+    completed_in_window: u64,
+    /// End-to-end duration of each successful request.
     durations_to_get_responses: Vec<Duration>,
+    /// Configured measurement-window duration.
+    measurement_elapsed: Duration,
+    /// Time spent waiting for in-flight requests after measurement.
+    drain_elapsed: Duration,
+    /// Total measurement and drain duration.
     collect_elapsed: Duration,
+    /// Requests scheduled by the rate generator.
     offered: u64,
+    /// Requests that completed with an error or panicked.
     failed: u64,
+    /// Requests skipped because the requests-in-flight limit was reached.
     shed: u64,
+    /// Whether requests were shed or remained after the 30s drain timeout.
     saturated: bool,
+    /// Encoded request bytes sent during measurement.
     request_payload_bytes: u64,
+    /// Encoded request messages sent during measurement.
     request_payload_messages: u64,
+    /// Encoded response bytes received, including during drain.
     response_payload_bytes: u64,
+    /// Encoded response messages received, including during drain.
     response_payload_messages: u64,
+    /// Encoded response bytes received before the measurement deadline.
+    response_payload_bytes_in_window: u64,
+    /// Encoded response messages received before the measurement deadline.
+    response_payload_messages_in_window: u64,
+    /// Host-interface traffic observed during measurement.
+    network: Option<NetworkMetrics>,
 }
 
 /// Metrics computed from a rate-test run: throughput, payloads, and latency stats.
 struct DecryptRateMetrics {
+    /// Requested rate in logical decryptions per second.
     target_rate: u64,
+    /// Configured measurement duration.
     duration_secs: u64,
+    /// Maximum number of concurrent decryptions.
     max_in_flight: usize,
+    /// Requests scheduled by the rate generator.
     offered: u64,
+    /// Total successful requests, including drain completions.
     completed: u64,
+    /// Successful requests completed during measurement.
+    completed_in_window: u64,
+    /// Successful requests completed during drain.
+    completed_during_drain: u64,
+    /// Configured measurement-window duration.
+    measurement_elapsed: Duration,
+    /// Time spent draining in-flight requests.
+    drain_elapsed: Duration,
+    /// Requests that completed with an error or panicked.
     failed: u64,
+    /// Requests skipped at the in-flight limit.
     shed: u64,
+    /// Measurement-window completions per second.
     achieved_rate: f64,
+    /// Whether requests were shed or remained after draining.
     saturated: bool,
+    /// Encoded request bytes sent during measurement.
     request_payload_bytes: u64,
+    /// Encoded request messages sent during measurement.
     request_payload_messages: u64,
+    /// Measurement-window request throughput.
     request_payload_mib_per_sec: f64,
+    /// Mean encoded request-message size.
     request_payload_avg_bytes: f64,
+    /// Encoded response bytes received, including during drain.
     response_payload_bytes: u64,
+    /// Encoded response messages received, including during drain.
     response_payload_messages: u64,
+    /// Encoded response bytes received during measurement.
+    response_payload_bytes_in_window: u64,
+    /// Encoded response messages received during measurement.
+    response_payload_messages_in_window: u64,
+    /// Measurement-window response throughput.
     response_payload_mib_per_sec: f64,
+    /// Mean encoded response-message size.
     response_payload_avg_bytes: f64,
+    /// Host-interface traffic observed during measurement.
+    network: Option<NetworkMetrics>,
+    /// Requests whose client-side post-processing failed.
     post_process_failed: u64,
+    /// End-to-end request latency statistics.
     latency_stat: crate::DurationStat,
+    /// Client-side post-processing latency statistics.
     post_process_stat: crate::DurationStat,
+    /// Wall time spent on client-side post-processing.
     post_process_wall: Duration,
 }
 
@@ -188,6 +247,10 @@ struct DecryptRateMetricsJson {
     max_in_flight: usize,
     offered: u64,
     completed: u64,
+    completed_in_window: u64,
+    completed_during_drain: u64,
+    measurement_elapsed_seconds: f64,
+    drain_elapsed_seconds: f64,
     failed: u64,
     shed: u64,
     achieved_rate: f64,
@@ -198,9 +261,110 @@ struct DecryptRateMetricsJson {
     request_payload_avg_bytes: f64,
     response_payload_bytes: u64,
     response_payload_messages: u64,
+    response_payload_bytes_in_window: u64,
+    response_payload_messages_in_window: u64,
     response_payload_mib_per_sec: f64,
     response_payload_avg_bytes: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    network: Option<NetworkMetrics>,
     latency_ms: DurationStatMsJson,
+}
+
+const RATE_NETWORK_INTERFACE: &str = "eth0";
+
+/// Traffic deltas and rates for the rate-test pod's network interface.
+#[derive(Clone, Debug, serde::Serialize)]
+struct NetworkMetrics {
+    iface: &'static str,
+    sample_secs: f64,
+    mtu: u64,
+    rx_bytes: u64,
+    tx_bytes: u64,
+    rx_packets: u64,
+    tx_packets: u64,
+    rx_errors: u64,
+    tx_errors: u64,
+    rx_dropped: u64,
+    tx_dropped: u64,
+    rx_mib_per_sec: f64,
+    tx_mib_per_sec: f64,
+    rx_gbps: f64,
+    tx_gbps: f64,
+}
+
+/// Raw interface counters captured at one point in time.
+#[derive(Clone, Copy, Debug)]
+struct NetworkSnapshot {
+    mtu: u64,
+    rx_bytes: u64,
+    tx_bytes: u64,
+    rx_packets: u64,
+    tx_packets: u64,
+    rx_errors: u64,
+    tx_errors: u64,
+    rx_dropped: u64,
+    tx_dropped: u64,
+}
+
+impl NetworkSnapshot {
+    fn read(iface: &str) -> std::io::Result<Self> {
+        let base = format!("/sys/class/net/{iface}");
+        let read = |name: &str| -> std::io::Result<u64> {
+            let value = std::fs::read_to_string(format!("{base}/{name}"))?;
+            value.trim().parse().map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("invalid {iface} {name} counter: {error}"),
+                )
+            })
+        };
+        let stat = |name: &str| read(&format!("statistics/{name}"));
+
+        Ok(Self {
+            mtu: read("mtu")?,
+            rx_bytes: stat("rx_bytes")?,
+            tx_bytes: stat("tx_bytes")?,
+            rx_packets: stat("rx_packets")?,
+            tx_packets: stat("tx_packets")?,
+            rx_errors: stat("rx_errors")?,
+            tx_errors: stat("tx_errors")?,
+            rx_dropped: stat("rx_dropped")?,
+            tx_dropped: stat("tx_dropped")?,
+        })
+    }
+
+    fn delta(self, after: Self, sample_elapsed: Duration) -> Option<NetworkMetrics> {
+        let sample_secs = sample_elapsed.as_secs_f64();
+        if sample_secs == 0.0 {
+            return None;
+        }
+        let rx_bytes = after.rx_bytes.checked_sub(self.rx_bytes)?;
+        let tx_bytes = after.tx_bytes.checked_sub(self.tx_bytes)?;
+        let rx_packets = after.rx_packets.checked_sub(self.rx_packets)?;
+        let tx_packets = after.tx_packets.checked_sub(self.tx_packets)?;
+        let rx_errors = after.rx_errors.checked_sub(self.rx_errors)?;
+        let tx_errors = after.tx_errors.checked_sub(self.tx_errors)?;
+        let rx_dropped = after.rx_dropped.checked_sub(self.rx_dropped)?;
+        let tx_dropped = after.tx_dropped.checked_sub(self.tx_dropped)?;
+
+        Some(NetworkMetrics {
+            iface: RATE_NETWORK_INTERFACE,
+            sample_secs,
+            mtu: after.mtu,
+            rx_bytes,
+            tx_bytes,
+            rx_packets,
+            tx_packets,
+            rx_errors,
+            tx_errors,
+            rx_dropped,
+            tx_dropped,
+            rx_mib_per_sec: rx_bytes as f64 / (1024.0 * 1024.0 * sample_secs),
+            tx_mib_per_sec: tx_bytes as f64 / (1024.0 * 1024.0 * sample_secs),
+            rx_gbps: rx_bytes as f64 * 8.0 / (1_000_000_000.0 * sample_secs),
+            tx_gbps: tx_bytes as f64 * 8.0 / (1_000_000_000.0 * sample_secs),
+        })
+    }
 }
 
 /// Per-phase latency percentiles in milliseconds, plus wall-clock duration.
@@ -238,6 +402,10 @@ impl From<&DecryptRateMetrics> for DecryptRateMetricsJson {
             max_in_flight: m.max_in_flight,
             offered: m.offered,
             completed: m.completed,
+            completed_in_window: m.completed_in_window,
+            completed_during_drain: m.completed_during_drain,
+            measurement_elapsed_seconds: m.measurement_elapsed.as_secs_f64(),
+            drain_elapsed_seconds: m.drain_elapsed.as_secs_f64(),
             failed: m.failed,
             shed: m.shed,
             achieved_rate: m.achieved_rate,
@@ -248,8 +416,11 @@ impl From<&DecryptRateMetrics> for DecryptRateMetricsJson {
             request_payload_avg_bytes: m.request_payload_avg_bytes,
             response_payload_bytes: m.response_payload_bytes,
             response_payload_messages: m.response_payload_messages,
+            response_payload_bytes_in_window: m.response_payload_bytes_in_window,
+            response_payload_messages_in_window: m.response_payload_messages_in_window,
             response_payload_mib_per_sec: m.response_payload_mib_per_sec,
             response_payload_avg_bytes: m.response_payload_avg_bytes,
+            network: m.network.clone(),
             latency_ms: duration_stat_ms(&m.latency_stat),
         }
     }
@@ -837,25 +1008,68 @@ fn duration_stat_ms(stat: &crate::DurationStat) -> DurationStatMsJson {
     }
 }
 
+/// Classifies completed requests against the measurement deadline.
+struct DecryptRateAccumulator<T> {
+    collected: Vec<T>,
+    durations: Vec<Duration>,
+    failed: u64,
+    completed_in_window: u64,
+    response_payload_bytes_in_window: u64,
+    response_payload_messages_in_window: u64,
+}
+
+impl<T: CollectedDecryptRateResult> DecryptRateAccumulator<T> {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            collected: Vec::with_capacity(capacity),
+            durations: Vec::with_capacity(capacity),
+            failed: 0,
+            completed_in_window: 0,
+            response_payload_bytes_in_window: 0,
+            response_payload_messages_in_window: 0,
+        }
+    }
+
+    fn record(
+        &mut self,
+        label: &'static str,
+        measurement_deadline: Instant,
+        completed_at: Instant,
+        result: anyhow::Result<T>,
+    ) {
+        match result {
+            Ok(collected_result) => {
+                if completed_at <= measurement_deadline {
+                    self.completed_in_window += 1;
+                    self.response_payload_bytes_in_window +=
+                        collected_result.response_payload_bytes();
+                    self.response_payload_messages_in_window +=
+                        collected_result.response_payload_messages();
+                }
+                self.durations.push(collected_result.collect_duration());
+                self.collected.push(collected_result);
+            }
+            Err(error) => {
+                self.failed += 1;
+                tracing::debug!("{label} request failed: {error}");
+            }
+        }
+    }
+}
+
 fn drain_finished_decrypts<T: CollectedDecryptRateResult + 'static>(
     label: &'static str,
-    join_set: &mut JoinSet<Result<T, anyhow::Error>>,
-    collected: &mut Vec<T>,
-    durations: &mut Vec<Duration>,
-    failed: &mut u64,
+    join_set: &mut JoinSet<(Instant, anyhow::Result<T>)>,
+    accumulator: &mut DecryptRateAccumulator<T>,
+    measurement_deadline: Instant,
 ) {
     while let Some(result) = join_set.try_join_next() {
         match result {
-            Ok(Ok(collected_result)) => {
-                durations.push(collected_result.collect_duration());
-                collected.push(collected_result);
-            }
-            Ok(Err(e)) => {
-                *failed += 1;
-                tracing::debug!("{label} request failed: {e}");
+            Ok((completed_at, result)) => {
+                accumulator.record(label, measurement_deadline, completed_at, result);
             }
             Err(e) => {
-                *failed += 1;
+                accumulator.failed += 1;
                 tracing::warn!("{label} task panicked: {e}");
             }
         }
@@ -882,17 +1096,16 @@ where
     Spawn: FnMut(Req) -> Fut,
     PayloadBytes: FnMut(&Req) -> u64,
 {
-    let mut join_set: JoinSet<Result<T, anyhow::Error>> = JoinSet::new();
-    let mut collected = Vec::with_capacity(total_requests);
-    let mut durations_to_get_responses = Vec::with_capacity(total_requests);
+    let mut join_set: JoinSet<(Instant, anyhow::Result<T>)> = JoinSet::new();
+    let mut accumulator = DecryptRateAccumulator::with_capacity(total_requests);
     let mut offered = 0_u64;
-    let mut failed = 0_u64;
     let mut shed = 0_u64;
     let mut saturated = false;
     let mut request_payload_bytes_total = 0_u64;
     let mut request_payload_messages = 0_u64;
 
     // PHASE 2: launch requests at the configured rate and collect completed work.
+    let network_before = NetworkSnapshot::read(RATE_NETWORK_INTERFACE).ok();
     let run_start = Instant::now();
     let deadline = run_start + Duration::from_secs(duration_secs);
     let tick_period = Duration::from_millis(5);
@@ -918,18 +1131,15 @@ where
     while Instant::now() < deadline {
         ticker.tick().await;
         let tick_now = Instant::now();
+        if tick_now >= deadline {
+            break;
+        }
         // We consider a tick that fires 2 x tick period (10ms) as being "late".
         if tick_now.duration_since(last_tick) > tick_period * 2 {
             late_ticks += 1;
         }
         last_tick = tick_now;
-        drain_finished_decrypts(
-            label,
-            &mut join_set,
-            &mut collected,
-            &mut durations_to_get_responses,
-            &mut failed,
-        );
+        drain_finished_decrypts(label, &mut join_set, &mut accumulator, deadline);
 
         // Add this tick's `rate` tokens, launch one request per whole `ticks_per_sec` accumulated, and carry the
         // fractional remainder to the next tick.
@@ -951,9 +1161,24 @@ where
             request_payload_bytes_total +=
                 request_payload_bytes(&request) * payload_targets_per_request as u64;
             request_payload_messages += payload_targets_per_request as u64;
-            join_set.spawn(spawn_request(request));
+            let request_future = spawn_request(request);
+            join_set.spawn(async move {
+                let result = request_future.await;
+                (Instant::now(), result)
+            });
         }
     }
+
+    let network_sample_elapsed = run_start.elapsed();
+    let network = network_before.and_then(|before| {
+        NetworkSnapshot::read(RATE_NETWORK_INTERFACE)
+            .ok()
+            .and_then(|after| before.delta(after, network_sample_elapsed))
+    });
+
+    // A task can finish before the deadline without being observed until the final
+    // pacing tick. Its own completion timestamp determines which window owns it.
+    drain_finished_decrypts(label, &mut join_set, &mut accumulator, deadline);
 
     if late_ticks > 0 {
         tracing::warn!(
@@ -972,16 +1197,11 @@ where
             tokio::time::timeout_at(drain_deadline, join_set.join_next()).await
         {
             match result {
-                Ok(Ok(collected_result)) => {
-                    durations_to_get_responses.push(collected_result.collect_duration());
-                    collected.push(collected_result);
-                }
-                Ok(Err(e)) => {
-                    failed += 1;
-                    tracing::debug!("{label} request failed: {e}");
+                Ok((completed_at, result)) => {
+                    accumulator.record(label, deadline, completed_at, result);
                 }
                 Err(e) => {
-                    failed += 1;
+                    accumulator.failed += 1;
                     tracing::warn!("{label} task panicked: {e}");
                 }
             }
@@ -992,35 +1212,45 @@ where
     if !join_set.is_empty() {
         saturated = true;
         let remaining = join_set.len();
-        failed += remaining as u64;
+        accumulator.failed += remaining as u64;
         tracing::warn!("{label} drain timed out with {remaining} requests still in flight");
         join_set.abort_all();
     }
 
     let collect_elapsed = run_start.elapsed();
-    let response_payload_bytes = collected
+    let measurement_elapsed = Duration::from_secs(duration_secs);
+    let drain_elapsed = collect_elapsed.saturating_sub(measurement_elapsed);
+    let response_payload_bytes = accumulator
+        .collected
         .iter()
         .map(CollectedDecryptRateResult::response_payload_bytes)
         .sum();
-    let response_payload_messages = collected
+    let response_payload_messages = accumulator
+        .collected
         .iter()
         .map(CollectedDecryptRateResult::response_payload_messages)
         .sum();
 
-    let completed = collected.len() as u64;
+    let completed = accumulator.collected.len() as u64;
     DecryptRateCollection {
-        collected,
+        collected: accumulator.collected,
         completed,
-        durations_to_get_responses,
+        completed_in_window: accumulator.completed_in_window,
+        durations_to_get_responses: accumulator.durations,
+        measurement_elapsed,
+        drain_elapsed,
         collect_elapsed,
         offered,
-        failed,
+        failed: accumulator.failed,
         shed,
         saturated,
         request_payload_bytes: request_payload_bytes_total,
         request_payload_messages,
         response_payload_bytes,
         response_payload_messages,
+        response_payload_bytes_in_window: accumulator.response_payload_bytes_in_window,
+        response_payload_messages_in_window: accumulator.response_payload_messages_in_window,
+        network,
     }
 }
 
@@ -1033,22 +1263,22 @@ fn decrypt_rate_metrics<T>(
     post_process_durations: &[Duration],
     post_process_wall: Duration,
 ) -> DecryptRateMetrics {
-    let request_payload_mib_per_sec = if collection.collect_elapsed.is_zero() {
+    let request_payload_mib_per_sec = if collection.measurement_elapsed.is_zero() {
         0.0
     } else {
         collection.request_payload_bytes as f64
-            / (1024.0 * 1024.0 * collection.collect_elapsed.as_secs_f64())
+            / (1024.0 * 1024.0 * collection.measurement_elapsed.as_secs_f64())
     };
     let request_payload_avg_bytes = if collection.request_payload_messages == 0 {
         0.0
     } else {
         collection.request_payload_bytes as f64 / collection.request_payload_messages as f64
     };
-    let response_payload_mib_per_sec = if collection.collect_elapsed.is_zero() {
+    let response_payload_mib_per_sec = if collection.measurement_elapsed.is_zero() {
         0.0
     } else {
-        collection.response_payload_bytes as f64
-            / (1024.0 * 1024.0 * collection.collect_elapsed.as_secs_f64())
+        collection.response_payload_bytes_in_window as f64
+            / (1024.0 * 1024.0 * collection.measurement_elapsed.as_secs_f64())
     };
     let response_payload_avg_bytes = if collection.response_payload_messages == 0 {
         0.0
@@ -1062,10 +1292,19 @@ fn decrypt_rate_metrics<T>(
         max_in_flight,
         offered: collection.offered,
         completed: collection.completed,
+        completed_in_window: collection.completed_in_window,
+        completed_during_drain: collection
+            .completed
+            .saturating_sub(collection.completed_in_window),
+        measurement_elapsed: collection.measurement_elapsed,
+        drain_elapsed: collection.drain_elapsed,
         failed: collection.failed,
         shed: collection.shed,
-        // TODO: consider also reporting completed / duration_secs; this includes drain time.
-        achieved_rate: collection.completed as f64 / collection.collect_elapsed.as_secs_f64(),
+        achieved_rate: if collection.measurement_elapsed.is_zero() {
+            0.0
+        } else {
+            collection.completed_in_window as f64 / collection.measurement_elapsed.as_secs_f64()
+        },
         saturated: collection.saturated,
         request_payload_bytes: collection.request_payload_bytes,
         request_payload_messages: collection.request_payload_messages,
@@ -1073,8 +1312,11 @@ fn decrypt_rate_metrics<T>(
         request_payload_avg_bytes,
         response_payload_bytes: collection.response_payload_bytes,
         response_payload_messages: collection.response_payload_messages,
+        response_payload_bytes_in_window: collection.response_payload_bytes_in_window,
+        response_payload_messages_in_window: collection.response_payload_messages_in_window,
         response_payload_mib_per_sec,
         response_payload_avg_bytes,
+        network: collection.network.clone(),
         post_process_failed,
         latency_stat: crate::compute_stat_on_durations(&collection.durations_to_get_responses),
         post_process_stat: crate::compute_stat_on_durations(post_process_durations),
@@ -1751,12 +1993,32 @@ mod tests {
         post_process_failed: u64,
     ) -> DecryptRateMetrics {
         let sample = [Duration::from_millis(10), Duration::from_millis(20)];
+        let network_before = NetworkSnapshot {
+            mtu: 9_001,
+            rx_bytes: 0,
+            tx_bytes: 0,
+            rx_packets: 0,
+            tx_packets: 0,
+            rx_errors: 0,
+            tx_errors: 0,
+            rx_dropped: 0,
+            tx_dropped: 0,
+        };
+        let network_after = NetworkSnapshot {
+            rx_bytes: 1_000_000_000,
+            tx_bytes: 2_000_000_000,
+            ..network_before
+        };
         DecryptRateMetrics {
             target_rate,
             duration_secs: 60,
             max_in_flight: 10_000,
             offered,
             completed: offered - 100,
+            completed_in_window: offered - 120,
+            completed_during_drain: 20,
+            measurement_elapsed: Duration::from_secs(60),
+            drain_elapsed: Duration::from_secs(2),
             failed: 10,
             shed: 0,
             achieved_rate: target_rate as f64 - 0.2,
@@ -1767,8 +2029,11 @@ mod tests {
             request_payload_avg_bytes: 30.75,
             response_payload_bytes: 456,
             response_payload_messages: 4,
+            response_payload_bytes_in_window: 400,
+            response_payload_messages_in_window: 3,
             response_payload_mib_per_sec: 2.5,
             response_payload_avg_bytes: 114.0,
+            network: network_before.delta(network_after, Duration::from_secs(60)),
             post_process_failed,
             latency_stat: crate::compute_stat_on_durations(&sample),
             post_process_stat: crate::compute_stat_on_durations(&sample),
@@ -1789,6 +2054,12 @@ mod tests {
         assert_eq!(v["duration"], 60);
         assert_eq!(v["max_in_flight"], 10_000);
         assert_eq!(v["offered"], 30_000);
+        assert_eq!(v["completed_in_window"], 29_880);
+        assert_eq!(v["completed_during_drain"], 20);
+        assert_eq!(v["measurement_elapsed_seconds"], 60.0);
+        assert_eq!(v["drain_elapsed_seconds"], 2.0);
+        assert_eq!(v["network"]["sample_secs"], 60.0);
+        assert!(v["network"]["tx_gbps"].is_number());
         assert!(v["achieved_rate"].is_number());
         assert!(v["latency_ms"]["p50"].is_number());
         assert!(v["latency_ms"]["p99"].is_number());
@@ -1817,6 +2088,12 @@ mod tests {
         assert_eq!(v["duration"], 60); // renamed from `duration_secs`
         assert_eq!(v["max_in_flight"], 10_000);
         assert_eq!(v["offered"], 144_000);
+        assert_eq!(v["completed_in_window"], 143_880);
+        assert_eq!(v["completed_during_drain"], 20);
+        assert_eq!(v["measurement_elapsed_seconds"], 60.0);
+        assert_eq!(v["drain_elapsed_seconds"], 2.0);
+        assert_eq!(v["network"]["sample_secs"], 60.0);
+        assert!(v["network"]["tx_gbps"].is_number());
         assert!(v["achieved_rate"].is_number());
         assert!(v["latency_ms"]["p50"].is_number());
         assert!(v["latency_ms"]["p99"].is_number());
@@ -1830,5 +2107,77 @@ mod tests {
         )
         .unwrap();
         assert_eq!(v_failed["reconstruction_failed"], 3);
+    }
+
+    #[test]
+    fn rate_metrics_exclude_drain_completions_and_time() {
+        const MIB: u64 = 1024 * 1024;
+        let durations = [Duration::from_millis(10), Duration::from_millis(20)];
+        let collection = DecryptRateCollection::<()> {
+            collected: Vec::new(),
+            completed: 100,
+            completed_in_window: 80,
+            durations_to_get_responses: durations.to_vec(),
+            measurement_elapsed: Duration::from_secs(10),
+            drain_elapsed: Duration::from_secs(5),
+            collect_elapsed: Duration::from_secs(15),
+            offered: 120,
+            failed: 0,
+            shed: 0,
+            saturated: false,
+            request_payload_bytes: 20 * MIB,
+            request_payload_messages: 120,
+            response_payload_bytes: 30 * MIB,
+            response_payload_messages: 100,
+            response_payload_bytes_in_window: 8 * MIB,
+            response_payload_messages_in_window: 80,
+            network: None,
+        };
+
+        let metrics =
+            decrypt_rate_metrics(12, 10, 1_000, &collection, 0, &durations, Duration::ZERO);
+
+        assert_eq!(metrics.completed, 100);
+        assert_eq!(metrics.completed_in_window, 80);
+        assert_eq!(metrics.completed_during_drain, 20);
+        assert_eq!(metrics.achieved_rate, 8.0);
+        assert_eq!(metrics.request_payload_mib_per_sec, 2.0);
+        assert_eq!(metrics.response_payload_mib_per_sec, 0.8);
+    }
+
+    #[test]
+    fn network_delta_uses_its_measurement_sample_duration() {
+        let before = NetworkSnapshot {
+            mtu: 9_001,
+            rx_bytes: 100,
+            tx_bytes: 200,
+            rx_packets: 10,
+            tx_packets: 20,
+            rx_errors: 1,
+            tx_errors: 2,
+            rx_dropped: 3,
+            tx_dropped: 4,
+        };
+        let after = NetworkSnapshot {
+            mtu: 9_001,
+            rx_bytes: 10_000_100,
+            tx_bytes: 20_000_200,
+            rx_packets: 110,
+            tx_packets: 220,
+            rx_errors: 2,
+            tx_errors: 4,
+            rx_dropped: 6,
+            tx_dropped: 8,
+        };
+
+        let metrics = before.delta(after, Duration::from_secs(10)).unwrap();
+
+        assert_eq!(metrics.sample_secs, 10.0);
+        assert_eq!(metrics.rx_bytes, 10_000_000);
+        assert_eq!(metrics.tx_bytes, 20_000_000);
+        assert_eq!(metrics.rx_gbps, 0.008);
+        assert_eq!(metrics.tx_gbps, 0.016);
+        assert_eq!(metrics.rx_errors, 1);
+        assert_eq!(metrics.tx_dropped, 4);
     }
 }


### PR DESCRIPTION
**perf-test stabilization: PR 1/5** 

I noticed that there was a bug in the way we computed the achieved rate (and thus how we determine pass/fail status). When doing `udec`, 9/13 responses are enough and the core-client can safely discard the outstanding 4 responses. Before this PR we included the time necessary to drain these last 4 requests in the time to complete a request, which is incorrect.

tl;dr: with this PR the `achieved_rate` is `completed_in_window`/`duration of measurement window`. Before it was `completed`/`duration of measurement window`.

I have moved the network metrics collection into the core-client itself, so we can align the collection with the start/end of the measurement window. This is also (arguably) easier to read&maintain.