### PR TITLE
perf: make core-client faster and the setup less brittle (3/5)

### DIFF
--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -525,7 +525,7 @@ jobs:
 
           echo "Fetching final workflow logs..."
           if ! timeout --signal=TERM 10m \
-            argo logs "${WORKFLOW_NAME}" -n "${NAMESPACE}" \
+            argo logs "${WORKFLOW_NAME}" -n "${NAMESPACE}" --timestamps \
               | tee argo-workflow-logs.txt; then
             echo "::warning::Could not fetch complete logs for ${WORKFLOW_NAME}"
           fi

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -503,21 +503,44 @@ jobs:
           fi
           echo "Slack report link: ${JOB_LABEL} (${JOB_URL})"
 
-          echo "Submitting Argo workflow..."
-          argo submit -n argo \
-            "${WORKFLOW_TEMPLATE}" \
-            -p tls="${TLS_STATUS}" \
-            -p client-logs="${CLIENT_LOGS_STATUS}" \
-            "${EXTRA_SUBMIT_ARGS[@]}" \
-            -p run_url="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}" \
-            -p job_url="${JOB_URL}" \
-            -p job_label="${JOB_LABEL}"
+          SUBMIT_JSON="$(
+            timeout --signal=TERM 5m argo submit -n argo \
+              "${WORKFLOW_TEMPLATE}" \
+              -p tls="${TLS_STATUS}" \
+              -p client-logs="${CLIENT_LOGS_STATUS}" \
+              "${EXTRA_SUBMIT_ARGS[@]}" \
+              -p run_url="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}" \
+              -p job_url="${JOB_URL}" \
+              -p job_label="${JOB_LABEL}" \
+              -o json
+          )"
+          WORKFLOW_NAME="$(jq -er '.metadata.name' <<< "${SUBMIT_JSON}")"
+          echo "Submitted Argo workflow: ${WORKFLOW_NAME}"
+          echo "PERF_WORKFLOW_NAME=${WORKFLOW_NAME}" >> "${GITHUB_ENV}"
 
-          echo "Streaming workflow logs..."
-          argo logs @latest -f -n "${NAMESPACE}" | tee argo-workflow-logs.txt
+          echo "Waiting up to two hours for ${WORKFLOW_NAME}..."
+          wait_exit=0
+          timeout --signal=TERM 2h \
+            argo wait "${WORKFLOW_NAME}" -n "${NAMESPACE}" || wait_exit=$?
 
-          workflow_phase=$(argo get @latest -n "${NAMESPACE}" -o json | jq -r '.status.phase')
+          echo "Fetching final workflow logs..."
+          if ! timeout --signal=TERM 10m \
+            argo logs "${WORKFLOW_NAME}" -n "${NAMESPACE}" \
+              | tee argo-workflow-logs.txt; then
+            echo "::warning::Could not fetch complete logs for ${WORKFLOW_NAME}"
+          fi
+
+          workflow_phase=$(
+            argo get "${WORKFLOW_NAME}" -n "${NAMESPACE}" \
+              --request-timeout 1m -o json | jq -r '.status.phase'
+          )
           echo "Argo workflow phase: ${workflow_phase}"
+          if [[ "${wait_exit}" -eq 124 ]]; then
+            echo "::error::Timed out waiting for ${WORKFLOW_NAME}"
+            exit 1
+          elif [[ "${wait_exit}" -ne 0 ]]; then
+            echo "::warning::argo wait exited with status ${wait_exit}"
+          fi
           if [[ "${workflow_phase}" != "Succeeded" ]]; then
             exit 1
           fi
@@ -629,6 +652,8 @@ jobs:
 
           # Clean up workflow
           echo "Cleaning up workflow..."
-          argo delete @latest -n kms-ci -n "${NAMESPACE}" || true
+          if [[ -n "${PERF_WORKFLOW_NAME:-}" ]]; then
+            argo delete "${PERF_WORKFLOW_NAME}" -n "${NAMESPACE}" || true
+          fi
 
           echo "✅ Cleanup completed successfully"

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -514,7 +514,7 @@ jobs:
           echo "Slack report link: ${JOB_LABEL} (${JOB_URL})"
 
           SUBMIT_JSON="$(
