### PR TITLE
fix: bug that removes public keys during failed resharing

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -189,10 +189,12 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   request, whereas a pure set 2 party (a node joining the new context) never held
   the key and logs a warning instead. When resharing legacy key material that
   has no dedicated OPRF secret-key share, the OPRF sub-protocol is skipped and
-the reshared private keyset keeps that field absent. A storage failure during
-resharing rolls the new epoch back on the party that fails. That party attempts to delete
-the key shares, the CRS metadata and the epoch data of the new epoch. If cleanup succeeds,
-it forgets the epoch; otherwise, it keeps the epoch registered so that deletion can be retried. `DestroyMpcContext` carries
+  the reshared private keyset keeps that field absent. A storage failure during
+  resharing rolls the new epoch back on the party that fails. 
+  That party attempts to delete the key shares, the CRS metadata and the epoch data of the new epoch. 
+  Observe that no public data is deleted as this is, and should be, unaffected by an epoch change. 
+  If cleanup succeeds, it forgets the epoch; otherwise, it keeps the epoch registered so that deletion can be retried. 
+  `DestroyMpcContext` carries
   the context's epoch IDs and erases their secret shares (cascading to the
   existing per-epoch deletion) before forgetting the context, so retiring a
   party set leaves no usable key shares behind; the kms-connector is the source

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -189,10 +189,10 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   request, whereas a pure set 2 party (a node joining the new context) never held
   the key and logs a warning instead. When resharing legacy key material that
   has no dedicated OPRF secret-key share, the OPRF sub-protocol is skipped and
-  the reshared private keyset keeps that field absent. A storage failure during
-  resharing rolls the new epoch back on the party that fails. That party deletes
-  the key shares, the CRS metadata and the epoch data of the new epoch, and it
-  forgets the epoch. `DestroyMpcContext` carries
+the reshared private keyset keeps that field absent. A storage failure during
+resharing rolls the new epoch back on the party that fails. That party attempts to delete
+the key shares, the CRS metadata and the epoch data of the new epoch. If cleanup succeeds,
+it forgets the epoch; otherwise, it keeps the epoch registered so that deletion can be retried. `DestroyMpcContext` carries
   the context's epoch IDs and erases their secret shares (cascading to the
   existing per-epoch deletion) before forgetting the context, so retiring a
   party set leaves no usable key shares behind; the kms-connector is the source

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -189,7 +189,10 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   request, whereas a pure set 2 party (a node joining the new context) never held
   the key and logs a warning instead. When resharing legacy key material that
   has no dedicated OPRF secret-key share, the OPRF sub-protocol is skipped and
-  the reshared private keyset keeps that field absent. `DestroyMpcContext` carries
+  the reshared private keyset keeps that field absent. A storage failure during
+  resharing rolls the new epoch back on the party that fails. That party deletes
+  the key shares, the CRS metadata and the epoch data of the new epoch, and it
+  forgets the epoch. `DestroyMpcContext` carries
   the context's epoch IDs and erases their secret shares (cascading to the
   existing per-epoch deletion) before forgetting the context, so retiring a
   party set leaves no usable key shares behind; the kms-connector is the source

--- a/core/grpc/proto/kms-service.v1.proto
+++ b/core/grpc/proto/kms-service.v1.proto
@@ -97,6 +97,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
+  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
   // * `request_id` in `request` must be present, valid, fresh and unique [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   // * `params` in `request` must be castable to a [`FheParameter`], currently this means 0 or 1.
   // * `preproc_id` in `request` must be present, and a valid [`RequestId`] which has already been used to start a preprocessing request with method `key_gen_preproc` that has completed successfully
@@ -150,6 +151,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
+  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
   // * `request` must be a valid [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   //   Furthermore, the request ID must be the same as the one used to start a preprocessing generation with method `KeyGenPreproc`.
   //   In the threshold KMS the preprocessing or key generation identified by the `preproc_id` must be ongoing.
@@ -320,6 +322,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
+  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
   // * `request_id` in `request` must be present, valid, fresh and unique [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   // * `params` in `request` must be castable to a [`FheParameter`], currently this means 0 or 1.
   // * `max_number_bits` is the amount of bits that can be proven for ciphertext vector using the generated CRS. If this is not provided, then it defaults to the maximum supported by the fhevm.
@@ -356,6 +359,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
+  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
   // * `request` must be a valid [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   //   Furthermore, the request ID must be the same as the one used to start a CRS generation with method `CrsGen`.
   //   The CRS generation identified by the `crs_id` in `request` must be ongoing.
