### PR TITLE
fix: fix metrics for perf testing

### DIFF
--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -213,9 +213,10 @@ jobs:
           NAMESPACE: 'kms-ci'
           KMS_CHART_VERSION: ${{ inputs.kms_chart_version || 'repository' }}
           TKMS_INFRA_CHART_VERSION: ${{ inputs.tkms_infra_chart_version || '0.3.2' }}
-          # Metrics are collected on the nightly only; workflow_dispatch is already
-          # at the 10-input limit, so there is no knob to opt a manual run in.
-          ENABLE_KMS_METRICS: ${{ github.event_name == 'schedule' }}
+          # No dispatch input: the workflow is already at GitHub's 10-input
+          # limit. Enable on both schedule and workflow_dispatch so a branch
+          # run can verify scrape/remote-write without waiting for the nightly.
+          ENABLE_KMS_METRICS: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
           {
             echo "ENABLE_KMS_METRICS=${ENABLE_KMS_METRICS}"

--- a/ci/scripts/lib/common.sh
+++ b/ci/scripts/lib/common.sh
@@ -49,10 +49,12 @@ Options:
   --enable-tls             Explicitly enable TLS (default for threshold mode)
   --disable-tls            Explicitly disable TLS (overrides default for threshold mode)
   --enable-metrics         Expose KMS metrics to Prometheus. On kind, installs
-                           kube-prometheus-stack and remote-writes to Grafana Cloud
-                           (reads GRAFANA_CLOUD_PROM_* from env). On aws targets,
-                           only enables the kms-core ServiceMonitor and lets the
-                           cluster's own Prometheus scrape it.
+                           kube-prometheus-stack, prefixes metric names with ci_,
+                           and remote-writes to Grafana Cloud (reads
+                           GRAFANA_CLOUD_PROM_* from env). On aws targets, only
+                           enables the kms-core ServiceMonitor (unprefixed names;
+                           distinguish by namespace) and lets the cluster's own
+                           Prometheus scrape it.
   --tracing-endpoint <url> Enable kms-core tracing and send OTLP traces to <url>
                            (e.g. http://jaeger:4317; default: disabled)
   --debug                  Enable debug logging (port-forward logs to ./logs/port-forward/)

--- a/ci/scripts/lib/kms_deployment.sh
+++ b/ci/scripts/lib/kms_deployment.sh
@@ -215,8 +215,7 @@ deploy_threshold_mode() {
 
         # Enable the ServiceMonitor (scraped by kube-prometheus-stack). Kind CI
         # prefixes names with ci_ so Grafana Cloud can keep them apart from
-        # production. aws-perf rides the cluster Prometheus, whose remote-write
-        # keep list only matches kms_.+ — leave names unprefixed and tell the
+        # production. For aws-perf we remove the prefix and tell the
         # run apart with namespace=kms-ci.
         if [[ "${ENABLE_METRICS:-false}" == "true" ]]; then
             HELM_ARGS+=(

--- a/ci/scripts/lib/kms_deployment.sh
+++ b/ci/scripts/lib/kms_deployment.sh
@@ -213,14 +213,20 @@ deploy_threshold_mode() {
             log_info "TLS enabled for threshold mode (target: ${TARGET})"
         fi
 
-        # Enable the ServiceMonitor (scraped by kube-prometheus-stack) and
-        # prefix metric names with ci_ so the central Prometheus can separate
-        # CI metrics from production series.
+        # Enable the ServiceMonitor (scraped by kube-prometheus-stack). Kind CI
+        # prefixes names with ci_ so Grafana Cloud can keep them apart from
+        # production. aws-perf rides the cluster Prometheus, whose remote-write
+        # keep list only matches kms_.+ — leave names unprefixed and tell the
+        # run apart with namespace=kms-ci.
         if [[ "${ENABLE_METRICS:-false}" == "true" ]]; then
             HELM_ARGS+=(
                 --set kmsCore.serviceMonitor.enabled=true
-                --set kmsCore.serviceMonitor.metricNamePrefix=ci_
             )
+            if [[ "${TARGET}" == *"kind"* ]]; then
+                HELM_ARGS+=(
+                    --set kmsCore.serviceMonitor.metricNamePrefix=ci_
+                )
+            fi
         fi
 
         # Enable OTLP tracing export when an endpoint is provided.
@@ -400,12 +406,16 @@ deploy_centralized_mode() {
         --set kmsCoreClient.nameOverride="kms-core-client"
     )
 
-    # Same ServiceMonitor / ci_ metric-prefix enablement as threshold mode.
+    # Same ServiceMonitor enablement as threshold mode (ci_ prefix on kind only).
     if [[ "${ENABLE_METRICS:-false}" == "true" ]]; then
         HELM_ARGS+=(
             --set kmsCore.serviceMonitor.enabled=true
-            --set kmsCore.serviceMonitor.metricNamePrefix=ci_
         )
+        if [[ "${TARGET}" == *"kind"* ]]; then
+            HELM_ARGS+=(
+                --set kmsCore.serviceMonitor.metricNamePrefix=ci_
+            )
+        fi
     fi
 
     # Enable OTLP tracing export when an endpoint is provided.

--- a/docs/developer/metrics.md
+++ b/docs/developer/metrics.md
@@ -303,7 +303,9 @@ Conventions:
   by `init_enclave.sh` from a config sent over vsock, so it never sees the parent container's
   `KMS_METRICS_LABELS`. Distinguish enclave deployments by their `namespace` label instead — that one
   is attached by Prometheus at scrape time. (The nightly `aws-perf` run does exactly this,
-  `namespace="kms-ci"`.)
+  `namespace="kms-ci"`. It does **not** apply the `ci_` metric-name prefix: the cluster
+  Prometheus remote-write keep list only matches `kms_.+`, so prefixed names would never
+  reach Grafana Cloud. Query the existing KMS dashboard with `namespace="kms-ci"`.)
 - The threshold and centralized matrices deploy to separate namespaces (`kms-test-threshold` /
   `kms-test-centralized`, from the CI `DEPLOYMENT_TYPE`), so their metrics are already told apart by
   Prometheus' `namespace` label — there is no `deployment_type` const-label. You could add one via


### PR DESCRIPTION
## Description
Change metrics for perf testing
We only keep `kms_ci_` prefix for kind-testing

### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
