### PR TITLE
fix: accidential deletion of public material when resharing fails

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -151,7 +151,14 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   the context's epoch IDs and erases their secret shares (cascading to the
   existing per-epoch deletion) before forgetting the context, so retiring a
   party set leaves no usable key shares behind; the kms-connector is the source
-  of truth for which epochs belong to a context.
+  of truth for which epochs belong to a context. In-memory lifecycle leases
+  serialize creation against destruction: `NewMpcEpoch` holds shared leases for
+  its target context and epoch through all PRSS, resharing and persistence work,
+  while `DestroyMpcEpoch` and `DestroyMpcContext` require exclusive leases before
+  taking snapshots or deleting data. A conflicting destruction is refused with
+  `FailedPrecondition`, including while PRSS is still running and the new epoch
+  has not yet been registered in the session maker; callers retry once creation
+  has settled.
 - **Session management** — creation, result retrieval, and cleanup for
   long-running threshold sessions.
 

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -147,7 +147,12 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   refreshes secret shares as part of epoch creation; the outcome is fetched
   via `GetEpochResult`. When resharing legacy key material that has no
   dedicated OPRF secret-key share, the OPRF sub-protocol is skipped and the
-  reshared private keyset keeps that field absent. `DestroyMpcContext` carries
+  reshared private keyset keeps that field absent. A storage failure during
+  resharing rolls the new epoch back on the party that fails. 
+  That party attempts to delete the key shares, the CRS metadata and the epoch data of the new epoch. 
+  Observe that no public data is deleted as this is, and should be, unaffected by an epoch change. 
+  If cleanup succeeds, it forgets the epoch; otherwise, it keeps the epoch registered so that deletion can be retried. 
+  `DestroyMpcContext` carries
   the context's epoch IDs and erases their secret shares (cascading to the
   existing per-epoch deletion) before forgetting the context, so retiring a
   party set leaves no usable key shares behind; the kms-connector is the source

--- a/core/grpc/proto/kms-service.v1.proto
+++ b/core/grpc/proto/kms-service.v1.proto
@@ -97,7 +97,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
-  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
+  // * No `NewMpcEpoch`, `DestroyMpcEpoch`, or `DestroyMpcContext` call may be executed concurrently!
   // * `request_id` in `request` must be present, valid, fresh and unique [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   // * `params` in `request` must be castable to a [`FheParameter`], currently this means 0 or 1.
   // * `preproc_id` in `request` must be present, and a valid [`RequestId`] which has already been used to start a preprocessing request with method `key_gen_preproc` that has completed successfully
@@ -151,7 +151,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
-  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
+  // * No `NewMpcEpoch`, `DestroyMpcEpoch`, or `DestroyMpcContext` call may be executed concurrently!
   // * `request` must be a valid [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   //   Furthermore, the request ID must be the same as the one used to start a preprocessing generation with method `KeyGenPreproc`.
   //   In the threshold KMS the preprocessing or key generation identified by the `preproc_id` must be ongoing.
@@ -256,7 +256,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
-  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
+  // * No `NewMpcEpoch`, `DestroyMpcEpoch`, or `DestroyMpcContext` call may be executed concurrently!
   // * `request_id` in `request` must be present, valid, fresh and unique [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   // * `params` in `request` must be castable to a [`FheParameter`], currently this means 0 or 1.
   // * `max_number_bits` is the amount of bits that can be proven for ciphertext vector using the generated CRS. If this is not provided, then it defaults to the maximum supported by the fhevm.
@@ -293,7 +293,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
-  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
+  // * No `NewMpcEpoch`, `DestroyMpcEpoch`, or `DestroyMpcContext` call may be executed concurrently!
   // * `request` must be a valid [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   //   Furthermore, the request ID must be the same as the one used to start a CRS generation with method `CrsGen`.
   //   The CRS generation identified by the `crs_id` in `request` must be ongoing.
