### PR TITLE
feat (ci): collect KMS metrics on the nightly perf run

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -102,9 +102,9 @@ const-label: the nightly runs `thresholdWithEnclave`, and const-labels come from
 
 The aws path deliberately installs nothing: that cluster is long-lived and shared,
 so a second Prometheus operator would compete with the existing one over the same
-ServiceMonitors. If no operator is present the deploy warns and continues
-**without** metrics rather than failing — the ServiceMonitor CRD is what makes the
-resource renderable.
+ServiceMonitors. If the ServiceMonitor CRD is absent the deploy warns and
+continues **without** metrics rather than failing, since Kubernetes cannot create
+the resource without its CRD.
 
 #### `kind-metrics` label
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -84,12 +84,29 @@ Builds Docker images **once per PR** and fans out to dependent workflows. Saves 
 
 Concurrency: groups by PR head ref, cancels in-progress runs.
 
-### Opt-in kind metrics (`kind-metrics` label)
+### KMS metrics
 
-When the PR carries the `kind-metrics` label, `kind-testing` installs a lean
-kube-prometheus-stack in the kind cluster and remote-writes the KMS metrics
-(names `ci_`-prefixed, const-label `deployment_profile=kind-ci`, external label
-`ci_run_id`) to Grafana Cloud using the `GRAFANA_CLOUD_PROM_*` secrets.
+`deploy.sh --enable-metrics` turns on the kms-core ServiceMonitor, which prefixes
+every metric name with `ci_` at scrape time. Two CI paths use it, and they get the
+metrics out in different ways:
+
+| Where | When | Scraped by | Identified by |
+|-------|------|------------|---------------|
+| `performance-testing` on `aws-perf` | every nightly | the cluster's own Prometheus operator — nothing is installed | `namespace="kms-ci"` |
+| `kind-testing` on kind | PRs carrying the `kind-metrics` label | a lean kube-prometheus-stack installed into the throwaway kind cluster, remote-writing to Grafana Cloud via `GRAFANA_CLOUD_PROM_*` | `deployment_profile="kind-ci"` |
+
+The perf rows are identified by namespace rather than a `deployment_profile`
+const-label: the nightly runs `thresholdWithEnclave`, and const-labels come from
+`KMS_METRICS_LABELS` in the server's environment, which a Nitro enclave never sees
+(see the developer metrics guide).
+
+The aws path deliberately installs nothing: that cluster is long-lived and shared,
+so a second Prometheus operator would compete with the existing one over the same
+ServiceMonitors. If no operator is present the deploy warns and continues
+**without** metrics rather than failing — the ServiceMonitor CRD is what makes the
+resource renderable.
+
+#### `kind-metrics` label
 
 Note: adding the label does **not** start a run by itself — `labeled` events
 only trigger CI for the `docker` and `pr-preview-*` labels — and re-running an

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -213,8 +213,12 @@ jobs:
           NAMESPACE: 'kms-ci'
           KMS_CHART_VERSION: ${{ inputs.kms_chart_version || 'repository' }}
           TKMS_INFRA_CHART_VERSION: ${{ inputs.tkms_infra_chart_version || '0.3.2' }}