-            timeout --signal=TERM 5m argo submit -n argo \
+            timeout --signal=TERM 5m argo submit -n "${NAMESPACE}" \
               "${WORKFLOW_TEMPLATE}" \
               -p tls="${TLS_STATUS}" \
               -p client-logs="${CLIENT_LOGS_STATUS}" \

--- a/ci/perf-testing/PERF_TEST_README.md
+++ b/ci/perf-testing/PERF_TEST_README.md
@@ -88,6 +88,9 @@ Note that `FHE parameters` only affects preprocessing and keygen. The decrypt
 scenarios always run with production-size `Default` parameters, so the numbers
 they produce are real regardless of this setting.
 
+Rate-tests run on a `c6in.32xlarge` instance to get as much network bandwidth as possible. Both threshold deployment
+modes configure a 30,000-entry MetaStore decryption store for these tests.
+
 ## Reading the results
 
 The public- and user-decrypt rates, their durations, and their budgets
@@ -197,8 +200,8 @@ What the workflow does, end to end:
 6. Print a terse `before-perf` placement and network-counter snapshot.
 7. Submit the Argo workflow
    (`ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml`).
-8. Stream the Argo logs and send the Slack report.
-9. Print terse `after-perf` KMS core pod network-counter deltas in the CI logs.
+8. Collect logs and send the Slack report.
+9. Print `after-perf` KMS core pod network-counter deltas in the CI logs.
 
 ## Network diagnostics
 

--- a/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
+++ b/ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml
@@ -382,7 +382,7 @@ spec:
           app: kms-perf
       nodeSelector:
         karpenter.sh/nodepool: kms-pool
-        karpenter.k8s.aws/instance-family: m5n
+        node.kubernetes.io/instance-type: c6in.32xlarge
       script:
         image: hub.zama.org/ghcr/zama-ai/kms/core-client:<client-version>
         command: ["/bin/bash", "-c"]
@@ -1088,7 +1088,7 @@ spec:
           # Two physical lines: the '\n' renders as a line break in the Slack context element.
           config_line=$(printf '%s\n%s' \
             "payload={{workflow.parameters.batch-size}} x {{workflow.parameters.data-type}}, preproc/keygen params={{workflow.parameters.fhe-params}}, decrypt params=Default, max-in-flight={{inputs.parameters.max-in-flight}}, TLS={{inputs.parameters.tls}}" \
-            "core=c7a.16xlarge, core-client=m5n, tokioWorkerThreads=10, rayonNumThreads=40, core-img=<version>, client-img=<client-version>")
+            "core=c7a.16xlarge, rate-test client=c6in.32xlarge, setup client=m5n, core Tokio workers=10, core Rayon threads=40, rate-client Tokio workers=available CPUs, core-img=<version>, client-img=<client-version>")
           if echo "{{inputs.parameters.job_url}}" | grep -q '^http'; then
             run_line="<{{inputs.parameters.job_url}}|{{inputs.parameters.job_label}}>"
           else
@@ -1124,7 +1124,10 @@ spec:
             }'
           )
 
-          curl -s -X POST -H "Content-type: application/json" -d "$slack_message" "$slack_webhook_url"
+          curl --fail-with-body --silent --show-error \
+            --connect-timeout 10 --max-time 30 \
+            -X POST -H "Content-type: application/json" \
+            -d "$slack_message" "$slack_webhook_url"
 
           if [ $finite_failed -gt 0 ] || [ $pdec_failed -gt 0 ] || [ $udec_failed -gt 0 ]; then
             exit 1