@@ -359,7 +359,7 @@ service CoreServiceEndpoint {
   // * `NewMpcEpochRequest` - Struct containing all the data of the request
   //
   // # Conditions
-  // *  No `KeyGen`, `CrsGen` or `AbortKeyGen` call may be executed concurrently!
+  // *  No `KeyGen`, `CrsGen`, `AbortKeyGen`, or `AbortCrsGen` call may be executed concurrently!
   // * `context_id` in `request` must be present, valid, and unique [`RequestId`] of an MPC context that has been constructed with `NewMpcContext`.
   // * `epoch_id` in `request` must be present, valid, and unique. It represents the ID of the new epoch that is created.
   // * `previous_epoch` is optional, if set we perform a resharing from the previous epoch to the new one.
@@ -385,7 +385,7 @@ service CoreServiceEndpoint {
   // * `DestroyMpcEpochRequest` - Struct containing all the data of the request
   //
   // # Conditions
-  // *  No `KeyGen`, `CrsGen` or `AbortKeyGen` call may be executed concurrently!
+  // *  No `KeyGen`, `CrsGen`, `AbortKeyGen`, or `AbortCrsGen` call may be executed concurrently!
   rpc DestroyMpcEpoch(kms.v1.DestroyMpcEpochRequest) returns (kms.v1.Empty);
 
   // Constructs a new custodian context.

--- a/core/grpc/proto/kms-service.v1.proto
+++ b/core/grpc/proto/kms-service.v1.proto
@@ -97,6 +97,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
+  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
   // * `request_id` in `request` must be present, valid, fresh and unique [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   // * `params` in `request` must be castable to a [`FheParameter`], currently this means 0 or 1.
   // * `preproc_id` in `request` must be present, and a valid [`RequestId`] which has already been used to start a preprocessing request with method `key_gen_preproc` that has completed successfully
@@ -150,6 +151,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
+  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
   // * `request` must be a valid [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   //   Furthermore, the request ID must be the same as the one used to start a preprocessing generation with method `KeyGenPreproc`.
   //   In the threshold KMS the preprocessing or key generation identified by the `preproc_id` must be ongoing.
@@ -254,6 +256,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
+  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
   // * `request_id` in `request` must be present, valid, fresh and unique [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   // * `params` in `request` must be castable to a [`FheParameter`], currently this means 0 or 1.
   // * `max_number_bits` is the amount of bits that can be proven for ciphertext vector using the generated CRS. If this is not provided, then it defaults to the maximum supported by the fhevm.
@@ -290,6 +293,7 @@ service CoreServiceEndpoint {
   //
   // # Conditions
   // ## Pre-condition:
+  // *  No `NewMpcEpoch` or `DestroyMpcEpoch` call may be executed concurrently!
   // * `request` must be a valid [`RequestId`]. I.e. 32 byte lower-case hex encoding without `0x` prefix.
   //   Furthermore, the request ID must be the same as the one used to start a CRS generation with method `CrsGen`.
   //   The CRS generation identified by the `crs_id` in `request` must be ongoing.
@@ -354,7 +358,8 @@ service CoreServiceEndpoint {
   // # Parameters
   // * `NewMpcEpochRequest` - Struct containing all the data of the request
   //
-  // #Conditions
+  // # Conditions
+  // *  No `KeyGen`, `CrsGen` or `AbortKeyGen` call may be executed concurrently!
   // * `context_id` in `request` must be present, valid, and unique [`RequestId`] of an MPC context that has been constructed with `NewMpcContext`.
   // * `epoch_id` in `request` must be present, valid, and unique. It represents the ID of the new epoch that is created.
   // * `previous_epoch` is optional, if set we perform a resharing from the previous epoch to the new one.
@@ -377,7 +382,10 @@ service CoreServiceEndpoint {
   // and if the shares of the secret key.
   //
   // # Parameters
+  // * `DestroyMpcEpochRequest` - Struct containing all the data of the request
+  //
   // # Conditions
+  // *  No `KeyGen`, `CrsGen` or `AbortKeyGen` call may be executed concurrently!
   rpc DestroyMpcEpoch(kms.v1.DestroyMpcEpochRequest) returns (kms.v1.Empty);
 
   // Constructs a new custodian context.

--- a/core/service/src/engine/threshold/endpoint.rs
+++ b/core/service/src/engine/threshold/endpoint.rs
@@ -247,7 +247,8 @@ impl_endpoint! {
                 .context_id
                 .as_ref()
                 .ok_or_else(|| Status::invalid_argument("context_id is required"))?;
-            parse_grpc_request_id::<ContextId>(proto_context_id, RequestIdParsingErr::Context)?;
+            let context_id =
+                parse_grpc_request_id::<ContextId>(proto_context_id, RequestIdParsingErr::Context)?;
 
             // Bound the epoch list so a malformed or hostile request cannot trigger unbounded
             // deletion work.
@@ -264,6 +265,19 @@ impl_endpoint! {
                 .iter()
                 .map(|id| parse_grpc_request_id::<EpochId>(id, RequestIdParsingErr::Epoch))
                 .collect::<Result<Vec<EpochId>, _>>()?;
+
+            // Hold the exclusive context lease across both phases. This makes the epoch snapshot
+            // stable with respect to `NewMpcEpoch`, including creations that are still running PRSS
+            // and therefore have not registered their epoch in the session maker yet.
+            let _destruction_lease = self
+                .session_maker
+                .try_start_context_destruction(&context_id)
+                .await
+                .map_err(|e| {
+                    Status::failed_precondition(format!(
+                        "Cannot destroy MPC context {context_id}: {e}. Retry once epoch creation has settled."
+                    ))
+                })?;
 
             // Destroy the associated epochs first: their secret key shares and PRSS randomness are security-sensitive
             // material. Erase them before touching anything else so that if there is a problem, the worst transient

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1149,10 +1149,29 @@ impl<
     ///
     /// [`Self::destroy_epoch`] only touches storage, so the cache must be cleared here as well or the decompressed keys
     /// stay resident until restart. The cache is purged regardless of the deletion outcome.
+    ///
+    /// An exclusive lifecycle lease prevents creation of the same epoch from starting or completing
+    /// concurrently with deletion.
     async fn destroy_epoch_and_purge_cache(
         &self,
         epoch_id: &EpochId,
     ) -> Result<Response<Empty>, MetricedError> {
+        let _destruction_lease = self
+            .session_maker
+            .try_get_epoch_destruction_lease(epoch_id)
+            .await
+            .map_err(|e| {
+                MetricedError::new(
+                    OP_DESTROY_EPOCH,
+                    Some((*epoch_id).into()),
+                    anyhow::anyhow!(
+                        "Cannot destroy epoch ID {epoch_id}: {e}. Retry once epoch creation has \
+                         settled."
+                    ),
+                    tonic::Code::FailedPrecondition,
+                )
+            })?;
+
         let priv_storage = Arc::clone(&self.crypto_storage.inner.private_storage);
 
         // NOTE: destroy_epoch will also destroy PRSS data
@@ -1291,6 +1310,21 @@ impl<
             resharing: resharing_params,
         } = validate_new_mpc_epoch_request(inner)?;
 
+        // Retain both shared leases until the background task has completed every write. Context
+        // and epoch destruction acquire the corresponding exclusive lease before mutating state.
+        let creation_lease = self
+            .session_maker
+            .try_get_epoch_creation_lease(&context_id, &epoch_id)
+            .await
+            .map_err(|e| {
+                MetricedError::new(
+                    OP_NEW_EPOCH,
+                    Some(epoch_id.into()),
+                    anyhow::anyhow!("Cannot create epoch ID {epoch_id}: {e}"),
+                    tonic::Code::FailedPrecondition,
+                )
+            })?;
+
         if self.session_maker.epoch_exists(&epoch_id).await {
             return Err(MetricedError::new(
                 OP_NEW_EPOCH,
@@ -1344,6 +1378,7 @@ impl<
         let session_maker = self.session_maker.clone();
         let crypto_storage = self.crypto_storage.clone();
         self.tracker.spawn(async move {
+            let _creation_lease = creation_lease;
             let _rate_limiter_permit = rate_limiter_permit;
             let crypto_storage = crypto_storage;
             let context_id = context_id;
@@ -2342,6 +2377,87 @@ pub(crate) mod tests {
         .unwrap_err();
 
         assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    /// The creation lease remains live after PRSS registers the epoch, preventing destruction while
+    /// resharing can still write private shares. Releasing the lease makes destruction retryable.
+    #[tokio::test]
+    async fn test_destroy_epoch_rejected_while_creation_in_flight() {
+        use crate::vault::storage::StorageReader;
+
+        let mut rng = AesRng::seed_from_u64(44);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+
+        let epoch_id = *DEFAULT_EPOCH_ID;
+        let prss = PRSSSetupCombined {
+            prss_setup_z128: PRSSSetup::<ResiduePolyF4Z128>::new_testing_prss(vec![], vec![]),
+            prss_setup_z64: PRSSSetup::<ResiduePolyF4Z64>::new_testing_prss(vec![], vec![]),
+            num_parties: 4,
+            threshold: 1,
+        };
+        epoch_manager
+            .session_maker
+            .add_epoch(epoch_id, prss.clone())
+            .await;
+        let private_storage = epoch_manager.crypto_storage.get_private_storage();
+        {
+            let mut priv_storage = private_storage.lock().await;
+            store_versioned_at_request_id(
+                &mut (*priv_storage),
+                &epoch_id.into(),
+                &prss,
+                &PrivDataType::PrssSetupCombined.to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        // Mirror a creation task that has registered its epoch after PRSS but is still resharing.
+        let creation_lease = epoch_manager
+            .session_maker
+            .try_get_epoch_creation_lease(&DEFAULT_MPC_CONTEXT, &epoch_id)
+            .await
+            .unwrap();
+
+        let err = epoch_manager
+            .destroy_epoch_and_purge_cache(&epoch_id)
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+
+        // Destruction must return before touching the registered epoch or its persisted PRSS data.
+        assert!(epoch_manager.session_maker.epoch_exists(&epoch_id).await);
+        {
+            let priv_storage = private_storage.lock().await;
+            assert!(
+                priv_storage
+                    .data_exists(
+                        &epoch_id.into(),
+                        &PrivDataType::PrssSetupCombined.to_string()
+                    )
+                    .await
+                    .unwrap()
+            );
+        }
+
+        // Success, failure, panic and task cancellation all drop this owned lease, allowing cleanup.
+        drop(creation_lease);
+        epoch_manager
+            .destroy_epoch_and_purge_cache(&epoch_id)
+            .await
+            .unwrap();
+
+        assert!(!epoch_manager.session_maker.epoch_exists(&epoch_id).await);
+        let priv_storage = private_storage.lock().await;
+        assert!(
+            !priv_storage
+                .data_exists(
+                    &epoch_id.into(),
+                    &PrivDataType::PrssSetupCombined.to_string()
+                )
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -2395,6 +2395,87 @@ pub(crate) mod tests {
         assert_eq!(err.code(), tonic::Code::NotFound);
     }
 
+    /// The creation lease remains live after PRSS registers the epoch, preventing destruction while
+    /// resharing can still write private shares. Releasing the lease makes destruction retryable.
+    #[tokio::test]
+    async fn test_destroy_epoch_rejected_while_creation_in_flight() {
+        use crate::vault::storage::StorageReader;
+
+        let mut rng = AesRng::seed_from_u64(44);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+
+        let epoch_id = *DEFAULT_EPOCH_ID;
+        let prss = PRSSSetupCombined {
+            prss_setup_z128: PRSSSetup::<ResiduePolyF4Z128>::new_testing_prss(vec![], vec![]),
+            prss_setup_z64: PRSSSetup::<ResiduePolyF4Z64>::new_testing_prss(vec![], vec![]),
+            num_parties: 4,
+            threshold: 1,
+        };
+        epoch_manager
+            .session_maker
+            .add_epoch(epoch_id, prss.clone())
+            .await;
+        let private_storage = epoch_manager.crypto_storage.get_private_storage();
+        {
+            let mut priv_storage = private_storage.lock().await;
+            store_versioned_at_request_id(
+                &mut (*priv_storage),
+                &epoch_id.into(),
+                &prss,
+                &PrivDataType::PrssSetupCombined.to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        // Mirror a creation task that has registered its epoch after PRSS but is still resharing.
+        let creation_lease = epoch_manager
+            .session_maker
+            .try_get_epoch_creation_lease(&DEFAULT_MPC_CONTEXT, &epoch_id)
+            .await
+            .unwrap();
+
+        let err = epoch_manager
+            .destroy_epoch_and_purge_cache(&epoch_id)
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+
+        // Destruction must return before touching the registered epoch or its persisted PRSS data.
+        assert!(epoch_manager.session_maker.epoch_exists(&epoch_id).await);
+        {
+            let priv_storage = private_storage.lock().await;
+            assert!(
+                priv_storage
+                    .data_exists(
+                        &epoch_id.into(),
+                        &PrivDataType::PrssSetupCombined.to_string()
+                    )
+                    .await
+                    .unwrap()
+            );
+        }
+
+        // Success, failure, panic and task cancellation all drop this owned lease, allowing cleanup.
+        drop(creation_lease);
+        epoch_manager
+            .destroy_epoch_and_purge_cache(&epoch_id)
+            .await
+            .unwrap();
+
+        assert!(!epoch_manager.session_maker.epoch_exists(&epoch_id).await);
+        let priv_storage = private_storage.lock().await;
+        assert!(
+            !priv_storage
+                .data_exists(
+                    &epoch_id.into(),
+                    &PrivDataType::PrssSetupCombined.to_string()
+                )
+                .await
+                .unwrap()
+        );
+    }
+
     #[tokio::test]
     async fn test_destroy_mpc_epochs() {
         use crate::vault::storage::{

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -2421,7 +2421,6 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-      
         let err = epoch_manager
             .destroy_epoch_with_lease(&epoch_id)
             .await

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -238,7 +238,7 @@ fn verify_epoch_info(
     })
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum EpochOutput {
     PRSSInitOnly,
     Reshare((Vec<KeyGenMetadata>, Vec<CrsGenMetadata>)),
@@ -1045,7 +1045,6 @@ impl<
     /// node can still see the epoch and hence finish the deletion.
     async fn purge_epoch_material(
         epoch_id: &EpochId,
-        priv_data_types: &[PrivDataType],
         priv_storage: &tokio::sync::Mutex<PrivS>,
     ) -> anyhow::Result<()> {
         let mut priv_storage_guard = priv_storage.lock().await;
@@ -1054,7 +1053,7 @@ impl<
         // but track the first error to report back to the caller.
         let mut first_error: Option<anyhow::Error> = None;
 
-        for priv_data_type in priv_data_types {
+        for priv_data_type in &[PrivDataType::FheKeyInfo, PrivDataType::CrsInfo] {
             // Delete all data stored under this epoch for the given private data type
             // first find all data IDs
             let data_ids = match priv_storage_guard
@@ -1093,35 +1092,21 @@ impl<
             }
         }
 
-        // Delete legacy data to avoid it coming back on migration at restart.
-        #[expect(deprecated)]
-        let legacy_prss_type = PrivDataType::PrssSetupCombined.to_string();
-        if first_error.is_none()
-            && let Err(e) = delete_at_request_id(
-                &mut (*priv_storage_guard),
-                &epoch_id.into(),
-                &legacy_prss_type,
-            )
-            .await
-        {
-            tracing::error!("Error deleting PrssSetupCombined on epoch ID {epoch_id}: {e:?}");
-            first_error = Some(e);
-        }
-
         // Delete the epoch data (stored under epoch_id as a request_id) only once every key/CRS
         // meta data deletion above has succeeded. The epoch data (which holds the PRSS setup) is what
         // resurrects the epoch after a restart — the session maker is rebuilt from epoch-data
         // storage on startup — hence keeping the epoch data for last guarantees a restarted node still
         // sees the epoch and can finish the deletion.
+        let legacy_prss_type = PrivDataType::PrssSetupCombined.to_string();
         if first_error.is_none()
             && let Err(e) = delete_at_request_id(
                 &mut (*priv_storage_guard),
-                &epoch_id.into(),
-                &PrivDataType::EpochData.to_string(),
+                &(*epoch_id).into(),
+                &legacy_prss_type,
             )
             .await
         {
-            tracing::error!("Error deleting EpochData epoch ID {epoch_id}: {e:?}");
+            tracing::error!("Error deleting PrssSetupCombined on epoch ID {epoch_id}: {e:?}");
             first_error = Some(e);
         }
 
@@ -1598,7 +1583,6 @@ impl<
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-
     use crate::{
         client::test_tools::{self},
         consts::{
@@ -1620,10 +1604,12 @@ pub(crate) mod tests {
             rate_limiter::RateLimiterConfig,
         },
         vault::storage::{
-            StorageType,
+            StorageReader, StorageReaderExt, StorageType,
             file::FileStorage,
             ram::{self, RamStorage},
-            read_all_data_versioned, store_versioned_at_request_id,
+            read_all_data_versioned, store_versioned_at_request_and_epoch_id,
+            store_versioned_at_request_id,
+            tests::TestType,
         },
     };
     use aes_prng::AesRng;
@@ -1637,6 +1623,7 @@ pub(crate) mod tests {
     use threshold_execution::{
         endpoints::reshare_sk::SecureReshareSecretKeys,
         malicious_execution::small_execution::malicious_prss::EmptyPrss,
+        tfhe_internals::test_feature::gen_key_set,
     };
 
     impl<
@@ -2357,7 +2344,6 @@ pub(crate) mod tests {
         }
 
         // Destroy the epoch
-        let priv_storage = epoch_manager.crypto_storage.get_private_storage();
         RealThresholdEpochManager::<
             ram::RamStorage,
             ram::RamStorage,
@@ -2376,98 +2362,14 @@ pub(crate) mod tests {
 
         // Verify data is gone from storage
         {
-            let priv_storage = priv_storage.lock().await;
-            let ids = priv_storage
+            let priv_storage = epoch_manager.crypto_storage.get_private_storage();
+            let priv_storage_guard = priv_storage.lock().await;
+            let ids = priv_storage_guard
                 .all_data_ids_at_epoch(&epoch_id, &data_type.to_string())
                 .await
                 .unwrap();
             assert!(ids.is_empty());
         }
-    }
-
-    /// A destroyed epoch must also drop any lingering legacy `PrssSetupCombined` stored under its
-    /// epoch id as it might otherwise be resurrected on the next restart by the migration code.
-    #[tokio::test]
-    async fn test_destroy_epoch_removes_legacy_prss() {
-        let mut rng = AesRng::seed_from_u64(43);
-        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
-        let epoch_id = *DEFAULT_EPOCH_ID;
-
-        let epoch = dummy_epoch_data(*DEFAULT_MPC_CONTEXT);
-        epoch_manager
-            .session_maker
-            .add_epoch(epoch_id, epoch.clone())
-            .await;
-
-        // A "keeper" epoch so the target is not the last remaining one (`destroy_epoch` refuses to
-        // remove the final epoch).
-        let keeper_epoch_id = EpochId::new_random(&mut rng);
-        epoch_manager
-            .session_maker
-            .add_epoch(keeper_epoch_id, epoch.clone())
-            .await;
-
-        {
-            let private_storage = epoch_manager.crypto_storage.get_private_storage();
-            let mut priv_storage = private_storage.lock().await;
-            // The current epoch data, plus a lingering legacy combined PRSS at the same epoch id
-            // (as left behind by a pre-0.16 install where the legacy PRSS is not yet deleted).
-            store_versioned_at_request_id(
-                &mut (*priv_storage),
-                &epoch_id.into(),
-                &epoch,
-                &PrivDataType::EpochData.to_string(),
-            )
-            .await
-            .unwrap();
-            store_versioned_at_request_id(
-                &mut (*priv_storage),
-                &epoch_id.into(),
-                &epoch.prss,
-                #[expect(deprecated)]
-                &PrivDataType::PrssSetupCombined.to_string(),
-            )
-            .await
-            .unwrap();
-        }
-
-        let priv_storage = epoch_manager.crypto_storage.get_private_storage();
-        RealThresholdEpochManager::<
-            ram::RamStorage,
-            ram::RamStorage,
-            EmptyPrss,
-            SecureReshareSecretKeys,
-        >::destroy_epoch(
-            &epoch_id,
-            &epoch_manager.crypto_storage,
-            &epoch_manager.session_maker,
-        )
-        .await
-        .unwrap();
-
-        assert!(!epoch_manager.session_maker.epoch_exists(&epoch_id).await);
-
-        // Both the epoch data and the legacy combined PRSS must be gone, so nothing can revive the
-        // epoch on the next restart.
-        let priv_storage = priv_storage.lock().await;
-        assert!(
-            !priv_storage
-                .data_exists(&epoch_id.into(), &PrivDataType::EpochData.to_string())
-                .await
-                .unwrap(),
-            "EpochData must be deleted"
-        );
-        assert!(
-            !priv_storage
-                .data_exists(
-                    &epoch_id.into(),
-                    #[expect(deprecated)]
-                    &PrivDataType::PrssSetupCombined.to_string(),
-                )
-                .await
-                .unwrap(),
-            "legacy PrssSetupCombined must be deleted so migration cannot resurrect the epoch"
-        );
     }
 
     #[tokio::test]
@@ -2491,334 +2393,6 @@ pub(crate) mod tests {
         .unwrap_err();
 
         assert_eq!(err.code(), tonic::Code::NotFound);
-    }
-
-    /// The creation lease remains live after PRSS registers the epoch, preventing destruction while
-    /// resharing can still write private shares. Releasing the lease makes destruction retryable.
-    #[tokio::test]
-    async fn test_destroy_epoch_rejected_while_creation_in_flight() {
-        use crate::vault::storage::StorageReader;
-
-        let mut rng = AesRng::seed_from_u64(44);
-        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
-
-        let epoch_id = *DEFAULT_EPOCH_ID;
-        let prss = PRSSSetupCombined {
-            prss_setup_z128: PRSSSetup::<ResiduePolyF4Z128>::new_testing_prss(vec![], vec![]),
-            prss_setup_z64: PRSSSetup::<ResiduePolyF4Z64>::new_testing_prss(vec![], vec![]),
-            num_parties: 4,
-            threshold: 1,
-        };
-        epoch_manager
-            .session_maker
-            .add_epoch(epoch_id, prss.clone())
-            .await;
-        let private_storage = epoch_manager.crypto_storage.get_private_storage();
-        {
-            let mut priv_storage = private_storage.lock().await;
-            store_versioned_at_request_id(
-                &mut (*priv_storage),
-                &epoch_id.into(),
-                &prss,
-                &PrivDataType::PrssSetupCombined.to_string(),
-            )
-            .await
-            .unwrap();
-        }
-
-        // Mirror a creation task that has registered its epoch after PRSS but is still resharing.
-        let creation_lease = epoch_manager
-            .session_maker
-            .try_get_epoch_creation_lease(&DEFAULT_MPC_CONTEXT, &epoch_id)
-            .await
-            .unwrap();
-
-        let err = epoch_manager
-            .destroy_epoch_with_lease(&epoch_id)
-            .await
-            .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-
-        // Destruction must return before touching the registered epoch or its persisted PRSS data.
-        assert!(epoch_manager.session_maker.epoch_exists(&epoch_id).await);
-        {
-            let priv_storage = private_storage.lock().await;
-            assert!(
-                priv_storage
-                    .data_exists(
-                        &epoch_id.into(),
-                        &PrivDataType::PrssSetupCombined.to_string()
-                    )
-                    .await
-                    .unwrap()
-            );
-        }
-
-        // Success, failure, panic and task cancellation all drop this owned lease, allowing cleanup.
-        drop(creation_lease);
-        epoch_manager
-            .destroy_epoch_with_lease(&epoch_id)
-            .await
-            .unwrap();
-
-        assert!(!epoch_manager.session_maker.epoch_exists(&epoch_id).await);
-        let priv_storage = private_storage.lock().await;
-        assert!(
-            !priv_storage
-                .data_exists(
-                    &epoch_id.into(),
-                    &PrivDataType::PrssSetupCombined.to_string()
-                )
-                .await
-                .unwrap()
-        );
-    }
-
-    /// Validates partial-failure in destroying MPC epoch:
-    /// If deleting the private data fails, retrying should be possible until success,
-    /// at which point all epoch Ids associated to the destroyed context should be returned.
-    #[tokio::test]
-    async fn test_destroy_epoch_partial_failure_is_retryable() {
-        let mut rng = AesRng::seed_from_u64(42);
-        // We only borrow the session maker; the storage below is a separate, fault-injecting one.
-        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
-        let session_maker = &epoch_manager.session_maker;
-
-        let prss_setup_z128 = PRSSSetup::<ResiduePolyF4Z128>::new_testing_prss(vec![], vec![]);
-        let prss_setup_z64 = PRSSSetup::<ResiduePolyF4Z64>::new_testing_prss(vec![], vec![]);
-        let epoch = EpochData {
-            context_id: *DEFAULT_MPC_CONTEXT,
-            prss: PRSSSetupCombined {
-                prss_setup_z128,
-                prss_setup_z64,
-                num_parties: 4,
-                threshold: 1,
-            },
-        };
-
-        // Target epoch to destroy plus a "keeper" so the target is not the last remaining epoch.
-        let epoch_id = EpochId::new_random(&mut rng);
-        let keeper_epoch_id = EpochId::new_random(&mut rng);
-        session_maker.add_epoch(epoch_id, epoch.clone()).await;
-        session_maker
-            .add_epoch(keeper_epoch_id, epoch.clone())
-            .await;
-
-        // Fault-injecting private storage that we can flip between failing and succeeding on delete.
-        let crypto_storage = ThresholdCryptoMaterialStorage::new(
-            RamStorage::new(),
-            FailingRamStorage::new(100),
-            None,
-            HashMap::new(),
-        );
-        let priv_storage = crypto_storage.get_private_storage();
-
-        let data_type = PrivDataType::FheKeyInfo;
-        let data = TestType { i: 42 };
-        let data_id = derive_request_id("partial_failure_data").unwrap();
-        let epoch_data_id: RequestId = epoch_id.into();
-
-        {
-            let mut guard = priv_storage.lock().await;
-            store_versioned_at_request_and_epoch_id(
-                &mut (*guard),
-                &data_id,
-                &epoch_id,
-                &data,
-                &data_type.to_string(),
-            )
-            .await
-            .unwrap();
-            // The EpochData acts as the durable retry marker that resurrects the epoch on restart.
-            store_versioned_at_request_id(
-                &mut (*guard),
-                &epoch_data_id,
-                &epoch,
-                &PrivDataType::EpochData.to_string(),
-            )
-            .await
-            .unwrap();
-            // Make every delete fail to simulate a partial failure mid-destruction.
-            guard.set_fail_deletes(true);
-        }
-
-        // First attempt: deletion fails, so the whole operation must fail.
-        let err = RealThresholdEpochManager::<
-            ram::RamStorage,
-            FailingRamStorage,
-            EmptyPrss,
-            SecureReshareSecretKeys,
-        >::destroy_epoch(&epoch_id, &crypto_storage, session_maker)
-        .await
-        .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::Internal);
-
-        // The epoch must still be present so the caller can retry, and the keeper must be untouched.
-        assert!(
-            session_maker.epoch_exists(&epoch_id).await,
-            "epoch must remain in the session maker after a failed destruction"
-        );
-        assert!(session_maker.epoch_exists(&keeper_epoch_id).await);
-
-        // Both the key share and the durable EpochData retry marker must still be on disk.
-        {
-            let guard = priv_storage.lock().await;
-            let ids = guard
-                .all_data_ids_at_epoch(&epoch_id, &data_type.to_string())
-                .await
-                .unwrap();
-            assert!(
-                ids.contains(&data_id),
-                "key share must survive a failed destruction so it can be retried"
-            );
-            assert!(
-                guard
-                    .data_exists(&epoch_data_id, &PrivDataType::EpochData.to_string())
-                    .await
-                    .unwrap(),
-                "EpochData retry marker must not be deleted while other data still lingers on disk"
-            );
-        }
-
-        // Now let deletes succeed and retry: the operation must now complete and clean everything up.
-        priv_storage.lock().await.set_fail_deletes(false);
-        RealThresholdEpochManager::<
-            ram::RamStorage,
-            FailingRamStorage,
-            EmptyPrss,
-            SecureReshareSecretKeys,
-        >::destroy_epoch(&epoch_id, &crypto_storage, session_maker)
-        .await
-        .unwrap();
-
-        // The retry succeeded: epoch gone, keeper remains, and all on-disk data is cleared.
-        assert!(!session_maker.epoch_exists(&epoch_id).await);
-        assert!(session_maker.epoch_exists(&keeper_epoch_id).await);
-        {
-            let guard = priv_storage.lock().await;
-            let ids = guard
-                .all_data_ids_at_epoch(&epoch_id, &data_type.to_string())
-                .await
-                .unwrap();
-            assert!(ids.is_empty());
-            assert!(
-                !guard
-                    .data_exists(&epoch_data_id, &PrivDataType::EpochData.to_string())
-                    .await
-                    .unwrap()
-            );
-        }
-    }
-
-    /// The public key material of a key carries no epoch in its storage path, hence it belongs to
-    /// every epoch of that key. A reshare that fails to store its shares must therefore keep that
-    /// material, and delete the private material of the new epoch only.
-    /// This test validates a fix of a bug found in E2E test on 0.14.x
-    #[tokio::test]
-    async fn test_failed_reshare_keeps_public_key_material() {
-        let mut rng = AesRng::seed_from_u64(45);
-        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
-        let crypto_storage = &epoch_manager.crypto_storage;
-
-        let new_epoch_id = EpochId::new_random(&mut rng);
-        let key_id = derive_request_id("reshared_key").unwrap();
-        let preproc_id = derive_request_id("reshared_key_preproc").unwrap();
-
-        {
-            let public_storage = crypto_storage.inner.get_public_storage();
-            let mut guard = public_storage.lock().await;
-            for public_type in PubDataType::iter() {
-                store_versioned_at_request_id(
-                    &mut (*guard),
-                    &key_id,
-                    &TestType { i: 7 },
-                    &public_type.to_string(),
-                )
-                .await
-                .unwrap();
-            }
-        }
-
-        // Occupy the slot that the reshare writes its shares to, which makes the reshare fail and
-        // roll the new epoch back. The duplicate check only tests for presence, hence the content of
-        // the slot is irrelevant.
-        {
-            let private_storage = crypto_storage.get_private_storage();
-            let mut guard = private_storage.lock().await;
-            store_versioned_at_request_and_epoch_id(
-                &mut (*guard),
-                &key_id,
-                &new_epoch_id,
-                &TestType { i: 42 },
-                &PrivDataType::FheKeyInfo.to_string(),
-            )
-            .await
-            .unwrap();
-        }
-
-        let (_keyset, compressed_keyset) =
-            gen_key_set(crate::consts::TEST_PARAM, tfhe::Tag::default(), &mut rng).unwrap();
-        let sk = epoch_manager.base_kms.sig_key().unwrap();
-        let res = RealThresholdEpochManager::<
-            RamStorage,
-            RamStorage,
-            EmptyPrss,
-            SecureReshareSecretKeys,
-        >::store_reshared_keys(
-            crypto_storage,
-            &epoch_manager.session_maker,
-            &sk,
-            &[SigningSchemeType::Ecdsa256k1],
-            new_epoch_id,
-            vec![],
-            &make_verified_previous_epoch(
-                *DEFAULT_EPOCH_ID,
-                &key_id,
-                &preproc_id,
-                crate::consts::TEST_PARAM,
-            ),
-            vec![VerifiedPublicMaterial::Compressed(compressed_keyset)],
-            vec![PrivateKeySet::init_dummy(crate::consts::TEST_PARAM)],
-            &dummy_domain(),
-            vec![],
-        )
-        .await;
-        assert!(
-            res.unwrap_err()
-                .to_string()
-                .contains("Failed to store all reshared keys for new epoch 8b4803c41504a7acc9a59ebfb4838379f2b50c3ba0dd4a0b984bd7e566ab1b56: [Err(Duplicate)]")
-        );
-
-        {
-            let public_storage = crypto_storage.inner.get_public_storage();
-            let guard = public_storage.lock().await;
-            // Validate that no public material of the key was deleted.
-            for public_type in PubDataType::iter() {
-                assert!(
-                    guard
-                        .data_exists(&key_id, &public_type.to_string())
-                        .await
-                        .unwrap(),
-                    "{public_type} of key {key_id} must survive a failed reshare"
-                );
-            }
-        }
-
-        // The rollback ran: the private material of the new epoch is gone.
-        {
-            let private_storage = crypto_storage.get_private_storage();
-            let guard = private_storage.lock().await;
-            assert!(
-                !guard
-                    .data_exists_at_epoch(
-                        &key_id,
-                        &new_epoch_id,
-                        &PrivDataType::FheKeyInfo.to_string()
-                    )
-                    .await
-                    .unwrap()
-            );
-        }
     }
 
     #[tokio::test]
@@ -2915,5 +2489,134 @@ pub(crate) mod tests {
             .destroy_mpc_epochs(&[epoch_ids[0], epoch_ids[1], nonexistent])
             .await
             .unwrap();
+    }
+
+    /// The public key material of a key carries no epoch in its storage path, hence it belongs to
+    /// every epoch of that key. A reshare that fails to store its shares must therefore keep that
+    /// material, and delete the private material of the new epoch only.
+    /// This test validates a fix of a bug found in E2E test on 0.14.x
+    #[tokio::test]
+    async fn test_failed_reshare_keeps_public_key_material() {
+        let mut rng = AesRng::seed_from_u64(45);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+        let crypto_storage = &epoch_manager.crypto_storage;
+
+        let new_epoch_id = EpochId::new_random(&mut rng);
+        let key_id = derive_request_id("reshared_key").unwrap();
+        let preproc_id = derive_request_id("reshared_key_preproc").unwrap();
+
+        {
+            let public_storage = crypto_storage.inner.get_public_storage();
+            let mut guard = public_storage.lock().await;
+            for public_type in PubDataType::iter() {
+                store_versioned_at_request_id(
+                    &mut (*guard),
+                    &key_id,
+                    &TestType { i: 7 },
+                    &public_type.to_string(),
+                )
+                .await
+                .unwrap();
+            }
+        }
+
+        // Occupy the slot that the reshare writes its shares to, which makes the reshare fail and
+        // roll the new epoch back. The duplicate check only tests for presence, hence the content of
+        // the slot is irrelevant.
+        {
+            let private_storage = crypto_storage.get_private_storage();
+            let mut guard = private_storage.lock().await;
+            store_versioned_at_request_and_epoch_id(
+                &mut (*guard),
+                &key_id,
+                &new_epoch_id,
+                &TestType { i: 42 },
+                &PrivDataType::FheKeyInfo.to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let (_keyset, compressed_keyset) =
+            gen_key_set(crate::consts::TEST_PARAM, tfhe::Tag::default(), &mut rng).unwrap();
+        let sk = epoch_manager.base_kms.sig_key().unwrap();
+        let res = RealThresholdEpochManager::<
+            RamStorage,
+            RamStorage,
+            EmptyPrss,
+            SecureReshareSecretKeys,
+        >::store_reshared_keys(
+            crypto_storage,
+            &epoch_manager.session_maker,
+            &sk,
+            new_epoch_id,
+            vec![],
+            &make_verified_previous_epoch(
+                *DEFAULT_EPOCH_ID,
+                &key_id,
+                &preproc_id,
+                crate::consts::TEST_PARAM,
+            ),
+            vec![VerifiedPublicMaterial::Compressed(compressed_keyset)],
+            vec![PrivateKeySet::init_dummy(crate::consts::TEST_PARAM)],
+            &dummy_domain(),
+            vec![],
+        )
+        .await;
+        assert!(
+            res.unwrap_err()
+                .to_string()
+                .contains("Failed to store all reshared keys for new epoch 8b4803c41504a7acc9a59ebfb4838379f2b50c3ba0dd4a0b984bd7e566ab1b56: [Err(Duplicate)]")
+        );
+
+        {
+            let public_storage = crypto_storage.inner.get_public_storage();
+            let guard = public_storage.lock().await;
+            // Validate that no public material of the key was deleted.
+            for public_type in PubDataType::iter() {
+                assert!(
+                    guard
+                        .data_exists(&key_id, &public_type.to_string())
+                        .await
+                        .unwrap(),
+                    "{public_type} of key {key_id} must survive a failed reshare"
+                );
+            }
+        }
+
+        // The rollback ran: the private material of the new epoch is gone.
+        {
+            let private_storage = crypto_storage.get_private_storage();
+            let guard = private_storage.lock().await;
+            assert!(
+                !guard
+                    .data_exists_at_epoch(
+                        &key_id,
+                        &new_epoch_id,
+                        &PrivDataType::FheKeyInfo.to_string()
+                    )
+                    .await
+                    .unwrap()
+            );
+        }
+    }
+
+    fn make_verified_previous_epoch(
+        previous_epoch_id: EpochId,
+        key_id: &RequestId,
+        preproc_id: &RequestId,
+        key_parameters: DKGParams,
+    ) -> VerifiedPreviousEpochInfo {
+        VerifiedPreviousEpochInfo {
+            context_id: *DEFAULT_MPC_CONTEXT,
+            epoch_id: previous_epoch_id,
+            keys_info: vec![VerifiedKeyInfo {
+                key_id: *key_id,
+                preproc_id: *preproc_id,
+                key_parameters,
+                key_digests: HashMap::new(),
+            }],
+            crs_info: vec![],
+        }
     }
 }

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -604,6 +604,7 @@ impl<
     #[expect(clippy::too_many_arguments)]
     async fn store_reshared_keys(
         crypto_storage: &ThresholdCryptoMaterialStorage<PubS, PrivS>,
+        session_maker: &SessionMaker,
         sk: &PrivateSigKey,
         new_epoch_id: EpochId,
         new_extra_data: Vec<u8>,
@@ -759,31 +760,19 @@ impl<
 
             // Roll back any partial successes in case something fails during the resharing,
             // to not leave the storage in a partial state.
-            for key_info in verified_previous_epoch.keys_info.iter() {
-                if !crypto_storage
-                    .purge_fhe_keys(&key_info.key_id, &new_epoch_id)
-                    .await
-                {
-                    tracing::warn!(
-                        "Best-effort rollback failed to purge threshold key material for key_id={} new_epoch_id={}",
-                        key_info.key_id,
-                        new_epoch_id
-                    );
-                }
+            let priv_storage = crypto_storage.get_private_storage();
+            match Self::purge_epoch_material(&new_epoch_id, &priv_storage).await {
+                Ok(()) => session_maker.remove_epoch(&new_epoch_id).await,
+                Err(e) => tracing::error!(
+                    "Rollback of epoch {new_epoch_id} failed to delete its private material: {e:?}. The \
+                 epoch remains registered so that the deletion can be retried."
+                ),
             }
-            for crs_info in verified_previous_epoch.crs_info.iter() {
-                if !crypto_storage
-                    .inner
-                    .purge_crs_material(&crs_info.crs_id, &new_epoch_id)
-                    .await
-                {
-                    tracing::warn!(
-                        "Best-effort rollback failed to purge CRS material for crs_id={} new_epoch_id={}",
-                        crs_info.crs_id,
-                        new_epoch_id
-                    );
-                }
-            }
+            // Remove regardless of whether the rollback succeeded or not, to avoid leaving the in-memory cache in a partial state.
+            let removed = crypto_storage.purge_epoch_from_cache(&new_epoch_id).await;
+            tracing::info!(
+                "Freed {removed} in-memory FHE key cache entries for rolled back epoch {new_epoch_id}"
+            );
 
             return Err(anyhow::anyhow!(storage_err_msg));
         }
@@ -841,6 +830,7 @@ impl<
         })?;
 
         let crypto_storage = self.crypto_storage.clone();
+        let session_maker = self.session_maker.clone();
 
         let task = async move {
             let (mut session_z128, mut session_z64, session_online) =
@@ -895,6 +885,7 @@ impl<
 
             Self::store_reshared_keys(
                 &crypto_storage,
+                &session_maker,
                 &sk,
                 new_epoch_id,
                 new_extra_data,
@@ -958,6 +949,7 @@ impl<
         })?;
 
         let crypto_storage = self.crypto_storage.clone();
+        let session_maker = self.session_maker.clone();
 
         let task = async move {
             let (mut session_z128_set_1, mut session_z64_set_1) = Self::create_set1_sessions(
@@ -1029,6 +1021,7 @@ impl<
 
             Self::store_reshared_keys(
                 &crypto_storage,
+                &session_maker,
                 &sk,
                 new_epoch_id,
                 new_extra_data,
@@ -1044,24 +1037,17 @@ impl<
         Ok(task)
     }
 
-    /// Destroys an epoch by removing all private data stored under the given epoch for each of the
-    /// given data types, then removing the PRSS setup data, and finally removing the epoch from the
-    /// session maker.
-    async fn destroy_epoch(
+    /// Deletes every piece of private material that belongs to `epoch_id`: the FHE key shares and
+    /// the CRS metadata stored under the epoch, followed by the epoch data itself.
+    ///
+    /// The deletion continues past a failure and the first error is returned.
+    /// However, only if all deletions succeed is the epoch data itself deleted, so that a restarted
+    /// node can still see the epoch and hence finish the deletion.
+    async fn purge_epoch_material(
         epoch_id: &EpochId,
         priv_data_types: &[PrivDataType],
         priv_storage: &tokio::sync::Mutex<PrivS>,
-        session_maker: &SessionMaker,
-    ) -> Result<Response<Empty>, MetricedError> {
-        if !session_maker.epoch_exists(epoch_id).await {
-            return Err(MetricedError::new(
-                OP_DESTROY_EPOCH,
-                Some((*epoch_id).into()),
-                anyhow::anyhow!("Epoch ID {} does not exist", epoch_id),
-                tonic::Code::NotFound,
-            ));
-        }
-
+    ) -> anyhow::Result<()> {
         let mut priv_storage_guard = priv_storage.lock().await;
 
         // At this point we're committed to deleting the epoch, so do not return if there's an error,
@@ -1107,35 +1093,97 @@ impl<
             }
         }
 
-        // Delete the PRSS setup (stored under epoch_id as a request_id) only once every key/CRS
-        // deletion above has succeeded. The PRSS is what resurrects the epoch after a restart —
-        // the session maker is rebuilt from PRSS storage on startup — so it doubles as the durable
-        // retry marker. Deleting it while key/CRS shares remain would let a restarted node skip the
-        // epoch (its PRSS, hence the epoch itself, is gone) and strand those shares forever.
-        // Keeping PRSS for last guarantees a restarted node still sees the epoch and can finish the
-        // deletion.
+        // Delete legacy data to avoid it coming back on migration at restart.
+        #[expect(deprecated)]
+        let legacy_prss_type = PrivDataType::PrssSetupCombined.to_string();
         if first_error.is_none()
             && let Err(e) = delete_at_request_id(
                 &mut (*priv_storage_guard),
-                &(*epoch_id).into(),
-                &PrivDataType::PrssSetupCombined.to_string(),
+                &epoch_id.into(),
+                &legacy_prss_type,
             )
             .await
         {
-            tracing::error!("Error deleting PrssSetupCombined epoch ID {epoch_id}: {e:?}");
+            tracing::error!("Error deleting PrssSetupCombined on epoch ID {epoch_id}: {e:?}");
             first_error = Some(e);
         }
 
-        if let Some(e) = first_error {
-            // If there was a problem, stop and signal error here so that the operation can be retried. We must never
-            // end up in a situation where the epoch is gone, but data lingers on disk.
+        // Delete the epoch data (stored under epoch_id as a request_id) only once every key/CRS
+        // meta data deletion above has succeeded. The epoch data (which holds the PRSS setup) is what
+        // resurrects the epoch after a restart — the session maker is rebuilt from epoch-data
+        // storage on startup — hence keeping the epoch data for last guarantees a restarted node still
+        // sees the epoch and can finish the deletion.
+        if first_error.is_none()
+            && let Err(e) = delete_at_request_id(
+                &mut (*priv_storage_guard),
+                &epoch_id.into(),
+                &PrivDataType::EpochData.to_string(),
+            )
+            .await
+        {
+            tracing::error!("Error deleting EpochData epoch ID {epoch_id}: {e:?}");
+            first_error = Some(e);
+        }
+
+        match first_error {
+            // If there was a problem, stop and signal the error here so that the operation can be
+            // retried.
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    /// Destroys an epoch by removing all private data stored under the given epoch, dropping its
+    /// entries from the key cache, and then removing the epoch from the session maker.
+    ///
+    /// The epoch must exist and must not be the last epoch on the node. A rejected precondition
+    /// leaves the epoch untouched, cache included.
+    ///
+    /// In case of any error during the deletion of private data, the epoch will not be removed from the session maker,
+    /// and an error will be returned. This allows the caller to retry the operation until it succeeds.
+    async fn destroy_epoch(
+        epoch_id: &EpochId,
+        crypto_storage: &ThresholdCryptoMaterialStorage<PubS, PrivS>,
+        session_maker: &SessionMaker,
+    ) -> Result<Response<Empty>, MetricedError> {
+        if !session_maker.epoch_exists(epoch_id).await {
             return Err(MetricedError::new(
+                OP_DESTROY_EPOCH,
+                Some((*epoch_id).into()),
+                anyhow::anyhow!("Epoch ID {} does not exist", epoch_id),
+                tonic::Code::NotFound,
+            ));
+        }
+
+        if session_maker.epoch_count().await < 2 {
+            return Err(MetricedError::new(
+                OP_DESTROY_EPOCH,
+                Some((*epoch_id).into()),
+                anyhow::anyhow!(
+                    "Cannot destroy epoch ID {} because it is the only epoch remaining",
+                    epoch_id
+                ),
+                tonic::Code::FailedPrecondition,
+            ));
+        }
+
+        let priv_storage = crypto_storage.get_private_storage();
+        let purge_res = Self::purge_epoch_material(epoch_id, &priv_storage).await;
+
+        // The cache is dropped whatever the outcome of the deletion to avoid orphaned data in RAM.
+        let removed = crypto_storage.purge_epoch_from_cache(epoch_id).await;
+        tracing::info!(
+            "Freed {removed} in-memory FHE key cache entries for destroyed epoch {epoch_id}"
+        );
+
+        purge_res.map_err(|e| {
+            MetricedError::new(
                 OP_DESTROY_EPOCH,
                 Some((*epoch_id).into()),
                 e,
                 tonic::Code::Internal,
-            ));
-        }
+            )
+        })?;
 
         // Only forget the epoch once every piece of its private data has been deleted.
         session_maker.remove_epoch(epoch_id).await;
@@ -1144,15 +1192,12 @@ impl<
         Ok(Response::new(Empty {}))
     }
 
-    /// Fully erase a single epoch: delete its on-disk private key shares, CRS and PRSS setup, then drop the in-memory
-    /// decompressed-key cache for that epoch.
+    /// Takes the exclusive lifecycle lease of the epoch and then erases it through
+    /// [`Self::destroy_epoch`].
     ///
-    /// [`Self::destroy_epoch`] only touches storage, so the cache must be cleared here as well or the decompressed keys
-    /// stay resident until restart. The cache is purged regardless of the deletion outcome.
-    ///
-    /// An exclusive lifecycle lease prevents creation of the same epoch from starting or completing
-    /// concurrently with deletion.
-    async fn destroy_epoch_and_purge_cache(
+    /// In case anything goes wrong, an error will be returned and epoch meta-data will remain in the RAM despite being deleted from disk.
+    /// This is to allow the caller to retry the operation until it succeeds.
+    async fn destroy_epoch_with_lease(
         &self,
         epoch_id: &EpochId,
     ) -> Result<Response<Empty>, MetricedError> {
@@ -1172,23 +1217,8 @@ impl<
                 )
             })?;
 
-        let priv_storage = Arc::clone(&self.crypto_storage.inner.private_storage);
-
         // NOTE: destroy_epoch will also destroy PRSS data
-        let res = Self::destroy_epoch(
-            epoch_id,
-            &[PrivDataType::FheKeyInfo, PrivDataType::CrsInfo],
-            &priv_storage,
-            &self.session_maker,
-        )
-        .await;
-
-        let removed = self.crypto_storage.purge_epoch_from_cache(epoch_id).await;
-        tracing::info!(
-            "Freed {removed} in-memory FHE key cache entries for destroyed epoch {epoch_id}"
-        );
-
-        res
+        Self::destroy_epoch(epoch_id, &self.crypto_storage, &self.session_maker).await
     }
 
     async fn initiate_resharing_and_crs_resign(
@@ -1425,7 +1455,7 @@ impl<
                 |e| MetricedError::new(OP_DESTROY_EPOCH, None, e, tonic::Code::InvalidArgument),
             )?;
 
-        self.destroy_epoch_and_purge_cache(&epoch_id).await
+        self.destroy_epoch_with_lease(&epoch_id).await
     }
 
     async fn destroy_mpc_epochs(&self, epoch_ids: &[EpochId]) -> Result<(), MetricedError> {
@@ -1441,10 +1471,11 @@ impl<
             // Attempt to destroy every epoch even if an earlier one fails, but keep the first failure to return so the
             // caller learns that some shares may remain and can retry. Later failures are logged via their own
             // `MetricedError` drop handling.
-            if let Err(e) = self.destroy_epoch_and_purge_cache(epoch_id).await
-                && first_error.is_none()
-            {
-                first_error = Some(e);
+            if let Err(e) = self.destroy_epoch_with_lease(epoch_id).await {
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+                continue;
             }
         }
 
@@ -1602,6 +1633,7 @@ pub(crate) mod tests {
         rpc_types::{KMSType, PrivDataType, alloy_to_protobuf_domain},
     };
     use rand::SeedableRng;
+    use strum::IntoEnumIterator;
     use threshold_execution::{
         endpoints::reshare_sk::SecureReshareSecretKeys,
         malicious_execution::small_execution::malicious_prss::EmptyPrss,
@@ -2333,8 +2365,7 @@ pub(crate) mod tests {
             SecureReshareSecretKeys,
         >::destroy_epoch(
             &epoch_id,
-            &[PrivDataType::FheKeyInfo],
-            &priv_storage,
+            &epoch_manager.crypto_storage,
             &epoch_manager.session_maker,
         )
         .await
@@ -2354,6 +2385,91 @@ pub(crate) mod tests {
         }
     }
 
+    /// A destroyed epoch must also drop any lingering legacy `PrssSetupCombined` stored under its
+    /// epoch id as it might otherwise be resurrected on the next restart by the migration code.
+    #[tokio::test]
+    async fn test_destroy_epoch_removes_legacy_prss() {
+        let mut rng = AesRng::seed_from_u64(43);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+        let epoch_id = *DEFAULT_EPOCH_ID;
+
+        let epoch = dummy_epoch_data(*DEFAULT_MPC_CONTEXT);
+        epoch_manager
+            .session_maker
+            .add_epoch(epoch_id, epoch.clone())
+            .await;
+
+        // A "keeper" epoch so the target is not the last remaining one (`destroy_epoch` refuses to
+        // remove the final epoch).
+        let keeper_epoch_id = EpochId::new_random(&mut rng);
+        epoch_manager
+            .session_maker
+            .add_epoch(keeper_epoch_id, epoch.clone())
+            .await;
+
+        {
+            let private_storage = epoch_manager.crypto_storage.get_private_storage();
+            let mut priv_storage = private_storage.lock().await;
+            // The current epoch data, plus a lingering legacy combined PRSS at the same epoch id
+            // (as left behind by a pre-0.16 install where the legacy PRSS is not yet deleted).
+            store_versioned_at_request_id(
+                &mut (*priv_storage),
+                &epoch_id.into(),
+                &epoch,
+                &PrivDataType::EpochData.to_string(),
+            )
+            .await
+            .unwrap();
+            store_versioned_at_request_id(
+                &mut (*priv_storage),
+                &epoch_id.into(),
+                &epoch.prss,
+                #[expect(deprecated)]
+                &PrivDataType::PrssSetupCombined.to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let priv_storage = epoch_manager.crypto_storage.get_private_storage();
+        RealThresholdEpochManager::<
+            ram::RamStorage,
+            ram::RamStorage,
+            EmptyPrss,
+            SecureReshareSecretKeys,
+        >::destroy_epoch(
+            &epoch_id,
+            &epoch_manager.crypto_storage,
+            &epoch_manager.session_maker,
+        )
+        .await
+        .unwrap();
+
+        assert!(!epoch_manager.session_maker.epoch_exists(&epoch_id).await);
+
+        // Both the epoch data and the legacy combined PRSS must be gone, so nothing can revive the
+        // epoch on the next restart.
+        let priv_storage = priv_storage.lock().await;
+        assert!(
+            !priv_storage
+                .data_exists(&epoch_id.into(), &PrivDataType::EpochData.to_string())
+                .await
+                .unwrap(),
+            "EpochData must be deleted"
+        );
+        assert!(
+            !priv_storage
+                .data_exists(
+                    &epoch_id.into(),
+                    #[expect(deprecated)]
+                    &PrivDataType::PrssSetupCombined.to_string(),
+                )
+                .await
+                .unwrap(),
+            "legacy PrssSetupCombined must be deleted so migration cannot resurrect the epoch"
+        );
+    }
+
     #[tokio::test]
     async fn test_destroy_epoch_not_found() {
         let mut rng = AesRng::seed_from_u64(42);
@@ -2361,7 +2477,6 @@ pub(crate) mod tests {
 
         let nonexistent_epoch_id = EpochId::new_random(&mut rng);
 
-        let priv_storage = epoch_manager.crypto_storage.get_private_storage();
         let err = RealThresholdEpochManager::<
             ram::RamStorage,
             ram::RamStorage,
@@ -2369,8 +2484,7 @@ pub(crate) mod tests {
             SecureReshareSecretKeys,
         >::destroy_epoch(
             &nonexistent_epoch_id,
-            &[PrivDataType::FheKeyInfo],
-            &priv_storage,
+            &epoch_manager.crypto_storage,
             &epoch_manager.session_maker,
         )
         .await
@@ -2420,7 +2534,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let err = epoch_manager
-            .destroy_epoch_and_purge_cache(&epoch_id)
+            .destroy_epoch_with_lease(&epoch_id)
             .await
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
@@ -2443,7 +2557,7 @@ pub(crate) mod tests {
         // Success, failure, panic and task cancellation all drop this owned lease, allowing cleanup.
         drop(creation_lease);
         epoch_manager
-            .destroy_epoch_and_purge_cache(&epoch_id)
+            .destroy_epoch_with_lease(&epoch_id)
             .await
             .unwrap();
 
@@ -2458,6 +2572,253 @@ pub(crate) mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    /// Validates partial-failure in destroying MPC epoch:
+    /// If deleting the private data fails, retrying should be possible until success,
+    /// at which point all epoch Ids associated to the destroyed context should be returned.
+    #[tokio::test]
+    async fn test_destroy_epoch_partial_failure_is_retryable() {
+        let mut rng = AesRng::seed_from_u64(42);
+        // We only borrow the session maker; the storage below is a separate, fault-injecting one.
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+        let session_maker = &epoch_manager.session_maker;
+
+        let prss_setup_z128 = PRSSSetup::<ResiduePolyF4Z128>::new_testing_prss(vec![], vec![]);
+        let prss_setup_z64 = PRSSSetup::<ResiduePolyF4Z64>::new_testing_prss(vec![], vec![]);
+        let epoch = EpochData {
+            context_id: *DEFAULT_MPC_CONTEXT,
+            prss: PRSSSetupCombined {
+                prss_setup_z128,
+                prss_setup_z64,
+                num_parties: 4,
+                threshold: 1,
+            },
+        };
+
+        // Target epoch to destroy plus a "keeper" so the target is not the last remaining epoch.
+        let epoch_id = EpochId::new_random(&mut rng);
+        let keeper_epoch_id = EpochId::new_random(&mut rng);
+        session_maker.add_epoch(epoch_id, epoch.clone()).await;
+        session_maker
+            .add_epoch(keeper_epoch_id, epoch.clone())
+            .await;
+
+        // Fault-injecting private storage that we can flip between failing and succeeding on delete.
+        let crypto_storage = ThresholdCryptoMaterialStorage::new(
+            RamStorage::new(),
+            FailingRamStorage::new(100),
+            None,
+            HashMap::new(),
+        );
+        let priv_storage = crypto_storage.get_private_storage();
+
+        let data_type = PrivDataType::FheKeyInfo;
+        let data = TestType { i: 42 };
+        let data_id = derive_request_id("partial_failure_data").unwrap();
+        let epoch_data_id: RequestId = epoch_id.into();
+
+        {
+            let mut guard = priv_storage.lock().await;
+            store_versioned_at_request_and_epoch_id(
+                &mut (*guard),
+                &data_id,
+                &epoch_id,
+                &data,
+                &data_type.to_string(),
+            )
+            .await
+            .unwrap();
+            // The EpochData acts as the durable retry marker that resurrects the epoch on restart.
+            store_versioned_at_request_id(
+                &mut (*guard),
+                &epoch_data_id,
+                &epoch,
+                &PrivDataType::EpochData.to_string(),
+            )
+            .await
+            .unwrap();
+            // Make every delete fail to simulate a partial failure mid-destruction.
+            guard.set_fail_deletes(true);
+        }
+
+        // First attempt: deletion fails, so the whole operation must fail.
+        let err = RealThresholdEpochManager::<
+            ram::RamStorage,
+            FailingRamStorage,
+            EmptyPrss,
+            SecureReshareSecretKeys,
+        >::destroy_epoch(&epoch_id, &crypto_storage, session_maker)
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Internal);
+
+        // The epoch must still be present so the caller can retry, and the keeper must be untouched.
+        assert!(
+            session_maker.epoch_exists(&epoch_id).await,
+            "epoch must remain in the session maker after a failed destruction"
+        );
+        assert!(session_maker.epoch_exists(&keeper_epoch_id).await);
+
+        // Both the key share and the durable EpochData retry marker must still be on disk.
+        {
+            let guard = priv_storage.lock().await;
+            let ids = guard
+                .all_data_ids_at_epoch(&epoch_id, &data_type.to_string())
+                .await
+                .unwrap();
+            assert!(
+                ids.contains(&data_id),
+                "key share must survive a failed destruction so it can be retried"
+            );
+            assert!(
+                guard
+                    .data_exists(&epoch_data_id, &PrivDataType::EpochData.to_string())
+                    .await
+                    .unwrap(),
+                "EpochData retry marker must not be deleted while other data still lingers on disk"
+            );
+        }
+
+        // Now let deletes succeed and retry: the operation must now complete and clean everything up.
+        priv_storage.lock().await.set_fail_deletes(false);
+        RealThresholdEpochManager::<
+            ram::RamStorage,
+            FailingRamStorage,
+            EmptyPrss,
+            SecureReshareSecretKeys,
+        >::destroy_epoch(&epoch_id, &crypto_storage, session_maker)
+        .await
+        .unwrap();
+
+        // The retry succeeded: epoch gone, keeper remains, and all on-disk data is cleared.
+        assert!(!session_maker.epoch_exists(&epoch_id).await);
+        assert!(session_maker.epoch_exists(&keeper_epoch_id).await);
+        {
+            let guard = priv_storage.lock().await;
+            let ids = guard
+                .all_data_ids_at_epoch(&epoch_id, &data_type.to_string())
+                .await
+                .unwrap();
+            assert!(ids.is_empty());
+            assert!(
+                !guard
+                    .data_exists(&epoch_data_id, &PrivDataType::EpochData.to_string())
+                    .await
+                    .unwrap()
+            );
+        }
+    }
+
+    /// The public key material of a key carries no epoch in its storage path, hence it belongs to
+    /// every epoch of that key. A reshare that fails to store its shares must therefore keep that
+    /// material, and delete the private material of the new epoch only.
+    /// This test validates a fix of a bug found in E2E test on 0.14.x
+    #[tokio::test]
+    async fn test_failed_reshare_keeps_public_key_material() {
+        let mut rng = AesRng::seed_from_u64(45);
+        let epoch_manager = make_epoch_manager::<EmptyPrss>(&mut rng).await;
+        let crypto_storage = &epoch_manager.crypto_storage;
+
+        let new_epoch_id = EpochId::new_random(&mut rng);
+        let key_id = derive_request_id("reshared_key").unwrap();
+        let preproc_id = derive_request_id("reshared_key_preproc").unwrap();
+
+        {
+            let public_storage = crypto_storage.inner.get_public_storage();
+            let mut guard = public_storage.lock().await;
+            for public_type in PubDataType::iter() {
+                store_versioned_at_request_id(
+                    &mut (*guard),
+                    &key_id,
+                    &TestType { i: 7 },
+                    &public_type.to_string(),
+                )
+                .await
+                .unwrap();
+            }
+        }
+
+        // Occupy the slot that the reshare writes its shares to, which makes the reshare fail and
+        // roll the new epoch back. The duplicate check only tests for presence, hence the content of
+        // the slot is irrelevant.
+        {
+            let private_storage = crypto_storage.get_private_storage();
+            let mut guard = private_storage.lock().await;
+            store_versioned_at_request_and_epoch_id(
+                &mut (*guard),
+                &key_id,
+                &new_epoch_id,
+                &TestType { i: 42 },
+                &PrivDataType::FheKeyInfo.to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let (_keyset, compressed_keyset) =
+            gen_key_set(crate::consts::TEST_PARAM, tfhe::Tag::default(), &mut rng).unwrap();
+        let sk = epoch_manager.base_kms.sig_key().unwrap();
+        let res = RealThresholdEpochManager::<
+            RamStorage,
+            RamStorage,
+            EmptyPrss,
+            SecureReshareSecretKeys,
+        >::store_reshared_keys(
+            crypto_storage,
+            &epoch_manager.session_maker,
+            &sk,
+            &[SigningSchemeType::Ecdsa256k1],
+            new_epoch_id,
+            vec![],
+            &make_verified_previous_epoch(
+                *DEFAULT_EPOCH_ID,
+                &key_id,
+                &preproc_id,
+                crate::consts::TEST_PARAM,
+            ),
+            vec![VerifiedPublicMaterial::Compressed(compressed_keyset)],
+            vec![PrivateKeySet::init_dummy(crate::consts::TEST_PARAM)],
+            &dummy_domain(),
+            vec![],
+        )
+        .await;
+        assert!(
+            res.unwrap_err()
+                .to_string()
+                .contains("Failed to store all reshared keys for new epoch 8b4803c41504a7acc9a59ebfb4838379f2b50c3ba0dd4a0b984bd7e566ab1b56: [Err(Duplicate)]")
+        );
+
+        {
+            let public_storage = crypto_storage.inner.get_public_storage();
+            let guard = public_storage.lock().await;
+            // Validate that no public material of the key was deleted.
+            for public_type in PubDataType::iter() {
+                assert!(
+                    guard
+                        .data_exists(&key_id, &public_type.to_string())
+                        .await
+                        .unwrap(),
+                    "{public_type} of key {key_id} must survive a failed reshare"
+                );
+            }
+        }
+
+        // The rollback ran: the private material of the new epoch is gone.
+        {
+            let private_storage = crypto_storage.get_private_storage();
+            let guard = private_storage.lock().await;
+            assert!(
+                !guard
+                    .data_exists_at_epoch(
+                        &key_id,
+                        &new_epoch_id,
+                        &PrivDataType::FheKeyInfo.to_string()
+                    )
+                    .await
+                    .unwrap()
+            );
+        }
     }
 
     #[tokio::test]

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -1121,8 +1121,7 @@ impl<
     /// Destroys an epoch by removing all private data stored under the given epoch, dropping its
     /// entries from the key cache, and then removing the epoch from the session maker.
     ///
-    /// The epoch must exist and must not be the last epoch on the node. A rejected precondition
-    /// leaves the epoch untouched, cache included.
+    /// The epoch must exist. A rejected precondition leaves the epoch untouched, cache included.
     ///
     /// In case of any error during the deletion of private data, the epoch will not be removed from the session maker,
     /// and an error will be returned. This allows the caller to retry the operation until it succeeds.
@@ -1137,18 +1136,6 @@ impl<
                 Some((*epoch_id).into()),
                 anyhow::anyhow!("Epoch ID {} does not exist", epoch_id),
                 tonic::Code::NotFound,
-            ));
-        }
-
-        if session_maker.epoch_count().await < 2 {
-            return Err(MetricedError::new(
-                OP_DESTROY_EPOCH,
-                Some((*epoch_id).into()),
-                anyhow::anyhow!(
-                    "Cannot destroy epoch ID {} because it is the only epoch remaining",
-                    epoch_id
-                ),
-                tonic::Code::FailedPrecondition,
             ));
         }
 
@@ -1456,11 +1443,10 @@ impl<
             // Attempt to destroy every epoch even if an earlier one fails, but keep the first failure to return so the
             // caller learns that some shares may remain and can retry. Later failures are logged via their own
             // `MetricedError` drop handling.
-            if let Err(e) = self.destroy_epoch_with_lease(epoch_id).await {
-                if first_error.is_none() {
-                    first_error = Some(e);
-                }
-                continue;
+            if let Err(e) = self.destroy_epoch_with_lease(epoch_id).await
+                && first_error.is_none()
+            {
+                first_error = Some(e);
             }
         }
 
@@ -2436,7 +2422,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let err = epoch_manager
-            .destroy_epoch_and_purge_cache(&epoch_id)
+            .destroy_epoch_with_lease(&epoch_id)
             .await
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
@@ -2459,7 +2445,7 @@ pub(crate) mod tests {
         // Success, failure, panic and task cancellation all drop this owned lease, allowing cleanup.
         drop(creation_lease);
         epoch_manager
-            .destroy_epoch_and_purge_cache(&epoch_id)
+            .destroy_epoch_with_lease(&epoch_id)
             .await
             .unwrap();
 

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -1,7 +1,8 @@
 // === Standard Library ===
 use std::{
     collections::{HashMap, hash_map::Entry},
-    sync::Arc,
+    hash::Hash,
+    sync::{Arc, Weak},
 };
 
 use crate::{
@@ -35,12 +36,13 @@ use rand::{RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
 use tfhe::Versionize;
 use tfhe_versionable::VersionsDispatch;
+use thiserror::Error;
 use threshold_types::session_id::SessionId;
 use threshold_types::{
     network::NetworkMode,
     party::{Identity, MpcIdentity, RoleAssignment},
 };
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 use tonic::Code;
 
 struct Context {
@@ -76,11 +78,81 @@ impl tfhe::named::Named for PRSSSetupCombined {
 
 type ContextMap = HashMap<ContextId, Context>;
 
+/// Hands out one lock per ID, keyed by the identifier type of the guarded resource.
+///
+/// Weak entries ensure rejected requests for random IDs do not grow the registry forever.
+/// The owned lock guards taken by the callers keep their lock alive for exactly the lifecycle
+/// operation.
+#[derive(Clone)]
+struct LockRegistry<Id> {
+    locks: Arc<Mutex<HashMap<Id, Weak<RwLock<()>>>>>,
+}
+
+// Hand-written because `#[derive(Default)]` would add a spurious `Id: Default` bound.
+impl<Id> Default for LockRegistry<Id> {
+    fn default() -> Self {
+        Self {
+            locks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl<Id: Copy + Eq + Hash> LockRegistry<Id> {
+    async fn lock(&self, id: &Id) -> Arc<RwLock<()>> {
+        let mut locks = self.locks.lock().await;
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(id).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        let lock = Arc::new(RwLock::new(()));
+        locks.insert(*id, Arc::downgrade(&lock));
+        lock
+    }
+}
+
+#[derive(Clone, Default)]
+struct LifecycleCoordinator {
+    context_locks: LockRegistry<ContextId>,
+    epoch_locks: LockRegistry<EpochId>,
+}
+
+/// Identifies the lifecycle resource that is already held by a conflicting operation.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub(crate) enum LifecycleConflict {
+    /// A context is being destroyed while an epoch creation wants to use it, or vice versa.
+    #[error("MPC context {0} has a conflicting lifecycle operation in progress")]
+    Context(ContextId),
+    /// An epoch is being created while it is being destroyed, or vice versa.
+    #[error("epoch {0} has a conflicting lifecycle operation in progress")]
+    Epoch(EpochId),
+}
+
+/// Keeps an epoch creation mutually exclusive with destruction of its epoch and context.
+#[derive(Debug)]
+pub(crate) struct EpochCreationLease {
+    _context: OwnedRwLockReadGuard<()>,
+    _epoch: OwnedRwLockReadGuard<()>,
+}
+
+/// Prevents epoch creation for a context while that context and its epochs are destroyed.
+#[derive(Debug)]
+pub(crate) struct ContextDestructionLease {
+    _context: OwnedRwLockWriteGuard<()>,
+}
+
+/// Prevents creation of an epoch while that epoch is destroyed.
+#[derive(Debug)]
+pub(crate) struct EpochDestructionLease {
+    _epoch: OwnedRwLockWriteGuard<()>,
+}
+
 #[derive(Clone)]
 pub(crate) struct SessionMaker {
     networking_manager: Arc<RwLock<GrpcNetworkingManager>>,
     context_map: Arc<RwLock<ContextMap>>,
     epoch_map: Arc<RwLock<HashMap<EpochId, PRSSSetupCombined>>>,
+    lifecycle: LifecycleCoordinator,
     verifier: Option<Arc<AttestedVerifier>>, // optional as it's not used when there's no TLS
     rng: Arc<Mutex<AesRng>>,
 }
@@ -148,9 +220,67 @@ impl SessionMaker {
             networking_manager,
             context_map: Arc::new(RwLock::new(HashMap::new())),
             epoch_map: Arc::new(RwLock::new(HashMap::new())),
+            lifecycle: LifecycleCoordinator::default(),
             verifier,
             rng: Arc::new(Mutex::new(rng)),
         }
+    }
+
+    /// Reserve `context_id` and `epoch_id` for an epoch creation.
+    ///
+    /// The returned lease must live until the creation task has finished every persistent write.
+    /// Destruction uses exclusive leases for the same IDs and therefore fails while this lease is
+    /// alive.
+    pub(crate) async fn try_get_epoch_creation_lease(
+        &self,
+        context_id: &ContextId,
+        epoch_id: &EpochId,
+    ) -> Result<EpochCreationLease, LifecycleConflict> {
+        let context = self.lifecycle.context_locks.lock(context_id).await;
+        let context = context
+            .try_read_owned()
+            .map_err(|_| LifecycleConflict::Context(*context_id))?;
+
+        let epoch = self.lifecycle.epoch_locks.lock(epoch_id).await;
+        let epoch = epoch
+            .try_read_owned()
+            .map_err(|_| LifecycleConflict::Epoch(*epoch_id))?;
+
+        Ok(EpochCreationLease {
+            _context: context,
+            _epoch: epoch,
+        })
+    }
+
+    /// Exclusively reserve a context for destruction.
+    ///
+    /// The caller must retain the lease while taking the epoch snapshot, deleting every associated
+    /// epoch, and deleting the context itself. Acquiring it fails while an epoch creation for this
+    /// context is in flight.
+    pub(crate) async fn try_get_context_destruction_lease(
+        &self,
+        context_id: &ContextId,
+    ) -> Result<ContextDestructionLease, LifecycleConflict> {
+        let context = self.lifecycle.context_locks.lock(context_id).await;
+        let context = context
+            .try_write_owned()
+            .map_err(|_| LifecycleConflict::Context(*context_id))?;
+        Ok(ContextDestructionLease { _context: context })
+    }
+
+    /// Exclusively reserve an epoch for destruction.
+    ///
+    /// Acquiring this lease fails while creation of the same epoch is in flight. The caller must
+    /// retain it through all storage and cache deletion.
+    pub(crate) async fn try_get_epoch_destruction_lease(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<EpochDestructionLease, LifecycleConflict> {
+        let epoch = self.lifecycle.epoch_locks.lock(epoch_id).await;
+        let epoch = epoch
+            .try_write_owned()
+            .map_err(|_| LifecycleConflict::Epoch(*epoch_id))?;
+        Ok(EpochDestructionLease { _epoch: epoch })
     }
 
     /// Returns the number of active sessions.
@@ -183,6 +313,7 @@ impl SessionMaker {
             networking_manager,
             context_map: Arc::new(RwLock::new(HashMap::new())),
             epoch_map: Arc::new(RwLock::new(HashMap::new())),
+            lifecycle: LifecycleCoordinator::default(),
             verifier: None,
             rng: Arc::new(Mutex::new(rng)),
         }
@@ -240,6 +371,7 @@ impl SessionMaker {
                 Some(prss) => HashMap::from_iter([(*epoch_id, prss)]),
                 None => HashMap::new(),
             })),
+            lifecycle: LifecycleCoordinator::default(),
             verifier: None,
             rng: Arc::new(Mutex::new(rng)),
         }
@@ -790,6 +922,16 @@ pub(crate) struct ImmutableSessionMaker {
 }
 
 impl ImmutableSessionMaker {
+    /// Exclusively reserve a context while its epochs and context metadata are destroyed.
+    pub(crate) async fn try_start_context_destruction(
+        &self,
+        context_id: &ContextId,
+    ) -> Result<ContextDestructionLease, LifecycleConflict> {
+        self.inner
+            .try_get_context_destruction_lease(context_id)
+            .await
+    }
+
     #[allow(dead_code)]
     pub(crate) async fn context_exists(&self, context_id: &ContextId) -> bool {
         self.inner.context_exists(context_id).await
@@ -936,4 +1078,103 @@ pub(crate) async fn validate_context_and_epoch(
         ));
     }
     Ok(my_role)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An epoch creation is visible to lifecycle coordination before it is registered in
+    /// `epoch_map`, so neither its context nor its epoch can be destroyed in that window.
+    #[tokio::test]
+    async fn epoch_creation_lease_blocks_matching_destruction_only() {
+        let mut rng = AesRng::seed_from_u64(6);
+        let session_maker = SessionMaker::empty_dummy_session(AesRng::seed_from_u64(7));
+        let context_id = ContextId::new_random(&mut rng);
+        let epoch_id = EpochId::new_random(&mut rng);
+        let endpoint_session_maker = session_maker.make_immutable();
+
+        let creation = session_maker
+            .try_get_epoch_creation_lease(&context_id, &epoch_id)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            endpoint_session_maker
+                .try_start_context_destruction(&context_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Context(context_id)
+        );
+        assert_eq!(
+            session_maker
+                .try_get_epoch_destruction_lease(&epoch_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Epoch(epoch_id)
+        );
+
+        // Unrelated lifecycle operations remain independent.
+        let other_context_id = ContextId::new_random(&mut rng);
+        let other_epoch_id = EpochId::new_random(&mut rng);
+        endpoint_session_maker
+            .try_start_context_destruction(&other_context_id)
+            .await
+            .unwrap();
+        session_maker
+            .try_get_epoch_destruction_lease(&other_epoch_id)
+            .await
+            .unwrap();
+
+        drop(creation);
+        endpoint_session_maker
+            .try_start_context_destruction(&context_id)
+            .await
+            .unwrap();
+        session_maker
+            .try_get_epoch_destruction_lease(&epoch_id)
+            .await
+            .unwrap();
+    }
+
+    /// Whichever destructive operation acquires its exclusive lease first prevents a conflicting
+    /// epoch creation from beginning until that lease is released.
+    #[tokio::test]
+    async fn destruction_leases_block_epoch_creation_until_drop() {
+        let mut rng = AesRng::seed_from_u64(8);
+        let session_maker = SessionMaker::empty_dummy_session(AesRng::seed_from_u64(9));
+        let context_id = ContextId::new_random(&mut rng);
+        let epoch_id = EpochId::new_random(&mut rng);
+
+        let context_destruction = session_maker
+            .try_get_context_destruction_lease(&context_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            session_maker
+                .try_get_epoch_creation_lease(&context_id, &epoch_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Context(context_id)
+        );
+        drop(context_destruction);
+
+        let epoch_destruction = session_maker
+            .try_get_epoch_destruction_lease(&epoch_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            session_maker
+                .try_get_epoch_creation_lease(&context_id, &epoch_id)
+                .await
+                .unwrap_err(),
+            LifecycleConflict::Epoch(epoch_id)
+        );
+        drop(epoch_destruction);
+
+        session_maker
+            .try_get_epoch_creation_lease(&context_id, &epoch_id)
+            .await
+            .unwrap();
+    }
 }

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -300,6 +300,7 @@ impl SessionMaker {
         self.context_map.read().await.len()
     }
 
+    #[cfg(test)]
     pub(crate) async fn epoch_count(&self) -> usize {
         self.epoch_map.read().await.len()
     }

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -300,7 +300,6 @@ impl SessionMaker {
         self.context_map.read().await.len()
     }
 
-    #[cfg(test)]
     pub(crate) async fn epoch_count(&self) -> usize {
         self.epoch_map.read().await.len()
     }

--- a/core/service/src/vault/storage/mod.rs
+++ b/core/service/src/vault/storage/mod.rs
@@ -413,23 +413,6 @@ pub async fn delete_at_request_and_epoch_id<S: StorageExt>(
     }
 }
 
-/// Helper method to remove public key given a request ID.
-pub async fn delete_pk_at_request_id<S: Storage>(
-    storage: &mut S,
-    request_id: &RequestId,
-) -> anyhow::Result<()> {
-    delete_at_request_id(storage, request_id, &PubDataType::PublicKey.to_string()).await?;
-    // Best-effort delete of legacy PublicKeyMetadata (ignore errors if not found)
-    #[allow(deprecated)]
-    let _ = delete_at_request_id(
-        storage,
-        request_id,
-        &PubDataType::PublicKeyMetadata.to_string(),
-    )
-    .await;
-    Ok(())
-}
-
 /// Read some data stored in a location defined by `request_id` and `data_type`.
 /// The returned result is automatically unversioned.
 pub async fn read_versioned_at_request_id<


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->
Backports the fix in https://github.com/zama-ai/kms/pull/792

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->
NOTE: has to be merged after https://github.com/zama-ai/kms/pull/795

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