+          # Metrics are collected on the nightly only; workflow_dispatch is already
+          # at the 10-input limit, so there is no knob to opt a manual run in.
+          ENABLE_KMS_METRICS: ${{ github.event_name == 'schedule' }}
         run: |
           {
+            echo "ENABLE_KMS_METRICS=${ENABLE_KMS_METRICS}"
             echo "DEPLOYMENT_TYPE=${DEPLOYMENT_TYPE}"
             echo "TLS=${TLS}"
             echo "CLIENT_LOGS=${CLIENT_LOGS}"
@@ -412,6 +416,11 @@ jobs:
           sudo chmod +x /usr/local/bin/jq
           echo "JQ version: $(jq --version)"
 
+          METRICS_FLAG=()
+          if [[ "${ENABLE_KMS_METRICS}" == "true" ]]; then
+            METRICS_FLAG=(--enable-metrics)
+          fi
+
           chmod +x ci/scripts/deploy.sh
           ./ci/scripts/deploy.sh \
             --target aws-perf \
@@ -421,7 +430,8 @@ jobs:
             --client-tag "${KMS_CORE_CLIENT_IMAGE_TAG}" \
             --num-parties 13 \
             --kms-chart-version "${KMS_CHART_VERSION}" \
-            --tkms-infra-version "${TKMS_INFRA_CHART_VERSION}"
+            --tkms-infra-version "${TKMS_INFRA_CHART_VERSION}" \
+            "${METRICS_FLAG[@]}"
 
       - name: Capture network diagnostics before perf
         if: always()

--- a/ci/scripts/lib/common.sh
+++ b/ci/scripts/lib/common.sh
@@ -48,9 +48,11 @@ Options:
   --collect-logs           Only collect logs from pods and exit
   --enable-tls             Explicitly enable TLS (default for threshold mode)
   --disable-tls            Explicitly disable TLS (overrides default for threshold mode)
-  --enable-metrics         Install kube-prometheus-stack and remote-write KMS metrics
-                           to Grafana Cloud (kind targets only; reads
-                           GRAFANA_CLOUD_PROM_* from env)
+  --enable-metrics         Expose KMS metrics to Prometheus. On kind, installs
+                           kube-prometheus-stack and remote-writes to Grafana Cloud
+                           (reads GRAFANA_CLOUD_PROM_* from env). On aws targets,
+                           only enables the kms-core ServiceMonitor and lets the
+                           cluster's own Prometheus scrape it.
   --tracing-endpoint <url> Enable kms-core tracing and send OTLP traces to <url>
                            (e.g. http://jaeger:4317; default: disabled)
   --debug                  Enable debug logging (port-forward logs to ./logs/port-forward/)

--- a/ci/scripts/lib/infrastructure.sh
+++ b/ci/scripts/lib/infrastructure.sh
@@ -42,11 +42,18 @@ setup_infrastructure() {
         deploy_tkms_infra           # S3 buckets, IAM roles, service accounts
         deploy_registry_credentials # GHCR access via sync-secrets
 
-        # Metrics are kind-only: without the kube-prometheus-stack installed above
-        # there is no ServiceMonitor CRD and deploy_kms would fail rendering one.
+        # Metrics here ride the cluster's own Prometheus operator: we only enable
+        # the kms-core ServiceMonitor and let it scrape, rather than installing a
+        # second stack into a shared cluster. Its CRD is what makes the
+        # ServiceMonitor renderable, so without the operator turn metrics off
+        # instead of failing the deploy.
         if [[ "${ENABLE_METRICS:-false}" == "true" ]]; then
-            log_warn "--enable-metrics is only supported on kind targets; disabling for TARGET=${TARGET}."
-            export ENABLE_METRICS="false"
+            if kubectl get crd servicemonitors.monitoring.coreos.com > /dev/null 2>&1; then
+                log_info "Prometheus operator found; enabling the kms-core ServiceMonitor."
+            else
+                log_warn "No ServiceMonitor CRD in this cluster (no Prometheus operator); continuing without metrics."
+                export ENABLE_METRICS="false"
+            fi
         fi
     fi
 }

--- a/ci/scripts/lib/infrastructure.sh
+++ b/ci/scripts/lib/infrastructure.sh
@@ -42,16 +42,15 @@ setup_infrastructure() {
         deploy_tkms_infra           # S3 buckets, IAM roles, service accounts
         deploy_registry_credentials # GHCR access via sync-secrets
 
-        # Metrics here ride the cluster's own Prometheus operator: we only enable
-        # the kms-core ServiceMonitor and let it scrape, rather than installing a
-        # second stack into a shared cluster. Its CRD is what makes the
-        # ServiceMonitor renderable, so without the operator turn metrics off
-        # instead of failing the deploy.
+        # Metrics here ride the cluster's own Prometheus: we only enable the
+        # kms-core ServiceMonitor, rather than installing a second stack into a
+        # shared cluster. Without the CRD the resource cannot be created at all,
+        # so turn metrics off instead of failing the deploy.
         if [[ "${ENABLE_METRICS:-false}" == "true" ]]; then
             if kubectl get crd servicemonitors.monitoring.coreos.com > /dev/null 2>&1; then
-                log_info "Prometheus operator found; enabling the kms-core ServiceMonitor."
+                log_info "ServiceMonitor CRD present; enabling the kms-core ServiceMonitor."
             else
-                log_warn "No ServiceMonitor CRD in this cluster (no Prometheus operator); continuing without metrics."
+                log_warn "No ServiceMonitor CRD in this cluster; continuing without metrics."
                 export ENABLE_METRICS="false"
             fi
         fi

--- a/docs/developer/metrics.md
+++ b/docs/developer/metrics.md
@@ -299,6 +299,11 @@ Conventions:
 
 - `deployment_profile=kind-ci` — the only const-label the kind overlay applies, marking every metric
   from the kind-cluster integration tests.
+- Const-labels cannot reach a **Nitro enclave** deployment: `kms-server` runs in a separate VM started
+  by `init_enclave.sh` from a config sent over vsock, so it never sees the parent container's
+  `KMS_METRICS_LABELS`. Distinguish enclave deployments by their `namespace` label instead — that one
+  is attached by Prometheus at scrape time. (The nightly `aws-perf` run does exactly this,
+  `namespace="kms-ci"`.)
 - The threshold and centralized matrices deploy to separate namespaces (`kms-test-threshold` /
   `kms-test-centralized`, from the CI `DEPLOYMENT_TYPE`), so their metrics are already told apart by
   Prometheus' `namespace` label — there is no `deployment_type` const-label. You could add one via


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->

The nightly perf run now collects KMS metrics. On `aws-perf` it enables the kms-core ServiceMonitor and lets the cluster's existing Prometheus scrape it. If the cluster has no Prometheus operator, the deploy warns and continues without metrics, so this cannot fail the perf run. Series are `ci_`-prefixed and identified by `namespace="kms-ci"`

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

https://github.com/zama-ai/kms-internal/issues/3180

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