--- a/ci/perf-testing/perf-scenarios.toml
+++ b/ci/perf-testing/perf-scenarios.toml
@@ -34,6 +34,6 @@ key = "udec-key-gen"                          # task whose request-id becomes ea
 after = ["pdec"]                              # extra deps for the first rate (run after pdec)
 rates = [
   { rate = 2400 },
-  { rate = 2700, maxfail = 1, maxshed = 1, pct = 95 },
-  { rate = 2750, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
+  { rate = 2800, maxfail = 1, maxshed = 1, pct = 95 },
+  { rate = 3200, maxfail = 10, maxshed = 25, pct = 70, allowfail = true },
 ]

--- a/ci/perf-testing/threshold/kms-ci/kms-service/values-kms-ci.yaml
+++ b/ci/perf-testing/threshold/kms-ci/kms-service/values-kms-ci.yaml
@@ -34,6 +34,7 @@ kmsCore:
     bucketSize: 50000
   thresholdMode:
     enabled: true
+    decCapacity: 30000
     initializationScript:
       enabled: true
     tls:

--- a/ci/perf-testing/thresholdWithEnclave/kms-ci/kms-service/values-kms-enclave-ci.yaml
+++ b/ci/perf-testing/thresholdWithEnclave/kms-ci/kms-service/values-kms-enclave-ci.yaml
@@ -5,6 +5,7 @@ kmsPeers:
 kmsCore:
   thresholdMode:
     enabled: true
+    decCapacity: 30000
     # peersList is generated dynamically by deploy.sh and should not be set here
     tls:
       enabled: true  # TLS is enabled by default for enclave deployments

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -533,8 +533,7 @@ async fn rate_endpoint_client_pairs(
             Vec::with_capacity(USER_DECRYPT_RATE_SUBMIT_CONNECTIONS_PER_CORE);
         submit_connections.push(submit.clone());
         for connection_index in 1..USER_DECRYPT_RATE_SUBMIT_CONNECTIONS_PER_CORE {
-            let connection = CoreEndpointClient::connect(url.clone())
-                .await
+            let connection = crate::retry!(CoreEndpointClient::connect(url.clone()).await, 5, 100)
                 .with_context(|| {
                     format!(
                         "failed to create user decrypt submit connection {} for party {} at {}",

--- a/core-client/src/decrypt.rs
+++ b/core-client/src/decrypt.rs
@@ -1,5 +1,6 @@
 use crate::{CoreConf, SLEEP_TIME_BETWEEN_REQUESTS_MS, print_phased_timings};
 use alloy_sol_types::Eip712Domain;
+use anyhow::Context as _;
 use kms_grpc::{
     ContextId, EpochId, KeyId, RequestId,
     kms::v1::{
@@ -18,7 +19,14 @@ use kms_lib::{
 };
 use prost::Message as _;
 use rand::{CryptoRng, Rng};
-use std::{collections::HashMap, future::Future, sync::Arc};
+use std::{
+    collections::HashMap,
+    future::Future,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 use tokio::{
     sync::RwLock,
     task::JoinSet,
@@ -28,6 +36,24 @@ use tonic::transport::Channel;
 
 type CoreEndpointClient = CoreServiceEndpointClient<Channel>;
 type CoreEndpointClients = Arc<[CoreEndpointClient]>;
+
+/// Tonic clients for request submission and result polling against one KMS core.
+struct CoreEndpointClientPair {
+    submit: Arc<[CoreEndpointClient]>,
+    result: CoreEndpointClient,
+}
+
+impl CoreEndpointClientPair {
+    fn submit(&self, index: usize) -> CoreEndpointClient {
+        self.submit[index % self.submit.len()].clone()
+    }
+}
+
+type CoreEndpointClientPairs = Arc<[CoreEndpointClientPair]>;
+
+// Rate tests use a global counter to rotate requests across four tonic clients per KMS core.
+const USER_DECRYPT_RATE_SUBMIT_CONNECTIONS_PER_CORE: usize = 4;
+static NEXT_USER_DECRYPT_SUBMIT_CONNECTION: AtomicUsize = AtomicUsize::new(0);
 
 /// check that the external signature on the decryption result(s) is valid, i.e. was made by one of the supplied addresses
 fn check_ext_pt_signature(
@@ -293,6 +319,68 @@ fn endpoint_clients(
     core_endpoints: &HashMap<CoreConf, CoreServiceEndpointClient<Channel>>,
 ) -> CoreEndpointClients {
     Arc::<[CoreEndpointClient]>::from(core_endpoints.values().cloned().collect::<Vec<_>>())
+}
+
+fn endpoint_client_pairs(
+    submit_endpoints: &HashMap<CoreConf, CoreEndpointClient>,
+    result_endpoints: &HashMap<CoreConf, CoreEndpointClient>,
+) -> CoreEndpointClientPairs {
+    let pairs = submit_endpoints
+        .iter()
+        .map(|(core, submit)| {
+            // Both endpoint maps are built from the same core configuration.
+            let result = result_endpoints
+                .get(core)
+                .expect("each submission endpoint must have a result endpoint");
+            CoreEndpointClientPair {
+                submit: Arc::from([submit.clone()]),
+                result: result.clone(),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Arc::from(pairs)
+}
+
+/// Builds four independent tonic clients per KMS core for UDEC rate-test submissions.
+async fn rate_endpoint_client_pairs(
+    submit_endpoints: &HashMap<CoreConf, CoreEndpointClient>,
+    result_endpoints: &HashMap<CoreConf, CoreEndpointClient>,
+) -> anyhow::Result<CoreEndpointClientPairs> {
+    let mut pairs = Vec::with_capacity(submit_endpoints.len());
+    for (core, submit) in submit_endpoints {
+        // Both endpoint maps are built from the same core configuration.
+        let result = result_endpoints
+            .get(core)
+            .expect("each submission endpoint must have a result endpoint");
+        let url = if core.address.starts_with("http://") {
+            core.address.clone()
+        } else {
+            format!("http://{}", core.address)
+        };
+        let mut submit_connections =
+            Vec::with_capacity(USER_DECRYPT_RATE_SUBMIT_CONNECTIONS_PER_CORE);
+        submit_connections.push(submit.clone());
+        for connection_index in 1..USER_DECRYPT_RATE_SUBMIT_CONNECTIONS_PER_CORE {
+            let connection = CoreEndpointClient::connect(url.clone())
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to create user decrypt submit connection {} for party {} at {}",
+                        connection_index + 1,
+                        core.party_id,
+                        core.address
+                    )
+                })?;
+            submit_connections.push(connection);
+        }
+        pairs.push(CoreEndpointClientPair {
+            submit: Arc::from(submit_connections),
+            result: result.clone(),
+        });
+    }
+
+    Ok(Arc::from(pairs))
 }
 
 /// Collect responses from a set of already-spawned per-party fetch tasks, stopping as soon as
@@ -1085,13 +1173,14 @@ fn decrypt_rate_metrics<T>(
 /// Fan out the request to the sync endpoint, which returns the decryption result directly.
 fn spawn_user_decrypt_sync(
     user_decrypt_req: &UserDecryptionRequest,
-    core_endpoints: &CoreEndpointClients,
+    core_endpoints: &CoreEndpointClientPairs,
     max_iter: usize,
 ) -> JoinSet<anyhow::Result<UserDecryptionResponse>> {
     let mut resp_tasks = JoinSet::new();
+    let submit_index = NEXT_USER_DECRYPT_SUBMIT_CONNECTION.fetch_add(1, Ordering::Relaxed);
     for ce in core_endpoints.iter() {
         let req_cloned = user_decrypt_req.clone();
-        let mut cur_client = ce.clone();
+        let mut cur_client = ce.submit(submit_index);
         resp_tasks.spawn(async move {
             let mut response = cur_client
                 .user_decrypt_sync(tonic::Request::new(req_cloned.clone()))
@@ -1124,48 +1213,10 @@ fn spawn_user_decrypt_sync(
     resp_tasks
 }
 
-/// Fan out the request to the async endpoint and check that enough cores accepted it.
-async fn send_user_decrypt_requests(
+/// Submits to each KMS core and starts polling that core when its submission completes.
+fn spawn_user_decrypt(
     user_decrypt_req: &UserDecryptionRequest,
-    core_endpoints: &CoreEndpointClients,
-    num_parties: usize,
-    num_expected_responses: usize,
-) -> anyhow::Result<()> {
-    let mut req_tasks = JoinSet::new();
-    for ce in core_endpoints.iter() {
-        let req_cloned = user_decrypt_req.clone();
-        let mut cur_client = ce.clone();
-        req_tasks.spawn(async move {
-            cur_client
-                .user_decrypt(tonic::Request::new(req_cloned))
-                .await
-        });
-    }
-
-    let mut succeeded = 0_usize;
-    while let Some(inner) = req_tasks.join_next().await {
-        match inner {
-            Ok(Ok(_resp)) => succeeded += 1,
-            Ok(Err(e)) => {
-                tracing::debug!("User decrypt request to a core failed: {e}");
-            }
-            Err(e) => {
-                tracing::debug!("User decrypt request task panicked: {e}");
-            }
-        }
-    }
-    if succeeded < num_expected_responses {
-        anyhow::bail!(
-            "Only {succeeded}/{num_parties} user decrypt requests succeeded, need at least {num_expected_responses}"
-        );
-    }
-    Ok(())
-}
-
-/// Poll the async endpoint until every core has a decryption result available.
-fn spawn_get_user_decrypt_result(
-    user_decrypt_req: &UserDecryptionRequest,
-    core_endpoints: &CoreEndpointClients,
+    core_endpoints: &CoreEndpointClientPairs,
     max_iter: usize,
 ) -> anyhow::Result<JoinSet<anyhow::Result<UserDecryptionResponse>>> {
     let req_id = user_decrypt_req
@@ -1174,12 +1225,20 @@ fn spawn_get_user_decrypt_result(
         .ok_or_else(|| anyhow::anyhow!("request_id not set in user decrypt request"))?;
 
     let mut resp_tasks = JoinSet::new();
+    let submit_index = NEXT_USER_DECRYPT_SUBMIT_CONNECTION.fetch_add(1, Ordering::Relaxed);
     for ce in core_endpoints.iter() {
-        let mut cur_client = ce.clone();
+        let req_cloned = user_decrypt_req.clone();
+        let mut submit_client = ce.submit(submit_index);
+        let mut result_client = ce.result.clone();
         let req_id_clone = req_id.clone();
 
         resp_tasks.spawn(async move {
-            let mut response = cur_client
+            submit_client
+                .user_decrypt(tonic::Request::new(req_cloned))
+                .await
+                .map_err(|e| anyhow::anyhow!("user decryption request failed: {e}"))?;
+
+            let mut response = result_client
                 .get_user_decryption_result(tonic::Request::new(req_id_clone.clone()))
                 .await;
             let mut ctr = 0_usize;
@@ -1193,7 +1252,7 @@ fn spawn_get_user_decrypt_result(
                     );
                 }
                 ctr += 1;
-                response = cur_client
+                response = result_client
                     .get_user_decryption_result(tonic::Request::new(req_id_clone.clone()))
                     .await;
             }
@@ -1212,8 +1271,7 @@ async fn send_and_collect_user_decrypt(
     user_decrypt_req: UserDecryptionRequest,
     enc_pk: UnifiedPublicEncKey,
     enc_sk: UnifiedPrivateEncKey,
-    core_endpoints_req: CoreEndpointClients,
-    core_endpoints_resp: CoreEndpointClients,
+    core_endpoints: CoreEndpointClientPairs,
     num_parties: usize,
     max_iter: usize,
     num_expected_responses: usize,
@@ -1222,18 +1280,10 @@ async fn send_and_collect_user_decrypt(
     let request_start = Instant::now();
 
     let (label, resp_tasks) = if use_sync_endpoint {
-        let tasks = spawn_user_decrypt_sync(&user_decrypt_req, &core_endpoints_req, max_iter);
+        let tasks = spawn_user_decrypt_sync(&user_decrypt_req, &core_endpoints, max_iter);
         ("sync user decrypt", tasks)
     } else {
-        send_user_decrypt_requests(
-            &user_decrypt_req,
-            &core_endpoints_req,
-            num_parties,
-            num_expected_responses,
-        )
-        .await?;
-        let tasks =
-            spawn_get_user_decrypt_result(&user_decrypt_req, &core_endpoints_resp, max_iter)?;
+        let tasks = spawn_user_decrypt(&user_decrypt_req, &core_endpoints, max_iter)?;
         ("user decrypt", tasks)
     };
 
@@ -1331,8 +1381,7 @@ pub(crate) async fn do_user_decrypt_once<R: Rng + CryptoRng>(
 ) -> anyhow::Result<Vec<(Option<RequestId>, String)>> {
     let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
     let expected = TestingPlaintext::try_from(ptxt)?;
-    let core_endpoints_req = endpoint_clients(core_endpoints_req);
-    let core_endpoints_resp = endpoint_clients(core_endpoints_resp);
+    let core_endpoints = endpoint_client_pairs(core_endpoints_req, core_endpoints_resp);
 
     let req_id = RequestId::new_random(rng);
     let (user_decrypt_req, enc_pk, enc_sk) =
@@ -1352,8 +1401,7 @@ pub(crate) async fn do_user_decrypt_once<R: Rng + CryptoRng>(
         user_decrypt_req,
         enc_pk,
         enc_sk,
-        core_endpoints_req,
-        core_endpoints_resp,
+        core_endpoints,
         num_parties,
         max_iter,
         num_expected_responses,
@@ -1402,8 +1450,8 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
     let total_requests = (rate * duration_secs) as usize;
     let extra_data = crate::extra_data_from_context_epoch(context_id, epoch_id)?;
     let expected = TestingPlaintext::try_from(ptxt)?;
-    let core_endpoints_req = endpoint_clients(core_endpoints_req);
-    let core_endpoints_resp = endpoint_clients(core_endpoints_resp);
+    let core_endpoints =
+        rate_endpoint_client_pairs(core_endpoints_req, core_endpoints_resp).await?;
 
     // PHASE 1: build the request batch before the timed launch window.
     tracing::info!(
@@ -1433,19 +1481,17 @@ pub(crate) async fn do_user_decrypt<R: Rng + CryptoRng>(
         drain_timeout_secs,
         total_requests,
         requests.into_iter(),
-        core_endpoints_req.len(),
+        core_endpoints.len(),
         |(_req_id, user_decrypt_req, _enc_pk, _enc_sk)| user_decrypt_req.encoded_len() as u64,
         |(req_id, user_decrypt_req, enc_pk, enc_sk)| {
-            let core_endpoints_req = Arc::clone(&core_endpoints_req);
-            let core_endpoints_resp = Arc::clone(&core_endpoints_resp);
+            let core_endpoints = Arc::clone(&core_endpoints);
             send_and_collect_user_decrypt(
                 rate,
                 req_id,
                 user_decrypt_req,
                 enc_pk,
                 enc_sk,
-                core_endpoints_req,
-                core_endpoints_resp,
+                core_endpoints,
                 num_parties,
                 max_iter,
                 num_expected_responses,

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -91,6 +91,7 @@ macro_rules! retry {
         retry!($f, 5, 100)
     };
 }
+pub(crate) use retry;
 
 #[derive(Serialize, Clone, Validate, Debug)]
 #[validate(schema(function = validate_core_client_conf))]


### PR DESCRIPTION
PR 3/5 - perf-test stabilization

This is the PR that is the closest thing to a fix for the perf issues.

Two changes are straight forward and easy:

1. Use the beefiest possible instance from a networking pov: c6in.32xlarge
2. Give the MetaStore more space for completed items, 30k instead of 10k.

The third change is a bit more complex. Before this PR, to submit one udec request, the core-client would first submit one GRPC request to each of the 13 cores, then start 13 response polling requests. If a few of the nodes find themselves in trouble and are slow to accept the submission, the result would be that we would not start polling for replies before the slowest core accepted the submission.
After this PR, we submit requests and start polling for response in pairs, and do it asap. This is a significant improvement in resilience and overall performance.

With all of the above we can run higher rungs and doing so for 60s is not a problem.