@@ -414,7 +418,8 @@ service CoreServiceEndpoint {
   // # Parameters
   // * `NewMpcEpochRequest` - Struct containing all the data of the request
   //
-  // #Conditions
+  // # Conditions
+  // *  No `KeyGen`, `CrsGen` or `AbortKeyGen` call may be executed concurrently!
   // * `context_id` in `request` must be present, valid, and unique [`RequestId`] of an MPC context that has been constructed with `NewMpcContext`.
   // * `epoch_id` in `request` must be present, valid, and unique. It represents the ID of the new epoch that is created.
   // * `previous_epoch` is optional, if set we perform a resharing from the previous epoch to the new one.
@@ -437,7 +442,10 @@ service CoreServiceEndpoint {
   // and if the shares of the secret key.
   //
   // # Parameters
+  // * `DestroyMpcEpochRequest` - Struct containing all the data of the request
+  //
   // # Conditions
+  // *  No `KeyGen`, `CrsGen` or `AbortKeyGen` call may be executed concurrently!
   rpc DestroyMpcEpoch(kms.v1.DestroyMpcEpochRequest) returns (kms.v1.Empty);
 
   // Constructs a new custodian context.

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1808,6 +1808,7 @@ pub(crate) mod tests {
         rpc_types::{KMSType, PrivDataType, alloy_to_protobuf_domain},
     };
     use rand::SeedableRng;
+    use strum::IntoEnumIterator;
     use threshold_execution::{
         endpoints::reshare_sk::SecureReshareSecretKeys,
         malicious_execution::small_execution::malicious_prss::EmptyPrss,
@@ -3154,16 +3155,10 @@ pub(crate) mod tests {
         let key_id = derive_request_id("reshared_key").unwrap();
         let preproc_id = derive_request_id("reshared_key_preproc").unwrap();
 
-        // Stand-ins for the real key material, since the assertions below only test for presence.
-        let public_types = [
-            PubDataType::PublicKey,
-            PubDataType::ServerKey,
-            PubDataType::CompressedXofKeySet,
-        ];
         {
             let public_storage = crypto_storage.inner.get_public_storage();
             let mut guard = public_storage.lock().await;
-            for public_type in &public_types {
+            for public_type in PubDataType::iter() {
                 store_versioned_at_request_id(
                     &mut (*guard),
                     &key_id,
@@ -3225,7 +3220,8 @@ pub(crate) mod tests {
         {
             let public_storage = crypto_storage.inner.get_public_storage();
             let guard = public_storage.lock().await;
-            for public_type in &public_types {
+            // Validate that no public material of the key was deleted.
+            for public_type in PubDataType::iter() {
                 assert!(
                     guard
                         .data_exists(&key_id, &public_type.to_string())

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -287,7 +287,7 @@ fn check_preproc_id_matches(
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum EpochOutput {
     PRSSInitOnly,
     Reshare((Vec<KeyGenMetadata>, Vec<CrsGenMetadata>)),
@@ -3214,8 +3214,11 @@ pub(crate) mod tests {
             vec![],
         )
         .await;
-        // `EpochOutput` has no `Debug`, hence `is_err` instead of `unwrap_err`.
-        assert!(res.is_err(), "the reshare must fail on the occupied slot");
+        assert!(
+            res.unwrap_err()
+                .to_string()
+                .contains("the reshare must fail on the occupied slot")
+        );
 
         {
             let public_storage = crypto_storage.inner.get_public_storage();

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -818,7 +818,7 @@ impl<
                  epoch remains registered so that the deletion can be retried."
                 ),
             }
-
+            // Remove regardless of whether the rollback succeeded or not, to avoid leaving the in-memory cache in a partial state.
             let removed = crypto_storage.purge_epoch_from_cache(&new_epoch_id).await;
             tracing::info!(
                 "Freed {removed} in-memory FHE key cache entries for rolled back epoch {new_epoch_id}"
@@ -1178,8 +1178,7 @@ impl<
 
         match first_error {
             // If there was a problem, stop and signal the error here so that the operation can be
-            // retried. We must never end up in a situation where the epoch is gone, but data
-            // lingers on disk.
+            // retried.
             Some(e) => Err(e),
             None => Ok(()),
         }

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -3217,7 +3217,7 @@ pub(crate) mod tests {
         assert!(
             res.unwrap_err()
                 .to_string()
-                .contains("the reshare must fail on the occupied slot")
+                .contains("Failed to store all reshared keys for new epoch 8b4803c41504a7acc9a59ebfb4838379f2b50c3ba0dd4a0b984bd7e566ab1b56: [Err(Duplicate)]")
         );
 
         {

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -2489,20 +2489,6 @@ pub(crate) mod tests {
         verify_epoch_info(&new_epoch_id, missing_field_previous_epoch).unwrap_err();
     }
 
-    /// Builds epoch data with an empty PRSS setup, for a test that only needs the epoch to be
-    /// present in the session maker or in storage.
-    fn dummy_epoch_data() -> EpochData {
-        EpochData {
-            context_id: *DEFAULT_MPC_CONTEXT,
-            prss: PRSSSetupCombined {
-                prss_setup_z128: PRSSSetup::<ResiduePolyF4Z128>::new_testing_prss(vec![], vec![]),
-                prss_setup_z64: PRSSSetup::<ResiduePolyF4Z64>::new_testing_prss(vec![], vec![]),
-                num_parties: 4,
-                threshold: 1,
-            },
-        }
-    }
-
     /// Builds key material whose metadata records `preproc_id`. Cheap enough for a unit test
     /// because it pairs the small `TEST_PARAM` keyset with a dummy private keyset.
     fn make_threshold_keys_with_preproc_id(
@@ -3147,133 +3133,61 @@ pub(crate) mod tests {
         }
     }
 
-    /// A share deletion that fails must leave the epoch markers in place, so that a restarted node
-    /// still sees the epoch and can complete the deletion. Only the epoch-scoped deletions fail
-    /// here, hence the markers are deletable and the guard on them is what keeps them.
+    /// The public key material of a key carries no epoch in its storage path, hence it belongs to
+    /// every epoch of that key. A reshare that fails to store its shares must therefore keep that
+    /// material, and delete the private material of the new epoch only.
+    /// This test validates a fix of a bug found in E2E test on 0.14.x
     #[tokio::test]
-    async fn test_destroy_epoch_keeps_markers_when_share_deletion_fails() {
-        let mut rng = AesRng::seed_from_u64(44);
+    async fn test_failed_reshare_keeps_public_key_material() {
+        let mut rng = AesRng::seed_from_u64(45);
         let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
-        let session_maker = &epoch_manager.session_maker;
+        let crypto_storage = &epoch_manager.crypto_storage;
 
-        let epoch = dummy_epoch_data();
-        let epoch_id = EpochId::new_random(&mut rng);
-        let keeper_epoch_id = EpochId::new_random(&mut rng);
-        session_maker.add_epoch(epoch_id, epoch.clone()).await;
-        session_maker
-            .add_epoch(keeper_epoch_id, epoch.clone())
-            .await;
+        let new_epoch_id = EpochId::new_random(&mut rng);
+        let key_id = derive_request_id("reshared_key").unwrap();
+        let preproc_id = derive_request_id("reshared_key_preproc").unwrap();
 
-        let priv_storage = tokio::sync::Mutex::new(FailingRamStorage::new(100));
-        let data_id = derive_request_id("marker_guard_data").unwrap();
-        let epoch_data_id: RequestId = epoch_id.into();
-
+        // Stand-ins for the real key material, since the assertions below only test for presence.
+        let public_types = [
+            PubDataType::PublicKey,
+            PubDataType::ServerKey,
+            PubDataType::CompressedXofKeySet,
+        ];
         {
-            let mut guard = priv_storage.lock().await;
+            let public_storage = crypto_storage.inner.get_public_storage();
+            let mut guard = public_storage.lock().await;
+            for public_type in &public_types {
+                store_versioned_at_request_id(
+                    &mut (*guard),
+                    &key_id,
+                    &TestType { i: 7 },
+                    &public_type.to_string(),
+                )
+                .await
+                .unwrap();
+            }
+        }
+
+        // Occupy the slot that the reshare writes its shares to, which makes the reshare fail and
+        // roll the new epoch back. The duplicate check only tests for presence, hence the content of
+        // the slot is irrelevant.
+        {
+            let private_storage = crypto_storage.get_private_storage();
+            let mut guard = private_storage.lock().await;
             store_versioned_at_request_and_epoch_id(
                 &mut (*guard),
-                &data_id,
-                &epoch_id,
+                &key_id,
+                &new_epoch_id,
                 &TestType { i: 42 },
                 &PrivDataType::FheKeyInfo.to_string(),
             )
             .await
             .unwrap();
-            store_versioned_at_request_id(
-                &mut (*guard),
-                &epoch_data_id,
-                &epoch,
-                &PrivDataType::EpochData.to_string(),
-            )
-            .await
-            .unwrap();
-            guard.set_fail_epoch_deletes(true);
         }
 
-        let err = RealThresholdEpochManager::<
-            ram::RamStorage,
-            FailingRamStorage,
-            EmptyPrss,
-            SecureReshareSecretKeys,
-        >::destroy_epoch(&epoch_id, &priv_storage, session_maker)
-        .await
-        .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::Internal);
-
-        assert!(
-            session_maker.epoch_exists(&epoch_id).await,
-            "epoch must remain in the session maker after a failed destruction"
-        );
-        {
-            let guard = priv_storage.lock().await;
-            assert!(
-                guard
-                    .all_data_ids_at_epoch(&epoch_id, &PrivDataType::FheKeyInfo.to_string())
-                    .await
-                    .unwrap()
-                    .contains(&data_id)
-            );
-            assert!(
-                guard
-                    .data_exists(&epoch_data_id, &PrivDataType::EpochData.to_string())
-                    .await
-                    .unwrap(),
-                "EpochData retry marker must survive while a key share lingers on disk"
-            );
-        }
-    }
-
-    /// Store the last key of `key_ids` in `new_epoch_id`, then attempt to reshare all keys into the new epoch.
-    /// This leaves an inconsistent partial state in the storage.
-    async fn failing_reshare_into_epoch(
-        epoch_manager: &RealThresholdEpochManager<
-            RamStorage,
-            RamStorage,
-            EmptyPrss,
-            SecureReshareSecretKeys,
-        >,
-        key_ids: &[RequestId],
-        previous_epoch_id: &EpochId,
-        new_epoch_id: &EpochId,
-        rng: &mut AesRng,
-    ) -> anyhow::Error {
-        let crypto_storage = &epoch_manager.crypto_storage;
-        let preproc_id = derive_request_id("failing_reshare_preproc").unwrap();
-
-        let mut keys_info = Vec::new();
-        let mut verified_materials = Vec::new();
-        let mut new_private_keysets = Vec::new();
-        for key_id in key_ids {
-            let (_keyset, compressed_keyset) =
-                gen_key_set(crate::consts::TEST_PARAM, tfhe::Tag::default(), rng).unwrap();
-            keys_info.push(VerifiedKeyInfo {
-                key_id: *key_id,
-                preproc_id,
-                key_parameters: crate::consts::TEST_PARAM,
-                key_digests: HashMap::new(),
-            });
-            verified_materials.push(VerifiedPublicMaterial::Compressed(compressed_keyset));
-            new_private_keysets.push(PrivateKeySet::init_dummy(crate::consts::TEST_PARAM));
-        }
-
-        // Occupy the slot of the last key in the new epoch, which makes its write fail.
-        let blocked_key_id = key_ids.last().expect("the reshare needs at least one key");
-        store_previous_epoch_keys(
-            crypto_storage,
-            blocked_key_id,
-            new_epoch_id,
-            &make_threshold_keys_with_preproc_id(blocked_key_id, &preproc_id, rng),
-        )
-        .await;
-
-        let verified_previous_epoch = VerifiedPreviousEpochInfo {
-            context_id: *DEFAULT_MPC_CONTEXT,
-            epoch_id: *previous_epoch_id,
-            keys_info,
-            crs_info: vec![],
-        };
+        let (_keyset, compressed_keyset) =
+            gen_key_set(crate::consts::TEST_PARAM, tfhe::Tag::default(), &mut rng).unwrap();
         let sk = epoch_manager.base_kms.sig_key().unwrap();
-
         let res = RealThresholdEpochManager::<
             RamStorage,
             RamStorage,
@@ -3284,214 +3198,38 @@ pub(crate) mod tests {
             &epoch_manager.session_maker,
             &sk,
             &[SigningSchemeType::Ecdsa256k1],
-            *new_epoch_id,
+            new_epoch_id,
             vec![],
-            &verified_previous_epoch,
-            verified_materials,
-            new_private_keysets,
+            &make_verified_previous_epoch(
+                *DEFAULT_EPOCH_ID,
+                &key_id,
+                &preproc_id,
+                crate::consts::TEST_PARAM,
+            ),
+            vec![VerifiedPublicMaterial::Compressed(compressed_keyset)],
+            vec![PrivateKeySet::init_dummy(crate::consts::TEST_PARAM)],
             &dummy_domain(),
             vec![],
         )
         .await;
+        // `EpochOutput` has no `Debug`, hence `is_err` instead of `unwrap_err`.
+        assert!(res.is_err(), "the reshare must fail on the occupied slot");
 
-        match res {
-            // `EpochOutput` has no `Debug`, hence the match instead of `unwrap_err`.
-            Ok(_) => panic!("the reshare must fail, as a key slot of the new epoch is taken"),
-            Err(e) => e,
-        }
-    }
-
-    /// The public key material of a key belongs to every epoch of that key, because public storage
-    /// has no epoch dimension. A failed reshare must therefore keep it, and delete the private
-    /// material of the new epoch only.
-    #[tokio::test]
-    async fn test_failed_reshare_keeps_public_key_material() {
-        let mut rng = AesRng::seed_from_u64(45);
-        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
-        let crypto_storage = &epoch_manager.crypto_storage;
-        let session_maker = &epoch_manager.session_maker;
-
-        let previous_epoch_id = *DEFAULT_EPOCH_ID;
-        let new_epoch_id = EpochId::new_random(&mut rng);
-        // The reshare writes the first key and fails on the second one.
-        let reshared_key_id = derive_request_id("reshared_key").unwrap();
-        let blocked_key_id = derive_request_id("blocked_key").unwrap();
-        let preproc_id = derive_request_id("previous_epoch_preproc").unwrap();
-
-        // Stand-ins for the real key material: the test asserts on the presence of the objects, not
-        // on their content.
-        let public_types = [PubDataType::PublicKey, PubDataType::ServerKey];
-        {
-            let public_storage = crypto_storage.inner.get_public_storage();
-            let mut guard = public_storage.lock().await;
-            for key_id in [&reshared_key_id, &blocked_key_id] {
-                for public_type in &public_types {
-                    store_versioned_at_request_id(
-                        &mut (*guard),
-                        key_id,
-                        &TestType { i: 7 },
-                        &public_type.to_string(),
-                    )
-                    .await
-                    .unwrap();
-                }
-            }
-        }
-
-        // The state before the reshare: both epochs are known, and the previous epoch holds the
-        // shares of the key that the reshare writes. Writing those shares through the resharing path
-        // also puts them in the key cache, which lets the assertions below pin down what the
-        // rollback purges from the cache.
-        let epoch = dummy_epoch_data();
-        session_maker
-            .add_epoch(previous_epoch_id, epoch.clone())
-            .await;
-        session_maker.add_epoch(new_epoch_id, epoch.clone()).await;
-        {
-            let private_storage = crypto_storage.get_private_storage();
-            let mut guard = private_storage.lock().await;
-            store_versioned_at_request_id(
-                &mut (*guard),
-                &new_epoch_id.into(),
-                &epoch,
-                &PrivDataType::EpochData.to_string(),
-            )
-            .await
-            .unwrap();
-        }
-        crypto_storage
-            .resharing_fhe_write_no_backup(
-                &reshared_key_id,
-                &previous_epoch_id,
-                make_threshold_keys_with_preproc_id(&reshared_key_id, &preproc_id, &mut rng),
-            )
-            .await
-            .unwrap();
-        assert_eq!(crypto_storage.cached_fhe_key_count(), Some(1));
-
-        let err = failing_reshare_into_epoch(
-            &epoch_manager,
-            &[reshared_key_id, blocked_key_id],
-            &previous_epoch_id,
-            &new_epoch_id,
-            &mut rng,
-        )
-        .await;
-        assert!(
-            err.to_string()
-                .contains("Failed to store all reshared keys"),
-            "the reshare must fail in its storage step, got: {err}"
-        );
-
-        // The public material of both keys survives, since the previous epoch still serves it.
-        // This validates a bug fix where the rollback deleted public material of the failed reshare.
         {
             let public_storage = crypto_storage.inner.get_public_storage();
             let guard = public_storage.lock().await;
-            for key_id in [&reshared_key_id, &blocked_key_id] {
-                for public_type in &public_types {
-                    assert!(
-                        guard
-                            .data_exists(key_id, &public_type.to_string())
-                            .await
-                            .unwrap(),
-                        "{public_type} of key {key_id} must survive a failed reshare"
-                    );
-                }
-            }
-        }
-
-        // The new epoch is gone from storage and from the session maker, while the previous epoch
-        // keeps its shares.
-        {
-            let private_storage = crypto_storage.get_private_storage();
-            let guard = private_storage.lock().await;
-            for key_id in [&reshared_key_id, &blocked_key_id] {
+            for public_type in &public_types {
                 assert!(
-                    !guard
-                        .data_exists_at_epoch(
-                            key_id,
-                            &new_epoch_id,
-                            &PrivDataType::FheKeyInfo.to_string()
-                        )
+                    guard
+                        .data_exists(&key_id, &public_type.to_string())
                         .await
                         .unwrap(),
-                    "the shares of key {key_id} in the new epoch must be rolled back"
+                    "{public_type} of key {key_id} must survive a failed reshare"
                 );
             }
-            assert!(
-                !guard
-                    .data_exists(&new_epoch_id.into(), &PrivDataType::EpochData.to_string())
-                    .await
-                    .unwrap()
-            );
-            assert!(
-                guard
-                    .data_exists_at_epoch(
-                        &reshared_key_id,
-                        &previous_epoch_id,
-                        &PrivDataType::FheKeyInfo.to_string()
-                    )
-                    .await
-                    .unwrap(),
-                "the shares of the previous epoch must survive a failed reshare"
-            );
         }
-        // Only the entry of the previous epoch is left in the cache.
-        assert_eq!(crypto_storage.cached_fhe_key_count(), Some(1));
-        crypto_storage
-            .read_guarded_fhe_keys(&reshared_key_id, &previous_epoch_id)
-            .await
-            .expect("the key of the previous epoch stays usable");
-        assert!(
-            crypto_storage
-                .read_guarded_fhe_keys(&reshared_key_id, &new_epoch_id)
-                .await
-                .is_err(),
-            "the key of the rolled back epoch must not be readable"
-        );
 
-        assert!(!session_maker.epoch_exists(&new_epoch_id).await);
-        assert!(session_maker.epoch_exists(&previous_epoch_id).await);
-    }
-
-    /// A node that joins the cluster holds the new epoch as its only epoch. A failed reshare must
-    /// still clean that epoch up, unlike
-    /// [`RealThresholdEpochManager::destroy_epoch`], which refuses to remove the last epoch of a
-    /// node.
-    #[tokio::test]
-    async fn test_failed_reshare_rolls_back_only_epoch() {
-        let mut rng = AesRng::seed_from_u64(46);
-        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
-        let crypto_storage = &epoch_manager.crypto_storage;
-        let session_maker = &epoch_manager.session_maker;
-
-        // A joining node holds no material of the previous epoch, and the new epoch is its first.
-        let previous_epoch_id = EpochId::new_random(&mut rng);
-        let new_epoch_id = EpochId::new_random(&mut rng);
-        let key_id = derive_request_id("only_epoch_key").unwrap();
-
-        session_maker
-            .add_epoch(new_epoch_id, dummy_epoch_data())
-            .await;
-        assert_eq!(session_maker.epoch_count().await, 1);
-
-        let err = failing_reshare_into_epoch(
-            &epoch_manager,
-            &[key_id],
-            &previous_epoch_id,
-            &new_epoch_id,
-            &mut rng,
-        )
-        .await;
-        assert!(
-            err.to_string()
-                .contains("Failed to store all reshared keys"),
-            "the reshare must fail in its storage step, got: {err}"
-        );
-
-        assert!(!session_maker.epoch_exists(&new_epoch_id).await);
-        assert_eq!(crypto_storage.cached_fhe_key_count(), Some(0));
+        // The rollback ran: the private material of the new epoch is gone.
         {
             let private_storage = crypto_storage.get_private_storage();
             let guard = private_storage.lock().await;

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -656,6 +656,7 @@ impl<
     #[expect(clippy::too_many_arguments)]
     async fn store_reshared_keys(
         crypto_storage: &ThresholdCryptoMaterialStorage<PubS, PrivS>,
+        session_maker: &SessionMaker,
         sk: &PrivateSigKey,
         signing_schemes: &[SigningSchemeType],
         new_epoch_id: EpochId,
@@ -809,31 +810,19 @@ impl<
 
             // Roll back any partial successes in case something fails during the resharing,
             // to not leave the storage in a partial state.
-            for key_info in verified_previous_epoch.keys_info.iter() {
-                if !crypto_storage
-                    .purge_fhe_keys(&key_info.key_id, &new_epoch_id)
-                    .await
-                {
-                    tracing::warn!(
-                        "Best-effort rollback failed to purge threshold key material for key_id={} new_epoch_id={}",
-                        key_info.key_id,
-                        new_epoch_id
-                    );
-                }
+            let priv_storage = crypto_storage.get_private_storage();
+            match Self::purge_epoch_material(&new_epoch_id, &priv_storage).await {
+                Ok(()) => session_maker.remove_epoch(&new_epoch_id).await,
+                Err(e) => tracing::error!(
+                    "Rollback of epoch {new_epoch_id} failed to delete its private material: {e:?}. The \
+                 epoch remains registered so that the deletion can be retried."
+                ),
             }
-            for crs_info in verified_previous_epoch.crs_info.iter() {
-                if !crypto_storage
-                    .inner
-                    .purge_crs_material(&crs_info.crs_id, &new_epoch_id)
-                    .await
-                {
-                    tracing::warn!(
-                        "Best-effort rollback failed to purge CRS material for crs_id={} new_epoch_id={}",
-                        crs_info.crs_id,
-                        new_epoch_id
-                    );
-                }
-            }
+
+            let removed = crypto_storage.purge_epoch_from_cache(&new_epoch_id).await;
+            tracing::info!(
+                "Freed {removed} in-memory FHE key cache entries for rolled back epoch {new_epoch_id}"
+            );
 
             return Err(anyhow::anyhow!(storage_err_msg));
         }
@@ -892,6 +881,7 @@ impl<
         })?;
 
         let crypto_storage = self.crypto_storage.clone();
+        let session_maker = self.session_maker.clone();
 
         let task = async move {
             let (mut session_z128, mut session_z64, session_online) =
@@ -946,6 +936,7 @@ impl<
 
             Self::store_reshared_keys(
                 &crypto_storage,
+                &session_maker,
                 &sk,
                 &signing_schemes,
                 new_epoch_id,
@@ -1011,6 +1002,7 @@ impl<
         })?;
 
         let crypto_storage = self.crypto_storage.clone();
+        let session_maker = self.session_maker.clone();
 
         let task = async move {
             let (mut session_z128_set_1, mut session_z64_set_1) = Self::create_set1_sessions(
@@ -1082,6 +1074,7 @@ impl<
 
             Self::store_reshared_keys(
                 &crypto_storage,
+                &session_maker,
                 &sk,
                 &signing_schemes,
                 new_epoch_id,
@@ -1098,38 +1091,15 @@ impl<
         Ok(task)
     }
 
-    /// Destroys an epoch by removing all private data stored under the given epoch for each of the
-    /// given data types, then removing the PRSS setup data, and finally removing the epoch from the
-    /// session maker.
+    /// Deletes every piece of private material that belongs to `epoch_id`: the FHE key shares and
+    /// the CRS metadata stored under the epoch, followed by the epoch data itself.
     ///
-    /// In case of any error during the deletion of private data, the epoch will not be removed from the session maker,
-    /// and an error will be returned. This allows the caller to retry the operation until it succeeds.
-    async fn destroy_epoch(
+    /// The deletion continues past a failure and the first error is returned, so that a caller can
+    /// retry until it succeeds.
+    async fn purge_epoch_material(
         epoch_id: &EpochId,
         priv_storage: &tokio::sync::Mutex<PrivS>,
-        session_maker: &SessionMaker,
-    ) -> Result<Response<Empty>, MetricedError> {
-        if !session_maker.epoch_exists(epoch_id).await {
-            return Err(MetricedError::new(
-                OP_DESTROY_EPOCH,
-                Some((*epoch_id).into()),
-                anyhow::anyhow!("Epoch ID {} does not exist", epoch_id),
-                tonic::Code::NotFound,
-            ));
-        }
-
-        if session_maker.epoch_count().await < 2 {
-            return Err(MetricedError::new(
-                OP_DESTROY_EPOCH,
-                Some((*epoch_id).into()),
-                anyhow::anyhow!(
-                    "Cannot destroy epoch ID {} because it is the only epoch remaining",
-                    epoch_id
-                ),
-                tonic::Code::FailedPrecondition,
-            ));
-        }
-
+    ) -> anyhow::Result<()> {
         let mut priv_storage_guard = priv_storage.lock().await;
 
         // At this point we're committed to deleting the epoch, so do not return if there's an error,
@@ -1180,43 +1150,84 @@ impl<
         // resurrects the epoch after a restart — the session maker is rebuilt from epoch-data
         // storage on startup — hence keeping the epoch data for last guarantees a restarted node still
         // sees the epoch and can finish the deletion.
-        if let Err(e) = delete_at_request_id(
-            &mut (*priv_storage_guard),
-            &epoch_id.into(),
-            &PrivDataType::EpochData.to_string(),
-        )
-        .await
+        if first_error.is_none()
+            && let Err(e) = delete_at_request_id(
+                &mut (*priv_storage_guard),
+                &epoch_id.into(),
+                &PrivDataType::EpochData.to_string(),
+            )
+            .await
         {
             tracing::error!("Error deleting EpochData epoch ID {epoch_id}: {e:?}");
-            if first_error.is_none() {
-                first_error = Some(e);
-            }
+            first_error = Some(e);
         }
         // Also delete legacy data to avoid it coming back on migration at restart.
-        if let Err(e) = delete_at_request_id(
-            &mut (*priv_storage_guard),
-            &epoch_id.into(),
-            #[expect(deprecated)]
-            &PrivDataType::PrssSetupCombined.to_string(),
-        )
-        .await
+        #[expect(deprecated)]
+        let legacy_prss_type = PrivDataType::PrssSetupCombined.to_string();
+        if first_error.is_none()
+            && let Err(e) = delete_at_request_id(
+                &mut (*priv_storage_guard),
+                &epoch_id.into(),
+                &legacy_prss_type,
+            )
+            .await
         {
             tracing::error!("Error deleting PrssSetupCombined on epoch ID {epoch_id}: {e:?}");
-            if first_error.is_none() {
-                first_error = Some(e);
-            }
+            first_error = Some(e);
         }
 
-        if let Some(e) = first_error {
-            // If there was a problem, stop and signal error here so that the operation can be retried. We must never
-            // end up in a situation where the epoch is gone, but data lingers on disk.
+        match first_error {
+            // If there was a problem, stop and signal the error here so that the operation can be
+            // retried. We must never end up in a situation where the epoch is gone, but data
+            // lingers on disk.
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    /// Destroys an epoch by removing all private data stored under the given epoch, and then
+    /// removing the epoch from the session maker.
+    ///
+    /// The epoch must exist and must not be the last epoch on the node.
+    ///
+    /// In case of any error during the deletion of private data, the epoch will not be removed from the session maker,
+    /// and an error will be returned. This allows the caller to retry the operation until it succeeds.
+    async fn destroy_epoch(
+        epoch_id: &EpochId,
+        priv_storage: &tokio::sync::Mutex<PrivS>,
+        session_maker: &SessionMaker,
+    ) -> Result<Response<Empty>, MetricedError> {
+        if !session_maker.epoch_exists(epoch_id).await {
             return Err(MetricedError::new(
                 OP_DESTROY_EPOCH,
                 Some((*epoch_id).into()),
-                e,
-                tonic::Code::Internal,
+                anyhow::anyhow!("Epoch ID {} does not exist", epoch_id),
+                tonic::Code::NotFound,
             ));
         }
+
+        if session_maker.epoch_count().await < 2 {
+            return Err(MetricedError::new(
+                OP_DESTROY_EPOCH,
+                Some((*epoch_id).into()),
+                anyhow::anyhow!(
+                    "Cannot destroy epoch ID {} because it is the only epoch remaining",
+                    epoch_id
+                ),
+                tonic::Code::FailedPrecondition,
+            ));
+        }
+
+        Self::purge_epoch_material(epoch_id, priv_storage)
+            .await
+            .map_err(|e| {
+                MetricedError::new(
+                    OP_DESTROY_EPOCH,
+                    Some((*epoch_id).into()),
+                    e,
+                    tonic::Code::Internal,
+                )
+            })?;
 
         // Only forget the epoch once every piece of its private data has been deleted.
         session_maker.remove_epoch(epoch_id).await;
@@ -2478,6 +2489,20 @@ pub(crate) mod tests {
         verify_epoch_info(&new_epoch_id, missing_field_previous_epoch).unwrap_err();
     }
 
+    /// Builds epoch data with an empty PRSS setup, for a test that only needs the epoch to be
+    /// present in the session maker or in storage.
+    fn dummy_epoch_data() -> EpochData {
+        EpochData {
+            context_id: *DEFAULT_MPC_CONTEXT,
+            prss: PRSSSetupCombined {
+                prss_setup_z128: PRSSSetup::<ResiduePolyF4Z128>::new_testing_prss(vec![], vec![]),
+                prss_setup_z64: PRSSSetup::<ResiduePolyF4Z64>::new_testing_prss(vec![], vec![]),
+                num_parties: 4,
+                threshold: 1,
+            },
+        }
+    }
+
     /// Builds key material whose metadata records `preproc_id`. Cheap enough for a unit test
     /// because it pairs the small `TEST_PARAM` keyset with a dummy private keyset.
     fn make_threshold_keys_with_preproc_id(
@@ -3116,6 +3141,252 @@ pub(crate) mod tests {
             assert!(
                 !guard
                     .data_exists(&epoch_data_id, &PrivDataType::EpochData.to_string())
+                    .await
+                    .unwrap()
+            );
+        }
+    }
+
+    /// A share deletion that fails must leave the epoch markers in place, so that a restarted node
+    /// still sees the epoch and can complete the deletion. Only the epoch-scoped deletions fail
+    /// here, hence the markers are deletable and the guard on them is what keeps them.
+    #[tokio::test]
+    async fn test_destroy_epoch_keeps_markers_when_share_deletion_fails() {
+        let mut rng = AesRng::seed_from_u64(44);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+        let session_maker = &epoch_manager.session_maker;
+
+        let epoch = dummy_epoch_data();
+        let epoch_id = EpochId::new_random(&mut rng);
+        let keeper_epoch_id = EpochId::new_random(&mut rng);
+        session_maker.add_epoch(epoch_id, epoch.clone()).await;
+        session_maker
+            .add_epoch(keeper_epoch_id, epoch.clone())
+            .await;
+
+        let priv_storage = tokio::sync::Mutex::new(FailingRamStorage::new(100));
+        let data_id = derive_request_id("marker_guard_data").unwrap();
+        let epoch_data_id: RequestId = epoch_id.into();
+
+        {
+            let mut guard = priv_storage.lock().await;
+            store_versioned_at_request_and_epoch_id(
+                &mut (*guard),
+                &data_id,
+                &epoch_id,
+                &TestType { i: 42 },
+                &PrivDataType::FheKeyInfo.to_string(),
+            )
+            .await
+            .unwrap();
+            store_versioned_at_request_id(
+                &mut (*guard),
+                &epoch_data_id,
+                &epoch,
+                &PrivDataType::EpochData.to_string(),
+            )
+            .await
+            .unwrap();
+            guard.set_fail_epoch_deletes(true);
+        }
+
+        let err = RealThresholdEpochManager::<
+            ram::RamStorage,
+            FailingRamStorage,
+            EmptyPrss,
+            SecureReshareSecretKeys,
+        >::destroy_epoch(&epoch_id, &priv_storage, session_maker)
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Internal);
+
+        assert!(
+            session_maker.epoch_exists(&epoch_id).await,
+            "epoch must remain in the session maker after a failed destruction"
+        );
+        {
+            let guard = priv_storage.lock().await;
+            assert!(
+                guard
+                    .all_data_ids_at_epoch(&epoch_id, &PrivDataType::FheKeyInfo.to_string())
+                    .await
+                    .unwrap()
+                    .contains(&data_id)
+            );
+            assert!(
+                guard
+                    .data_exists(&epoch_data_id, &PrivDataType::EpochData.to_string())
+                    .await
+                    .unwrap(),
+                "EpochData retry marker must survive while a key share lingers on disk"
+            );
+        }
+    }
+
+    /// The public key material of a key belongs to every epoch of that key, because public storage
+    /// has no epoch dimension. A rollback of a failed reshare must therefore keep it, and delete the
+    /// private material of the new epoch only.
+    #[tokio::test]
+    async fn test_rollback_failed_epoch_keeps_public_key_material() {
+        let mut rng = AesRng::seed_from_u64(45);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+        let crypto_storage = &epoch_manager.crypto_storage;
+        let session_maker = &epoch_manager.session_maker;
+
+        let previous_epoch_id = *DEFAULT_EPOCH_ID;
+        let new_epoch_id = EpochId::new_random(&mut rng);
+        let key_id = derive_request_id("rollback_key").unwrap();
+        let preproc_id = derive_request_id("rollback_preproc").unwrap();
+
+        // Stand-ins for the real key material: the test asserts on the presence of the objects, not
+        // on their content.
+        let public_types = [PubDataType::PublicKey, PubDataType::ServerKey];
+        {
+            let public_storage = crypto_storage.inner.get_public_storage();
+            let mut guard = public_storage.lock().await;
+            for public_type in &public_types {
+                store_versioned_at_request_id(
+                    &mut (*guard),
+                    &key_id,
+                    &TestType { i: 7 },
+                    &public_type.to_string(),
+                )
+                .await
+                .unwrap();
+            }
+        }
+
+        // The state a partially completed reshare leaves behind: the key shares of the previous
+        // epoch, plus the shares and the epoch data of the new epoch.
+        let keys = make_threshold_keys_with_preproc_id(&key_id, &preproc_id, &mut rng);
+        store_previous_epoch_keys(crypto_storage, &key_id, &previous_epoch_id, &keys).await;
+        let epoch = dummy_epoch_data();
+        session_maker
+            .add_epoch(previous_epoch_id, epoch.clone())
+            .await;
+        session_maker.add_epoch(new_epoch_id, epoch.clone()).await;
+        {
+            let private_storage = crypto_storage.get_private_storage();
+            let mut guard = private_storage.lock().await;
+            store_versioned_at_request_id(
+                &mut (*guard),
+                &new_epoch_id.into(),
+                &epoch,
+                &PrivDataType::EpochData.to_string(),
+            )
+            .await
+            .unwrap();
+        }
+        crypto_storage
+            .resharing_fhe_write_no_backup(&key_id, &new_epoch_id, keys)
+            .await
+            .unwrap();
+        assert_eq!(crypto_storage.cached_fhe_key_count(), Some(1));
+
+        RealThresholdEpochManager::<
+            ram::RamStorage,
+            ram::RamStorage,
+            EmptyPrss,
+            SecureReshareSecretKeys,
+        >::rollback_failed_epoch(crypto_storage, session_maker, &new_epoch_id)
+        .await;
+
+        // The public material of the key survives, since the previous epoch still serves it.
+        {
+            let public_storage = crypto_storage.inner.get_public_storage();
+            let guard = public_storage.lock().await;
+            for public_type in &public_types {
+                assert!(
+                    guard
+                        .data_exists(&key_id, &public_type.to_string())
+                        .await
+                        .unwrap(),
+                    "{public_type} of key {key_id} must survive the rollback"
+                );
+            }
+        }
+
+        // The new epoch is gone from storage, from the cache and from the session maker, while the
+        // previous epoch keeps its shares.
+        {
+            let private_storage = crypto_storage.get_private_storage();
+            let guard = private_storage.lock().await;
+            assert!(
+                !guard
+                    .data_exists_at_epoch(
+                        &key_id,
+                        &new_epoch_id,
+                        &PrivDataType::FheKeyInfo.to_string()
+                    )
+                    .await
+                    .unwrap()
+            );
+            assert!(
+                !guard
+                    .data_exists(&new_epoch_id.into(), &PrivDataType::EpochData.to_string())
+                    .await
+                    .unwrap()
+            );
+            assert!(
+                guard
+                    .data_exists_at_epoch(
+                        &key_id,
+                        &previous_epoch_id,
+                        &PrivDataType::FheKeyInfo.to_string()
+                    )
+                    .await
+                    .unwrap(),
+                "the shares of the previous epoch must survive the rollback"
+            );
+        }
+        assert_eq!(crypto_storage.cached_fhe_key_count(), Some(0));
+        assert!(!session_maker.epoch_exists(&new_epoch_id).await);
+        assert!(session_maker.epoch_exists(&previous_epoch_id).await);
+    }
+
+    /// A node that joins the cluster holds the new epoch as its only epoch. The rollback must clean
+    /// that epoch up, unlike [`RealThresholdEpochManager::destroy_epoch`], which refuses to remove
+    /// the last epoch of a node.
+    #[tokio::test]
+    async fn test_rollback_failed_epoch_on_only_epoch() {
+        let mut rng = AesRng::seed_from_u64(46);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+        let crypto_storage = &epoch_manager.crypto_storage;
+        let session_maker = &epoch_manager.session_maker;
+
+        let new_epoch_id = EpochId::new_random(&mut rng);
+        let key_id = derive_request_id("rollback_only_epoch_key").unwrap();
+        let preproc_id = derive_request_id("rollback_only_epoch_preproc").unwrap();
+
+        let epoch = dummy_epoch_data();
+        session_maker.add_epoch(new_epoch_id, epoch.clone()).await;
+        let keys = make_threshold_keys_with_preproc_id(&key_id, &preproc_id, &mut rng);
+        crypto_storage
+            .resharing_fhe_write_no_backup(&key_id, &new_epoch_id, keys)
+            .await
+            .unwrap();
+        assert_eq!(session_maker.epoch_count().await, 1);
+
+        RealThresholdEpochManager::<
+            ram::RamStorage,
+            ram::RamStorage,
+            EmptyPrss,
+            SecureReshareSecretKeys,
+        >::rollback_failed_epoch(crypto_storage, session_maker, &new_epoch_id)
+        .await;
+
+        assert!(!session_maker.epoch_exists(&new_epoch_id).await);
+        assert_eq!(crypto_storage.cached_fhe_key_count(), Some(0));
+        {
+            let private_storage = crypto_storage.get_private_storage();
+            let guard = private_storage.lock().await;
+            assert!(
+                !guard
+                    .data_exists_at_epoch(
+                        &key_id,
+                        &new_epoch_id,
+                        &PrivDataType::FheKeyInfo.to_string()
+                    )
                     .await
                     .unwrap()
             );

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1185,16 +1185,17 @@ impl<
         }
     }
 
-    /// Destroys an epoch by removing all private data stored under the given epoch, and then
-    /// removing the epoch from the session maker.
+    /// Destroys an epoch by removing all private data stored under the given epoch, dropping its
+    /// entries from the key cache, and then removing the epoch from the session maker.
     ///
-    /// The epoch must exist and must not be the last epoch on the node.
+    /// The epoch must exist and must not be the last epoch on the node. A rejected precondition
+    /// leaves the epoch untouched, cache included.
     ///
     /// In case of any error during the deletion of private data, the epoch will not be removed from the session maker,
     /// and an error will be returned. This allows the caller to retry the operation until it succeeds.
     async fn destroy_epoch(
         epoch_id: &EpochId,
-        priv_storage: &tokio::sync::Mutex<PrivS>,
+        crypto_storage: &ThresholdCryptoMaterialStorage<PubS, PrivS>,
         session_maker: &SessionMaker,
     ) -> Result<Response<Empty>, MetricedError> {
         if !session_maker.epoch_exists(epoch_id).await {
@@ -1218,16 +1219,23 @@ impl<
             ));
         }
 
-        Self::purge_epoch_material(epoch_id, priv_storage)
-            .await
-            .map_err(|e| {
-                MetricedError::new(
-                    OP_DESTROY_EPOCH,
-                    Some((*epoch_id).into()),
-                    e,
-                    tonic::Code::Internal,
-                )
-            })?;
+        let priv_storage = crypto_storage.get_private_storage();
+        let purge_res = Self::purge_epoch_material(epoch_id, &priv_storage).await;
+
+        // The cache is dropped whatever the outcome of the deletion to avoid orphaned data in RAM.
+        let removed = crypto_storage.purge_epoch_from_cache(epoch_id).await;
+        tracing::info!(
+            "Freed {removed} in-memory FHE key cache entries for destroyed epoch {epoch_id}"
+        );
+
+        purge_res.map_err(|e| {
+            MetricedError::new(
+                OP_DESTROY_EPOCH,
+                Some((*epoch_id).into()),
+                e,
+                tonic::Code::Internal,
+            )
+        })?;
 
         // Only forget the epoch once every piece of its private data has been deleted.
         session_maker.remove_epoch(epoch_id).await;
@@ -1236,18 +1244,12 @@ impl<
         Ok(Response::new(Empty {}))
     }
 
-    /// Fully erase a single epoch: delete its on-disk private key shares, CRS and PRSS setup, then drop the in-memory
-    /// decompressed-key cache for that epoch.
+    /// Takes the exclusive lifecycle lease of the epoch and then erases it through
+    /// [`Self::destroy_epoch`].
     ///
     /// In case anything goes wrong, an error will be returned and epoch meta-data will remain in the RAM despite being deleted from disk.
     /// This is to allow the caller to retry the operation until it succeeds.
-    ///
-    /// [`Self::destroy_epoch`] only touches storage, so the cache must be cleared here as well or the decompressed keys
-    /// stay resident until restart. The cache is purged regardless of the deletion outcome.
-    ///
-    /// An exclusive lifecycle lease prevents creation of the same epoch from starting or completing
-    /// concurrently with deletion.
-    async fn destroy_epoch_and_purge_cache(
+    async fn destroy_epoch_with_lease(
         &self,
         epoch_id: &EpochId,
     ) -> Result<Response<Empty>, MetricedError> {
@@ -1267,17 +1269,8 @@ impl<
                 )
             })?;
 
-        let priv_storage = Arc::clone(&self.crypto_storage.inner.private_storage);
-
         // NOTE: destroy_epoch will also destroy PRSS data
-        let res = Self::destroy_epoch(epoch_id, &priv_storage, &self.session_maker).await;
-
-        let removed = self.crypto_storage.purge_epoch_from_cache(epoch_id).await;
-        tracing::info!(
-            "Freed {removed} in-memory FHE key cache entries for destroyed epoch {epoch_id}"
-        );
-
-        res
+        Self::destroy_epoch(epoch_id, &self.crypto_storage, &self.session_maker).await
     }
 
     /// Rejects the request unless every `preproc_id` supplied in [`PreviousEpochInfo`] matches the
@@ -1618,7 +1611,7 @@ impl<
                 |e| MetricedError::new(OP_DESTROY_EPOCH, None, e, tonic::Code::InvalidArgument),
             )?;
 
-        self.destroy_epoch_and_purge_cache(&epoch_id).await
+        self.destroy_epoch_with_lease(&epoch_id).await
     }
 
     async fn destroy_epochs_for_context(
@@ -1646,7 +1639,7 @@ impl<
             // Attempt to destroy every epoch even if an earlier one fails, but keep the first failure to return so the
             // caller learns that some shares may remain and can retry. Later failures are logged via their own
             // `MetricedError` drop handling.
-            if let Err(e) = self.destroy_epoch_and_purge_cache(epoch_id).await {
+            if let Err(e) = self.destroy_epoch_with_lease(epoch_id).await {
                 if first_error.is_none() {
                     first_error = Some(e);
                 }
@@ -2817,7 +2810,11 @@ pub(crate) mod tests {
             ram::RamStorage,
             EmptyPrss,
             SecureReshareSecretKeys,
-        >::destroy_epoch(&epoch_id, &priv_storage, &epoch_manager.session_maker)
+        >::destroy_epoch(
+            &epoch_id,
+            &epoch_manager.crypto_storage,
+            &epoch_manager.session_maker,
+        )
         .await
         .unwrap();
 
@@ -2893,7 +2890,11 @@ pub(crate) mod tests {
             ram::RamStorage,
             EmptyPrss,
             SecureReshareSecretKeys,
-        >::destroy_epoch(&epoch_id, &priv_storage, &epoch_manager.session_maker)
+        >::destroy_epoch(
+            &epoch_id,
+            &epoch_manager.crypto_storage,
+            &epoch_manager.session_maker,
+        )
         .await
         .unwrap();
 
@@ -2929,7 +2930,6 @@ pub(crate) mod tests {
 
         let nonexistent_epoch_id = EpochId::new_random(&mut rng);
 
-        let priv_storage = epoch_manager.crypto_storage.get_private_storage();
         let err = RealThresholdEpochManager::<
             ram::RamStorage,
             ram::RamStorage,
@@ -2937,7 +2937,7 @@ pub(crate) mod tests {
             SecureReshareSecretKeys,
         >::destroy_epoch(
             &nonexistent_epoch_id,
-            &priv_storage,
+            &epoch_manager.crypto_storage,
             &epoch_manager.session_maker,
         )
         .await
@@ -2968,7 +2968,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let err = epoch_manager
-            .destroy_epoch_and_purge_cache(&epoch_id)
+            .destroy_epoch_with_lease(&epoch_id)
             .await
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
@@ -2989,7 +2989,7 @@ pub(crate) mod tests {
         // Success, failure, panic and task cancellation all drop this owned lease, allowing cleanup.
         drop(creation_lease);
         epoch_manager
-            .destroy_epoch_and_purge_cache(&epoch_id)
+            .destroy_epoch_with_lease(&epoch_id)
             .await
             .unwrap();
 
@@ -3034,7 +3034,13 @@ pub(crate) mod tests {
             .await;
 
         // Fault-injecting private storage that we can flip between failing and succeeding on delete.
-        let priv_storage = tokio::sync::Mutex::new(FailingRamStorage::new(100));
+        let crypto_storage = ThresholdCryptoMaterialStorage::new(
+            RamStorage::new(),
+            FailingRamStorage::new(100),
+            None,
+            HashMap::new(),
+        );
+        let priv_storage = crypto_storage.get_private_storage();
 
         let data_type = PrivDataType::FheKeyInfo;
         let data = TestType { i: 42 };
@@ -3071,7 +3077,7 @@ pub(crate) mod tests {
             FailingRamStorage,
             EmptyPrss,
             SecureReshareSecretKeys,
-        >::destroy_epoch(&epoch_id, &priv_storage, session_maker)
+        >::destroy_epoch(&epoch_id, &crypto_storage, session_maker)
         .await
         .unwrap_err();
         assert_eq!(err.code(), tonic::Code::Internal);
@@ -3110,7 +3116,7 @@ pub(crate) mod tests {
             FailingRamStorage,
             EmptyPrss,
             SecureReshareSecretKeys,
-        >::destroy_epoch(&epoch_id, &priv_storage, session_maker)
+        >::destroy_epoch(&epoch_id, &crypto_storage, session_maker)
         .await
         .unwrap();
 

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1094,8 +1094,9 @@ impl<
     /// Deletes every piece of private material that belongs to `epoch_id`: the FHE key shares and
     /// the CRS metadata stored under the epoch, followed by the epoch data itself.
     ///
-    /// The deletion continues past a failure and the first error is returned, so that a caller can
-    /// retry until it succeeds.
+    /// The deletion continues past a failure and the first error is returned.
+    /// However, only if all deletions succeed is the epoch data itself deleted, so that a restarted
+    /// node can still see the epoch and hence finish the deletion.
     async fn purge_epoch_material(
         epoch_id: &EpochId,
         priv_storage: &tokio::sync::Mutex<PrivS>,
@@ -1145,6 +1146,21 @@ impl<
             }
         }
 
+        // Delete legacy data to avoid it coming back on migration at restart.
+        #[expect(deprecated)]
+        let legacy_prss_type = PrivDataType::PrssSetupCombined.to_string();
+        if first_error.is_none()
+            && let Err(e) = delete_at_request_id(
+                &mut (*priv_storage_guard),
+                &epoch_id.into(),
+                &legacy_prss_type,
+            )
+            .await
+        {
+            tracing::error!("Error deleting PrssSetupCombined on epoch ID {epoch_id}: {e:?}");
+            first_error = Some(e);
+        }
+
         // Delete the epoch data (stored under epoch_id as a request_id) only once every key/CRS
         // meta data deletion above has succeeded. The epoch data (which holds the PRSS setup) is what
         // resurrects the epoch after a restart — the session maker is rebuilt from epoch-data
@@ -1159,20 +1175,6 @@ impl<
             .await
         {
             tracing::error!("Error deleting EpochData epoch ID {epoch_id}: {e:?}");
-            first_error = Some(e);
-        }
-        // Also delete legacy data to avoid it coming back on migration at restart.
-        #[expect(deprecated)]
-        let legacy_prss_type = PrivDataType::PrssSetupCombined.to_string();
-        if first_error.is_none()
-            && let Err(e) = delete_at_request_id(
-                &mut (*priv_storage_guard),
-                &epoch_id.into(),
-                &legacy_prss_type,
-            )
-            .await
-        {
-            tracing::error!("Error deleting PrssSetupCombined on epoch ID {epoch_id}: {e:?}");
             first_error = Some(e);
         }
 

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -3223,11 +3223,89 @@ pub(crate) mod tests {
         }
     }
 
+    /// Store the last key of `key_ids` in `new_epoch_id`, then attempt to reshare all keys into the new epoch.
+    /// This leaves an inconsistent partial state in the storage.
+    async fn failing_reshare_into_epoch(
+        epoch_manager: &RealThresholdEpochManager<
+            RamStorage,
+            RamStorage,
+            EmptyPrss,
+            SecureReshareSecretKeys,
+        >,
+        key_ids: &[RequestId],
+        previous_epoch_id: &EpochId,
+        new_epoch_id: &EpochId,
+        rng: &mut AesRng,
+    ) -> anyhow::Error {
+        let crypto_storage = &epoch_manager.crypto_storage;
+        let preproc_id = derive_request_id("failing_reshare_preproc").unwrap();
+
+        let mut keys_info = Vec::new();
+        let mut verified_materials = Vec::new();
+        let mut new_private_keysets = Vec::new();
+        for key_id in key_ids {
+            let (_keyset, compressed_keyset) =
+                gen_key_set(crate::consts::TEST_PARAM, tfhe::Tag::default(), rng).unwrap();
+            keys_info.push(VerifiedKeyInfo {
+                key_id: *key_id,
+                preproc_id,
+                key_parameters: crate::consts::TEST_PARAM,
+                key_digests: HashMap::new(),
+            });
+            verified_materials.push(VerifiedPublicMaterial::Compressed(compressed_keyset));
+            new_private_keysets.push(PrivateKeySet::init_dummy(crate::consts::TEST_PARAM));
+        }
+
+        // Occupy the slot of the last key in the new epoch, which makes its write fail.
+        let blocked_key_id = key_ids.last().expect("the reshare needs at least one key");
+        store_previous_epoch_keys(
+            crypto_storage,
+            blocked_key_id,
+            new_epoch_id,
+            &make_threshold_keys_with_preproc_id(blocked_key_id, &preproc_id, rng),
+        )
+        .await;
+
+        let verified_previous_epoch = VerifiedPreviousEpochInfo {
+            context_id: *DEFAULT_MPC_CONTEXT,
+            epoch_id: *previous_epoch_id,
+            keys_info,
+            crs_info: vec![],
+        };
+        let sk = epoch_manager.base_kms.sig_key().unwrap();
+
+        let res = RealThresholdEpochManager::<
+            RamStorage,
+            RamStorage,
+            EmptyPrss,
+            SecureReshareSecretKeys,
+        >::store_reshared_keys(
+            crypto_storage,
+            &epoch_manager.session_maker,
+            &sk,
+            &[SigningSchemeType::Ecdsa256k1],
+            *new_epoch_id,
+            vec![],
+            &verified_previous_epoch,
+            verified_materials,
+            new_private_keysets,
+            &dummy_domain(),
+            vec![],
+        )
+        .await;
+
+        match res {
+            // `EpochOutput` has no `Debug`, hence the match instead of `unwrap_err`.
+            Ok(_) => panic!("the reshare must fail, as a key slot of the new epoch is taken"),
+            Err(e) => e,
+        }
+    }
+
     /// The public key material of a key belongs to every epoch of that key, because public storage
-    /// has no epoch dimension. A rollback of a failed reshare must therefore keep it, and delete the
-    /// private material of the new epoch only.
+    /// has no epoch dimension. A failed reshare must therefore keep it, and delete the private
+    /// material of the new epoch only.
     #[tokio::test]
-    async fn test_rollback_failed_epoch_keeps_public_key_material() {
+    async fn test_failed_reshare_keeps_public_key_material() {
         let mut rng = AesRng::seed_from_u64(45);
         let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
         let crypto_storage = &epoch_manager.crypto_storage;
@@ -3235,8 +3313,10 @@ pub(crate) mod tests {
 
         let previous_epoch_id = *DEFAULT_EPOCH_ID;
         let new_epoch_id = EpochId::new_random(&mut rng);
-        let key_id = derive_request_id("rollback_key").unwrap();
-        let preproc_id = derive_request_id("rollback_preproc").unwrap();
+        // The reshare writes the first key and fails on the second one.
+        let reshared_key_id = derive_request_id("reshared_key").unwrap();
+        let blocked_key_id = derive_request_id("blocked_key").unwrap();
+        let preproc_id = derive_request_id("previous_epoch_preproc").unwrap();
 
         // Stand-ins for the real key material: the test asserts on the presence of the objects, not
         // on their content.
@@ -3244,22 +3324,24 @@ pub(crate) mod tests {
         {
             let public_storage = crypto_storage.inner.get_public_storage();
             let mut guard = public_storage.lock().await;
-            for public_type in &public_types {
-                store_versioned_at_request_id(
-                    &mut (*guard),
-                    &key_id,
-                    &TestType { i: 7 },
-                    &public_type.to_string(),
-                )
-                .await
-                .unwrap();
+            for key_id in [&reshared_key_id, &blocked_key_id] {
+                for public_type in &public_types {
+                    store_versioned_at_request_id(
+                        &mut (*guard),
+                        key_id,
+                        &TestType { i: 7 },
+                        &public_type.to_string(),
+                    )
+                    .await
+                    .unwrap();
+                }
             }
         }
 
-        // The state a partially completed reshare leaves behind: the key shares of the previous
-        // epoch, plus the shares and the epoch data of the new epoch.
-        let keys = make_threshold_keys_with_preproc_id(&key_id, &preproc_id, &mut rng);
-        store_previous_epoch_keys(crypto_storage, &key_id, &previous_epoch_id, &keys).await;
+        // The state before the reshare: both epochs are known, and the previous epoch holds the
+        // shares of the key that the reshare writes. Writing those shares through the resharing path
+        // also puts them in the key cache, which lets the assertions below pin down what the
+        // rollback purges from the cache.
         let epoch = dummy_epoch_data();
         session_maker
             .add_epoch(previous_epoch_id, epoch.clone())
@@ -3278,49 +3360,65 @@ pub(crate) mod tests {
             .unwrap();
         }
         crypto_storage
-            .resharing_fhe_write_no_backup(&key_id, &new_epoch_id, keys)
+            .resharing_fhe_write_no_backup(
+                &reshared_key_id,
+                &previous_epoch_id,
+                make_threshold_keys_with_preproc_id(&reshared_key_id, &preproc_id, &mut rng),
+            )
             .await
             .unwrap();
         assert_eq!(crypto_storage.cached_fhe_key_count(), Some(1));
 
-        RealThresholdEpochManager::<
-            ram::RamStorage,
-            ram::RamStorage,
-            EmptyPrss,
-            SecureReshareSecretKeys,
-        >::rollback_failed_epoch(crypto_storage, session_maker, &new_epoch_id)
+        let err = failing_reshare_into_epoch(
+            &epoch_manager,
+            &[reshared_key_id, blocked_key_id],
+            &previous_epoch_id,
+            &new_epoch_id,
+            &mut rng,
+        )
         .await;
+        assert!(
+            err.to_string()
+                .contains("Failed to store all reshared keys"),
+            "the reshare must fail in its storage step, got: {err}"
+        );
 
-        // The public material of the key survives, since the previous epoch still serves it.
+        // The public material of both keys survives, since the previous epoch still serves it.
+        // This validates a bug fix where the rollback deleted public material of the failed reshare.
         {
             let public_storage = crypto_storage.inner.get_public_storage();
             let guard = public_storage.lock().await;
-            for public_type in &public_types {
-                assert!(
-                    guard
-                        .data_exists(&key_id, &public_type.to_string())
-                        .await
-                        .unwrap(),
-                    "{public_type} of key {key_id} must survive the rollback"
-                );
+            for key_id in [&reshared_key_id, &blocked_key_id] {
+                for public_type in &public_types {
+                    assert!(
+                        guard
+                            .data_exists(key_id, &public_type.to_string())
+                            .await
+                            .unwrap(),
+                        "{public_type} of key {key_id} must survive a failed reshare"
+                    );
+                }
             }
         }
 
-        // The new epoch is gone from storage, from the cache and from the session maker, while the
-        // previous epoch keeps its shares.
+        // The new epoch is gone from storage and from the session maker, while the previous epoch
+        // keeps its shares.
         {
             let private_storage = crypto_storage.get_private_storage();
             let guard = private_storage.lock().await;
-            assert!(
-                !guard
-                    .data_exists_at_epoch(
-                        &key_id,
-                        &new_epoch_id,
-                        &PrivDataType::FheKeyInfo.to_string()
-                    )
-                    .await
-                    .unwrap()
-            );
+            for key_id in [&reshared_key_id, &blocked_key_id] {
+                assert!(
+                    !guard
+                        .data_exists_at_epoch(
+                            key_id,
+                            &new_epoch_id,
+                            &PrivDataType::FheKeyInfo.to_string()
+                        )
+                        .await
+                        .unwrap(),
+                    "the shares of key {key_id} in the new epoch must be rolled back"
+                );
+            }
             assert!(
                 !guard
                     .data_exists(&new_epoch_id.into(), &PrivDataType::EpochData.to_string())
@@ -3330,50 +3428,67 @@ pub(crate) mod tests {
             assert!(
                 guard
                     .data_exists_at_epoch(
-                        &key_id,
+                        &reshared_key_id,
                         &previous_epoch_id,
                         &PrivDataType::FheKeyInfo.to_string()
                     )
                     .await
                     .unwrap(),
-                "the shares of the previous epoch must survive the rollback"
+                "the shares of the previous epoch must survive a failed reshare"
             );
         }
-        assert_eq!(crypto_storage.cached_fhe_key_count(), Some(0));
+        // Only the entry of the previous epoch is left in the cache.
+        assert_eq!(crypto_storage.cached_fhe_key_count(), Some(1));
+        crypto_storage
+            .read_guarded_fhe_keys(&reshared_key_id, &previous_epoch_id)
+            .await
+            .expect("the key of the previous epoch stays usable");
+        assert!(
+            crypto_storage
+                .read_guarded_fhe_keys(&reshared_key_id, &new_epoch_id)
+                .await
+                .is_err(),
+            "the key of the rolled back epoch must not be readable"
+        );
+
         assert!(!session_maker.epoch_exists(&new_epoch_id).await);
         assert!(session_maker.epoch_exists(&previous_epoch_id).await);
     }
 
-    /// A node that joins the cluster holds the new epoch as its only epoch. The rollback must clean
-    /// that epoch up, unlike [`RealThresholdEpochManager::destroy_epoch`], which refuses to remove
-    /// the last epoch of a node.
+    /// A node that joins the cluster holds the new epoch as its only epoch. A failed reshare must
+    /// still clean that epoch up, unlike
+    /// [`RealThresholdEpochManager::destroy_epoch`], which refuses to remove the last epoch of a
+    /// node.
     #[tokio::test]
-    async fn test_rollback_failed_epoch_on_only_epoch() {
+    async fn test_failed_reshare_rolls_back_only_epoch() {
         let mut rng = AesRng::seed_from_u64(46);
         let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
         let crypto_storage = &epoch_manager.crypto_storage;
         let session_maker = &epoch_manager.session_maker;
 
+        // A joining node holds no material of the previous epoch, and the new epoch is its first.
+        let previous_epoch_id = EpochId::new_random(&mut rng);
         let new_epoch_id = EpochId::new_random(&mut rng);
-        let key_id = derive_request_id("rollback_only_epoch_key").unwrap();
-        let preproc_id = derive_request_id("rollback_only_epoch_preproc").unwrap();
+        let key_id = derive_request_id("only_epoch_key").unwrap();
 
-        let epoch = dummy_epoch_data();
-        session_maker.add_epoch(new_epoch_id, epoch.clone()).await;
-        let keys = make_threshold_keys_with_preproc_id(&key_id, &preproc_id, &mut rng);
-        crypto_storage
-            .resharing_fhe_write_no_backup(&key_id, &new_epoch_id, keys)
-            .await
-            .unwrap();
+        session_maker
+            .add_epoch(new_epoch_id, dummy_epoch_data())
+            .await;
         assert_eq!(session_maker.epoch_count().await, 1);
 
-        RealThresholdEpochManager::<
-            ram::RamStorage,
-            ram::RamStorage,
-            EmptyPrss,
-            SecureReshareSecretKeys,
-        >::rollback_failed_epoch(crypto_storage, session_maker, &new_epoch_id)
+        let err = failing_reshare_into_epoch(
+            &epoch_manager,
+            &[key_id],
+            &previous_epoch_id,
+            &new_epoch_id,
+            &mut rng,
+        )
         .await;
+        assert!(
+            err.to_string()
+                .contains("Failed to store all reshared keys"),
+            "the reshare must fail in its storage step, got: {err}"
+        );
 
         assert!(!session_maker.epoch_exists(&new_epoch_id).await);
         assert_eq!(crypto_storage.cached_fhe_key_count(), Some(0));

--- a/core/service/src/vault/storage/mod.rs
+++ b/core/service/src/vault/storage/mod.rs
@@ -413,23 +413,6 @@ pub async fn delete_at_request_and_epoch_id<S: StorageExt>(
     }
 }
 
-/// Helper method to remove public key given a request ID.
-pub async fn delete_pk_at_request_id<S: Storage>(
-    storage: &mut S,
-    request_id: &RequestId,
-) -> anyhow::Result<()> {
-    delete_at_request_id(storage, request_id, &PubDataType::PublicKey.to_string()).await?;
-    // Best-effort delete of legacy PublicKeyMetadata (ignore errors if not found)
-    #[allow(deprecated)]
-    let _ = delete_at_request_id(
-        storage,
-        request_id,
-        &PubDataType::PublicKeyMetadata.to_string(),
-    )
-    .await;
-    Ok(())
-}
-
 /// Read some data stored in a location defined by `request_id` and `data_type`.
 /// The returned result is automatically unversioned.
 pub async fn read_versioned_at_request_id<

--- a/core/service/src/vault/storage/ram.rs
+++ b/core/service/src/vault/storage/ram.rs
@@ -324,9 +324,6 @@ pub struct FailingRamStorage {
     /// When set, every deletion (epoch-scoped or not) fails. Used to exercise the
     /// partial-failure retry logic in epoch/context destruction.
     fail_deletes: bool,
-    /// When set, only epoch-scoped deletions fail. Used to exercise a partial failure
-    /// that leaves the epoch markers, which are not epoch-scoped, deletable.
-    fail_epoch_deletes: bool,
     inner: RamStorage,
 }
 
@@ -336,7 +333,6 @@ impl FailingRamStorage {
         Self {
             available_writes: writes_before_failure,
             fail_deletes: false,
-            fail_epoch_deletes: false,
             inner: RamStorage::new(),
         }
     }
@@ -347,10 +343,6 @@ impl FailingRamStorage {
 
     pub fn set_fail_deletes(&mut self, fail_deletes: bool) {
         self.fail_deletes = fail_deletes
-    }
-
-    pub fn set_fail_epoch_deletes(&mut self, fail_epoch_deletes: bool) {
-        self.fail_epoch_deletes = fail_epoch_deletes
     }
 }
 
@@ -501,7 +493,7 @@ impl StorageExt for FailingRamStorage {
         epoch_id: &EpochId,
         data_type: &str,
     ) -> anyhow::Result<()> {
-        if self.fail_deletes || self.fail_epoch_deletes {
+        if self.fail_deletes {
             anyhow::bail!("storage delete failed!")
         }
         self.inner

--- a/core/service/src/vault/storage/ram.rs
+++ b/core/service/src/vault/storage/ram.rs
@@ -324,6 +324,9 @@ pub struct FailingRamStorage {
     /// When set, every deletion (epoch-scoped or not) fails. Used to exercise the
     /// partial-failure retry logic in epoch/context destruction.
     fail_deletes: bool,
+    /// When set, only epoch-scoped deletions fail. Used to exercise a partial failure
+    /// that leaves the epoch markers, which are not epoch-scoped, deletable.
+    fail_epoch_deletes: bool,
     inner: RamStorage,
 }
 
@@ -333,6 +336,7 @@ impl FailingRamStorage {
         Self {
             available_writes: writes_before_failure,
             fail_deletes: false,
+            fail_epoch_deletes: false,
             inner: RamStorage::new(),
         }
     }
@@ -343,6 +347,10 @@ impl FailingRamStorage {
 
     pub fn set_fail_deletes(&mut self, fail_deletes: bool) {
         self.fail_deletes = fail_deletes
+    }
+
+    pub fn set_fail_epoch_deletes(&mut self, fail_epoch_deletes: bool) {
+        self.fail_epoch_deletes = fail_epoch_deletes
     }
 }
 
@@ -493,7 +501,7 @@ impl StorageExt for FailingRamStorage {
         epoch_id: &EpochId,
         data_type: &str,
     ) -> anyhow::Result<()> {
-        if self.fail_deletes {
+        if self.fail_deletes || self.fail_epoch_deletes {
             anyhow::bail!("storage delete failed!")
         }
         self.inner


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->
This PR fixes the bug that E2E tests of 0.14 uncovered, where a failure in resharing accidentally removes public key material when cleaning up orphaned reshared data. 

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->
See this [discussion](https://zama-ai.slack.com/archives/C0A6WGZ5UAD/p1787643206326239)

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
