### PR TITLE
chore: fresh entropy on RNGs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,6 +4574,7 @@ dependencies = [
  "ed25519-dalek",
  "enum_dispatch",
  "futures-util",
+ "getrandom 0.4.3",
  "hex",
  "hybrid-array 0.2.3",
  "iam-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ enum_dispatch = "=0.3.13"  # Enum dispatch optimization - HIGH RISK: Individual 
 escargot = "=0.5.15" # Interact with cargo without spawning external processes. MEDIUM RISK: single maintainer, 8M downloads, test-only dependency.
 futures = "=0.3.32"  # Async futures - LOW RISK: rust-lang team
 futures-util = "=0.3.32"  # Futures utilities - LOW RISK: rust-lang team
-getrandom = "=0.4.3" # Random number generation - LOW RISK: rust-random team, 1.8B+ downloads
+getrandom = { version = "=0.4.3", features = ["wasm_js"] }  # Random number generation - LOW RISK: rust-random team, 1.8B+ downloads
 g2p = "=1.2.2"  # Galois field arithmetic (GF(2^p)) - LOW RISK: Essential for threshold cryptography, finite field operations
 hex = "=0.4.3"  # Hex encoding/decoding - HIGH RISK: Individual maintainer (KokaKiwi), despite 284M downloads
 http = "=1.3.1"  # HTTP types - LOW RISK: hyperium team, 100M+ downloads

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ enum_dispatch = "=0.3.13"  # Enum dispatch optimization - HIGH RISK: Individual 
 escargot = "=0.5.15" # Interact with cargo without spawning external processes. MEDIUM RISK: single maintainer, 8M downloads, test-only dependency.
 futures = "=0.3.32"  # Async futures - LOW RISK: rust-lang team
 futures-util = "=0.3.32"  # Futures utilities - LOW RISK: rust-lang team
+getrandom = "=0.4.3" # Random number generation - LOW RISK: rust-random team, 1.8B+ downloads
 g2p = "=1.2.2"  # Galois field arithmetic (GF(2^p)) - LOW RISK: Essential for threshold cryptography, finite field operations
 hex = "=0.4.3"  # Hex encoding/decoding - HIGH RISK: Individual maintainer (KokaKiwi), despite 284M downloads
 http = "=1.3.1"  # HTTP types - LOW RISK: hyperium team, 100M+ downloads

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ enum_dispatch = "=0.3.13"  # Enum dispatch optimization - HIGH RISK: Individual 
 escargot = "=0.5.15" # Interact with cargo without spawning external processes. MEDIUM RISK: single maintainer, 8M downloads, test-only dependency.
 futures = "=0.3.32"  # Async futures - LOW RISK: rust-lang team
 futures-util = "=0.3.32"  # Futures utilities - LOW RISK: rust-lang team
-getrandom = { version = "=0.4.3", features = ["wasm_js"] }  # Random number generation - LOW RISK: rust-random team, 1.8B+ downloads
+getrandom = "=0.4.3" # Random number generation - LOW RISK: rust-random team, 1.8B+ downloads
 g2p = "=1.2.2"  # Galois field arithmetic (GF(2^p)) - LOW RISK: Essential for threshold cryptography, finite field operations
 hex = "=0.4.3"  # Hex encoding/decoding - HIGH RISK: Individual maintainer (KokaKiwi), despite 284M downloads
 http = "=1.3.1"  # HTTP types - LOW RISK: hyperium team, 100M+ downloads

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -65,7 +65,7 @@ console_error_panic_hook.workspace = true
 ed25519-dalek.workspace = true
 enum_dispatch.workspace = true
 futures-util.workspace = true
-getrandom.workspace = true
+getrandom = { workspace = true, features = ["wasm_js"] }
 hashing.workspace = true
 hex.workspace = true
 hybrid-array.workspace = true

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -65,7 +65,7 @@ console_error_panic_hook.workspace = true
 ed25519-dalek.workspace = true
 enum_dispatch.workspace = true
 futures-util.workspace = true
-getrandom = { workspace = true, features = ["wasm_js"] }
+getrandom = { workspace = true, optional = true }
 hashing.workspace = true
 hex.workspace = true
 hybrid-array.workspace = true
@@ -191,6 +191,7 @@ non-wasm = [
     "dep:tower",
     "dep:tower-http",
     "dep:x509-parser",
+    "dep:getrandom",
 ]
 slow_tests = ["testing"]
 wasm_tests = ["testing"]

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -65,6 +65,7 @@ console_error_panic_hook.workspace = true
 ed25519-dalek.workspace = true
 enum_dispatch.workspace = true
 futures-util.workspace = true
+getrandom.workspace = true
 hashing.workspace = true
 hex.workspace = true
 hybrid-array.workspace = true

--- a/core/service/src/bin/kms-server.rs
+++ b/core/service/src/bin/kms-server.rs
@@ -600,7 +600,10 @@ async fn main_exec() -> anyhow::Result<()> {
 
     // load key
     let (base_kms, able_to_use_tls) = match get_core_signing_key(&private_vault).await {
-        Ok(sk) => (BaseKmsStruct::new(kms_type, sk)?, true), // The signing key is present, so we can use TLS if configured
+        Ok(sk) => (
+            BaseKmsStruct::new(kms_type, sk, security_module.clone()).await?,
+            true,
+        ), // The signing key is present, so we can use TLS if configured
         Err(e) => {
             tracing::warn!("Error loading signing key: {e:?}");
             tracing::warn!(
@@ -611,7 +614,11 @@ async fn main_exec() -> anyhow::Result<()> {
             let verf_key = public_storage
                 .read_data(&SIGNING_KEY_ID, &PubDataType::VerfKey.to_string())
                 .await?;
-            (BaseKmsStruct::new_no_signing_key(kms_type, verf_key), false) // No signing key, so we cannot use TLS even if configured
+            (
+                BaseKmsStruct::new_no_signing_key(kms_type, verf_key, security_module.clone())
+                    .await,
+                false,
+            ) // No signing key, so we cannot use TLS even if configured
         }
     };
 

--- a/core/service/src/client/test_tools.rs
+++ b/core/service/src/client/test_tools.rs
@@ -136,7 +136,9 @@ pub async fn setup_threshold_no_client<
 
         handles.spawn(async move {
             let sk = get_core_signing_key(&cur_priv_storage).await.unwrap();
-            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk).unwrap();
+            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk, None)
+                .await
+                .unwrap();
 
             // TODO pass in cert_paths for testing TLS
             let server = new_real_threshold_kms(
@@ -364,7 +366,9 @@ pub async fn setup_threshold_with_custom_peers<
         let server_idx = idx; // Track the physical server index
         handles.push(tokio::spawn(async move {
             let sk = get_core_signing_key(&cur_priv_storage).await.unwrap();
-            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk).unwrap();
+            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk, None)
+                .await
+                .unwrap();
 
             // Note: explicit some of the types to avoid clippy complaining
             let server: anyhow::Result<(

--- a/core/service/src/cryptography/attestation/nitro.rs
+++ b/core/service/src/cryptography/attestation/nitro.rs
@@ -51,8 +51,7 @@ impl SecurityModule for Nitro {
         Ok(document)
     }
 
-    /// Request random bytes from the Nitro security module. Only used for generating initialization
-    /// vectors in symmetric encryption and attestation document nonces at the moment.
+    /// Request random bytes from the Nitro security module.
     async fn get_random(&self, num_bytes: usize) -> anyhow::Result<Vec<u8>> {
         let nsm_request = NSMRequest::GetRandom;
         let guarded_nsm_fd = self.nsm_fd.lock().await;

--- a/core/service/src/cryptography/attestation/nitro_mock.rs
+++ b/core/service/src/cryptography/attestation/nitro_mock.rs
@@ -20,7 +20,7 @@ impl SecurityModule for DevNitro {
     }
 
     async fn get_random(&self, num_bytes: usize) -> anyhow::Result<Vec<u8>> {
-        let mut vec = Vec::with_capacity(num_bytes);
+        let mut vec = vec![0u8; num_bytes];
         OsRng.try_fill_bytes(&mut vec)?;
         Ok(vec)
     }

--- a/core/service/src/engine/backup_operator.rs
+++ b/core/service/src/engine/backup_operator.rs
@@ -104,7 +104,7 @@ where
         backup_id: RequestId,
         cts: BTreeMap<Role, InnerOperatorBackupOutput>,
     ) -> anyhow::Result<(RecoveryRequest, UnifiedPrivateEncKey, UnifiedPublicEncKey)> {
-        let mut rng = self.base_kms.new_rng().await;
+        let mut rng = self.base_kms.fork_rng().await;
         let operator_verf_key = self.base_kms.verf_key().to_legacy_bytes()?;
         // Generate asymmetric ephemeral keys for the operator to use to encrypt the backup
         let mut enc = Encryption::new(PkeSchemeType::MlKem512, &mut rng);

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -1,13 +1,13 @@
 use super::traits::BaseKms;
 use crate::consts::ID_LENGTH;
 use crate::consts::SAFE_SER_SIZE_LIMIT;
-use crate::cryptography::attestation::SecurityModule;
 use crate::cryptography::attestation::SecurityModuleProxy;
 use crate::cryptography::decompression;
 use crate::cryptography::internal_crypto_types::WrappedDKGParams;
 use crate::cryptography::signatures::internal_sign;
 use crate::cryptography::signatures::{PrivateSigKey, PublicSigKey, Signature};
 use crate::cryptography::signing::SigningSchemeType;
+use crate::engine::rng_registry::RngRegistry;
 use crate::engine::traits::PrivateKeyMaterialMetadata;
 use crate::util::key_setup::FhePrivateKey;
 use aes_prng::AesRng;
@@ -40,7 +40,6 @@ use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::LazyLock;
-use std::sync::Weak;
 use tfhe::FheUint80;
 use tfhe::integer::BooleanBlock;
 use tfhe::integer::compression_keys::DecompressionKey;
@@ -1080,7 +1079,6 @@ pub struct BaseKmsStruct {
     verf_key: Arc<PublicSigKey>,
     rng: Arc<Mutex<AesRng>>,
     security_module: Option<Arc<SecurityModuleProxy>>,
-    rng_registry: Arc<Mutex<Vec<Weak<Mutex<AesRng>>>>>,
 }
 
 impl BaseKmsStruct {
@@ -1089,17 +1087,13 @@ impl BaseKmsStruct {
         sig_key: PrivateSigKey,
         security_module: Option<Arc<SecurityModuleProxy>>,
     ) -> anyhow::Result<Self> {
-        let rng = Arc::new(Mutex::new(AesRng::from_seed(
-            Self::fresh_seed(security_module.clone()).await,
-        )));
-        let registry = Arc::new(Mutex::new(vec![Arc::downgrade(&rng)]));
+        let rng = RngRegistry::fresh_registered_rng(None, security_module.clone()).await;
         Ok(BaseKmsStruct {
             kms_type,
             verf_key: Arc::new(sig_key.verf_key()),
             sig_key: Some(Arc::new(sig_key)),
             security_module,
             rng,
-            rng_registry: registry,
         })
     }
 
@@ -1111,17 +1105,13 @@ impl BaseKmsStruct {
         tracing::warn!(
             "Initializing KMS without a signing key. ONLY BACKUP RECOVERY OPERATIONS WILL BE POSSIBLE."
         );
-        let rng = Arc::new(Mutex::new(AesRng::from_seed(
-            Self::fresh_seed(security_module.clone()).await,
-        )));
-        let registry = Arc::new(Mutex::new(vec![Arc::downgrade(&rng)]));
+        let rng = RngRegistry::fresh_registered_rng(None, security_module.clone()).await;
         BaseKmsStruct {
             kms_type,
             sig_key: None,
             verf_key: Arc::new(verf_key),
             security_module,
             rng,
-            rng_registry: registry,
         }
     }
 
@@ -1153,7 +1143,6 @@ impl BaseKmsStruct {
             sig_key,
             security_module: self.security_module.clone(),
             rng,
-            rng_registry: Arc::clone(&self.rng_registry),
         }
     }
 
@@ -1161,6 +1150,7 @@ impl BaseKmsStruct {
     /// Useful for creating a new RNG for a ask that can run in parallel.
     ///
     /// __NOTE__: If the goal is to refresh entropy for the base RNG, use [`refresh_rng`] instead.
+    /// Forked rngs are not registered (and thus not refreshed) as they are meant to be short-lived
     pub(crate) async fn fork_rng(&self) -> AesRng {
         let mut seed = [0u8; crate::consts::RND_SIZE];
         // Make a seperate scope for the rng so that it is dropped before the lock is released
@@ -1171,86 +1161,10 @@ impl BaseKmsStruct {
         AesRng::from_seed(seed)
     }
 
-    /// Refreshes all RNGs in the registry with new RNGs seeded from the OS and optionally the security module.
-    pub(crate) async fn refresh_all_rngs_in_registry(&self) {
-        let mut registry = self.rng_registry.lock().await;
-        registry.retain(|weak_rng| weak_rng.upgrade().is_some());
-        for weak_rng in registry.iter() {
-            if let Some(rng) = weak_rng.upgrade() {
-                let fresh_rng =
-                    Self::fresh_rng(Arc::clone(&rng), self.security_module.clone()).await;
-                let mut rng_lock = rng.lock().await;
-                *rng_lock = fresh_rng;
-            }
-        }
-    }
-
-    async fn fresh_seed(
-        security_module: Option<Arc<SecurityModuleProxy>>,
-    ) -> [u8; crate::consts::RND_SIZE] {
-        // Pulls randomness from OS entropy pool.
-        let mut seed = [0u8; crate::consts::RND_SIZE];
-        if let Err(err) = getrandom::fill(seed.as_mut()) {
-            panic!("getrandom failed: {}", err);
-        }
-
-        // Pulls randomness from the security module if available.
-        if let Some(security_module) = security_module {
-            match security_module.get_random(crate::consts::RND_SIZE).await {
-                Ok(bytes) => {
-                    if bytes.len() != crate::consts::RND_SIZE {
-                        panic!(
-                            "Security module returned {} bytes, expected {}",
-                            bytes.len(),
-                            crate::consts::RND_SIZE
-                        );
-                    }
-                    // Mix in the randomness from the security module into the OS seed
-                    for i in 0..crate::consts::RND_SIZE {
-                        // Direct indexing as we just checked the size is correct
-                        seed[i] ^= bytes[i];
-                    }
-                }
-                Err(e) => {
-                    panic!("Failed to get random bytes from security module: {}", e);
-                }
-            }
-        };
-
-        seed
-    }
-
-    /// Creates a new RNG seeded with randomness from the OS, the base RNG, and optionally a security module.
-    async fn fresh_rng(
-        rng: Arc<Mutex<AesRng>>,
-        security_module: Option<Arc<SecurityModuleProxy>>,
-    ) -> AesRng {
-        let fresh_seed = Self::fresh_seed(security_module.clone()).await;
-
-        // Pulls randomness from the exisiting rng
-        let mut seed = [0u8; crate::consts::RND_SIZE];
-        // Make a seperate scope for the rng so that it is dropped before the lock is released
-        {
-            let mut base_rng = rng.lock().await;
-            base_rng.fill_bytes(seed.as_mut());
-        }
-
-        // Mix in all the randomness sources to create a new seed
-        for i in 0..crate::consts::RND_SIZE {
-            seed[i] ^= fresh_seed[i];
-        }
-
-        AesRng::from_seed(seed)
-    }
-
     /// Calls [`Self::fresh_rng`] and registers it in the rng_registry (so it gets refreshed upon [`Self::refresh_all_rngs_in_registry`]).
     pub(crate) async fn fresh_registered_rng(&self) -> Arc<Mutex<AesRng>> {
-        let rng = Arc::new(Mutex::new(
-            Self::fresh_rng(self.rng.clone(), self.security_module.clone()).await,
-        ));
-        let mut registry = self.rng_registry.lock().await;
-        registry.push(Arc::downgrade(&rng));
-        rng
+        RngRegistry::fresh_registered_rng(Some(Arc::clone(&self.rng)), self.security_module.clone())
+            .await
     }
 }
 
@@ -3115,19 +3029,23 @@ pub(crate) mod tests {
         );
     }
 
-    /// Tests for the RNG lifecycle machinery on [`super::BaseKmsStruct`]:
-    /// forking, fresh reseeding, per-instance registration in the shared
-    /// registry, and the single-shot `refresh_all` that reseeds every live
-    /// instance in one call.
+    /// Tests for the RNG lifecycle on [`super::BaseKmsStruct`]: forking (which is
+    /// deterministic in the base state and intentionally left unregistered),
+    /// spawning independent per-instance RNGs, and the in-place reseed performed
+    /// by the process-wide [`RngRegistry`] refresh.
     ///
-    /// These reach into the private `rng` / `rng_registry` fields (allowed since
-    /// this is a descendant module of the one defining the struct) so we can
-    /// pin the RNGs to deterministic seeds and observe the plumbing directly.
-    /// The security module is left as `None`, so seeding draws from OS entropy
-    /// only; that still exercises every code path added here.
-    mod rng_machinery {
+    /// Registry bookkeeping (entry counts, pruning) is covered in isolation in
+    /// `rng_registry`'s own tests, since the registry is a process-global
+    /// singleton shared by the whole crate's test suite and so cannot be counted
+    /// reliably from here.
+    ///
+    /// These reach into the private `rng` field (allowed from this descendant
+    /// module) to pin RNGs to deterministic seeds and observe the plumbing. The
+    /// security module is left as `None`, so seeding draws from OS entropy only.
+    mod rng_lifecycle {
         use super::super::BaseKmsStruct;
         use crate::cryptography::signatures::gen_sig_keys;
+        use crate::engine::rng_registry::RngRegistry;
         use aes_prng::AesRng;
         use kms_grpc::rpc_types::KMSType;
         use rand::{RngCore, SeedableRng};
@@ -3182,46 +3100,16 @@ pub(crate) mod tests {
         }
 
         #[tokio::test]
-        async fn fresh_rng_injects_new_entropy_on_every_call() {
+        async fn new_instance_has_an_independent_rng() {
             let base = test_base_kms().await;
-
-            // Even from an identical base state, `fresh_rng` mixes in fresh OS
-            // entropy, so two calls yield independent streams.
-            set_seed(&base.rng, 7).await;
-            let mut r1 = BaseKmsStruct::fresh_rng(base.rng.clone(), None).await;
-            set_seed(&base.rng, 7).await;
-            let mut r2 = BaseKmsStruct::fresh_rng(base.rng.clone(), None).await;
-            let (mut a, mut b) = ([0u8; 16], [0u8; 16]);
-            r1.fill_bytes(&mut a);
-            r2.fill_bytes(&mut b);
-            assert_ne!(a, b, "fresh_rng must reseed with new entropy on every call");
-        }
-
-        #[tokio::test]
-        async fn new_instance_registers_in_shared_registry_with_independent_rng() {
-            let base = test_base_kms().await;
-            // `new` seeds the registry with the base RNG.
-            assert_eq!(base.rng_registry.lock().await.len(), 1);
-
             let child = base.new_instance().await;
-            assert_eq!(
-                base.rng_registry.lock().await.len(),
-                2,
-                "new_instance must register its RNG in the shared registry"
-            );
-            // The registry Arc is shared across instances; the RNG allocations are not.
-            assert!(Arc::ptr_eq(&base.rng_registry, &child.rng_registry));
+
+            // Each instance owns a distinct RNG allocation.
             assert!(!Arc::ptr_eq(&base.rng, &child.rng));
 
-            // Registration is transitive: an instance spawned from a child lands
-            // in the same shared registry.
-            let grandchild = child.new_instance().await;
-            assert_eq!(base.rng_registry.lock().await.len(), 3);
-            assert!(Arc::ptr_eq(&base.rng_registry, &grandchild.rng_registry));
-
-            // Independent allocations: consuming from one RNG does not disturb
-            // another. Seed base and child identically, advance base twice but
-            // child once — the child's first draw still matches base's first draw.
+            // Independent state: seed both identically, advance the base twice but
+            // the child once — the child's first draw still matches the base's
+            // first draw, proving draws on one do not disturb the other.
             set_seed(&base.rng, 99).await;
             set_seed(&child.rng, 99).await;
             let base_first = draw(&base.rng).await;
@@ -3234,90 +3122,32 @@ pub(crate) mod tests {
         }
 
         #[tokio::test]
-        async fn refresh_all_reseeds_every_registered_instance_in_place() {
+        async fn registry_refresh_reseeds_a_base_kms_rng_in_place() {
             let base = test_base_kms().await;
-            let i1 = base.new_instance().await;
-            let i2 = base.new_instance().await;
-            let i3 = base.new_instance().await;
 
-            // Registry holds the base plus the three instances.
-            assert_eq!(base.rng_registry.lock().await.len(), 4);
+            // Pin to a known state and remember both the stream and the backing
+            // allocation. (`new` has already registered this RNG in the global
+            // registry.)
+            set_seed(&base.rng, 555).await;
+            let before = draw(&base.rng).await;
+            set_seed(&base.rng, 555).await;
+            let ptr_before = Arc::as_ptr(&base.rng);
 
-            let handles: [&Arc<Mutex<AesRng>>; 4] = [&base.rng, &i1.rng, &i2.rng, &i3.rng];
-            let seeds = [1u64, 2, 3, 4];
+            // The process-wide refresh (invoked on epoch init) must reseed this
+            // instance's RNG too, in place. Other RNGs registered by concurrently
+            // running tests are refreshed as well, which does not affect the
+            // assertions below about *this* handle.
+            RngRegistry::refresh_all_rngs_in_registry().await;
 
-            // Seed each RNG deterministically, record its stream and the pointer
-            // to its backing allocation, then restore the seed so `refresh_all`
-            // starts from a known state.
-            let mut pre = Vec::new();
-            let mut ptrs = Vec::new();
-            for (h, s) in handles.iter().copied().zip(seeds) {
-                set_seed(h, s).await;
-                pre.push(draw(h).await);
-                set_seed(h, s).await;
-                ptrs.push(Arc::as_ptr(h));
-            }
-
-            // A single call reseeds all of them.
-            base.refresh_all_rngs_in_registry().await;
-
-            for (idx, h) in handles.iter().copied().enumerate() {
-                assert_ne!(
-                    draw(h).await,
-                    pre[idx],
-                    "instance {idx} was not reseeded by refresh_all"
-                );
-                // Crucially, the refresh mutates the RNG *in place* behind the
-                // existing Arc: the allocation pointer is unchanged, so both the
-                // registry's Weak and each service's Arc keep pointing at the
-                // refreshed RNG rather than a stale one.
-                assert_eq!(
-                    Arc::as_ptr(h),
-                    ptrs[idx],
-                    "instance {idx} allocation changed; registry Weak would dangle"
-                );
-            }
-        }
-
-        #[tokio::test]
-        async fn refresh_all_prunes_weaks_for_dropped_instances() {
-            let base = test_base_kms().await;
-            let i1 = base.new_instance().await;
-            let i2 = base.new_instance().await;
-            assert_eq!(base.rng_registry.lock().await.len(), 3);
-
-            let base_ptr = Arc::as_ptr(&base.rng);
-            let i1_ptr = Arc::as_ptr(&i1.rng);
-
-            // Dropping an instance releases the only strong ref to its RNG, so the
-            // registry now holds a dangling Weak for it — but not yet pruned.
-            drop(i2);
+            assert_ne!(
+                draw(&base.rng).await,
+                before,
+                "registry refresh must reseed the BaseKmsStruct RNG"
+            );
             assert_eq!(
-                base.rng_registry.lock().await.len(),
-                3,
-                "a dead Weak is not pruned until the next refresh_all"
-            );
-
-            base.refresh_all_rngs_in_registry().await;
-
-            let registry = base.rng_registry.lock().await;
-            assert_eq!(
-                registry.len(),
-                2,
-                "refresh_all must prune Weaks for dropped instances"
-            );
-            let alive: Vec<_> = registry
-                .iter()
-                .filter_map(|w| w.upgrade())
-                .map(|arc| Arc::as_ptr(&arc))
-                .collect();
-            assert!(
-                alive.contains(&base_ptr),
-                "the base RNG must survive pruning"
-            );
-            assert!(
-                alive.contains(&i1_ptr),
-                "the live instance RNG must survive pruning"
+                Arc::as_ptr(&base.rng),
+                ptr_before,
+                "refresh must reseed in place so the registry Weak stays valid"
             );
         }
     }

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -1,6 +1,8 @@
 use super::traits::BaseKms;
 use crate::consts::ID_LENGTH;
 use crate::consts::SAFE_SER_SIZE_LIMIT;
+use crate::cryptography::attestation::SecurityModule;
+use crate::cryptography::attestation::SecurityModuleProxy;
 use crate::cryptography::decompression;
 use crate::cryptography::internal_crypto_types::WrappedDKGParams;
 use crate::cryptography::signatures::internal_sign;
@@ -38,6 +40,7 @@ use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::LazyLock;
+use std::sync::Weak;
 use tfhe::FheUint80;
 use tfhe::integer::BooleanBlock;
 use tfhe::integer::compression_keys::DecompressionKey;
@@ -1070,27 +1073,49 @@ pub struct BaseKmsStruct {
     sig_key: Option<Arc<PrivateSigKey>>,
     verf_key: Arc<PublicSigKey>,
     rng: Arc<Mutex<AesRng>>,
+    security_module: Option<Arc<SecurityModuleProxy>>,
+    rng_registry: Arc<Mutex<Vec<Weak<Mutex<AesRng>>>>>,
 }
 
 impl BaseKmsStruct {
-    pub fn new(kms_type: KMSType, sig_key: PrivateSigKey) -> anyhow::Result<Self> {
+    pub async fn new(
+        kms_type: KMSType,
+        sig_key: PrivateSigKey,
+        security_module: Option<Arc<SecurityModuleProxy>>,
+    ) -> anyhow::Result<Self> {
+        let rng = Arc::new(Mutex::new(AesRng::from_seed(
+            Self::fresh_seed(security_module.clone()).await,
+        )));
+        let registry = Arc::new(Mutex::new(vec![Arc::downgrade(&rng)]));
         Ok(BaseKmsStruct {
             kms_type,
             verf_key: Arc::new(sig_key.verf_key()),
             sig_key: Some(Arc::new(sig_key)),
-            rng: Arc::new(Mutex::new(AesRng::from_entropy())),
+            security_module,
+            rng,
+            rng_registry: registry,
         })
     }
 
-    pub fn new_no_signing_key(kms_type: KMSType, verf_key: PublicSigKey) -> Self {
+    pub async fn new_no_signing_key(
+        kms_type: KMSType,
+        verf_key: PublicSigKey,
+        security_module: Option<Arc<SecurityModuleProxy>>,
+    ) -> Self {
         tracing::warn!(
             "Initializing KMS without a signing key. ONLY BACKUP RECOVERY OPERATIONS WILL BE POSSIBLE."
         );
+        let rng = Arc::new(Mutex::new(AesRng::from_seed(
+            Self::fresh_seed(security_module.clone()).await,
+        )));
+        let registry = Arc::new(Mutex::new(vec![Arc::downgrade(&rng)]));
         BaseKmsStruct {
             kms_type,
             sig_key: None,
             verf_key: Arc::new(verf_key),
-            rng: Arc::new(Mutex::new(AesRng::from_entropy())),
+            security_module,
+            rng,
+            rng_registry: registry,
         }
     }
 
@@ -1109,21 +1134,28 @@ impl BaseKmsStruct {
         Arc::clone(&self.verf_key)
     }
 
-    /// Make a clone of this struct with a newly initialized RNG s.t. that both the new and old struct are safe to use.
+    /// Make a clone of this struct with a newly initialized RNG s.t. that both the new and old struct are safe to use (the RNG is pushed into the shared registry).
     pub async fn new_instance(&self) -> Self {
         let sig_key = match &self.sig_key {
             Some(sk) => Some(Arc::clone(sk)),
             None => None,
         };
+        let rng = self.fresh_registered_rng().await;
         Self {
             kms_type: self.kms_type,
             verf_key: Arc::clone(&self.verf_key),
             sig_key,
-            rng: Arc::new(Mutex::new(self.new_rng().await)),
+            security_module: self.security_module.clone(),
+            rng,
+            rng_registry: Arc::clone(&self.rng_registry),
         }
     }
 
-    pub async fn new_rng(&self) -> AesRng {
+    /// Forks a new RNG from the base RNG, ensuring that the new RNG is independent of the base RNG.
+    /// Useful for creating a new RNG for a ask that can run in parallel.
+    ///
+    /// __NOTE__: If the goal is to refresh entropy for the base RNG, use [`refresh_rng`] instead.
+    pub async fn fork_rng(&self) -> AesRng {
         let mut seed = [0u8; crate::consts::RND_SIZE];
         // Make a seperate scope for the rng so that it is dropped before the lock is released
         {
@@ -1131,6 +1163,94 @@ impl BaseKmsStruct {
             base_rng.fill_bytes(seed.as_mut());
         }
         AesRng::from_seed(seed)
+    }
+
+    /// Refreshes the base RNG with a new RNG seeded from the OS and optionally the security module.
+    pub async fn refresh_self_rng(&self) {
+        let rng = Self::fresh_rng(self.rng.clone(), self.security_module.clone()).await;
+
+        let mut self_rng = self.rng.lock().await;
+        *self_rng = rng;
+    }
+
+    pub async fn refresh_all_rngs_in_registry(&self) {
+        let mut registry = self.rng_registry.lock().await;
+        registry.retain(|weak_rng| weak_rng.upgrade().is_some());
+        for weak_rng in registry.iter() {
+            if let Some(rng) = weak_rng.upgrade() {
+                let fresh_rng =
+                    Self::fresh_rng(Arc::clone(&rng), self.security_module.clone()).await;
+                let mut rng_lock = rng.lock().await;
+                *rng_lock = fresh_rng;
+            }
+        }
+    }
+
+    async fn fresh_seed(
+        security_module: Option<Arc<SecurityModuleProxy>>,
+    ) -> [u8; crate::consts::RND_SIZE] {
+        // Pulls randomness from freshly OS seeded rng.
+        //
+        // Note to reviewer: Using AesRng::from_entropy here because getrandom isn't
+        // one of our dependencies, but might be fine also to add it just for this?
+        let mut os_rng = AesRng::from_entropy();
+        let mut seed = [0u8; crate::consts::RND_SIZE];
+        os_rng.fill_bytes(seed.as_mut());
+
+        // Pulls randomness from the security module if available.
+        if let Some(security_module) = security_module {
+            match security_module.get_random(crate::consts::RND_SIZE).await {
+                Ok(bytes) => {
+                    // Mix in the randomness from the security module into the OS seed
+                    for i in 0..crate::consts::RND_SIZE {
+                        // Sanity check but if the call to the security module is successful, we should have the right number of bytes.
+                        if i < bytes.len() {
+                            seed[i] ^= bytes[i];
+                        }
+                    }
+                }
+                Err(e) => {
+                    // Qu: Do we want to abort here if the security module failed to give
+                    // us the randomness we expected ?
+                    tracing::error!("Failed to get random bytes from security module: {}", e);
+                }
+            }
+        };
+
+        seed
+    }
+
+    /// Creates a new RNG seeded with randomness from the OS, the base RNG, and optionally a security module.
+    async fn fresh_rng(
+        rng: Arc<Mutex<AesRng>>,
+        security_module: Option<Arc<SecurityModuleProxy>>,
+    ) -> AesRng {
+        let fresh_seed = Self::fresh_seed(security_module.clone()).await;
+
+        // Pulls randomness from the exisiting rng
+        let mut seed = [0u8; crate::consts::RND_SIZE];
+        // Make a seperate scope for the rng so that it is dropped before the lock is released
+        {
+            let mut base_rng = rng.lock().await;
+            base_rng.fill_bytes(seed.as_mut());
+        }
+
+        // Mix in all the randomness sources to create a new seed
+        for i in 0..crate::consts::RND_SIZE {
+            seed[i] ^= fresh_seed[i];
+        }
+
+        AesRng::from_seed(seed)
+    }
+
+    /// Calls [`Self::fresh_rng`] and registers it in the rng_registry (so it gets refreshed upon [`Self::refresh_all_rngs_in_registry`]).
+    pub async fn fresh_registered_rng(&self) -> Arc<Mutex<AesRng>> {
+        let rng = Arc::new(Mutex::new(
+            Self::fresh_rng(self.rng.clone(), self.security_module.clone()).await,
+        ));
+        let mut registry = self.rng_registry.lock().await;
+        registry.push(Arc::downgrade(&rng));
+        rng
     }
 }
 

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -3114,4 +3114,234 @@ pub(crate) mod tests {
             q126.external_signature
         );
     }
+
+    /// Tests for the RNG lifecycle machinery on [`super::BaseKmsStruct`]:
+    /// forking, fresh reseeding, per-instance registration in the shared
+    /// registry, and the single-shot `refresh_all` that reseeds every live
+    /// instance in one call.
+    ///
+    /// These reach into the private `rng` / `rng_registry` fields (allowed since
+    /// this is a descendant module of the one defining the struct) so we can
+    /// pin the RNGs to deterministic seeds and observe the plumbing directly.
+    /// The security module is left as `None`, so seeding draws from OS entropy
+    /// only; that still exercises every code path added here.
+    mod rng_machinery {
+        use super::super::BaseKmsStruct;
+        use crate::cryptography::signatures::gen_sig_keys;
+        use aes_prng::AesRng;
+        use kms_grpc::rpc_types::KMSType;
+        use rand::{RngCore, SeedableRng};
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        async fn test_base_kms() -> BaseKmsStruct {
+            let mut rng = AesRng::seed_from_u64(0xDEAD_BEEF);
+            let (_pk, sk) = gen_sig_keys(&mut rng);
+            BaseKmsStruct::new(KMSType::Threshold, sk, None)
+                .await
+                .expect("building a BaseKmsStruct with a signing key must succeed")
+        }
+
+        /// Draw 16 bytes from an RNG handle, advancing its state.
+        async fn draw(rng: &Arc<Mutex<AesRng>>) -> [u8; 16] {
+            let mut out = [0u8; 16];
+            let mut guard = rng.lock().await;
+            guard.fill_bytes(&mut out);
+            out
+        }
+
+        /// Pin an RNG handle to a deterministic seed so its output is reproducible.
+        async fn set_seed(rng: &Arc<Mutex<AesRng>>, seed: u64) {
+            let mut guard = rng.lock().await;
+            *guard = AesRng::seed_from_u64(seed);
+        }
+
+        #[tokio::test]
+        async fn fork_rng_is_deterministic_in_base_state_and_advances_it() {
+            let base = test_base_kms().await;
+
+            // Two consecutive forks observe different base states (each fork
+            // consumes entropy from the base), so their streams differ.
+            let mut f1 = base.fork_rng().await;
+            let mut f2 = base.fork_rng().await;
+            let (mut a, mut b) = ([0u8; 16], [0u8; 16]);
+            f1.fill_bytes(&mut a);
+            f2.fill_bytes(&mut b);
+            assert_ne!(a, b, "consecutive forks must not share a stream");
+
+            // Forking is a pure function of the base RNG state: from an identical
+            // base seed the fork output is reproducible.
+            set_seed(&base.rng, 42).await;
+            let mut g1 = base.fork_rng().await;
+            set_seed(&base.rng, 42).await;
+            let mut g2 = base.fork_rng().await;
+            let (mut c, mut d) = ([0u8; 16], [0u8; 16]);
+            g1.fill_bytes(&mut c);
+            g2.fill_bytes(&mut d);
+            assert_eq!(c, d, "fork from an identical base state must reproduce");
+        }
+
+        #[tokio::test]
+        async fn fresh_rng_injects_new_entropy_on_every_call() {
+            let base = test_base_kms().await;
+
+            // Even from an identical base state, `fresh_rng` mixes in fresh OS
+            // entropy, so two calls yield independent streams.
+            set_seed(&base.rng, 7).await;
+            let mut r1 = BaseKmsStruct::fresh_rng(base.rng.clone(), None).await;
+            set_seed(&base.rng, 7).await;
+            let mut r2 = BaseKmsStruct::fresh_rng(base.rng.clone(), None).await;
+            let (mut a, mut b) = ([0u8; 16], [0u8; 16]);
+            r1.fill_bytes(&mut a);
+            r2.fill_bytes(&mut b);
+            assert_ne!(a, b, "fresh_rng must reseed with new entropy on every call");
+        }
+
+        #[tokio::test]
+        async fn new_instance_registers_in_shared_registry_with_independent_rng() {
+            let base = test_base_kms().await;
+            // `new` seeds the registry with the base RNG.
+            assert_eq!(base.rng_registry.lock().await.len(), 1);
+
+            let child = base.new_instance().await;
+            assert_eq!(
+                base.rng_registry.lock().await.len(),
+                2,
+                "new_instance must register its RNG in the shared registry"
+            );
+            // The registry Arc is shared across instances; the RNG allocations are not.
+            assert!(Arc::ptr_eq(&base.rng_registry, &child.rng_registry));
+            assert!(!Arc::ptr_eq(&base.rng, &child.rng));
+
+            // Registration is transitive: an instance spawned from a child lands
+            // in the same shared registry.
+            let grandchild = child.new_instance().await;
+            assert_eq!(base.rng_registry.lock().await.len(), 3);
+            assert!(Arc::ptr_eq(&base.rng_registry, &grandchild.rng_registry));
+
+            // Independent allocations: consuming from one RNG does not disturb
+            // another. Seed base and child identically, advance base twice but
+            // child once — the child's first draw still matches base's first draw.
+            set_seed(&base.rng, 99).await;
+            set_seed(&child.rng, 99).await;
+            let base_first = draw(&base.rng).await;
+            let _ = draw(&base.rng).await; // advance base only
+            let child_first = draw(&child.rng).await;
+            assert_eq!(
+                base_first, child_first,
+                "child RNG must be unaffected by draws on the base RNG"
+            );
+        }
+
+        #[tokio::test]
+        async fn refresh_self_rng_replaces_the_base_rng() {
+            let base = test_base_kms().await;
+
+            // Capture the deterministic stream at a fixed seed.
+            set_seed(&base.rng, 555).await;
+            let before = draw(&base.rng).await;
+
+            // Control: without a refresh the stream is reproducible.
+            set_seed(&base.rng, 555).await;
+            assert_eq!(draw(&base.rng).await, before);
+
+            // After a refresh the base RNG is reseeded with fresh entropy, so the
+            // "seed 555" stream is gone.
+            set_seed(&base.rng, 555).await;
+            base.refresh_self_rng().await;
+            assert_ne!(
+                draw(&base.rng).await,
+                before,
+                "refresh_self_rng must reseed the base RNG"
+            );
+        }
+
+        #[tokio::test]
+        async fn refresh_all_reseeds_every_registered_instance_in_place() {
+            let base = test_base_kms().await;
+            let i1 = base.new_instance().await;
+            let i2 = base.new_instance().await;
+            let i3 = base.new_instance().await;
+
+            // Registry holds the base plus the three instances.
+            assert_eq!(base.rng_registry.lock().await.len(), 4);
+
+            let handles: [&Arc<Mutex<AesRng>>; 4] = [&base.rng, &i1.rng, &i2.rng, &i3.rng];
+            let seeds = [1u64, 2, 3, 4];
+
+            // Seed each RNG deterministically, record its stream and the pointer
+            // to its backing allocation, then restore the seed so `refresh_all`
+            // starts from a known state.
+            let mut pre = Vec::new();
+            let mut ptrs = Vec::new();
+            for (h, s) in handles.iter().copied().zip(seeds) {
+                set_seed(h, s).await;
+                pre.push(draw(h).await);
+                set_seed(h, s).await;
+                ptrs.push(Arc::as_ptr(h));
+            }
+
+            // A single call reseeds all of them.
+            base.refresh_all_rngs_in_registry().await;
+
+            for (idx, h) in handles.iter().copied().enumerate() {
+                assert_ne!(
+                    draw(h).await,
+                    pre[idx],
+                    "instance {idx} was not reseeded by refresh_all"
+                );
+                // Crucially, the refresh mutates the RNG *in place* behind the
+                // existing Arc: the allocation pointer is unchanged, so both the
+                // registry's Weak and each service's Arc keep pointing at the
+                // refreshed RNG rather than a stale one.
+                assert_eq!(
+                    Arc::as_ptr(h),
+                    ptrs[idx],
+                    "instance {idx} allocation changed; registry Weak would dangle"
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn refresh_all_prunes_weaks_for_dropped_instances() {
+            let base = test_base_kms().await;
+            let i1 = base.new_instance().await;
+            let i2 = base.new_instance().await;
+            assert_eq!(base.rng_registry.lock().await.len(), 3);
+
+            let base_ptr = Arc::as_ptr(&base.rng);
+            let i1_ptr = Arc::as_ptr(&i1.rng);
+
+            // Dropping an instance releases the only strong ref to its RNG, so the
+            // registry now holds a dangling Weak for it — but not yet pruned.
+            drop(i2);
+            assert_eq!(
+                base.rng_registry.lock().await.len(),
+                3,
+                "a dead Weak is not pruned until the next refresh_all"
+            );
+
+            base.refresh_all_rngs_in_registry().await;
+
+            let registry = base.rng_registry.lock().await;
+            assert_eq!(
+                registry.len(),
+                2,
+                "refresh_all must prune Weaks for dropped instances"
+            );
+            let alive: Vec<_> = registry
+                .iter()
+                .filter_map(|w| w.upgrade())
+                .map(|arc| Arc::as_ptr(&arc))
+                .collect();
+            assert!(
+                alive.contains(&base_ptr),
+                "the base RNG must survive pruning"
+            );
+            assert!(
+                alive.contains(&i1_ptr),
+                "the live instance RNG must survive pruning"
+            );
+        }
+    }
 }

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -1125,7 +1125,7 @@ impl BaseKmsStruct {
         }
     }
 
-    pub fn kms_type(&self) -> KMSType {
+    pub(crate) fn kms_type(&self) -> KMSType {
         self.kms_type
     }
 
@@ -1141,7 +1141,7 @@ impl BaseKmsStruct {
     }
 
     /// Make a clone of this struct with a newly initialized RNG s.t. that both the new and old struct are safe to use (the RNG is pushed into the shared registry).
-    pub async fn new_instance(&self) -> Self {
+    pub(crate) async fn new_instance(&self) -> Self {
         let sig_key = match &self.sig_key {
             Some(sk) => Some(Arc::clone(sk)),
             None => None,
@@ -1161,7 +1161,7 @@ impl BaseKmsStruct {
     /// Useful for creating a new RNG for a ask that can run in parallel.
     ///
     /// __NOTE__: If the goal is to refresh entropy for the base RNG, use [`refresh_rng`] instead.
-    pub async fn fork_rng(&self) -> AesRng {
+    pub(crate) async fn fork_rng(&self) -> AesRng {
         let mut seed = [0u8; crate::consts::RND_SIZE];
         // Make a seperate scope for the rng so that it is dropped before the lock is released
         {
@@ -1171,16 +1171,8 @@ impl BaseKmsStruct {
         AesRng::from_seed(seed)
     }
 
-    /// Refreshes the base RNG with a new RNG seeded from the OS and optionally the security module.
-    pub async fn refresh_self_rng(&self) {
-        let rng = Self::fresh_rng(self.rng.clone(), self.security_module.clone()).await;
-
-        let mut self_rng = self.rng.lock().await;
-        *self_rng = rng;
-    }
-
     /// Refreshes all RNGs in the registry with new RNGs seeded from the OS and optionally the security module.
-    pub async fn refresh_all_rngs_in_registry(&self) {
+    pub(crate) async fn refresh_all_rngs_in_registry(&self) {
         let mut registry = self.rng_registry.lock().await;
         registry.retain(|weak_rng| weak_rng.upgrade().is_some());
         for weak_rng in registry.iter() {
@@ -1196,30 +1188,31 @@ impl BaseKmsStruct {
     async fn fresh_seed(
         security_module: Option<Arc<SecurityModuleProxy>>,
     ) -> [u8; crate::consts::RND_SIZE] {
-        // Pulls randomness from freshly OS seeded rng.
-        //
-        // Note to reviewer: Using AesRng::from_entropy here because getrandom isn't
-        // one of our dependencies, but might be fine also to add it just for this?
-        let mut os_rng = AesRng::from_entropy();
+        // Pulls randomness from OS entropy pool.
         let mut seed = [0u8; crate::consts::RND_SIZE];
-        os_rng.fill_bytes(seed.as_mut());
+        if let Err(err) = getrandom::fill(seed.as_mut()) {
+            panic!("getrandom failed: {}", err);
+        }
 
         // Pulls randomness from the security module if available.
         if let Some(security_module) = security_module {
             match security_module.get_random(crate::consts::RND_SIZE).await {
                 Ok(bytes) => {
+                    if bytes.len() != crate::consts::RND_SIZE {
+                        panic!(
+                            "Security module returned {} bytes, expected {}",
+                            bytes.len(),
+                            crate::consts::RND_SIZE
+                        );
+                    }
                     // Mix in the randomness from the security module into the OS seed
                     for i in 0..crate::consts::RND_SIZE {
-                        // Sanity check but if the call to the security module is successful, we should have the right number of bytes.
-                        if i < bytes.len() {
-                            seed[i] ^= bytes[i];
-                        }
+                        // Direct indexing as we just checked the size is correct
+                        seed[i] ^= bytes[i];
                     }
                 }
                 Err(e) => {
-                    // Question to reviewer: Do we want to abort/err here if the security module failed to give
-                    // us the randomness we expected ? (Note that we'd still get randomness from the OS)
-                    tracing::error!("Failed to get random bytes from security module: {}", e);
+                    panic!("Failed to get random bytes from security module: {}", e);
                 }
             }
         };
@@ -1251,7 +1244,7 @@ impl BaseKmsStruct {
     }
 
     /// Calls [`Self::fresh_rng`] and registers it in the rng_registry (so it gets refreshed upon [`Self::refresh_all_rngs_in_registry`]).
-    pub async fn fresh_registered_rng(&self) -> Arc<Mutex<AesRng>> {
+    pub(crate) async fn fresh_registered_rng(&self) -> Arc<Mutex<AesRng>> {
         let rng = Arc::new(Mutex::new(
             Self::fresh_rng(self.rng.clone(), self.security_module.clone()).await,
         ));
@@ -3237,29 +3230,6 @@ pub(crate) mod tests {
             assert_eq!(
                 base_first, child_first,
                 "child RNG must be unaffected by draws on the base RNG"
-            );
-        }
-
-        #[tokio::test]
-        async fn refresh_self_rng_replaces_the_base_rng() {
-            let base = test_base_kms().await;
-
-            // Capture the deterministic stream at a fixed seed.
-            set_seed(&base.rng, 555).await;
-            let before = draw(&base.rng).await;
-
-            // Control: without a refresh the stream is reproducible.
-            set_seed(&base.rng, 555).await;
-            assert_eq!(draw(&base.rng).await, before);
-
-            // After a refresh the base RNG is reseeded with fresh entropy, so the
-            // "seed 555" stream is gone.
-            set_seed(&base.rng, 555).await;
-            base.refresh_self_rng().await;
-            assert_ne!(
-                draw(&base.rng).await,
-                before,
-                "refresh_self_rng must reseed the base RNG"
             );
         }
 

--- a/core/service/src/engine/base.rs
+++ b/core/service/src/engine/base.rs
@@ -1068,6 +1068,12 @@ fn sign_decryption_result<P: Serialize, D: SolStruct>(
     })
 }
 
+/// A base struct for KMS implementations, containing common fields and methods.
+///
+/// In particular, it contains a rng_registry that allows for refreshing all RNGs in the registry with new RNGs seeded from the OS and optionally the security module.
+/// A call to [`BaseKmsStruct::new_instance`] or [`BaseKmsStruct::fresh_registered_rng`]
+/// will add a new RNG to the registry, and a call to [`BaseKmsStruct::refresh_all_rngs_in_registry`]
+/// will refresh all RNGs in the registry.
 pub struct BaseKmsStruct {
     kms_type: KMSType,
     sig_key: Option<Arc<PrivateSigKey>>,
@@ -1173,6 +1179,7 @@ impl BaseKmsStruct {
         *self_rng = rng;
     }
 
+    /// Refreshes all RNGs in the registry with new RNGs seeded from the OS and optionally the security module.
     pub async fn refresh_all_rngs_in_registry(&self) {
         let mut registry = self.rng_registry.lock().await;
         registry.retain(|weak_rng| weak_rng.upgrade().is_some());
@@ -1210,8 +1217,8 @@ impl BaseKmsStruct {
                     }
                 }
                 Err(e) => {
-                    // Qu: Do we want to abort here if the security module failed to give
-                    // us the randomness we expected ?
+                    // Question to reviewer: Do we want to abort/err here if the security module failed to give
+                    // us the randomness we expected ? (Note that we'd still get randomness from the OS)
                     tracing::error!("Failed to get random bytes from security module: {}", e);
                 }
             }

--- a/core/service/src/engine/centralized/central_kms.rs
+++ b/core/service/src/engine/centralized/central_kms.rs
@@ -974,7 +974,8 @@ impl<
             backup_vault,
             key_info,
         );
-        let base_kms = BaseKmsStruct::new(KMSType::Centralized, sk)?;
+        let base_kms =
+            BaseKmsStruct::new(KMSType::Centralized, sk, security_module.clone()).await?;
 
         let context_manager: CentralizedContextManager<PubS, PrivS> =
             CentralizedContextManager::new(
@@ -1845,7 +1846,7 @@ pub(crate) mod tests {
             }
             keys
         };
-        let mut rng = kms.base_kms.new_rng().await;
+        let mut rng = kms.base_kms.fork_rng().await;
 
         let raw_cipher = RealCentralizedKms::<FileStorage, FileStorage>::user_decrypt(
             &kms.crypto_storage

--- a/core/service/src/engine/centralized/service/crs_gen.rs
+++ b/core/service/src/engine/centralized/service/crs_gen.rs
@@ -91,7 +91,7 @@ pub async fn crs_gen_impl<
     // all validation must be done before inserting the request ID.
     let meta_permit =
         add_req_to_meta_store(&service.crs_meta_map, &verified.req_id, op_tag).await?;
-    let rng = service.base_kms.new_rng().await;
+    let rng = service.base_kms.fork_rng().await;
 
     let req_id = verified.req_id;
     let epoch_id = verified.epoch_id;

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -106,7 +106,7 @@ pub async fn user_decrypt_impl<
     })?;
 
     let meta_store = Arc::clone(&service.user_dec_meta_store);
-    let mut rng = service.base_kms.new_rng().await;
+    let mut rng = service.base_kms.fork_rng().await;
     let meta_permit = add_or_redo_failed_in_meta_store(
         &service.user_dec_meta_store,
         &request_id,

--- a/core/service/src/engine/context_manager.rs
+++ b/core/service/src/engine/context_manager.rs
@@ -315,7 +315,7 @@ where
         // `update_backup_vault`, which is the expensive part, but only custodian setups contend
         // for it and they must not run concurrently anyway.
         let _setup_guard = self.custodian_setup_lock.lock().await;
-        let mut rng = self.base_kms.new_rng().await;
+        let mut rng = self.base_kms.fork_rng().await;
         // Generate asymmetric keys for the operator to use to encrypt the backup
         let mut enc = Encryption::new(PkeSchemeType::MlKem512, &mut rng);
         let (backup_dec_key, backup_enc_key) = enc.keygen()?;
@@ -1338,7 +1338,9 @@ mod tests {
     #[tokio::test]
     async fn test_kms_context() {
         let (verification_key, sig_key, crypto_storage) = setup_crypto_storage(false).await;
-        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key, None)
+            .await
+            .unwrap();
         let context_id = ContextId::from_bytes([4u8; 32]);
         let new_context = ContextInfo {
             mpc_nodes: vec![NodeInfo {
@@ -1365,7 +1367,7 @@ mod tests {
         let request = Request::new(NewMpcContextRequest {
             new_context: Some(new_context.clone().try_into().unwrap()),
         });
-        let session_maker = SessionMaker::empty_dummy_session(base_kms.new_rng().await);
+        let session_maker = SessionMaker::empty_dummy_session(base_kms.fork_rng().await);
         let context_manager = ThresholdContextManager::new(
             base_kms,
             crypto_storage.clone(),
@@ -1528,8 +1530,10 @@ mod tests {
 
         // create the context manager and store the new context
         {
-            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone()).unwrap();
-            let session_maker = SessionMaker::empty_dummy_session(base_kms.new_rng().await);
+            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone(), None)
+                .await
+                .unwrap();
+            let session_maker = SessionMaker::empty_dummy_session(base_kms.fork_rng().await);
             let context_manager = ThresholdContextManager::new(
                 base_kms,
                 crypto_storage.clone(),
@@ -1565,8 +1569,10 @@ mod tests {
         // recreate another new context manager that's initially empty
         // and then we should have nothing in the session maker.
         {
-            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone()).unwrap();
-            let session_maker = SessionMaker::empty_dummy_session(base_kms.new_rng().await);
+            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone(), None)
+                .await
+                .unwrap();
+            let session_maker = SessionMaker::empty_dummy_session(base_kms.fork_rng().await);
             let context_manager = ThresholdContextManager::new(
                 base_kms,
                 crypto_storage.clone(),
@@ -1597,8 +1603,10 @@ mod tests {
 
         // Store 3 contexts
         {
-            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone()).unwrap();
-            let session_maker = SessionMaker::empty_dummy_session(base_kms.new_rng().await);
+            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone(), None)
+                .await
+                .unwrap();
+            let session_maker = SessionMaker::empty_dummy_session(base_kms.fork_rng().await);
             let context_manager = ThresholdContextManager::new(
                 base_kms,
                 crypto_storage.clone(),
@@ -1652,8 +1660,10 @@ mod tests {
 
         // Recreate an empty context manager and load all 3 from storage
         {
-            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone()).unwrap();
-            let session_maker = SessionMaker::empty_dummy_session(base_kms.new_rng().await);
+            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone(), None)
+                .await
+                .unwrap();
+            let session_maker = SessionMaker::empty_dummy_session(base_kms.fork_rng().await);
             let context_manager = ThresholdContextManager::new(
                 base_kms,
                 crypto_storage.clone(),
@@ -1682,8 +1692,10 @@ mod tests {
 
         // Store 3 valid contexts
         {
-            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone()).unwrap();
-            let session_maker = SessionMaker::empty_dummy_session(base_kms.new_rng().await);
+            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone(), None)
+                .await
+                .unwrap();
+            let session_maker = SessionMaker::empty_dummy_session(base_kms.fork_rng().await);
             let context_manager = ThresholdContextManager::new(
                 base_kms,
                 crypto_storage.clone(),
@@ -1777,8 +1789,10 @@ mod tests {
         // Recreate an empty context manager and load from storage:
         // the corrupted context should be skipped, loading only 2
         {
-            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone()).unwrap();
-            let session_maker = SessionMaker::empty_dummy_session(base_kms.new_rng().await);
+            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone(), None)
+                .await
+                .unwrap();
+            let session_maker = SessionMaker::empty_dummy_session(base_kms.fork_rng().await);
             let context_manager = ThresholdContextManager::new(
                 base_kms,
                 crypto_storage.clone(),
@@ -1827,8 +1841,10 @@ mod tests {
 
         // Store a context using a fully-initialized context manager
         {
-            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone()).unwrap();
-            let session_maker = SessionMaker::empty_dummy_session(base_kms.new_rng().await);
+            let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key.clone(), None)
+                .await
+                .unwrap();
+            let session_maker = SessionMaker::empty_dummy_session(base_kms.fork_rng().await);
             let context_manager = ThresholdContextManager::new(
                 base_kms,
                 crypto_storage.clone(),
@@ -1857,8 +1873,9 @@ mod tests {
         // Create a new context manager without a signing key (recovery mode)
         // and attempt to load contexts from storage
         {
-            let base_kms = BaseKmsStruct::new_no_signing_key(KMSType::Threshold, verification_key);
-            let session_maker = SessionMaker::empty_dummy_session(base_kms.new_rng().await);
+            let base_kms =
+                BaseKmsStruct::new_no_signing_key(KMSType::Threshold, verification_key, None).await;
+            let session_maker = SessionMaker::empty_dummy_session(base_kms.fork_rng().await);
             let context_manager = ThresholdContextManager::new(
                 base_kms,
                 crypto_storage.clone(),
@@ -1881,7 +1898,9 @@ mod tests {
     async fn test_custodian_context() {
         // We need the default MPC context to be able to use calls to custodian context APIs
         let (verification_key, sig_key, crypto_storage) = setup_crypto_storage(true).await;
-        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key, None)
+            .await
+            .unwrap();
         // Generate custodian keys
         let threshold = 1;
         let amount_custodians = 2 * threshold + 1; // Minimum amount of custodians is 2 * threshold + 1
@@ -1921,7 +1940,7 @@ mod tests {
                 None,
                 None,
                 &epoch_id,
-                base_kms.new_rng().await,
+                base_kms.fork_rng().await,
             );
             let context_manager = ThresholdContextManager::new(
                 base_kms,
@@ -2150,7 +2169,9 @@ mod tests {
     #[tokio::test]
     async fn test_custodian_context_fails_on_backup_update_failure() {
         let (_verification_key, sig_key, crypto_storage) = setup_crypto_storage(true).await;
-        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key, None)
+            .await
+            .unwrap();
 
         // Store corrupt data in private storage under ContextInfo type.
         {
@@ -2199,8 +2220,12 @@ mod tests {
             new_custodian_context: Some(context),
             mpc_context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
         });
-        let session_maker =
-            SessionMaker::four_party_dummy_session(None, None, &epoch_id, base_kms.new_rng().await);
+        let session_maker = SessionMaker::four_party_dummy_session(
+            None,
+            None,
+            &epoch_id,
+            base_kms.fork_rng().await,
+        );
         // Keep a handle on the backup vault so we can inspect the rollback after the failure.
         let backup_vault = crypto_storage.get_backup_vault().unwrap();
         let context_manager = ThresholdContextManager::new(
@@ -2268,7 +2293,9 @@ mod tests {
         use crate::vault::storage::{Storage, StorageReader};
 
         let (_verification_key, sig_key, crypto_storage) = setup_crypto_storage(true).await;
-        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key, None)
+            .await
+            .unwrap();
         let context_id = RequestId::from_bytes([7u8; 32]);
 
         // Make `write_all` inside `write_backup_keys` report a duplicate.
@@ -2315,8 +2342,12 @@ mod tests {
             }),
             mpc_context_id: Some((*DEFAULT_MPC_CONTEXT).into()),
         });
-        let session_maker =
-            SessionMaker::four_party_dummy_session(None, None, &epoch_id, base_kms.new_rng().await);
+        let session_maker = SessionMaker::four_party_dummy_session(
+            None,
+            None,
+            &epoch_id,
+            base_kms.fork_rng().await,
+        );
         let backup_vault = crypto_storage.get_backup_vault().unwrap();
         let context_manager = ThresholdContextManager::new(
             base_kms,
@@ -2361,7 +2392,9 @@ mod tests {
     #[tokio::test]
     async fn test_centralized_context_cache() {
         let (verification_key, sig_key, crypto_storage) = setup_crypto_storage(false).await;
-        let base_kms = BaseKmsStruct::new(KMSType::Centralized, sig_key).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Centralized, sig_key, None)
+            .await
+            .unwrap();
         let context_id = ContextId::from_bytes([5u8; 32]);
         let new_context = ContextInfo {
             mpc_nodes: vec![NodeInfo {
@@ -2491,7 +2524,9 @@ mod tests {
     #[tokio::test]
     async fn test_centralized_context_exists_and_consistent() {
         let (verification_key, sig_key, crypto_storage) = setup_crypto_storage(false).await;
-        let base_kms = BaseKmsStruct::new(KMSType::Centralized, sig_key).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Centralized, sig_key, None)
+            .await
+            .unwrap();
         let context_id = ContextId::from_bytes([6u8; 32]);
         let new_context = ContextInfo {
             mpc_nodes: vec![NodeInfo {
@@ -2596,7 +2631,9 @@ mod tests {
     #[tokio::test]
     async fn test_centralized_multiple_contexts() {
         let (verification_key, sig_key, crypto_storage) = setup_crypto_storage(false).await;
-        let base_kms = BaseKmsStruct::new(KMSType::Centralized, sig_key).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Centralized, sig_key, None)
+            .await
+            .unwrap();
 
         let context_manager = CentralizedContextManager::new(
             base_kms,

--- a/core/service/src/engine/mod.rs
+++ b/core/service/src/engine/mod.rs
@@ -22,6 +22,8 @@ pub mod migration;
 #[cfg(feature = "non-wasm")]
 pub(crate) mod public_material_verification;
 #[cfg(feature = "non-wasm")]
+pub mod rng_registry;
+#[cfg(feature = "non-wasm")]
 pub mod threshold;
 #[cfg(feature = "non-wasm")]
 pub mod traits;

--- a/core/service/src/engine/rng_registry.rs
+++ b/core/service/src/engine/rng_registry.rs
@@ -1,0 +1,283 @@
+use aes_prng::AesRng;
+use rand::{RngCore, SeedableRng};
+use std::sync::{Arc, OnceLock, Weak};
+use tokio::sync::Mutex;
+
+use crate::cryptography::attestation::{SecurityModule, SecurityModuleProxy};
+
+static RNG_REGISTRY: OnceLock<RngRegistry> = OnceLock::new();
+
+type RngRegistryEntry = (Option<Weak<SecurityModuleProxy>>, Weak<Mutex<AesRng>>);
+pub(crate) struct RngRegistry(Mutex<Vec<RngRegistryEntry>>);
+
+impl RngRegistry {
+    fn empty() -> Self {
+        Self(Mutex::new(Vec::new()))
+    }
+
+    /// The process-wide registry backing the public entry points
+    /// [`Self::fresh_registered_rng`] and [`Self::refresh_all_rngs_in_registry`].
+    fn global() -> &'static Self {
+        RNG_REGISTRY.get_or_init(Self::empty)
+    }
+
+    /// This function panics if the OS entropy pool is not available or if the security module exists but fails to provide randomness.
+    async fn fresh_seed(
+        security_module: Option<Arc<SecurityModuleProxy>>,
+    ) -> [u8; crate::consts::RND_SIZE] {
+        // Pulls randomness from OS entropy pool.
+        let mut seed = [0u8; crate::consts::RND_SIZE];
+        if let Err(err) = getrandom::fill(seed.as_mut()) {
+            panic!("getrandom failed: {}", err);
+        }
+
+        // Pulls randomness from the security module if available.
+        if let Some(security_module) = security_module {
+            match security_module.get_random(crate::consts::RND_SIZE).await {
+                Ok(bytes) => {
+                    if bytes.len() != crate::consts::RND_SIZE {
+                        panic!(
+                            "Security module returned {} bytes, expected {}",
+                            bytes.len(),
+                            crate::consts::RND_SIZE
+                        );
+                    }
+                    // Mix in the randomness from the security module into the OS seed
+                    for i in 0..crate::consts::RND_SIZE {
+                        // Direct indexing as we just checked the size is correct
+                        seed[i] ^= bytes[i];
+                    }
+                }
+                Err(e) => {
+                    panic!("Failed to get random bytes from security module: {}", e);
+                }
+            }
+        };
+
+        seed
+    }
+
+    /// Creates a new RNG seeded with randomness from the OS, the base RNG, and optionally a security module.
+    /// Optionally takes an existing RNG to pull randomness from, which is used to ensure that the new RNG is not seeded with weak randomness.
+    async fn fresh_rng(
+        existing_rng: Option<Arc<Mutex<AesRng>>>,
+        security_module: Option<Arc<SecurityModuleProxy>>,
+    ) -> AesRng {
+        let fresh_seed = Self::fresh_seed(security_module).await;
+
+        let mut seed = [0u8; crate::consts::RND_SIZE];
+        // Make a seperate scope for the rng so that it is dropped before the lock is released
+        if let Some(existing_rng) = existing_rng {
+            let mut existing_rng = existing_rng.lock().await;
+            existing_rng.fill_bytes(seed.as_mut());
+        }
+
+        // Mix in all the randomness sources to create a new seed
+        for i in 0..crate::consts::RND_SIZE {
+            seed[i] ^= fresh_seed[i];
+        }
+
+        AesRng::from_seed(seed)
+    }
+
+    /// Create a freshly-seeded RNG and register it in *this* registry.
+    async fn register_fresh_rng(
+        &self,
+        existing_rng: Option<Arc<Mutex<AesRng>>>,
+        security_module: Option<Arc<SecurityModuleProxy>>,
+    ) -> Arc<Mutex<AesRng>> {
+        let rng = Self::fresh_rng(existing_rng, security_module.clone()).await;
+        let rng = Arc::new(Mutex::new(rng));
+        let mut registry = self.0.lock().await;
+        registry.push((
+            security_module.as_ref().map(Arc::downgrade),
+            Arc::downgrade(&rng),
+        ));
+        rng
+    }
+
+    /// Reseed every live RNG in *this* registry in place, first pruning entries
+    /// whose RNG has been dropped. Each RNG is reseeded from its own (per-entry)
+    /// security module, falling back to OS-only entropy if that module is gone.
+    async fn refresh_all(&self) {
+        let mut registry = self.0.lock().await;
+        registry.retain(|entry| entry.1.upgrade().is_some());
+        for (weak_security_module, weak_rng) in registry.iter() {
+            if let Some(rng) = weak_rng.upgrade() {
+                let security_module = weak_security_module
+                    .as_ref()
+                    .and_then(|weak| weak.upgrade());
+                let fresh_rng = Self::fresh_rng(Some(Arc::clone(&rng)), security_module).await;
+                let mut rng_lock = rng.lock().await;
+                *rng_lock = fresh_rng;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    async fn entry_count(&self) -> usize {
+        self.0.lock().await.len()
+    }
+
+    /// Create a freshly-seeded RNG registered in the process-wide registry.
+    pub(crate) async fn fresh_registered_rng(
+        existing_rng: Option<Arc<Mutex<AesRng>>>,
+        security_module: Option<Arc<SecurityModuleProxy>>,
+    ) -> Arc<Mutex<AesRng>> {
+        Self::global()
+            .register_fresh_rng(existing_rng, security_module)
+            .await
+    }
+
+    /// Reseed every live RNG in the process-wide registry (e.g. on epoch init).
+    pub(crate) async fn refresh_all_rngs_in_registry() {
+        Self::global().refresh_all().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RngRegistry;
+    use aes_prng::AesRng;
+    use rand::{RngCore, SeedableRng};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    /// Draw 16 bytes from an RNG handle, advancing its state.
+    async fn draw(rng: &Arc<Mutex<AesRng>>) -> [u8; 16] {
+        let mut out = [0u8; 16];
+        let mut guard = rng.lock().await;
+        guard.fill_bytes(&mut out);
+        out
+    }
+
+    /// Pin an RNG handle to a deterministic seed so its output is reproducible.
+    async fn set_seed(rng: &Arc<Mutex<AesRng>>, seed: u64) {
+        let mut guard = rng.lock().await;
+        *guard = AesRng::seed_from_u64(seed);
+    }
+
+    #[tokio::test]
+    async fn fresh_seed_draws_fresh_os_entropy() {
+        let a = RngRegistry::fresh_seed(None).await;
+        let b = RngRegistry::fresh_seed(None).await;
+        assert_ne!(a, b, "OS entropy must differ between calls");
+        assert_ne!(
+            a,
+            [0u8; crate::consts::RND_SIZE],
+            "a fresh seed must not be all zeros"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_rng_always_injects_new_entropy() {
+        // No predecessor RNG: seeded purely from OS entropy, so two calls diverge.
+        let mut r1 = RngRegistry::fresh_rng(None, None).await;
+        let mut r2 = RngRegistry::fresh_rng(None, None).await;
+        let (mut a, mut b) = ([0u8; 16], [0u8; 16]);
+        r1.fill_bytes(&mut a);
+        r2.fill_bytes(&mut b);
+        assert_ne!(a, b, "fresh_rng(None) must be OS-seeded and never repeat");
+
+        // Even from an *identical* predecessor state, fresh_rng mixes in fresh OS
+        // entropy, so the output is not a deterministic function of the predecessor.
+        let existing = Arc::new(Mutex::new(AesRng::seed_from_u64(1234)));
+        let mut r3 = RngRegistry::fresh_rng(Some(Arc::clone(&existing)), None).await;
+        set_seed(&existing, 1234).await; // rewind predecessor to the same state
+        let mut r4 = RngRegistry::fresh_rng(Some(Arc::clone(&existing)), None).await;
+        let (mut c, mut d) = ([0u8; 16], [0u8; 16]);
+        r3.fill_bytes(&mut c);
+        r4.fill_bytes(&mut d);
+        assert_ne!(
+            c, d,
+            "identical predecessor state must still yield fresh entropy"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_fresh_rng_adds_one_entry_each() {
+        let registry = RngRegistry::empty();
+        assert_eq!(registry.entry_count().await, 0);
+
+        let _r1 = registry.register_fresh_rng(None, None).await;
+        assert_eq!(registry.entry_count().await, 1);
+
+        let _r2 = registry.register_fresh_rng(None, None).await;
+        assert_eq!(registry.entry_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn refresh_all_reseeds_in_place_keeping_the_same_allocation() {
+        let registry = RngRegistry::empty();
+        let rng = registry.register_fresh_rng(None, None).await;
+
+        set_seed(&rng, 777).await;
+        let before = draw(&rng).await;
+        set_seed(&rng, 777).await; // restore the known state for the refresh
+        let ptr_before = Arc::as_ptr(&rng);
+
+        registry.refresh_all().await;
+
+        assert_ne!(draw(&rng).await, before, "refresh must reseed the RNG");
+        // The refresh must mutate the RNG behind the *same* allocation, so the
+        // registry's Weak keeps pointing at the refreshed RNG rather than a stale one.
+        assert_eq!(
+            Arc::as_ptr(&rng),
+            ptr_before,
+            "refresh must reseed in place, not replace the allocation"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_all_reseeds_every_registered_rng() {
+        let registry = RngRegistry::empty();
+        let rngs = [
+            registry.register_fresh_rng(None, None).await,
+            registry.register_fresh_rng(None, None).await,
+            registry.register_fresh_rng(None, None).await,
+        ];
+        let seeds = [10u64, 20, 30];
+
+        let mut before = Vec::new();
+        for (rng, s) in rngs.iter().zip(seeds) {
+            set_seed(rng, s).await;
+            before.push(draw(rng).await);
+            set_seed(rng, s).await; // restore for the refresh
+        }
+
+        registry.refresh_all().await;
+
+        for (idx, rng) in rngs.iter().enumerate() {
+            assert_ne!(draw(rng).await, before[idx], "rng {idx} was not reseeded");
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_all_prunes_entries_for_dropped_rngs() {
+        let registry = RngRegistry::empty();
+        let keep1 = registry.register_fresh_rng(None, None).await;
+        let drop_me = registry.register_fresh_rng(None, None).await;
+        let keep2 = registry.register_fresh_rng(None, None).await;
+        assert_eq!(registry.entry_count().await, 3);
+
+        // Dropping the only strong ref leaves a dangling Weak in the registry...
+        drop(drop_me);
+        assert_eq!(
+            registry.entry_count().await,
+            3,
+            "a dead Weak is retained until the next refresh"
+        );
+
+        // ...which refresh_all prunes.
+        registry.refresh_all().await;
+        assert_eq!(
+            registry.entry_count().await,
+            2,
+            "refresh_all must prune the dropped RNG's entry"
+        );
+
+        // The survivors are still usable.
+        let _ = draw(&keep1).await;
+        let _ = draw(&keep2).await;
+    }
+}

--- a/core/service/src/engine/threshold/service/crs_generator.rs
+++ b/core/service/src/engine/threshold/service/crs_generator.rs
@@ -208,7 +208,7 @@ impl<
 
         // we do not need to hold the handle,
         // the result of the computation is tracked the crs_meta_store
-        let rng = self.base_kms.new_rng().await.to_owned();
+        let rng = self.base_kms.fork_rng().await.to_owned();
 
         let token = CancellationToken::new();
         {
@@ -699,7 +699,9 @@ mod tests {
         rng: &mut AesRng,
     ) -> RealCrsGenerator<ram::RamStorage, ram::RamStorage, C> {
         let (_pk, sk) = gen_sig_keys(rng);
-        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk, None)
+            .await
+            .unwrap();
         let prss_setup_z128 = Some(PRSSSetup::new_testing_prss(vec![], vec![]));
         let prss_setup_z64 = Some(PRSSSetup::new_testing_prss(vec![], vec![]));
         let epoch_id = *DEFAULT_EPOCH_ID;
@@ -707,7 +709,7 @@ mod tests {
             prss_setup_z128,
             prss_setup_z64,
             &epoch_id,
-            base_kms.new_rng().await,
+            base_kms.fork_rng().await,
         );
 
         let pub_storage = ram::RamStorage::new();

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -73,6 +73,7 @@ use crate::{
             compute_info_compressed_keygen, compute_info_crs, compute_info_uncompressed_keygen,
             retrieve_parameters, stored_scheme_signatures_to_proto,
         },
+        rng_registry::RngRegistry,
         threshold::service::{
             PublicKeyMaterial, ThresholdFheKeys,
             reshare_utils::{
@@ -1512,7 +1513,7 @@ impl<
         }
 
         // Refreshes all rngs that were derived from the same base_kms as this one.
-        self.base_kms.refresh_all_rngs_in_registry().await;
+        RngRegistry::refresh_all_rngs_in_registry().await;
 
         let resharing_task = match resharing_params {
             Some(ResharingParams {

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1476,6 +1476,8 @@ impl<
         &self,
         request: Request<NewMpcEpochRequest>,
     ) -> Result<Response<Empty>, MetricedError> {
+        // Refreshes all rngs that were derived from the same base_kms as this one.
+        self.base_kms.refresh_all_rngs_in_registry().await;
         let rate_limiter_permit = self.rate_limiter.start_new_epoch().await?;
 
         let inner = request.into_inner();

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1476,8 +1476,6 @@ impl<
         &self,
         request: Request<NewMpcEpochRequest>,
     ) -> Result<Response<Empty>, MetricedError> {
-        // Refreshes all rngs that were derived from the same base_kms as this one.
-        self.base_kms.refresh_all_rngs_in_registry().await;
         let rate_limiter_permit = self.rate_limiter.start_new_epoch().await?;
 
         let inner = request.into_inner();
@@ -1512,6 +1510,9 @@ impl<
                 tonic::Code::InvalidArgument,
             ));
         }
+
+        // Refreshes all rngs that were derived from the same base_kms as this one.
+        self.base_kms.refresh_all_rngs_in_registry().await;
 
         let resharing_task = match resharing_params {
             Some(ResharingParams {

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -491,8 +491,8 @@ impl<
         SmallSession<ResiduePolyF4Z64>,
     )> {
         let session_z128 =
-            // Note that we need to use the new epoch ID when deriving the session ID, otherwise we would not be able to create multiple 
-            // new epochs from the same previous epoch, in case an epoch creation failed, as the session ID would be the same and the 
+            // Note that we need to use the new epoch ID when deriving the session ID, otherwise we would not be able to create multiple
+            // new epochs from the same previous epoch, in case an epoch creation failed, as the session ID would be the same and the
             // session maker would return an error.
             async { new_epoch_id.derive_session_id_with_counter(LIFT_Z128_SESSION_COUNTER) }
                 .and_then(|id| {
@@ -2013,10 +2013,16 @@ pub(crate) mod tests {
     ) -> RealThresholdEpochManager<ram::RamStorage, ram::RamStorage, I, SecureReshareSecretKeys>
     {
         let (_pk, sk) = gen_sig_keys(rng);
-        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk, None)
+            .await
+            .unwrap();
         let epoch_id = *DEFAULT_EPOCH_ID;
-        let session_maker =
-            SessionMaker::four_party_dummy_session(None, None, &epoch_id, base_kms.new_rng().await);
+        let session_maker = SessionMaker::four_party_dummy_session(
+            None,
+            None,
+            &epoch_id,
+            base_kms.fork_rng().await,
+        );
 
         RealThresholdEpochManager::<ram::RamStorage, ram::RamStorage, I, SecureReshareSecretKeys>::init_test(
             base_kms,

--- a/core/service/src/engine/threshold/service/key_generator.rs
+++ b/core/service/src/engine/threshold/service/key_generator.rs
@@ -1978,7 +1978,9 @@ mod tests {
         use crate::cryptography::signatures::gen_sig_keys;
         let mut rng = AesRng::seed_from_u64(13371);
         let (_pk, sk) = gen_sig_keys(&mut rng);
-        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk, None)
+            .await
+            .unwrap();
         let epoch_id = *DEFAULT_EPOCH_ID;
         let prss_setup_z128 = Some(PRSSSetup::new_testing_prss(vec![], vec![]));
         let prss_setup_z64 = Some(PRSSSetup::new_testing_prss(vec![], vec![]));
@@ -1986,7 +1988,7 @@ mod tests {
             prss_setup_z128,
             prss_setup_z64,
             &epoch_id,
-            base_kms.new_rng().await,
+            base_kms.fork_rng().await,
         );
         let kg = RealKeyGenerator::<ram::RamStorage, ram::RamStorage, KG>::init_ram_keygen(
             base_kms,

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -739,7 +739,7 @@ where
         &crypto_storage,
         networking_manager,
         verifier,
-        base_kms.new_rng().await,
+        base_kms.fresh_registered_rng().await,
     )
     .await?;
     let immutable_session_maker = session_maker.make_immutable();

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -503,6 +503,10 @@ pub type RealThresholdKms<PubS, PrivS> = ThresholdKms<
     RealBackupOperator<PubS, PrivS>,
 >;
 
+/// Note: The RNGs in `BaseKmsStruct` derived from the `base_kms` parameter
+/// (and all RNGs derived from a call to `BaseKmsStruct::fresh_registered_rng` )
+/// parameter will be registered (in a shared registry).
+/// This allows the RNGs to be refreshed (re-seeded) when a new epoch is started, so that all derived RNGs are re-seeded from the OS and optionally the security module.
 #[expect(clippy::too_many_arguments)]
 pub async fn new_real_threshold_kms<PubS, PrivS, F>(
     config: CoreConfig,

--- a/core/service/src/engine/threshold/service/preprocessor.rs
+++ b/core/service/src/engine/threshold/service/preprocessor.rs
@@ -759,7 +759,9 @@ mod tests {
     ) -> RealPreprocessor<P> {
         let epoch_id = *DEFAULT_EPOCH_ID;
         let (_pk, sk) = gen_sig_keys(rng);
-        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk.clone()).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk.clone(), None)
+            .await
+            .unwrap();
         let prss_setup_z128 = if use_prss {
             Some(PRSSSetup::new_testing_prss(vec![], vec![]))
         } else {
@@ -775,7 +777,7 @@ mod tests {
             prss_setup_z128,
             prss_setup_z64,
             &epoch_id,
-            base_kms.new_rng().await,
+            base_kms.fork_rng().await,
         );
         RealPreprocessor::<P>::init_test(base_kms, session_maker.make_immutable())
     }

--- a/core/service/src/engine/threshold/service/public_decryptor.rs
+++ b/core/service/src/engine/threshold/service/public_decryptor.rs
@@ -875,7 +875,9 @@ mod tests {
         RealPublicDecryptor<ram::RamStorage, ram::RamStorage, DummyNoisefloodDecryptor>,
     ) {
         let (_pk, sk) = gen_sig_keys(rng);
-        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk.clone()).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk.clone(), None)
+            .await
+            .unwrap();
         let param = TEST_PARAM;
         let epoch_id = EpochId::new_random(rng);
 
@@ -885,7 +887,7 @@ mod tests {
             prss_setup_z128,
             prss_setup_z64,
             &epoch_id,
-            base_kms.new_rng().await,
+            base_kms.fork_rng().await,
         );
 
         let key_id = RequestId::new_random(rng);

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -181,7 +181,7 @@ impl SessionMaker {
         crypto_storage: &ThresholdCryptoMaterialStorage<PubS, PrivS>,
         networking_manager: Arc<RwLock<GrpcNetworkingManager>>,
         verifier: Option<Arc<AttestedVerifier>>,
-        rng: AesRng,
+        rng: Arc<Mutex<AesRng>>,
     ) -> anyhow::Result<Self> {
         let session_maker: SessionMaker =
             Self::new_uninitialized(networking_manager, verifier, rng);
@@ -217,7 +217,7 @@ impl SessionMaker {
     pub(crate) fn new_uninitialized(
         networking_manager: Arc<RwLock<GrpcNetworkingManager>>,
         verifier: Option<Arc<AttestedVerifier>>,
-        rng: AesRng,
+        rng: Arc<Mutex<AesRng>>,
     ) -> Self {
         Self {
             networking_manager,
@@ -225,7 +225,7 @@ impl SessionMaker {
             epoch_map: Arc::new(RwLock::new(HashMap::new())),
             lifecycle: LifecycleCoordinator::default(),
             verifier,
-            rng: Arc::new(Mutex::new(rng)),
+            rng,
         }
     }
 

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -575,6 +575,7 @@ impl SessionMaker {
         context_map.contains_key(context_id)
     }
 
+    /// Code duplication of [`crate::engine::base::BaseKmsStruct::fork_rng`]
     async fn new_rng(&self) -> AesRng {
         let mut seed = [0u8; crate::consts::RND_SIZE];
         // Make a seperate scope for the rng so that it is dropped before the lock is released

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -503,7 +503,7 @@ impl<
 
         let meta_store = Arc::clone(&self.user_decrypt_meta_store);
         let crypto_storage = self.crypto_storage.clone();
-        let rng = self.base_kms.new_rng().await;
+        let rng = self.base_kms.fork_rng().await;
 
         let sk = (*self.base_kms.sig_key().map_err(|e| {
             MetricedError::new(
@@ -788,7 +788,9 @@ mod tests {
     ) {
         let (_pk, sk) = gen_sig_keys(rng);
         let param = TEST_PARAM;
-        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk.clone()).unwrap();
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sk.clone(), None)
+            .await
+            .unwrap();
 
         let epoch_id = EpochId::new_random(rng);
         let prss_setup_z128 = Some(PRSSSetup::new_testing_prss(vec![], vec![]));
@@ -798,7 +800,7 @@ mod tests {
             prss_setup_z128,
             prss_setup_z64,
             &epoch_id,
-            base_kms.new_rng().await,
+            base_kms.fork_rng().await,
         );
 
         let key_id = RequestId::new_random(rng);


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->
Adds a global registry that holds weak references to the rngs derived from the BaseKmsStruct.
Upon new epoch, refresh all those RNGs by making a seed from current RNG and adding entropy from OS and ,if available, the security module.
### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->
https://github.com/zama-ai/kms-internal/issues/3150
## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
