### PR TITLE
chore: improve KMS perf-test diagnostics (4/5)

### DIFF
--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -447,10 +447,17 @@ jobs:
           # core CPU% against the rate rungs by timestamp (pairs with the eth0
           # diagnostics to distinguish CPU-bound vs network-bound at the top rungs).
           # Backgrounded here so it lives for this step's shell; killed on exit
-          # (incl. the exit-1 path). Failures are non-fatal — it must never break the run.
+          # (including the exit-1 path).
           bash ci/scripts/sample_core_cpu.sh "${NAMESPACE}" > core-cpu-samples.log 2>&1 &
           CPU_SAMPLER_PID=$!
-          trap 'kill "${CPU_SAMPLER_PID}" 2>/dev/null || true' EXIT
+          bash ci/scripts/sample_perf_diagnostics.sh "${NAMESPACE}" perf-diagnostics \
+            > perf-diagnostics-controller.log 2>&1 &
+          DIAGNOSTICS_PID=$!
+          stop_samplers() {
+            kill "${CPU_SAMPLER_PID}" "${DIAGNOSTICS_PID}" 2>/dev/null || true
+            wait "${CPU_SAMPLER_PID}" "${DIAGNOSTICS_PID}" 2>/dev/null || true
+          }
+          trap stop_samplers EXIT
 
           # Convert TLS boolean to enabled/disabled string
           if [[ "${TLS}" == "true" ]]; then
@@ -541,6 +548,16 @@ jobs:
         run: |
           bash ci/scripts/collect_network_diagnostics.sh after-perf "${NAMESPACE}"
 
+      - name: Report perf diagnostics
+        if: always()
+        run: |
+          echo "Placement snapshot:"
+          cat perf-diagnostics/pod-placement.tsv 2>/dev/null || echo "warning: placement snapshot unavailable"
+          echo "Application-metrics sampler status:"
+          grep -E 'sampler_(start|discovery|error)|scrape_(error|partial)' perf-diagnostics/core-metrics.log 2>/dev/null | tail -n 100 || true
+          echo "ENA probe status:"
+          cat perf-diagnostics/ena-start.log 2>/dev/null || echo "warning: ENA probe status unavailable"
+
       # ======================================================================
       # SAVE ARGO WORKFLOW LOGS
       # ======================================================================
@@ -559,6 +576,17 @@ jobs:
           name: core-cpu-samples.log
           path: core-cpu-samples.log
           retention-days: 30
+
+      - name: Upload perf diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: perf-diagnostics
+          path: |
+            perf-diagnostics/
+            perf-diagnostics-controller.log
+          retention-days: 30
+          if-no-files-found: warn
 
       # ======================================================================
       # LOG COLLECTION
@@ -621,6 +649,9 @@ jobs:
           # Clean up StatefulSets
           echo "Cleaning up StatefulSets..."
           kubectl delete sts -l app=kms-core-client -n "${NAMESPACE}" || true
+
+          # Clean up diagnostic probes
+          kubectl delete -f ci/perf-testing/ena-probe.yml --ignore-not-found || true
 
           # Clean up Jobs
           echo "Cleaning up Jobs..."

--- a/ci/perf-testing/PERF_TEST_README.md
+++ b/ci/perf-testing/PERF_TEST_README.md
@@ -207,8 +207,8 @@ Network diagnostics are printed directly in the GitHub Actions log. The output
 is intentionally terse: KMS core pod placement and after-run `eth0` rx/tx
 deltas for each running KMS core pod plus a total. The `perf-diagnostics`
 artifact contains the full time series from the KMS metrics endpoints and ENA
-interfaces, plus a placement snapshot containing the KMS cores and the first
-rate-test client pod.
+interfaces, ENA probe pod states and events, plus a placement snapshot
+containing the KMS cores and the first rate-test client pod.
 
 Each decrypt scenario also captures its own `eth0` rx/tx counters *inside* the
 Argo test pod, reported as `net_rx`/`net_tx` in Slack — the outer before/after

--- a/ci/perf-testing/PERF_TEST_README.md
+++ b/ci/perf-testing/PERF_TEST_README.md
@@ -194,25 +194,31 @@ What the workflow does, end to end:
 3. Validate the deployment type and the TLS combination.
 4. Verify the required image tags exist in the registry.
 5. Deploy KMS to the `kms-ci` namespace via `ci/scripts/deploy.sh`.
-6. Print a terse `before-perf` placement and network-counter snapshot.
+6. Print a terse `before-perf` network snapshot and start the diagnostics.
 7. Submit the Argo workflow
    (`ci/perf-testing/argo-workflow/kms-perf-workflow-kms-ci.yaml`).
 8. Stream the Argo logs and send the Slack report.
 9. Print terse `after-perf` KMS core pod network-counter deltas in the CI logs.
+10. Upload CPU, KMS metric, ENA counter, and pod placement samples.
 
 ## Network diagnostics
 
 Network diagnostics are printed directly in the GitHub Actions log. The output
-is intentionally terse: node placement, KMS core pod placement, and after-run
-`eth0` rx/tx deltas for each running KMS core pod plus a total.
+is intentionally terse: KMS core pod placement and after-run `eth0` rx/tx
+deltas for each running KMS core pod plus a total. The `perf-diagnostics`
+artifact contains the full time series from the KMS metrics endpoints and ENA
+interfaces, plus a placement snapshot containing the KMS cores and the first
+rate-test client pod.
 
 Each decrypt scenario also captures its own `eth0` rx/tx counters *inside* the
 Argo test pod, reported as `net_rx`/`net_tx` in Slack — the outer before/after
 diagnostics only include KMS core pods that are still running when the snapshot
 is taken.
 
-Pod-level `ethtool` can't see AWS ENA allowance counters; those need a
-privileged node-level probe.
+ENA (Elastic Network Adapter) is AWS's EC2 network interface and driver. It
+exposes hardware-level throttling and allowance counters that ordinary pod
+network interfaces do not. The workflow runs a host-networked DaemonSet on the
+KMS and benchmark node pools to collect them.
 
 ## Reference: workflow form fields
 

--- a/ci/perf-testing/ena-probe.yml
+++ b/ci/perf-testing/ena-probe.yml
@@ -1,0 +1,130 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ena-probe-placement
+  namespace: kms-ci
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app: ena-probe
+  ports:
+    - name: placement
+      port: 1
+      targetPort: 1
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ena-probe
+  namespace: kms-ci
+spec:
+  selector:
+    matchLabels:
+      app: ena-probe
+  template:
+    metadata:
+      labels:
+        app: ena-probe
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 1
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: karpenter.sh/nodepool
+                    operator: In
+                    values: [kms-pool]
+              - matchExpressions:
+                  - key: aws-nitro-enclaves-k8s-dp
+                    operator: In
+                    values: [enabled]
+              - matchExpressions:
+                  - key: karpenter.sh/nodepool
+                    operator: In
+                    values: [kms-bench-spot-64]
+      tolerations:
+        - key: karpenter.sh/nodepool
+          operator: Equal
+          value: kms-pool
+          effect: NoSchedule
+        - key: karpenter.sh/nodepool
+          operator: Equal
+          value: kms-bench-spot-64
+          effect: NoSchedule
+        - key: app
+          operator: Equal
+          value: kms-enclave-ci
+          effect: NoSchedule
+        - key: aws.ec2.nitro/nitro_enclaves
+          operator: Exists
+          effect: NoSchedule
+        - key: aws.ec2.nitro/nitro_enclaves_cpus
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: collector
+          image: public.ecr.aws/docker/library/alpine:3.23
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              apk add --no-cache ethtool
+
+              counter() {
+                ethtool -S "$1" 2>/dev/null |
+                  awk -v key="$2:" '$1 == key { print $2; found = 1 } END { if (!found) print 0 }'
+              }
+
+              while true; do
+                timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                found_ena=false
+                for path in /sys/class/net/*; do
+                  iface="${path##*/}"
+                  if ethtool -i "$iface" 2>/dev/null |
+                       awk '$1 == "driver:" && $2 == "ena" { found = 1 } END { exit !found }'; then
+                    found_ena=true
+                    printf '%s node=%s iface=%s rx_bytes=%s tx_bytes=%s bw_in=%s bw_out=%s pps=%s conntrack=%s linklocal=%s\n' \
+                      "$timestamp" "$NODE_NAME" "$iface" \
+                      "$(cat "/sys/class/net/$iface/statistics/rx_bytes")" \
+                      "$(cat "/sys/class/net/$iface/statistics/tx_bytes")" \
+                      "$(counter "$iface" bw_in_allowance_exceeded)" \
+                      "$(counter "$iface" bw_out_allowance_exceeded)" \
+                      "$(counter "$iface" pps_allowance_exceeded)" \
+                      "$(counter "$iface" conntrack_allowance_exceeded)" \
+                      "$(counter "$iface" linklocal_allowance_exceeded)"
+                  fi
+                done
+                if [ "$found_ena" = true ]; then
+                  touch /tmp/ena-probe-ready
+                else
+                  echo "$timestamp node=$NODE_NAME no-ena-interface-found"
+                fi
+                sleep 5
+              done
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "test -f /tmp/ena-probe-ready"]
+            periodSeconds: 2
+            timeoutSeconds: 1
+            failureThreshold: 150
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 2Gi

--- a/ci/scripts/README.md
+++ b/ci/scripts/README.md
@@ -18,6 +18,9 @@ ci/scripts/
 ├── manage_lifecycle.sh            # Lifecycle management
 ├── rolling_upgrade.sh             # Partially upgrade enclave KMS parties
 ├── sample_core_cpu.sh             # Sample KMS core CPU and memory during benchmarks
+├── sample_core_metrics.sh         # Scrape KMS Prometheus metrics throughout a benchmark
+├── sample_perf_diagnostics.sh     # Orchestrate metrics, ENA, and placement collection
+├── sample_pod_placement.sh        # Record core/client node and AZ placement
 └── lib/                           # Modular libraries
     ├── common.sh                  # Logging, parsing, utilities (277 lines)
     ├── context.sh                 # Kubernetes context setup (87 lines)
