### PR TITLE
don't install wasm tooling with curl | sh

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -49,9 +49,9 @@ jobs:
           tool: wasm-pack@0.15.0
 
       - name: Install node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24.16.0
+          node-version: 24.19.0
 
       - name: Install safe-chain
         run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -43,8 +43,10 @@ jobs:
           setup-rust: "false"
 
       # WASM handling
-      - name: Install
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
+        with:
+          tool: wasm-pack@0.15.0
 
       - name: Install node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -76,16 +76,15 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          rm -rf pkg
-          wasm-pack build --target nodejs . --no-default-features
-          sed -i 's/"kms"/"node-tkms"/g' pkg/package.json
-          sed -i "s/\"version\": *\"[^\"]*\"/\"version\": \"${TAG_NAME}\"/" pkg/package.json
-          echo "# node-tkms" > pkg/README.md
+          wasm-pack build --target nodejs --out-dir pkg-node . --no-default-features
+          sed -i 's/"kms"/"node-tkms"/g' pkg-node/package.json
+          sed -i "s/\"version\": *\"[^\"]*\"/\"version\": \"${TAG_NAME}\"/" pkg-node/package.json
+          echo "# node-tkms" > pkg-node/README.md
 
       - name: NPM publish Node package
         uses: JS-DevTools/npm-publish@7f8fe47b3bea1be0c3aec2b717c5ec1f3e03410b # v4.1.1
         with:
-          package: ./core/service/pkg/package.json
+          package: ./core/service/pkg-node/package.json
           dry-run: false
           provenance: true
           tag: ${{ env.NPM_TAG }}
@@ -96,20 +95,15 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          rm -rf pkg
-          wasm-pack build --target web . --no-default-features
-          sed -i 's/"kms"/"tkms"/g' pkg/package.json
-          sed -i "s/\"version\": *\"[^\"]*\"/\"version\": \"${TAG_NAME}\"/" pkg/package.json
-          echo "# tkms" > pkg/README.md
+          wasm-pack build --target web --out-dir pkg-web . --no-default-features
+          sed -i 's/"kms"/"tkms"/g' pkg-web/package.json
+          sed -i "s/\"version\": *\"[^\"]*\"/\"version\": \"${TAG_NAME}\"/" pkg-web/package.json
+          echo "# tkms" > pkg-web/README.md
 
       - name: NPM publish web package
         uses: JS-DevTools/npm-publish@7f8fe47b3bea1be0c3aec2b717c5ec1f3e03410b # v4.1.1
         with:
-          package: ./core/service/pkg/package.json
+          package: ./core/service/pkg-web/package.json
           dry-run: false
           provenance: true
           tag: ${{ env.NPM_TAG }}
-
-      - name: Remove aws credentials file
-        run: |
-          rm -rf ~/.aws

--- a/.github/workflows/wasm-testing.yml
+++ b/.github/workflows/wasm-testing.yml
@@ -70,8 +70,10 @@ jobs:
           rust-toolchain: ${{ env.RUST_IMAGE_VERSION }}
 
       # WASM handling
-      - name: Install
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
+        with:
+          tool: wasm-pack@0.15.0
 
       # Build the same artifact that gets published (no `wasm_tests`): the JS tests load a
       # stable JSON vector and only exercise the stable public API, so the transcript helpers

--- a/.github/workflows/wasm-testing.yml
+++ b/.github/workflows/wasm-testing.yml
@@ -69,7 +69,6 @@ jobs:
         with:
           rust-toolchain: ${{ env.RUST_IMAGE_VERSION }}
 
-      # WASM handling
       - name: Install wasm-pack
         uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
         with:
@@ -136,7 +135,6 @@ jobs:
             exit 1
           fi
 
-          rm -rf ./test-material
           ln -s "${EFS_TEST_MATERIAL_PATH}" ./test-material
           echo "Linked ./test-material -> ${EFS_TEST_MATERIAL_PATH}"
           du -shL ./test-material || true
@@ -165,12 +163,10 @@ jobs:
         run: |
           echo "NPM_TAG=prerelease" >> "${GITHUB_ENV}"
 
-      # Node package build and publish
-      - name: NPM build node package
+      # Node package preparation and publish
+      - name: Prepare Node package
         working-directory: ./core/service
         run: |
-          rm -rf pkg
-          wasm-pack build --target nodejs . --no-default-features
           sed -i 's/"kms"/"node-tkms"/g' pkg/package.json
           echo "# node-tkms" > pkg/README.md
 
@@ -186,19 +182,14 @@ jobs:
       - name: NPM build web package
         working-directory: ./core/service
         run: |
-          rm -rf pkg
-          wasm-pack build --target web . --no-default-features
-          sed -i 's/"kms"/"tkms"/g' pkg/package.json
-          echo "# tkms" > pkg/README.md
+          wasm-pack build --target web --out-dir pkg-web . --no-default-features
+          sed -i 's/"kms"/"tkms"/g' pkg-web/package.json
+          echo "# tkms" > pkg-web/README.md
 
       - name: NPM publish web package
         uses: JS-DevTools/npm-publish@7f8fe47b3bea1be0c3aec2b717c5ec1f3e03410b # v4.1.1
         with:
-          package: ./core/service/pkg/package.json
+          package: ./core/service/pkg-web/package.json
           dry-run: true
           provenance: true
           tag: ${{ env.NPM_TAG }}
-
-      - name: Remove aws credentials file
-        run: |
-          rm -rf ~/.aws

--- a/.github/workflows/wasm-testing.yml
+++ b/.github/workflows/wasm-testing.yml
@@ -83,9 +83,9 @@ jobs:
         run: wasm-pack build --target nodejs . --no-default-features
 
       - name: Install node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24.16.0
+          node-version: 24.19.0
 
       # Generate the insecure test material set for parties 4, 10.
       - name: Generate Test Material


### PR DESCRIPTION
- Before this PR we install the wasm-pack tool with `curl … … | sh` which is opaque and dangerous. This PR uses the de-facto official GA action to install it.
- Also updates node to latest in the v24 LTS line and the GH actions that install it.
- Misc WF cleanup

Closes https://github.com/zama-ai/kms-internal/issues/3012
