### PR TITLE
chore: epoch/context lease in session maker for v0.14.x

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -151,7 +151,14 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   the context's epoch IDs and erases their secret shares (cascading to the
   existing per-epoch deletion) before forgetting the context, so retiring a
   party set leaves no usable key shares behind; the kms-connector is the source
-  of truth for which epochs belong to a context.
+  of truth for which epochs belong to a context. In-memory lifecycle leases
+  serialize creation against destruction: `NewMpcEpoch` holds shared leases for
+  its target context and epoch through all PRSS, resharing and persistence work,
+  while `DestroyMpcEpoch` and `DestroyMpcContext` require exclusive leases before
+  taking snapshots or deleting data. A conflicting destruction is refused with
+  `FailedPrecondition`, including while PRSS is still running and the new epoch
+  has not yet been registered in the session maker; callers retry once creation
+  has settled.
 - **Session management** — creation, result retrieval, and cleanup for
   long-running threshold sessions.
 

--- a/core/service/src/engine/threshold/endpoint.rs
+++ b/core/service/src/engine/threshold/endpoint.rs
@@ -275,7 +275,7 @@ impl_endpoint! {
                 .await
                 .map_err(|e| {
                     Status::failed_precondition(format!(
-                        "Cannot destroy MPC context {context_id}: {e}. Retry once epoch creation has settled."
+"Cannot destroy MPC context {context_id}: {e}. Retry once the conflicting lifecycle operation has settled."
                     ))
                 })?;
 

--- a/core/service/src/engine/threshold/endpoint.rs
+++ b/core/service/src/engine/threshold/endpoint.rs
@@ -247,7 +247,8 @@ impl_endpoint! {
                 .context_id
                 .as_ref()
                 .ok_or_else(|| Status::invalid_argument("context_id is required"))?;
-            parse_grpc_request_id::<ContextId>(proto_context_id, RequestIdParsingErr::Context)?;
+            let context_id =
+                parse_grpc_request_id::<ContextId>(proto_context_id, RequestIdParsingErr::Context)?;
 
             // Bound the epoch list so a malformed or hostile request cannot trigger unbounded
             // deletion work.
@@ -264,6 +265,19 @@ impl_endpoint! {
                 .iter()
                 .map(|id| parse_grpc_request_id::<EpochId>(id, RequestIdParsingErr::Epoch))
                 .collect::<Result<Vec<EpochId>, _>>()?;
+
+            // Hold the exclusive context lease across both phases. This makes the epoch snapshot
+            // stable with respect to `NewMpcEpoch`, including creations that are still running PRSS
+            // and therefore have not registered their epoch in the session maker yet.
+            let _destruction_lease = self
+                .session_maker
+                .try_start_context_destruction(&context_id)
+                .await
+                .map_err(|e| {
+                    Status::failed_precondition(format!(
+                        "Cannot destroy MPC context {context_id}: {e}. Retry once epoch creation has settled."
+                    ))
+                })?;
 
             // Destroy the associated epochs first: their secret key shares and PRSS randomness are security-sensitive
             // material. Erase them before touching anything else so that if there is a problem, the worst transient

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1149,10 +1149,29 @@ impl<
     ///
     /// [`Self::destroy_epoch`] only touches storage, so the cache must be cleared here as well or the decompressed keys
     /// stay resident until restart. The cache is purged regardless of the deletion outcome.
+    ///
+    /// An exclusive lifecycle lease prevents creation of the same epoch from starting or completing
+    /// concurrently with deletion.
     async fn destroy_epoch_and_purge_cache(
         &self,
         epoch_id: &EpochId,
     ) -> Result<Response<Empty>, MetricedError> {
+        let _destruction_lease = self
+            .session_maker
+            .try_get_epoch_destruction_lease(epoch_id)
+            .await
+            .map_err(|e| {
+                MetricedError::new(
+                    OP_DESTROY_EPOCH,
+                    Some((*epoch_id).into()),
+                    anyhow::anyhow!(
+                        "Cannot destroy epoch ID {epoch_id}: {e}. Retry once epoch creation has \
+                         settled."
+                    ),
+                    tonic::Code::FailedPrecondition,
+                )
+            })?;
+
         let priv_storage = Arc::clone(&self.crypto_storage.inner.private_storage);
 
         // NOTE: destroy_epoch will also destroy PRSS data
@@ -1291,6 +1310,21 @@ impl<
             resharing: resharing_params,
         } = validate_new_mpc_epoch_request(inner)?;
 
+        // Retain both shared leases until the background task has completed every write. Context
+        // and epoch destruction acquire the corresponding exclusive lease before mutating state.
+        let creation_lease = self
+            .session_maker
+            .try_get_epoch_creation_lease(&context_id, &epoch_id)
+            .await
+            .map_err(|e| {
+                MetricedError::new(
+                    OP_NEW_EPOCH,
+                    Some(epoch_id.into()),
+                    anyhow::anyhow!("Cannot create epoch ID {epoch_id}: {e}"),
+                    tonic::Code::FailedPrecondition,
+                )
+            })?;
+
         if self.session_maker.epoch_exists(&epoch_id).await {
             return Err(MetricedError::new(
                 OP_NEW_EPOCH,
@@ -1344,6 +1378,7 @@ impl<
         let session_maker = self.session_maker.clone();
         let crypto_storage = self.crypto_storage.clone();
         self.tracker.spawn(async move {
+            let _creation_lease = creation_lease;
             let _rate_limiter_permit = rate_limiter_permit;
             let crypto_storage = crypto_storage;
             let context_id = context_id;
@@ -2342,6 +2377,87 @@ pub(crate) mod tests {
         .unwrap_err();
 
         assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    /// The creation lease remains live after PRSS registers the epoch, preventing destruction while
+    /// resharing can still write private shares. Releasing the lease makes destruction retryable.
+    #[tokio::test]
+    async fn test_destroy_epoch_rejected_while_creation_in_flight() {
+        use crate::vault::storage::StorageReader;
+
+        let mut rng = AesRng::seed_from_u64(44);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+
+        let epoch_id = *DEFAULT_EPOCH_ID;
+        let prss = PRSSSetupCombined {
+            prss_setup_z128: PRSSSetup::<ResiduePolyF4Z128>::new_testing_prss(vec![], vec![]),
+            prss_setup_z64: PRSSSetup::<ResiduePolyF4Z64>::new_testing_prss(vec![], vec![]),
+            num_parties: 4,
+            threshold: 1,
+        };
+        epoch_manager
+            .session_maker
+            .add_epoch(epoch_id, prss.clone())
+            .await;
+        let private_storage = epoch_manager.crypto_storage.get_private_storage();
+        {
+            let mut priv_storage = private_storage.lock().await;
+            store_versioned_at_request_id(
+                &mut (*priv_storage),
+                &epoch_id.into(),
+                &prss,
+                &PrivDataType::PrssSetupCombined.to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        // Mirror a creation task that has registered its epoch after PRSS but is still resharing.
+        let creation_lease = epoch_manager
+            .session_maker
+            .try_get_epoch_creation_lease(&DEFAULT_MPC_CONTEXT, &epoch_id)
+            .await
+            .unwrap();
+
+        let err = epoch_manager
+            .destroy_epoch_and_purge_cache(&epoch_id)
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+
+        // Destruction must return before touching the registered epoch or its persisted PRSS data.
+        assert!(epoch_manager.session_maker.epoch_exists(&epoch_id).await);
+        {
+            let priv_storage = private_storage.lock().await;
+            assert!(
+                priv_storage
+                    .data_exists(
+                        &epoch_id.into(),
+                        &PrivDataType::PrssSetupCombined.to_string()
+                    )
+                    .await
+                    .unwrap()
+            );
+        }
+
+        // Success, failure, panic and task cancellation all drop this owned lease, allowing cleanup.
+        drop(creation_lease);
+        epoch_manager
+            .destroy_epoch_and_purge_cache(&epoch_id)
+            .await
+            .unwrap();
+
+        assert!(!epoch_manager.session_maker.epoch_exists(&epoch_id).await);
+        let priv_storage = private_storage.lock().await;
+        assert!(
+            !priv_storage
+                .data_exists(
+                    &epoch_id.into(),
+                    &PrivDataType::PrssSetupCombined.to_string()
+                )
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1165,8 +1165,8 @@ impl<
                     OP_DESTROY_EPOCH,
                     Some((*epoch_id).into()),
                     anyhow::anyhow!(
-                        "Cannot destroy epoch ID {epoch_id}: {e}. Retry once epoch creation has \
-                         settled."
+"Cannot destroy epoch ID {epoch_id}: {e}. Retry once the conflicting lifecycle \
+ operation has settled."
                     ),
                     tonic::Code::FailedPrecondition,
                 )

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -1,7 +1,8 @@
 // === Standard Library ===
 use std::{
     collections::{HashMap, hash_map::Entry},
-    sync::Arc,
+    hash::Hash,
+    sync::{Arc, Weak},
 };
 
 use crate::{
@@ -35,12 +36,13 @@ use rand::{RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
 use tfhe::Versionize;
 use tfhe_versionable::VersionsDispatch;
+use thiserror::Error;
 use threshold_types::session_id::SessionId;
 use threshold_types::{
     network::NetworkMode,
     party::{Identity, MpcIdentity, RoleAssignment},
 };
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 use tonic::Code;
 
 struct Context {
@@ -76,11 +78,81 @@ impl tfhe::named::Named for PRSSSetupCombined {
 
 type ContextMap = HashMap<ContextId, Context>;
 
+/// Hands out one lock per ID, keyed by the identifier type of the guarded resource.
+///
+/// Weak entries ensure rejected requests for random IDs do not grow the registry forever.
+/// The owned lock guards taken by the callers keep their lock alive for exactly the lifecycle
+/// operation.
+#[derive(Clone)]
+struct LockRegistry<Id> {
+    locks: Arc<Mutex<HashMap<Id, Weak<RwLock<()>>>>>,
+}
+
+// Hand-written because `#[derive(Default)]` would add a spurious `Id: Default` bound.
+impl<Id> Default for LockRegistry<Id> {
+    fn default() -> Self {
+        Self {
+            locks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl<Id: Copy + Eq + Hash> LockRegistry<Id> {
+    async fn lock(&self, id: &Id) -> Arc<RwLock<()>> {
+        let mut locks = self.locks.lock().await;
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(id).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        let lock = Arc::new(RwLock::new(()));
+        locks.insert(*id, Arc::downgrade(&lock));
+        lock
+    }
+}
+
+#[derive(Clone, Default)]
+struct LifecycleCoordinator {
+    context_locks: LockRegistry<ContextId>,
+    epoch_locks: LockRegistry<EpochId>,
+}
+
+/// Identifies the lifecycle resource that is already held by a conflicting operation.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub(crate) enum LifecycleConflict {
+    /// A context is being destroyed while an epoch creation wants to use it, or vice versa.
+    #[error("MPC context {0} has a conflicting lifecycle operation in progress")]
+    Context(ContextId),
+    /// An epoch is being created while it is being destroyed, or vice versa.
+    #[error("epoch {0} has a conflicting lifecycle operation in progress")]
+    Epoch(EpochId),
+}
+
+/// Keeps an epoch creation mutually exclusive with destruction of its epoch and context.
+#[derive(Debug)]
+pub(crate) struct EpochCreationLease {
+    _context: OwnedRwLockReadGuard<()>,
+    _epoch: OwnedRwLockReadGuard<()>,
+}
+
+/// Prevents epoch creation for a context while that context and its epochs are destroyed.
+#[derive(Debug)]
+pub(crate) struct ContextDestructionLease {
+    _context: OwnedRwLockWriteGuard<()>,
+}
+
+/// Prevents creation of an epoch while that epoch is destroyed.
+#[derive(Debug)]
+pub(crate) struct EpochDestructionLease {
+    _epoch: OwnedRwLockWriteGuard<()>,
+}
+
 #[derive(Clone)]
 pub(crate) struct SessionMaker {
     networking_manager: Arc<RwLock<GrpcNetworkingManager>>,
     context_map: Arc<RwLock<ContextMap>>,
     epoch_map: Arc<RwLock<HashMap<EpochId, PRSSSetupCombined>>>,
+    lifecycle: LifecycleCoordinator,
     verifier: Option<Arc<AttestedVerifier>>, // optional as it's not used when there's no TLS
     rng: Arc<Mutex<AesRng>>,
 }
@@ -148,9 +220,67 @@ impl SessionMaker {
             networking_manager,
             context_map: Arc::new(RwLock::new(HashMap::new())),
             epoch_map: Arc::new(RwLock::new(HashMap::new())),
+            lifecycle: LifecycleCoordinator::default(),
             verifier,
             rng: Arc::new(Mutex::new(rng)),
         }
+    }
+
+    /// Reserve `context_id` and `epoch_id` for an epoch creation.
+    ///
+    /// The returned lease must live until the creation task has finished every persistent write.
+    /// Destruction uses exclusive leases for the same IDs and therefore fails while this lease is
+    /// alive.
+    pub(crate) async fn try_get_epoch_creation_lease(
+        &self,
+        context_id: &ContextId,
+        epoch_id: &EpochId,
+    ) -> Result<EpochCreationLease, LifecycleConflict> {
+        let context = self.lifecycle.context_locks.lock(context_id).await;
+        let context = context
+            .try_read_owned()
+            .map_err(|_| LifecycleConflict::Context(*context_id))?;
+
+        let epoch = self.lifecycle.epoch_locks.lock(epoch_id).await;
+        let epoch = epoch
+            .try_read_owned()
+            .map_err(|_| LifecycleConflict::Epoch(*epoch_id))?;
+
+        Ok(EpochCreationLease {
+            _context: context,
+            _epoch: epoch,
+        })
+    }
+
+    /// Exclusively reserve a context for destruction.
+    ///
+    /// The caller must retain the lease while taking the epoch snapshot, deleting every associated
+    /// epoch, and deleting the context itself. Acquiring it fails while an epoch creation for this
+    /// context is in flight.
+    pub(crate) async fn try_get_context_destruction_lease(
+        &self,
+        context_id: &ContextId,
+    ) -> Result<ContextDestructionLease, LifecycleConflict> {
+        let context = self.lifecycle.context_locks.lock(context_id).await;
+        let context = context
+            .try_write_owned()
+            .map_err(|_| LifecycleConflict::Context(*context_id))?;
+        Ok(ContextDestructionLease { _context: context })
+    }
+
+    /// Exclusively reserve an epoch for destruction.
+    ///
+    /// Acquiring this lease fails while creation of the same epoch is in flight. The caller must
+    /// retain it through all storage and cache deletion.
+    pub(crate) async fn try_get_epoch_destruction_lease(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<EpochDestructionLease, LifecycleConflict> {
+        let epoch = self.lifecycle.epoch_locks.lock(epoch_id).await;
+        let epoch = epoch
+            .try_write_owned()
+            .map_err(|_| LifecycleConflict::Epoch(*epoch_id))?;
+        Ok(EpochDestructionLease { _epoch: epoch })
     }
 
     /// Returns the number of active sessions.
@@ -183,6 +313,7 @@ impl SessionMaker {
             networking_manager,
             context_map: Arc::new(RwLock::new(HashMap::new())),
             epoch_map: Arc::new(RwLock::new(HashMap::new())),
+            lifecycle: LifecycleCoordinator::default(),
             verifier: None,
             rng: Arc::new(Mutex::new(rng)),
         }
@@ -240,6 +371,7 @@ impl SessionMaker {
                 Some(prss) => HashMap::from_iter([(*epoch_id, prss)]),
                 None => HashMap::new(),
             })),
+            lifecycle: LifecycleCoordinator::default(),
             verifier: None,
             rng: Arc::new(Mutex::new(rng)),
         }
@@ -790,6 +922,16 @@ pub(crate) struct ImmutableSessionMaker {
 }
 
 impl ImmutableSessionMaker {
+    /// Exclusively reserve a context while its epochs and context metadata are destroyed.
+    pub(crate) async fn try_start_context_destruction(
+        &self,
+        context_id: &ContextId,
+    ) -> Result<ContextDestructionLease, LifecycleConflict> {
+        self.inner
+            .try_get_context_destruction_lease(context_id)
+            .await
+    }
+
     #[allow(dead_code)]
     pub(crate) async fn context_exists(&self, context_id: &ContextId) -> bool {
         self.inner.context_exists(context_id).await
@@ -936,4 +1078,103 @@ pub(crate) async fn validate_context_and_epoch(
         ));
     }
     Ok(my_role)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An epoch creation is visible to lifecycle coordination before it is registered in
+    /// `epoch_map`, so neither its context nor its epoch can be destroyed in that window.
+    #[tokio::test]
+    async fn epoch_creation_lease_blocks_matching_destruction_only() {
+        let mut rng = AesRng::seed_from_u64(6);
+        let session_maker = SessionMaker::empty_dummy_session(AesRng::seed_from_u64(7));
+        let context_id = ContextId::new_random(&mut rng);
+        let epoch_id = EpochId::new_random(&mut rng);
+        let endpoint_session_maker = session_maker.make_immutable();
+
+        let creation = session_maker
+            .try_get_epoch_creation_lease(&context_id, &epoch_id)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            endpoint_session_maker
+                .try_start_context_destruction(&context_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Context(context_id)
+        );
+        assert_eq!(
+            session_maker
+                .try_get_epoch_destruction_lease(&epoch_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Epoch(epoch_id)
+        );
+
+        // Unrelated lifecycle operations remain independent.
+        let other_context_id = ContextId::new_random(&mut rng);
+        let other_epoch_id = EpochId::new_random(&mut rng);
+        endpoint_session_maker
+            .try_start_context_destruction(&other_context_id)
+            .await
+            .unwrap();
+        session_maker
+            .try_get_epoch_destruction_lease(&other_epoch_id)
+            .await
+            .unwrap();
+
+        drop(creation);
+        endpoint_session_maker
+            .try_start_context_destruction(&context_id)
+            .await
+            .unwrap();
+        session_maker
+            .try_get_epoch_destruction_lease(&epoch_id)
+            .await
+            .unwrap();
+    }
+
+    /// Whichever destructive operation acquires its exclusive lease first prevents a conflicting
+    /// epoch creation from beginning until that lease is released.
+    #[tokio::test]
+    async fn destruction_leases_block_epoch_creation_until_drop() {
+        let mut rng = AesRng::seed_from_u64(8);
+        let session_maker = SessionMaker::empty_dummy_session(AesRng::seed_from_u64(9));
+        let context_id = ContextId::new_random(&mut rng);
+        let epoch_id = EpochId::new_random(&mut rng);
+
+        let context_destruction = session_maker
+            .try_get_context_destruction_lease(&context_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            session_maker
+                .try_get_epoch_creation_lease(&context_id, &epoch_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Context(context_id)
+        );
+        drop(context_destruction);
+
+        let epoch_destruction = session_maker
+            .try_get_epoch_destruction_lease(&epoch_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            session_maker
+                .try_get_epoch_creation_lease(&context_id, &epoch_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Epoch(epoch_id)
+        );
+        drop(epoch_destruction);
+
+        session_maker
+            .try_get_epoch_creation_lease(&context_id, &epoch_id)
+            .await
+            .unwrap();
+    }
 }


### PR DESCRIPTION
## Description
Backport of https://github.com/zama-ai/kms/pull/739

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