@@ -100,6 +103,7 @@ The build process will:
 | **Log collection** | `lib/utils.sh` |
 | **Rolling KMS upgrades** ([docs](#rolling-upgrade-testing)) | `rolling_upgrade.sh` |
 | **Core CPU/memory benchmark samples** | `sample_core_cpu.sh` |
+| **Perf application, ENA, and placement diagnostics** | `sample_perf_diagnostics.sh` |
 
 ### Module Details
 

--- a/ci/scripts/sample_core_metrics.sh
+++ b/ci/scripts/sample_core_metrics.sh
@@ -36,9 +36,9 @@ extract_metrics() {
     /^kms_network_debug_events_total([[:space:]]|\{|$)/ ||
     /^kms_(active_sessions|inactive_sessions|completed_sessions|rate_limiter_usage|fhe_key_cache_size|meta_storage_user_decryptions|meta_storage_pub_decryptions|meta_storage_user_decryptions_in_store|meta_storage_pub_decryptions_in_store|network_rx_bytes_total|network_tx_bytes_total|tasks|cpu_load|process_cpu_usage|process_memory_usage|total_cpus|tokio_alive_tasks|tokio_global_queue_depth|user_decrypt_background_tasks|user_decrypt_stage_duration_microseconds_total|user_decrypt_stage_observations_total|network_sender_tasks|network_sender_tasks_spawned_total|network_sender_tasks_completed_total)([[:space:]]|\{|$)/ ||
     /^process_(cpu_seconds_total|threads)([[:space:]]|\{|$)/ ||
-    (/^kms_operation_duration_ms_(bucket|sum|count)\{/ && /operation_type="user_decrypt_/) ||
-    (/^kms_operations_total\{/ && /operation="user_decrypt_(request|result)"/) ||
-    (/^kms_operation_errors_total\{/ && /operation="user_decrypt_(request|result)"/) {
+    (/^kms_operation_duration_ms_(bucket|sum|count)\{/ && /operation_type="(user|public)_decrypt_/) ||
+    (/^kms_operations_total\{/ && /operation="(user|public)_decrypt_(request|result)"/) ||
+    (/^kms_operation_errors_total\{/ && /operation="(user|public)_decrypt_(request|result)"/) {
       print ts, pod, $1, $2
     }
   '

--- a/ci/scripts/sample_core_metrics.sh
+++ b/ci/scripts/sample_core_metrics.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Scrape selected Prometheus metrics from every KMS core at a fixed interval.
+# sample_perf_diagnostics.sh starts this during the performance-testing workflow.
+# Output is written to stdout as timestamped sampler status and one metric per line; the
+# diagnostics controller stores it in core-metrics.log.
+set -uo pipefail
+
+namespace="${1:-kms-ci}"
+interval="${2:-5}"
+metrics_port="${3:-9646}"
+scrape_timeout="${SCRAPE_TIMEOUT:-4}"
+tmp_root="$(mktemp -d)"
+expected_diagnostics=(
+  kms_completed_sessions
+  kms_network_debug_events_total
+  kms_network_sender_tasks
+  kms_tokio_alive_tasks
+  kms_tokio_global_queue_depth
+  kms_user_decrypt_background_tasks
+  kms_user_decrypt_stage_duration_microseconds_total
+  kms_user_decrypt_stage_observations_total
+)
+
+cleanup() {
+  trap - EXIT INT TERM
+  jobs -pr | xargs -r kill 2>/dev/null || true
+  wait 2>/dev/null || true
+  rm -rf "${tmp_root}"
+}
+trap cleanup EXIT
+trap 'exit 0' INT TERM
+
+extract_metrics() {
+  local timestamp="$1" pod="$2"
+  awk -v ts="${timestamp}" -v pod="${pod}" '
+    /^kms_network_debug_events_total([[:space:]]|\{|$)/ ||
+    /^kms_(active_sessions|inactive_sessions|completed_sessions|rate_limiter_usage|fhe_key_cache_size|meta_storage_user_decryptions|meta_storage_pub_decryptions|meta_storage_user_decryptions_in_store|meta_storage_pub_decryptions_in_store|network_rx_bytes_total|network_tx_bytes_total|tasks|cpu_load|process_cpu_usage|process_memory_usage|total_cpus|tokio_alive_tasks|tokio_global_queue_depth|user_decrypt_background_tasks|user_decrypt_stage_duration_microseconds_total|user_decrypt_stage_observations_total|network_sender_tasks|network_sender_tasks_spawned_total|network_sender_tasks_completed_total)([[:space:]]|\{|$)/ ||
+    /^process_(cpu_seconds_total|threads)([[:space:]]|\{|$)/ ||
+    (/^kms_operation_duration_ms_(bucket|sum|count)\{/ && /operation_type="user_decrypt_/) ||
+    (/^kms_operations_total\{/ && /operation="user_decrypt_(request|result)"/) ||
+    (/^kms_operation_errors_total\{/ && /operation="user_decrypt_(request|result)"/) {
+      print ts, pod, $1, $2
+    }
+  '
+}
+
+scrape_pod() {
+  local timestamp="$1" pod="$2" pod_ip="$3" output="$4"
+  local metrics="" method="" error_file="${output}.error"
+  if [[ -n "${pod_ip}" ]]; then
+    metrics="$(curl --fail --silent --show-error --connect-timeout "${scrape_timeout}" \
+      --max-time "${scrape_timeout}" "http://${pod_ip}:${metrics_port}/metrics" \
+      2> "${error_file}")" || metrics=""
+    [[ -z "${metrics}" ]] || method="pod-ip"
+  fi
+  if [[ -z "${metrics}" ]]; then
+    metrics="$(kubectl get --request-timeout="${scrape_timeout}s" --raw \
+      "/api/v1/namespaces/${namespace}/pods/${pod}:${metrics_port}/proxy/metrics" \
+      2> "${error_file}")" || metrics=""
+    [[ -z "${metrics}" ]] || method="pod-proxy"
+  fi
+  if [[ -z "${metrics}" ]]; then
+    printf '%s %s scrape_error error="%s"\n' "${timestamp}" "${pod}" \
+      "$(tr '\n' ' ' < "${error_file}")" > "${output}"
+    return
+  fi
+  local selected found_names expected missing=""
+  selected="$(extract_metrics "${timestamp}" "${pod}" <<< "${metrics}")"
+  found_names="$(awk '{ name=$3; sub(/\{.*/, "", name); print name }' <<< "${selected}" | sort -u)"
+  for expected in "${expected_diagnostics[@]}"; do
+    if ! grep -Fxq "${expected}" <<< "${found_names}"; then
+      missing="${missing}${missing:+,}${expected}"
+    fi
+  done
+  {
+    printf '%s %s scrape_ok method=%s\n' "${timestamp}" "${pod}" "${method}"
+    if [[ -n "${missing}" ]]; then
+      printf '%s %s scrape_partial missing=%s\n' "${timestamp}" "${pod}" "${missing}"
+    fi
+    printf '%s\n' "${selected}"
+  } > "${output}"
+}
+
+scrape_once() {
+  local timestamp pod_output round_dir i
+  timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  pod_output="$(kubectl get --request-timeout=10s pods -n "${namespace}" -l app=kms-core \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.podIP}{"\n"}{end}' 2>&1)" || {
+      printf '%s sampler_error pod_discovery="%s"\n' "${timestamp}" "${pod_output}"
+      return
+    }
+  local -a pods=() ips=() pids=() outputs=()
+  while IFS=$'\t' read -r pod pod_ip; do
+    [[ -z "${pod}" ]] || { pods+=("${pod}"); ips+=("${pod_ip}"); }
+  done <<< "${pod_output}"
+  printf '%s sampler_discovery namespace=%s pods=%d expected=13\n' \
+    "${timestamp}" "${namespace}" "${#pods[@]}"
+  round_dir="$(mktemp -d "${tmp_root}/round.XXXXXX")"
+  for i in "${!pods[@]}"; do
+    outputs[i]="${round_dir}/${i}.log"
+    scrape_pod "${timestamp}" "${pods[i]}" "${ips[i]}" "${outputs[i]}" &
+    pids[i]="$!"
+  done
+  for i in "${!pids[@]}"; do
+    wait "${pids[i]}" || true
+    cat "${outputs[i]}"
+  done
+  rm -rf "${round_dir}"
+}
+
+printf '%s sampler_start namespace=%s interval=%ss port=%s\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${namespace}" "${interval}" "${metrics_port}"
+while true; do
+  scrape_once
+  sleep "${interval}"
+done

--- a/ci/scripts/sample_perf_diagnostics.sh
+++ b/ci/scripts/sample_perf_diagnostics.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Coordinate application-metric, ENA-interface, and pod-placement collection.
 # The performance-testing workflow runs this alongside the Argo performance test.
-# Output is a directory containing core-metrics.log, pod-placement.tsv, ena-start.log, and
-# ena-samples.log.
+# Output is a directory containing core-metrics.log, pod-placement.tsv, and ENA probe samples
+# and lifecycle diagnostics.
 set -uo pipefail
 
 namespace="${1:-kms-ci}"
@@ -19,13 +19,63 @@ finish() {
   kubectl logs --request-timeout=30s -n "${namespace}" -l app=ena-probe \
     --prefix --all-containers \
     > "${output_dir}/ena-samples.log" 2>&1 || true
+  kubectl logs --request-timeout=30s -n "${namespace}" -l app=ena-probe \
+    --prefix --all-containers --previous \
+    > "${output_dir}/ena-previous.log" 2>&1 || true
+  {
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) final ENA probe descriptions"
+    kubectl describe --request-timeout=30s -n "${namespace}" daemonset/ena-probe
+    kubectl describe --request-timeout=30s -n "${namespace}" pods -l app=ena-probe
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) final ENA probe events"
+    kubectl events --request-timeout=30s -n "${namespace}" \
+      --for daemonset/ena-probe --types=Warning,Normal
+    kubectl get events --request-timeout=30s -n "${namespace}" \
+      --field-selector involvedObject.kind=Pod -o json |
+      jq -r '.items[] | select(.involvedObject.name | startswith("ena-probe-")) |
+        [.eventTime // .lastTimestamp // .metadata.creationTimestamp,
+         .involvedObject.name, .type, .reason, .message] | @tsv'
+  } >> "${output_dir}/ena-lifecycle.log" 2>&1 || true
 }
 trap finish EXIT
 trap 'exit 0' INT TERM
 
-kubectl apply --request-timeout=30s -f ci/perf-testing/ena-probe.yml \
-  > "${output_dir}/ena-start.log" 2>&1 ||
-  echo "warning: ENA probe could not be started; continuing" >> "${output_dir}/ena-start.log"
+{
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) applying ENA probe"
+  if kubectl apply --request-timeout=30s -f ci/perf-testing/ena-probe.yml; then
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ENA probe applied"
+  else
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) warning: ENA probe could not be started; continuing"
+  fi
+} > "${output_dir}/ena-start.log" 2>&1
+
+sample_ena_lifecycle() {
+  while true; do
+    timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    kubectl get --request-timeout=30s -n "${namespace}" daemonset/ena-probe -o json |
+      jq -r --arg timestamp "${timestamp}" '
+        [$timestamp, "daemonset", .metadata.creationTimestamp,
+         (.status.desiredNumberScheduled // 0), (.status.currentNumberScheduled // 0),
+         (.status.numberReady // 0), (.status.numberUnavailable // 0)] | @tsv' || true
+    kubectl get --request-timeout=30s -n "${namespace}" pods -l app=ena-probe -o json |
+      jq -r --arg timestamp "${timestamp}" '
+        .items[] |
+        .status.containerStatuses[0] as $container |
+        [$timestamp, "pod", .metadata.name, .metadata.creationTimestamp,
+         .status.startTime, .spec.nodeName, .status.phase,
+         ($container.ready // false), ($container.restartCount // 0),
+         ($container.state.running.startedAt // ""),
+         ($container.state.waiting.reason // ""),
+         ($container.state.terminated.reason // "")] | @tsv' || true
+    sleep 10
+  done
+}
+
+{
+  echo "# daemonset: timestamp kind created desired current ready unavailable"
+  echo "# pod: timestamp kind pod created started node phase ready restarts container_started waiting_reason terminated_reason"
+  sample_ena_lifecycle
+} > "${output_dir}/ena-lifecycle.log" 2>&1 &
+child_pids+=("$!")
 
 bash ci/scripts/sample_core_metrics.sh "${namespace}" \
   > "${output_dir}/core-metrics.log" 2>&1 &

--- a/ci/scripts/sample_perf_diagnostics.sh
+++ b/ci/scripts/sample_perf_diagnostics.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Coordinate application-metric, ENA-interface, and pod-placement collection.
+# The performance-testing workflow runs this alongside the Argo performance test.
+# Output is a directory containing core-metrics.log, pod-placement.tsv, ena-start.log, and
+# ena-samples.log.
+set -uo pipefail
+
+namespace="${1:-kms-ci}"
+output_dir="${2:-perf-diagnostics}"
+mkdir -p "${output_dir}"
+
+child_pids=()
+finish() {
+  trap - EXIT INT TERM
+  for pid in "${child_pids[@]}"; do
+    kill "${pid}" 2>/dev/null || true
+  done
+  wait 2>/dev/null || true
+  kubectl logs --request-timeout=30s -n "${namespace}" -l app=ena-probe \
+    --prefix --all-containers \
+    > "${output_dir}/ena-samples.log" 2>&1 || true
+}
+trap finish EXIT
+trap 'exit 0' INT TERM
+
+kubectl apply --request-timeout=30s -f ci/perf-testing/ena-probe.yml \
+  > "${output_dir}/ena-start.log" 2>&1 ||
+  echo "warning: ENA probe could not be started; continuing" >> "${output_dir}/ena-start.log"
+
+bash ci/scripts/sample_core_metrics.sh "${namespace}" \
+  > "${output_dir}/core-metrics.log" 2>&1 &
+child_pids+=("$!")
+bash ci/scripts/sample_pod_placement.sh "${namespace}" \
+  > "${output_dir}/pod-placement.tsv" 2>&1 &
+child_pids+=("$!")
+
+wait

--- a/ci/scripts/sample_perf_diagnostics.sh
+++ b/ci/scripts/sample_perf_diagnostics.sh
@@ -17,10 +17,10 @@ finish() {
   done
   wait 2>/dev/null || true
   kubectl logs --request-timeout=30s -n "${namespace}" -l app=ena-probe \
-    --prefix --all-containers \
+    --prefix --all-containers --tail=-1 \
     > "${output_dir}/ena-samples.log" 2>&1 || true
   kubectl logs --request-timeout=30s -n "${namespace}" -l app=ena-probe \
-    --prefix --all-containers --previous \
+    --prefix --all-containers --previous --tail=-1 \
     > "${output_dir}/ena-previous.log" 2>&1 || true
   {
     echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) final ENA probe descriptions"

--- a/ci/scripts/sample_pod_placement.sh
+++ b/ci/scripts/sample_pod_placement.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Join KMS core and rate-test client pods with their node and availability-zone information.
+# sample_perf_diagnostics.sh starts this during the performance-testing workflow.
+# Output is a tab-separated placement report on stdout after the first rate-test client appears.
+set -uo pipefail
+
+namespace="${1:-kms-ci}"
+interval="${2:-5}"
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "${tmp_root}"' EXIT
+
+printf 'timestamp\tpod\tworkflow_node\tnode\tzone\tinstance_type\tnodepool\n'
+for _attempt in {1..180}; do
+  timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if kubectl get --request-timeout=10s pods -n "${namespace}" -o json \
+       > "${tmp_root}/pods.json" 2>/dev/null &&
+     kubectl get --request-timeout=10s endpointslices.discovery.k8s.io -n "${namespace}" \
+       -l kubernetes.io/service-name=ena-probe-placement -o json \
+       > "${tmp_root}/slices.json" 2>/dev/null; then
+    if jq -e '([.items[] | select((.metadata.labels.app // "") == "kms-core")] | length) >= 13
+      and any(.items[]; ((.metadata.labels.test // "") | contains("-rate-")))' \
+      "${tmp_root}/pods.json" >/dev/null; then
+      jq -r --slurpfile slices "${tmp_root}/slices.json" --arg ts "${timestamp}" '
+        def endpoint_for($name):
+          ([$slices[0].items[]?.endpoints[]? | select(.nodeName == $name)][0] // {});
+        .items[]
+        | select((.spec.nodeName // "") != "")
+        | select((.metadata.labels.app // "") == "kms-core"
+            or ((.metadata.labels.test // "") | contains("-rate-")))
+        | . as $pod
+        | endpoint_for($pod.spec.nodeName) as $endpoint
+        | [$ts, ($pod.metadata.name // "-"),
+           ($pod.metadata.labels["workflows.argoproj.io/node-name"] // "-"),
+           ($pod.spec.nodeName // "-"),
+           ($endpoint.zone // $endpoint.deprecatedTopology["topology.kubernetes.io/zone"] // "-"),
+           ($endpoint.deprecatedTopology["node.kubernetes.io/instance-type"] //
+             $pod.spec.nodeSelector["node.kubernetes.io/instance-type"] // "-"),
+           ($endpoint.deprecatedTopology["karpenter.sh/nodepool"] //
+             $pod.spec.nodeSelector["karpenter.sh/nodepool"] // "-")]
+        | @tsv
+      ' "${tmp_root}/pods.json" | sort -u > "${tmp_root}/placement.tsv"
+      if [[ -s "${tmp_root}/placement.tsv" ]] &&
+         awk -F '\t' '$5 == "-" { missing = 1 } END { exit missing }' \
+           "${tmp_root}/placement.tsv"; then
+        cat "${tmp_root}/placement.tsv"
+        exit 0
+      fi
+    fi
+  fi
+  sleep "${interval}"
+done
+
+echo "# sampler_warning complete topology unavailable after 15 minutes"
+exit 0

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -591,12 +591,6 @@ impl SessionMaker {
         context_id: ContextId,
         network_mode: NetworkMode,
     ) -> anyhow::Result<BaseSession> {
-        tracing::info!(
-            "Making base session: session_id={}, context_id={}, network_mode={:?}",
-            session_id,
-            context_id,
-            network_mode
-        );
         let networking = self
             .get_networking(session_id, context_id, network_mode)
             .await;

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -25,7 +25,7 @@ use kms_grpc::{
     },
 };
 use observability::{
-    metrics,
+    metrics::{self, UserDecryptStage},
     metrics_names::{
         OP_USER_DECRYPT_INNER, OP_USER_DECRYPT_REQUEST, OP_USER_DECRYPT_RESULT, TAG_PARTY_ID,
         TAG_TFHE_TYPE, TAG_USER_DECRYPTION_KIND,
@@ -233,11 +233,16 @@ impl<
                 CiphertextFormat::SmallCompressed => keys.decompression_key(),
                 _ => None,
             };
+            let deserialize_timer =
+                metrics::METRICS.time_user_decrypt_stage(UserDecryptStage::Deserialize);
             let low_level_ct =
                 deserialize_to_low_level(fhe_type, ct_format, &ct, decomp_key.as_deref())?;
+            drop(deserialize_timer);
 
             let pdec: Result<PartialDecryption, anyhow::Error> = match dec_mode {
                 DecryptionMode::NoiseFloodSmall => {
+                    let session_timer =
+                        metrics::METRICS.time_user_decrypt_stage(UserDecryptStage::SessionCreate);
                     let session = session_maker
                         .make_small_async_session_z128(session_id, context_id, epoch_id)
                         .await
@@ -246,6 +251,7 @@ impl<
                                 "Could not prepare ddec data for noiseflood decryption: {e}",
                             )
                         })?;
+                    drop(session_timer);
                     let mut noiseflood_session = Dec::Prep::new(session);
 
                     // Only `Small` ciphertexts need switch&squash; the closure (and hence the
@@ -257,8 +263,11 @@ impl<
                     })?;
 
                     // TODO(github.com/zama-ai/kms-internal/issues/3159): make `partial_decrypt` return a zeroizing value.
+                    let partial_decrypt_timer =
+                        metrics::METRICS.time_user_decrypt_stage(UserDecryptStage::PartialDecrypt);
                     let pdec =
                         Dec::partial_decrypt(&mut noiseflood_session, ct, &keys.private_keys).await;
+                    drop(partial_decrypt_timer);
 
                     let res = match pdec {
                         Ok((partial_dec_map, packing_factor, time)) => {
@@ -287,6 +296,8 @@ impl<
                     Ok(res)
                 }
                 DecryptionMode::BitDecSmall => {
+                    let session_timer =
+                        metrics::METRICS.time_user_decrypt_stage(UserDecryptStage::SessionCreate);
                     let mut session = session_maker
                         .make_small_async_session_z64(session_id, context_id, epoch_id)
                         .await
@@ -295,7 +306,10 @@ impl<
                                 "Could not prepare ddec data for bitdec decryption: {e}",
                             )
                         })?;
+                    drop(session_timer);
 
+                    let partial_decrypt_timer =
+                        metrics::METRICS.time_user_decrypt_stage(UserDecryptStage::PartialDecrypt);
                     let pdec = secure_partial_decrypt_using_bitdec(
                         &mut session,
                         &low_level_ct.try_get_small_ct()?,
@@ -303,6 +317,7 @@ impl<
                         &keys.key_switching_key()?,
                     )
                     .await;
+                    drop(partial_decrypt_timer);
 
                     let res = match pdec {
                         Ok((partial_dec_map, time)) => {
@@ -339,6 +354,8 @@ impl<
 
             let (partial_signcryption, packing_factor) = match pdec {
                 Ok((pdec_serialized, packing_factor, time)) => {
+                    let signcrypt_timer =
+                        metrics::METRICS.time_user_decrypt_stage(UserDecryptStage::Signcrypt);
                     let enc_res = {
                         let mut rng = rng.lock().map_err(|_| {
                             CryptographyError::Other("Poisoned mutex guard".to_string())
@@ -351,6 +368,7 @@ impl<
                             &link,
                         )
                     }?;
+                    drop(signcrypt_timer);
 
                     tracing::debug!(
                         "User decryption {req_id} in session {session_id} completed for type {:?}. Partial decrypt took {:?} ms",
@@ -393,6 +411,8 @@ impl<
         };
 
         let domain = domain.clone();
+        let result_sign_timer =
+            metrics::METRICS.time_user_decrypt_stage(UserDecryptStage::ResultSign);
         let signed = spawn_compute_bound(move || {
             sign_user_decryption_result(
                 &signcryption_key.signing_key,
@@ -405,6 +425,7 @@ impl<
         })
         .await
         .map_err(|e| anyhow!("Failed to run signing task for user decryption {req_id}: {e}"))?;
+        drop(result_sign_timer);
         signed.map_err(|e| anyhow!("Failed to sign user decryption {req_id}: {e}"))
     }
 
@@ -459,6 +480,7 @@ impl<
         &self,
         request: Request<UserDecryptionRequest>,
     ) -> Result<Response<Empty>, MetricedError> {
+        let admission_timer = metrics::METRICS.time_user_decrypt_stage(UserDecryptStage::Admission);
         metrics::METRICS.increment_request_counter(OP_USER_DECRYPT_REQUEST);
 
         // Check for resource exhaustion once all the other checks are ok
@@ -471,7 +493,6 @@ impl<
             .start();
 
         let inner = Arc::new(request.into_inner());
-        tracing::info!("{}", format_user_request(&inner));
 
         let (
             typed_ciphertexts,
@@ -555,7 +576,11 @@ impl<
         // store's reaper fails the entry rather than leaving it Pending forever.
         let meta_permit =
             add_or_redo_failed_in_meta_store(&meta_store, &req_id, OP_USER_DECRYPT_REQUEST).await?;
+        drop(admission_timer);
+        let schedule_timer =
+            metrics::METRICS.time_user_decrypt_stage(UserDecryptStage::ScheduleDelay);
         let inner_dec_future = move |_permit| async move {
+            drop(schedule_timer);
             // Capture the timer, it is stopped when it's dropped
             let _timer = timer;
             let meta_permit = meta_permit;
@@ -578,10 +603,15 @@ impl<
                 metric_tags,
             )
             .await;
+            let meta_store_update_timer =
+                metrics::METRICS.time_user_decrypt_stage(UserDecryptStage::MetaStoreUpdate);
             update_req_in_meta_store(&meta_store, meta_permit, result, OP_USER_DECRYPT_REQUEST)
                 .await;
+            drop(meta_store_update_timer);
         };
+        let task_metrics = metrics::METRICS.track_user_decrypt_background_task();
         self.tracker.spawn(async move {
+            let _task_metrics = task_metrics;
             // Ignore the result since this is a background thread.
             let _ = inner_dec_future(permit)
                 .instrument(tracing::Span::current())
@@ -655,21 +685,6 @@ impl<
             extra_data,
         }))
     }
-}
-
-// We want most of the metadata but not the actual ciphertexts
-fn format_user_request(request: &UserDecryptionRequest) -> String {
-    format!(
-        "UserDecryptionRequest {{ request_id: {:?}, key_id: {:?}, context_id: {:?}, epoch_id: {:?}, client_address: {:?}, enc_key: {:?}, domain: {:?}, typed_ciphertexts_count: {} }}",
-        request.request_id,
-        request.key_id,
-        request.context_id,
-        request.epoch_id,
-        request.client_address,
-        hex::encode(&request.enc_key),
-        request.domain,
-        request.typed_ciphertexts.len(),
-    )
 }
 
 #[cfg(test)]

--- a/core/service/src/engine/utils.rs
+++ b/core/service/src/engine/utils.rs
@@ -7,7 +7,8 @@ use kms_grpc::utils::tonic_result::top_1k_chars;
 use kms_grpc::{ContextId, EpochId, RequestId};
 use observability::metrics::METRICS;
 use observability::metrics_names::{
-    ERR_ASYNC, OP_KEY_MATERIAL_AVAILABILITY, map_tonic_code_to_metric_err_tag,
+    ERR_ASYNC, OP_KEY_MATERIAL_AVAILABILITY, OP_PUBLIC_DECRYPT_REQUEST, OP_PUBLIC_DECRYPT_RESULT,
+    OP_USER_DECRYPT_REQUEST, OP_USER_DECRYPT_RESULT, map_tonic_code_to_metric_err_tag,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -247,6 +248,18 @@ pub struct MetricedError {
     returned: bool,
 }
 
+fn is_expected_grpc_outcome(operation: &str, code: tonic::Code) -> bool {
+    match operation {
+        OP_PUBLIC_DECRYPT_RESULT | OP_USER_DECRYPT_RESULT => {
+            code == tonic::Code::Unavailable || code == tonic::Code::NotFound
+        }
+        OP_PUBLIC_DECRYPT_REQUEST | OP_USER_DECRYPT_REQUEST => {
+            code == tonic::Code::AlreadyExists || code == tonic::Code::ResourceExhausted
+        }
+        _ => false,
+    }
+}
+
 impl MetricedError {
     /// Create a new MetricedError wrapping the given MetricedError and gRPC error code.
     ///
@@ -301,14 +314,12 @@ impl MetricedError {
         internal_error: E,
     ) {
         let error = internal_error.into(); // converts anyhow::Error or any other error
-        let error_string = format!(
-            "Failure on requestID {} with metric {}. Error: {}",
-            request_id.unwrap_or_default(),
-            op_metric,
-            error
+        tracing::error!(
+            request_id = %request_id.unwrap_or_default(),
+            operation = op_metric,
+            error = %error,
+            "asynchronous request failed"
         );
-
-        tracing::error!(error_string);
 
         // Increment the method specific metric
         METRICS.increment_error_counter(op_metric, ERR_ASYNC);
@@ -325,15 +336,15 @@ impl MetricedError {
                 self.op_metric,
                 map_tonic_code_to_metric_err_tag(self.error_code),
             );
-            let error_string = format!(
-                "Grpc failure on requestID {} with metric {} and error code {}. Error message: {}",
-                self.request_id.unwrap_or_default(),
-                self.op_metric,
-                self.error_code,
-                self.internal_error
-            );
-
-            tracing::error!(error_string);
+            if !is_expected_grpc_outcome(self.op_metric, self.error_code) {
+                tracing::error!(
+                    request_id = %self.request_id.unwrap_or_default(),
+                    operation = self.op_metric,
+                    code = %self.error_code,
+                    error = %self.internal_error,
+                    "gRPC request failed"
+                );
+            }
         }
     }
 }
@@ -446,6 +457,35 @@ mod tests {
         let status: Status = error.into();
         assert!(status.message().contains("test_op"));
         assert!(!status.message().contains("test error"));
+    }
+
+    #[test]
+    fn classifies_expected_decrypt_outcomes() {
+        assert!(is_expected_grpc_outcome(
+            OP_USER_DECRYPT_RESULT,
+            tonic::Code::Unavailable
+        ));
+        assert!(is_expected_grpc_outcome(
+            OP_PUBLIC_DECRYPT_RESULT,
+            tonic::Code::NotFound
+        ));
+        assert!(is_expected_grpc_outcome(
+            OP_USER_DECRYPT_REQUEST,
+            tonic::Code::ResourceExhausted
+        ));
+        assert!(is_expected_grpc_outcome(
+            OP_PUBLIC_DECRYPT_REQUEST,
+            tonic::Code::AlreadyExists
+        ));
+
+        assert!(!is_expected_grpc_outcome(
+            OP_USER_DECRYPT_RESULT,
+            tonic::Code::Internal
+        ));
+        assert!(!is_expected_grpc_outcome(
+            OP_KEY_MATERIAL_AVAILABILITY,
+            tonic::Code::ResourceExhausted
+        ));
     }
 
     #[test]

--- a/core/service/src/util/meta_store.rs
+++ b/core/service/src/util/meta_store.rs
@@ -1247,7 +1247,6 @@ pub(crate) async fn retrieve_from_meta_store<T>(
         Some(EntryState::Pending) => {
             let msg =
                 format!("Result in scope {metric_scope} with request ID {req_id} is not ready yet");
-            tracing::info!(msg);
             Err(MetricedError::new(
                 metric_scope,
                 Some(*req_id),
@@ -1302,7 +1301,6 @@ pub(crate) async fn retrieve_from_meta_store_with_timeout<T>(
     };
 
     let unavailable = |msg: String| {
-        tracing::info!(msg);
         MetricedError::new(
             metric_scope,
             Some(*req_id),

--- a/core/threshold-execution/src/endpoints/decryption_non_wasm.rs
+++ b/core/threshold-execution/src/endpoints/decryption_non_wasm.rs
@@ -507,7 +507,6 @@ where
         shared_masked_ptxts.push(res);
     }
 
-    tracing::info!("Noiseflood result in session {sid} is ready, got {len} blocks");
     results.insert(format!("{sid}"), shared_masked_ptxts);
 
     let execution_stop_timer = Instant::now();

--- a/core/threshold-networking/src/grpc/manager.rs
+++ b/core/threshold-networking/src/grpc/manager.rs
@@ -11,6 +11,7 @@ use crate::sending_service::{
     GrpcSendingService, NetworkSession, SendingService, now_activity_millis,
 };
 use dashmap::DashMap;
+use observability::metrics::{self, NetworkDebugEvent};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -84,6 +85,7 @@ impl GrpcNetworkingManager {
                 interval.tick().await;
                 let mut internal_inactive_sessions_count = 0;
                 let mut internal_active_sessions_count = 0;
+                let mut internal_completed_sessions_count = 0;
                 let mut to_remove = Vec::new();
                 for mut cur in session_store.iter_mut() {
                     let (session_id, status) = cur.pair_mut();
@@ -91,16 +93,19 @@ impl GrpcNetworkingManager {
                         SessionStatus::Completed(started) => {
                             // Remove completed sessions that have been completed for a very long time
                             if started.elapsed() > cleanup_interval {
+                                metrics::METRICS.increment_network_event(
+                                    NetworkDebugEvent::SessionCompletedRemoved,
+                                );
                                 to_remove.push(*session_id);
+                            } else {
+                                internal_completed_sessions_count += 1;
                             }
                         }
                         SessionStatus::Inactive((_, started)) => {
                             // Remove inactive sessions that have been inactive for awhile
                             if started.elapsed() > discard_inactive_interval {
-                                tracing::warn!(
-                                    "Discarding Inactive session {:?} after {:?} seconds. We never heard about such session.",
-                                    session_id,
-                                    started.elapsed().as_secs()
+                                metrics::METRICS.increment_network_event(
+                                    NetworkDebugEvent::SessionInactiveDiscarded,
                                 );
                                 to_remove.push(*session_id);
                                 continue;
@@ -118,10 +123,8 @@ impl GrpcNetworkingManager {
                                     ),
                                 );
                                 if time_since_last_rec > discard_inactive_interval {
-                                    tracing::warn!(
-                                        "Discarding Active session {:?} after {:?} seconds.",
-                                        session_id,
-                                        time_since_last_rec.as_secs()
+                                    metrics::METRICS.increment_network_event(
+                                        NetworkDebugEvent::SessionActiveDiscarded,
                                     );
                                     to_remove.push(*session_id);
                                     continue;
@@ -130,6 +133,9 @@ impl GrpcNetworkingManager {
                             }
                             None => {
                                 *status = SessionStatus::Completed(Instant::now());
+                                internal_completed_sessions_count += 1;
+                                metrics::METRICS
+                                    .increment_network_event(NetworkDebugEvent::SessionCompleted);
                             }
                         },
                     };
@@ -139,6 +145,7 @@ impl GrpcNetworkingManager {
                 }
                 inactive_session_count.store(internal_inactive_sessions_count, Ordering::Relaxed);
                 active_session_count.store(internal_active_sessions_count, Ordering::Relaxed);
+                metrics::METRICS.record_completed_sessions(internal_completed_sessions_count);
             }
         });
     }
@@ -245,7 +252,6 @@ impl GrpcNetworkingManager {
         my_role: R,
         network_mode: NetworkMode,
     ) -> anyhow::Result<Arc<impl Networking<R> + use<R>>> {
-        let party_count = role_assignment.len();
         let mut others = role_assignment.clone();
 
         // Removing self from the role_assignment map
@@ -297,6 +303,7 @@ impl GrpcNetworkingManager {
                 ));
 
                 *mutable_status = SessionStatus::Active(Arc::downgrade(&session));
+                metrics::METRICS.increment_network_event(NetworkDebugEvent::SessionActivated);
 
                 session
             }
@@ -318,17 +325,11 @@ impl GrpcNetworkingManager {
                 ));
 
                 vacant.insert(SessionStatus::Active(Arc::downgrade(&session)));
+                metrics::METRICS.increment_network_event(NetworkDebugEvent::SessionActiveCreated);
 
                 session
             }
         };
-
-        tracing::info!(
-            "[SESSION_CREATION] Starting session {:?} with {} parties. (Owner: {:?})",
-            session_id,
-            party_count,
-            owner,
-        );
 
         Ok(session)
     }

--- a/core/threshold-networking/src/grpc/server.rs
+++ b/core/threshold-networking/src/grpc/server.rs
@@ -11,6 +11,7 @@ use crate::grpc::{
 use crate::tls::extract_subject_from_cert;
 use async_trait::async_trait;
 use dashmap::DashMap;
+use observability::metrics::{self, NetworkDebugEvent};
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, LazyLock};
 use threshold_types::party::MpcIdentity;
@@ -107,6 +108,7 @@ impl NetworkingImpl {
     ) -> Result<Option<Arc<Sender<NetworkRoundValue>>>, tonic::Status> {
         match session_status {
             SessionStatus::Completed(_) => {
+                metrics::METRICS.increment_network_event(NetworkDebugEvent::MessageToCompleted);
                 tracing::debug!(
                     "Session {:?} found in session_store but is completed. Will be removed by background cleanup.",
                     tag.session_id
@@ -117,6 +119,7 @@ impl NetworkingImpl {
             }
             // Session is inactive, we may need to create a new channel for the sender
             SessionStatus::Inactive(message_queue) => {
+                metrics::METRICS.increment_network_event(NetworkDebugEvent::MessageToInactive);
                 tracing::debug!(
                     "Session {:?} found in session_store but is inactive.",
                     tag.session_id
@@ -208,6 +211,8 @@ impl NetworkingImpl {
                     }
                 } else {
                     // Session has been dropped, accept the message even if we won't do anything with it
+                    metrics::METRICS
+                        .increment_network_event(NetworkDebugEvent::MessageToDroppedActive);
                     Ok(None)
                 }
             }
@@ -433,6 +438,8 @@ impl Gnetworking for NetworkingImpl {
                         Instant::now(),
                     )));
                     *opened_session_tracker_entry += 1;
+                    metrics::METRICS
+                        .increment_network_event(NetworkDebugEvent::SessionInactiveCreated);
                     tx
                 }
             }
@@ -450,13 +457,7 @@ impl Gnetworking for NetworkingImpl {
         .await;
 
         if let Err(e) = send_result {
-            tracing::warn!(
-                "Failed to process value for session {:?}, sender {:?}, round {}. Queue has been full for {} seconds.",
-                tag.session_id,
-                &tag.sender,
-                tag.round_counter,
-                self.max_waiting_time_for_message_queue.as_secs()
-            );
+            metrics::METRICS.increment_network_event(NetworkDebugEvent::QueueFull);
 
             return Err(tonic::Status::new(
                 tonic::Code::ResourceExhausted,
@@ -466,6 +467,8 @@ impl Gnetworking for NetworkingImpl {
                 ),
             ));
         }
+
+        metrics::METRICS.increment_network_event(NetworkDebugEvent::MessageEnqueued);
 
         Ok(tonic::Response::new(SendValueResponse {
             status: Status::Active.into(),

--- a/core/threshold-networking/src/sending_service/service.rs
+++ b/core/threshold-networking/src/sending_service/service.rs
@@ -18,6 +18,7 @@ use backoff::future::retry_notify;
 use dashmap::DashSet;
 use error_utils::anyhow_error_and_log;
 use hyper_rustls_ring::{FixedServerNameResolver, HttpsConnectorBuilder};
+use observability::metrics::{self, NetworkDebugEvent};
 use observability::telemetry::ContextPropagator;
 use threshold_types::party::{Identity, RoleAssignment};
 use threshold_types::role::{RoleKind, RoleTrait};
@@ -209,6 +210,8 @@ impl GrpcSendingService {
 
             if receiver_completed {
                 skipped += 1;
+                metrics::METRICS
+                    .increment_network_event(NetworkDebugEvent::SendSkippedAfterCompleted);
                 continue;
             }
 
@@ -229,6 +232,7 @@ impl GrpcSendingService {
             };
 
             let on_network_fail = |e, duration: Duration| {
+                metrics::METRICS.increment_network_event(NetworkDebugEvent::SendRetry);
                 tracing::debug!(
                     "Network retry for message: {e:?} - Duration {:?} secs. Talking to {other_role_kind}.",
                     duration.as_secs()
@@ -242,11 +246,11 @@ impl GrpcSendingService {
                 Ok(send_response) => {
                     match send_response.status() {
                         Status::Active => {
-                            // All good, nothing to do
+                            metrics::METRICS.increment_network_event(NetworkDebugEvent::SendActive);
                         }
                         Status::Inactive => {
-                            // The receiver is inactive
-                            tracing::warn!("Receiver {other_role_kind} is inactive.");
+                            metrics::METRICS
+                                .increment_network_event(NetworkDebugEvent::SendInactive);
                         }
                         Status::Completed => {
                             // The receiver already completed this session.
@@ -254,9 +258,8 @@ impl GrpcSendingService {
                             // "channel closed" errors on subsequent sends.
                             // Instead, mark as completed and drain remaining messages.
                             completed_parties.insert(other_role_kind);
-                            tracing::warn!(
-                                "Failed to send message to {other_role_kind} party since it claims the session is already completed"
-                            );
+                            metrics::METRICS
+                                .increment_network_event(NetworkDebugEvent::SendCompleted);
                             incorrectly_sent += 1;
                             receiver_completed = true;
                         }
@@ -264,7 +267,8 @@ impl GrpcSendingService {
                 }
                 Err(status) => {
                     incorrectly_sent += 1;
-                    tracing::warn!(
+                    metrics::METRICS.increment_network_event(NetworkDebugEvent::SendFailed);
+                    tracing::debug!(
                         "Failed to send message to {other_role_kind} after {incorrectly_sent} retries: {} - {} (source: {:?})",
                         status.code(),
                         status.message(),
@@ -284,7 +288,7 @@ impl GrpcSendingService {
                 "No more listeners on {other_role_kind}, everything failed, {incorrectly_sent} errors, shutting down network task"
             );
         } else if incorrectly_sent > 0 {
-            tracing::warn!(
+            tracing::debug!(
                 "Network task with {other_role_kind} finished with: {incorrectly_sent} errors, {skipped} skipped, {received_request} total requests"
             );
         } else {
@@ -332,14 +336,20 @@ impl SendingService for GrpcSendingService {
             ..Default::default()
         };
 
-        // 4. Spawns the sender in its own task and discard the handle
-        tokio::spawn(Self::run_network_task(
-            receiver,
-            network_channel,
-            exponential_backoff,
-            other_role_kind,
-            aborted,
-        ));
+        // 4. Each session runs one sender task per peer. Track them to reveal tasks that accumulate
+        // or fail to finish.
+        let task_metrics = metrics::METRICS.track_network_sender_task();
+        tokio::spawn(async move {
+            let _task_metrics = task_metrics;
+            Self::run_network_task(
+                receiver,
+                network_channel,
+                exponential_backoff,
+                other_role_kind,
+                aborted,
+            )
+            .await;
+        });
 
         Ok(sender)
     }

--- a/core/threshold-networking/src/sending_service/session.rs
+++ b/core/threshold-networking/src/sending_service/session.rs
@@ -11,6 +11,7 @@ use crate::grpc::NETWORK_RECEIVED_MEASUREMENT;
 use crate::grpc::{CoreToCoreNetworkConfig, MessageQueueStore, NetworkRoundValue, Tag};
 use dashmap::DashSet;
 use error_utils::anyhow_error_and_log;
+use observability::metrics::{self, NetworkDebugEvent};
 use threshold_types::network::{NetworkMode, Networking};
 use threshold_types::party::Identity;
 use threshold_types::role::{RoleKind, RoleTrait};
@@ -241,13 +242,8 @@ impl<R: RoleTrait> Networking<R> for NetworkSession {
                         // Note that the sender is never warned of this failure, so a honest party
                         // won't try and re-send the message. But, this is a DoS mitigation: a malicious peer could
                         // otherwise flood us with future-round messages and exhaust memory.
-                        tracing::warn!(
-                            "@ round {} - dropping out-of-window/over-cap future-round message for round {} from {:?} (buffered: {})",
-                            network_round,
-                            round,
-                            sender,
-                            state.future.len()
-                        );
+                        metrics::METRICS
+                            .increment_network_event(NetworkDebugEvent::FutureMessageDropped);
                     }
                     continue;
                 }
@@ -403,11 +399,8 @@ impl NetworkSession {
     ) -> RecvOutcome {
         tokio::select! {
             _ = tick_interval.tick() => {
-                tracing::warn!(
-                    "Still waiting to receive from party {:?} for session {:?}",
-                    sender,
-                    self.session_id
-                );
+                metrics::METRICS
+                    .increment_network_event(NetworkDebugEvent::ReceiveWaitTimeout);
                 if self.completed_parties.contains(&sender.get_role_kind()) {
                     // The sender has said the session is complete: wait one more
                     // grace period for any lingering in-flight message, but still

--- a/docs/operations/advanced/metrics.md
+++ b/docs/operations/advanced/metrics.md
@@ -126,7 +126,26 @@ these operations therefore work unchanged whether clients use the async or the s
 - **Description**: Total number of bytes sent over the network by KMS.
 - **Alarm**: If the counter stops increasing during expected traffic periods.
 
+#### Threshold transport diagnostics
+- `kms_network_debug_events_total{event}` counts a fixed set of queue, session, send, retry,
+  timeout, and late-message outcomes. Use it to diagnose transport backpressure.
+- `kms_network_sender_tasks` is the number of active sender tasks;
+  `kms_network_sender_tasks_{spawned,completed}_total` make leaks or growing backlogs visible.
+- `kms_completed_sessions` counts completed MPC sessions retained so late peer messages are
+  acknowledged as completed instead of reopening the session. Retention is controlled by
+  `session_cleanup_interval_secs` (24 hours by default), so this measures recent session churn
+  over that window, not active work or a processing backlog.
+
 ### Performance Metrics
+
+#### Threshold user-decryption stages
+- `kms_user_decrypt_stage_duration_microseconds_total{stage}` and
+  `kms_user_decrypt_stage_observations_total{stage}` expose cumulative wall time and observation
+  count for admission, scheduler delay, deserialization, session creation, partial decryption,
+  signcryption, result signing, and meta-store update. Divide the totals to obtain the mean stage
+  duration over a chosen interval.
+- `kms_user_decrypt_background_tasks` is the number of submitted UDEC background tasks that have
+  not finished.
 
 #### Metric Name: `kms_operation_duration_ms`
 - **Type**: Histogram
@@ -159,7 +178,7 @@ these operations therefore work unchanged whether clients use the async or the s
 
 #### Other Gauges
 - **Type**: Gauge
-- **Description**: Point-in-time gauges (default `kms` prefix): `kms_active_sessions` / `kms_inactive_sessions`, `kms_tasks`, `kms_rate_limiter_usage`, `kms_meta_storage_{user,pub}_decryptions` and `..._in_store`, `kms_file_descriptors`, `kms_socat_file_descriptors` / `kms_socat_tasks`, `kms_total_cpus`, `kms_total_memory`, `kms_process_cpu_usage`, `kms_process_memory_usage`, and `kms_version` (build info; value always 1).
+- **Description**: Point-in-time gauges (default `kms` prefix): `kms_active_sessions` / `kms_inactive_sessions`, `kms_tasks`, `kms_rate_limiter_usage`, `kms_meta_storage_{user,pub}_decryptions` and `..._in_store`, `kms_file_descriptors`, `kms_socat_file_descriptors` / `kms_socat_tasks`, `kms_tokio_alive_tasks`, `kms_tokio_global_queue_depth`, `kms_total_cpus`, `kms_total_memory`, `kms_process_cpu_usage`, `kms_process_memory_usage`, and `kms_version` (build info; value always 1).
 - **Alarm**: e.g. alert if `kms_rate_limiter_usage` saturates or `kms_active_sessions` looks abnormal.
 
 ### Metric Tags

--- a/observability/src/metrics.rs
+++ b/observability/src/metrics.rs
@@ -56,6 +56,11 @@ pub struct CoreMetrics {
     backup_error_counter: IntCounterVec, // Keeps track of errors when making a backup. These MUST be handled as it means some party may not have everything backed up properly
     network_rx_counter: IntCounter, // Note: Because we use counter we need to increment from last seen value.
     network_tx_counter: IntCounter, // Note: Because we use counter we need to increment from last seen value.
+    network_debug_event_counters: [IntCounter; NetworkDebugEvent::COUNT],
+    user_decrypt_stage_duration_counters: [IntCounter; UserDecryptStage::COUNT],
+    user_decrypt_stage_observation_counters: [IntCounter; UserDecryptStage::COUNT],
+    network_sender_tasks_spawned_counter: IntCounter,
+    network_sender_tasks_completed_counter: IntCounter,
 
     // Histograms
     duration_histogram: HistogramVec,
@@ -66,12 +71,17 @@ pub struct CoreMetrics {
     socat_file_descriptor_gauge: IntGauge, // Number of socat file descriptors
     socat_task_gauge: IntGauge,      // Number of socat tasks
     task_gauge: IntGauge,            // Numbers active child processes of the KMS
+    tokio_alive_tasks_gauge: IntGauge,
+    tokio_global_queue_depth_gauge: IntGauge,
+    user_decrypt_background_tasks_gauge: IntGauge,
+    network_sender_tasks_gauge: IntGauge,
 
     // Internal system gauges
     // TODO rate limiter, session gauge and meta store should actually be counters but we need to add decorators to ensure it is always updated
     rate_limiter_gauge: IntGauge, // Number tokens used in the rate limiter
     active_session_gauge: IntGauge, // Number of active sessions
     inactive_session_gauge: IntGauge, // Number of inactive sessions
+    completed_session_gauge: IntGauge,
     meta_storage_pub_dec_gauge: IntGauge, // Number of ongoing public decryptions in meta storage
     meta_storage_user_dec_gauge: IntGauge, // Number of ongoing user decryptions in meta storage
     meta_storage_pub_dec_total_gauge: IntGauge, // Total number of public decryptions in meta storage
@@ -92,6 +102,142 @@ pub struct CoreMetrics {
 
     // Trace guard for file-based logging
     trace_guard: Arc<Mutex<Option<Box<dyn std::any::Any + Send + Sync>>>>,
+}
+
+/// Diagnostic events exposed by the threshold MPC transport.
+#[derive(Clone, Copy)]
+#[repr(usize)]
+pub enum NetworkDebugEvent {
+    /// A peer message arrived before its local MPC session existed.
+    SessionInactiveCreated,
+    /// A local protocol activated a session created by an earlier peer message.
+    SessionActivated,
+    /// A local MPC session started before any peer message arrived.
+    SessionActiveCreated,
+    /// An active session ended and entered the completed-session grace period.
+    SessionCompleted,
+    /// An inbound-only session expired before it was started locally.
+    SessionInactiveDiscarded,
+    /// An active session was discarded after its receive activity timed out.
+    SessionActiveDiscarded,
+    /// A completed session was removed after its grace period expired.
+    SessionCompletedRemoved,
+    /// An inbound peer message was added to its session queue.
+    MessageEnqueued,
+    /// An inbound peer message targeted a session not yet started locally.
+    MessageToInactive,
+    /// An inbound peer message targeted a session that had already completed.
+    MessageToCompleted,
+    /// An inbound peer message targeted an active session whose owner had exited.
+    MessageToDroppedActive,
+    /// An inbound peer message could not be queued before the queue timeout.
+    QueueFull,
+    /// A peer accepted an outbound message for an active session.
+    SendActive,
+    /// A peer reported that the outbound message's session was inactive.
+    SendInactive,
+    /// A peer reported that the outbound message's session had completed.
+    SendCompleted,
+    /// An outbound message send failed and was scheduled for another attempt.
+    SendRetry,
+    /// An outbound message still failed after all retry attempts.
+    SendFailed,
+    /// An outbound message was skipped after the peer reported completion.
+    SendSkippedAfterCompleted,
+    /// A receive operation reached its periodic wait timeout without a message.
+    ReceiveWaitTimeout,
+    /// A future-round message exceeded the configured window or buffer capacity.
+    FutureMessageDropped,
+}
+
+impl NetworkDebugEvent {
+    const COUNT: usize = 20;
+    const LABELS: [&'static str; Self::COUNT] = [
+        "session_inactive_created",
+        "session_activated",
+        "session_active_created",
+        "session_completed",
+        "session_inactive_discarded",
+        "session_active_discarded",
+        "session_completed_removed",
+        "message_enqueued",
+        "message_to_inactive",
+        "message_to_completed",
+        "message_to_dropped_active",
+        "queue_full",
+        "send_active",
+        "send_inactive",
+        "send_completed",
+        "send_retry",
+        "send_failed",
+        "send_skipped_after_completed",
+        "receive_wait_timeout",
+        "future_message_dropped",
+    ];
+}
+
+/// Measured stages of threshold user decryption.
+#[derive(Clone, Copy)]
+#[repr(usize)]
+pub enum UserDecryptStage {
+    /// Validate and admit a request before scheduling its background work.
+    Admission,
+    /// Wait between admission and the background task starting to run.
+    ScheduleDelay,
+    /// Convert one ciphertext from its wire format into its low-level representation.
+    Deserialize,
+    /// Create the MPC session used to decrypt one ciphertext.
+    SessionCreate,
+    /// Compute this KMS party's partial decryption of one ciphertext.
+    PartialDecrypt,
+    /// Encrypt and authenticate one partial decryption for the client.
+    Signcrypt,
+    /// Sign the assembled user-decryption response.
+    ResultSign,
+    /// Publish the background task's result to the meta store.
+    MetaStoreUpdate,
+}
+
+impl UserDecryptStage {
+    const COUNT: usize = 8;
+    const LABELS: [&'static str; Self::COUNT] = [
+        "admission",
+        "schedule_delay",
+        "deserialize",
+        "session_create",
+        "partial_decrypt",
+        "signcrypt",
+        "result_sign",
+        "meta_store_update",
+    ];
+}
+
+/// Decrements an active-task gauge when its task exits, including cancellation or panic.
+struct ActiveTaskGuard {
+    active: IntGauge,
+    completed: Option<IntCounter>,
+}
+
+struct UserDecryptStageGuard<'a> {
+    metrics: &'a CoreMetrics,
+    stage: UserDecryptStage,
+    start: Instant,
+}
+
+impl Drop for UserDecryptStageGuard<'_> {
+    fn drop(&mut self) {
+        self.metrics
+            .observe_user_decrypt_stage(self.stage, self.start.elapsed());
+    }
+}
+
+impl Drop for ActiveTaskGuard {
+    fn drop(&mut self) {
+        self.active.dec();
+        if let Some(completed) = &self.completed {
+            completed.inc();
+        }
+    }
 }
 
 impl Default for CoreMetrics {
@@ -194,6 +340,73 @@ impl CoreMetrics {
             .register(Box::new(network_tx_counter.clone()))
             .expect("failed to register network tx counter");
 
+        // Threshold-path diagnostics: transport events, cumulative UDEC stage timings and sample
+        // counts, and sender-task lifecycle totals.
+        let network_debug_event_counter = IntCounterVec::new(
+            opts(
+                format!("{prefix}_network_debug_events_total"),
+                "Diagnostic events in the threshold MPC transport",
+            ),
+            &["event"],
+        )
+        .expect("failed to create network debug event counter");
+        registry
+            .register(Box::new(network_debug_event_counter.clone()))
+            .expect("failed to register network debug event counter");
+        let network_debug_event_counters = std::array::from_fn(|index| {
+            network_debug_event_counter.with_label_values(&[NetworkDebugEvent::LABELS[index]])
+        });
+
+        let user_decrypt_stage_duration_counter = IntCounterVec::new(
+            opts(
+                format!("{prefix}_user_decrypt_stage_duration_microseconds_total"),
+                "Cumulative wall-clock time spent in threshold user-decryption stages",
+            ),
+            &["stage"],
+        )
+        .expect("failed to create user decrypt stage duration counter");
+        registry
+            .register(Box::new(user_decrypt_stage_duration_counter.clone()))
+            .expect("failed to register user decrypt stage duration counter");
+        let user_decrypt_stage_duration_counters = std::array::from_fn(|index| {
+            user_decrypt_stage_duration_counter
+                .with_label_values(&[UserDecryptStage::LABELS[index]])
+        });
+
+        let user_decrypt_stage_observation_counter = IntCounterVec::new(
+            opts(
+                format!("{prefix}_user_decrypt_stage_observations_total"),
+                "Number of observed threshold user-decryption stage executions",
+            ),
+            &["stage"],
+        )
+        .expect("failed to create user decrypt stage observation counter");
+        registry
+            .register(Box::new(user_decrypt_stage_observation_counter.clone()))
+            .expect("failed to register user decrypt stage observation counter");
+        let user_decrypt_stage_observation_counters = std::array::from_fn(|index| {
+            user_decrypt_stage_observation_counter
+                .with_label_values(&[UserDecryptStage::LABELS[index]])
+        });
+
+        let network_sender_tasks_spawned_counter = IntCounter::with_opts(opts(
+            format!("{prefix}_network_sender_tasks_spawned_total"),
+            "Threshold-network sender tasks spawned",
+        ))
+        .expect("failed to create network sender tasks spawned counter");
+        registry
+            .register(Box::new(network_sender_tasks_spawned_counter.clone()))
+            .expect("failed to register network sender tasks spawned counter");
+
+        let network_sender_tasks_completed_counter = IntCounter::with_opts(opts(
+            format!("{prefix}_network_sender_tasks_completed_total"),
+            "Threshold-network sender tasks completed",
+        ))
+        .expect("failed to create network sender tasks completed counter");
+        registry
+            .register(Box::new(network_sender_tasks_completed_counter.clone()))
+            .expect("failed to register network sender tasks completed counter");
+
         // Histograms
         let duration_histogram = HistogramVec::new(
             hist_opts(
@@ -258,6 +471,42 @@ impl CoreMetrics {
             .register(Box::new(task_gauge.clone()))
             .expect("failed to register task gauge");
 
+        let tokio_alive_tasks_gauge = IntGauge::with_opts(opts(
+            format!("{prefix}_tokio_alive_tasks"),
+            "Number of currently alive Tokio tasks",
+        ))
+        .expect("failed to create Tokio alive tasks gauge");
+        registry
+            .register(Box::new(tokio_alive_tasks_gauge.clone()))
+            .expect("failed to register Tokio alive tasks gauge");
+
+        let tokio_global_queue_depth_gauge = IntGauge::with_opts(opts(
+            format!("{prefix}_tokio_global_queue_depth"),
+            "Number of Tokio tasks currently queued in the runtime global queue",
+        ))
+        .expect("failed to create Tokio global queue depth gauge");
+        registry
+            .register(Box::new(tokio_global_queue_depth_gauge.clone()))
+            .expect("failed to register Tokio global queue depth gauge");
+
+        let user_decrypt_background_tasks_gauge = IntGauge::with_opts(opts(
+            format!("{prefix}_user_decrypt_background_tasks"),
+            "Number of unfinished threshold user-decryption background tasks",
+        ))
+        .expect("failed to create user decrypt background tasks gauge");
+        registry
+            .register(Box::new(user_decrypt_background_tasks_gauge.clone()))
+            .expect("failed to register user decrypt background tasks gauge");
+
+        let network_sender_tasks_gauge = IntGauge::with_opts(opts(
+            format!("{prefix}_network_sender_tasks"),
+            "Number of active threshold-network sender tasks",
+        ))
+        .expect("failed to create network sender tasks gauge");
+        registry
+            .register(Box::new(network_sender_tasks_gauge.clone()))
+            .expect("failed to register network sender tasks gauge");
+
         let rate_limiter_gauge = IntGauge::with_opts(opts(
             format!("{prefix}_rate_limiter_usage"),
             "Rate limiter usage for the KMS",
@@ -293,6 +542,15 @@ impl CoreMetrics {
         registry
             .register(Box::new(inactive_session_gauge.clone()))
             .expect("failed to register inactive session gauge");
+
+        let completed_session_gauge = IntGauge::with_opts(opts(
+            format!("{prefix}_completed_sessions"),
+            "Number of completed MPC sessions retained for late messages",
+        ))
+        .expect("failed to create completed session gauge");
+        registry
+            .register(Box::new(completed_session_gauge.clone()))
+            .expect("failed to register completed session gauge");
 
         let meta_storage_user_dec_gauge = IntGauge::with_opts(opts(
             format!("{prefix}_meta_storage_user_decryptions"),
@@ -391,6 +649,11 @@ impl CoreMetrics {
             backup_error_counter,
             network_rx_counter,
             network_tx_counter,
+            network_debug_event_counters,
+            user_decrypt_stage_duration_counters,
+            user_decrypt_stage_observation_counters,
+            network_sender_tasks_spawned_counter,
+            network_sender_tasks_completed_counter,
             duration_histogram,
             size_histogram,
             cpu_load_gauge,
@@ -399,10 +662,15 @@ impl CoreMetrics {
             socat_file_descriptor_gauge,
             socat_task_gauge,
             task_gauge,
+            tokio_alive_tasks_gauge,
+            tokio_global_queue_depth_gauge,
+            user_decrypt_background_tasks_gauge,
+            network_sender_tasks_gauge,
             rate_limiter_gauge,
             fhe_key_cache_size_gauge,
             active_session_gauge,
             inactive_session_gauge,
+            completed_session_gauge,
             meta_storage_pub_dec_gauge,
             meta_storage_user_dec_gauge,
             meta_storage_pub_dec_total_gauge,
@@ -465,6 +733,45 @@ impl CoreMetrics {
 
     pub fn increment_network_tx_counter(&self, bytes: u64) {
         self.network_tx_counter.inc_by(bytes);
+    }
+
+    /// Increment a diagnostic event in the threshold MPC transport.
+    pub fn increment_network_event(&self, event: NetworkDebugEvent) {
+        self.network_debug_event_counters[event as usize].inc();
+    }
+
+    fn observe_user_decrypt_stage(&self, stage: UserDecryptStage, duration: Duration) {
+        let duration_micros = u64::try_from(duration.as_micros()).unwrap_or(u64::MAX);
+        self.user_decrypt_stage_duration_counters[stage as usize].inc_by(duration_micros);
+        self.user_decrypt_stage_observation_counters[stage as usize].inc();
+    }
+
+    /// Time a threshold user-decryption stage until the returned guard is dropped.
+    pub fn time_user_decrypt_stage(&self, stage: UserDecryptStage) -> impl Drop + Send + '_ {
+        UserDecryptStageGuard {
+            metrics: self,
+            stage,
+            start: Instant::now(),
+        }
+    }
+
+    /// Track one active threshold-network sender task until the returned guard is dropped.
+    pub fn track_network_sender_task(&self) -> impl Drop + Send {
+        self.network_sender_tasks_spawned_counter.inc();
+        self.network_sender_tasks_gauge.inc();
+        ActiveTaskGuard {
+            active: self.network_sender_tasks_gauge.clone(),
+            completed: Some(self.network_sender_tasks_completed_counter.clone()),
+        }
+    }
+
+    /// Track one unfinished threshold UDEC background task until the returned guard is dropped.
+    pub fn track_user_decrypt_background_task(&self) -> impl Drop + Send {
+        self.user_decrypt_background_tasks_gauge.inc();
+        ActiveTaskGuard {
+            active: self.user_decrypt_background_tasks_gauge.clone(),
+            completed: None,
+        }
     }
 
     // Histogram methods
@@ -546,6 +853,18 @@ impl CoreMetrics {
         self.task_gauge.set(count as i64);
     }
 
+    /// Record the number of currently alive tasks in the Tokio runtime.
+    pub fn record_tokio_alive_tasks(&self, count: usize) {
+        self.tokio_alive_tasks_gauge
+            .set(i64::try_from(count).unwrap_or(i64::MAX));
+    }
+
+    /// Record the current depth of the Tokio runtime's global task queue.
+    pub fn record_tokio_global_queue_depth(&self, count: usize) {
+        self.tokio_global_queue_depth_gauge
+            .set(i64::try_from(count).unwrap_or(i64::MAX));
+    }
+
     /// Record the current number of open file descriptors into the gauge
     pub fn record_open_file_descriptors(&self, count: u64) {
         // Should never be 0
@@ -586,12 +905,17 @@ impl CoreMetrics {
         self.inactive_session_gauge.set(count as i64);
     }
 
-    /// Record the current number of ongoing public decryptions into the gauge
+    /// Record the number of completed MPC sessions retained for late messages.
+    pub fn record_completed_sessions(&self, count: u64) {
+        self.completed_session_gauge.set(count as i64);
+    }
+
+    /// Record the current number of ongoing user decryptions into the gauge.
     pub fn record_meta_storage_user_decryptions(&self, count: u64) {
         self.meta_storage_user_dec_gauge.set(count as i64);
     }
 
-    /// Record the current number of ongoing user decryptions into the gauge
+    /// Record the current number of ongoing public decryptions into the gauge.
     pub fn record_meta_storage_public_decryptions(&self, count: u64) {
         self.meta_storage_pub_dec_gauge.set(count as i64);
     }
@@ -857,7 +1181,7 @@ fn is_valid_label_name(name: &str) -> bool {
 /// configured const-label colliding with any of these would make Prometheus reject the metric at
 /// registration (panicking the `.expect`), so it is skipped instead.
 fn is_reserved_label_name(name: &str) -> bool {
-    const EXTRA_RESERVED: &[&str] = &["operation", "error", "version", "le"];
+    const EXTRA_RESERVED: &[&str] = &["operation", "error", "event", "stage", "version", "le"];
     DURATION_LABEL_KEYS.contains(&name) || EXTRA_RESERVED.contains(&name)
 }
 
@@ -887,6 +1211,7 @@ mod tests {
         let mut expected_metrics = vec![
             "kms_active_sessions",
             "kms_backup_errors_total",
+            "kms_completed_sessions",
             "kms_cpu_load",
             "kms_fhe_key_cache_size",
             "kms_file_descriptors",
@@ -896,7 +1221,11 @@ mod tests {
             "kms_meta_storage_pub_decryptions_in_store",
             "kms_meta_storage_user_decryptions",
             "kms_meta_storage_user_decryptions_in_store",
+            "kms_network_debug_events_total",
             "kms_network_rx_bytes_total",
+            "kms_network_sender_tasks",
+            "kms_network_sender_tasks_completed_total",
+            "kms_network_sender_tasks_spawned_total",
             "kms_network_tx_bytes_total",
             "kms_operation_duration_ms",
             "kms_operation_errors_total",
@@ -908,8 +1237,13 @@ mod tests {
             "kms_socat_file_descriptors",
             "kms_socat_tasks",
             "kms_tasks",
+            "kms_tokio_alive_tasks",
+            "kms_tokio_global_queue_depth",
             "kms_total_cpus",
             "kms_total_memory",
+            "kms_user_decrypt_background_tasks",
+            "kms_user_decrypt_stage_duration_microseconds_total",
+            "kms_user_decrypt_stage_observations_total",
             "kms_version",
         ];
         // process_* metrics come from the prometheus crate's `process` feature (linux only),
@@ -940,6 +1274,83 @@ mod tests {
 
         METRICS.record_fhe_key_cache_size(0);
         assert_eq!(METRICS.fhe_key_cache_size_gauge.get(), 0);
+    }
+
+    #[test]
+    fn diagnostic_task_guards_track_task_lifetimes() {
+        let registry = prometheus::Registry::new();
+        let metrics = CoreMetrics::with_config_in_registry(MetricsConfig::default(), &registry);
+
+        {
+            let _sender = metrics.track_network_sender_task();
+            assert_eq!(metrics.network_sender_tasks_gauge.get(), 1);
+            assert_eq!(metrics.network_sender_tasks_spawned_counter.get(), 1);
+            assert_eq!(metrics.network_sender_tasks_completed_counter.get(), 0);
+        }
+        assert_eq!(metrics.network_sender_tasks_gauge.get(), 0);
+        assert_eq!(metrics.network_sender_tasks_completed_counter.get(), 1);
+
+        {
+            let _udec = metrics.track_user_decrypt_background_task();
+            assert_eq!(metrics.user_decrypt_background_tasks_gauge.get(), 1);
+        }
+        assert_eq!(metrics.user_decrypt_background_tasks_gauge.get(), 0);
+    }
+
+    #[test]
+    fn diagnostic_metrics_record_events_stages_and_runtime_state() {
+        let registry = prometheus::Registry::new();
+        let metrics = CoreMetrics::with_config_in_registry(MetricsConfig::default(), &registry);
+
+        metrics.increment_network_event(NetworkDebugEvent::QueueFull);
+        assert_eq!(
+            metrics.network_debug_event_counters[NetworkDebugEvent::QueueFull as usize].get(),
+            1
+        );
+
+        let stage = UserDecryptStage::PartialDecrypt as usize;
+        {
+            let _timer = metrics.time_user_decrypt_stage(UserDecryptStage::PartialDecrypt);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(metrics.user_decrypt_stage_duration_counters[stage].get() > 0);
+        assert_eq!(
+            metrics.user_decrypt_stage_observation_counters[stage].get(),
+            1
+        );
+
+        metrics.record_tokio_alive_tasks(13);
+        metrics.record_tokio_global_queue_depth(7);
+        metrics.record_completed_sessions(5);
+        assert_eq!(metrics.tokio_alive_tasks_gauge.get(), 13);
+        assert_eq!(metrics.tokio_global_queue_depth_gauge.get(), 7);
+        assert_eq!(metrics.completed_session_gauge.get(), 5);
+    }
+
+    #[test]
+    fn diagnostic_labels_cover_each_enum_variant_once() {
+        assert_eq!(
+            NetworkDebugEvent::FutureMessageDropped as usize + 1,
+            NetworkDebugEvent::COUNT
+        );
+        assert_eq!(
+            NetworkDebugEvent::LABELS
+                .iter()
+                .collect::<BTreeSet<_>>()
+                .len(),
+            NetworkDebugEvent::COUNT
+        );
+        assert_eq!(
+            UserDecryptStage::MetaStoreUpdate as usize + 1,
+            UserDecryptStage::COUNT
+        );
+        assert_eq!(
+            UserDecryptStage::LABELS
+                .iter()
+                .collect::<BTreeSet<_>>()
+                .len(),
+            UserDecryptStage::COUNT
+        );
     }
 
     #[test]

--- a/observability/src/sys_metrics.rs
+++ b/observability/src/sys_metrics.rs
@@ -40,6 +40,10 @@ pub fn start_sys_metrics_collection(refresh_interval: Duration) -> anyhow::Resul
             tracing::debug!("CPU Load Average over all cores within 1 min {cpus_load_avg}");
             METRICS.record_cpu_load(cpus_load_avg);
 
+            let runtime_metrics = tokio::runtime::Handle::current().metrics();
+            METRICS.record_tokio_alive_tasks(runtime_metrics.num_alive_tasks());
+            METRICS.record_tokio_global_queue_depth(runtime_metrics.global_queue_depth());
+
             if let Ok(pid) = sysinfo::get_current_pid() {
                 if let Some(process) = system.process(pid) {
                     METRICS.record_process_memory_usage(process.memory());


### PR DESCRIPTION
PR 4/5 - perf-test stabilization

Add diagnostics and metrics that have been useful during the perf test stabilization effort.

Adds three types of metrics:

1. User decryption metrics (request admission, background task scehduling, MPC session, crypto work, metastore stats)
1. network metrics (count session, message-queues, send/retrty, timeouts; track active spawned and completed sender tasks)
1. tokio task count and queue depth

Also removes a few INFO-level logs that become problematic under high load just by the sheer volume of data.

Adds more debugging data on the infra level:

- AWS ENA interface counters
- Record AZ placement of nodes
