### PR TITLE
chore: reduce copying in algebra

### DIFF
--- a/core/experiments/benches/algebra.rs
+++ b/core/experiments/benches/algebra.rs
@@ -36,7 +36,8 @@ fn bench_lagrange_poly(c: &mut Criterion) {
 
         group.bench_function(BenchmarkId::new("lagrange_mem", p_str.clone()), |b| {
             b.iter(|| {
-                let interpolated = lagrange_interpolation_with_polys(&lagrange_polys, &ys);
+                let interpolated =
+                    lagrange_interpolation_with_polys(&lagrange_polys, ys.iter().copied());
                 assert_eq!(interpolated.unwrap().eval(&LevelOne::from_u128(0)), secret);
             });
         });

--- a/core/threshold-algebra/Cargo.toml
+++ b/core/threshold-algebra/Cargo.toml
@@ -44,3 +44,11 @@ harness = false
 [[bench]]
 name = "syndrome"
 harness = false
+
+[[bench]]
+name = "reconstruction"
+harness = false
+
+[[bench]]
+name = "gao_decoding"
+harness = false

--- a/core/threshold-algebra/benches/gao_decoding.rs
+++ b/core/threshold-algebra/benches/gao_decoding.rs
@@ -1,0 +1,95 @@
+//! Benchmarks Gao decoding's honest fast path and its partial extended-GCD error path.
+//!
+//! Run with `cargo bench -p threshold-algebra --bench gao_decoding`.
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+use threshold_algebra::{
+    galois_fields::gf256::GF256,
+    poly::{Poly, gao_decoding, gao_decoding_with_field_hints, lagrange_polynomials},
+    structure_traits::RingWithExceptionalSequence,
+};
+use threshold_types::role::Role;
+
+fn bench_gao_decoding(c: &mut Criterion) {
+    const NUM_POINTS: usize = 13;
+    const K: usize = 5;
+    const MAX_ERRORS: usize = 4;
+
+    let message = Poly::from_coefs(
+        (1..=K)
+            .map(|coefficient| GF256::from(coefficient as u8))
+            .collect(),
+    );
+    let points: Vec<_> = (1..=NUM_POINTS)
+        .map(|party| {
+            GF256::embed_role_to_exceptional_sequence(&Role::indexed_from_one(party)).unwrap()
+        })
+        .collect();
+    let lagrange_polys = lagrange_polynomials(&points);
+    let vanishing_poly = points
+        .iter()
+        .fold(Poly::from_coefs(vec![GF256::from(1)]), |product, point| {
+            product * Poly::from_coefs(vec![GF256::from(0) - *point, GF256::from(1)])
+        });
+
+    let mut group = c.benchmark_group("gao_decoding/n13_k5");
+    for error_count in [0, 1, MAX_ERRORS] {
+        let mut values: Vec<_> = points.iter().map(|point| message.eval(point)).collect();
+        for (index, value) in values.iter_mut().take(error_count).enumerate() {
+            *value += GF256::from((index + 1) as u8);
+        }
+
+        assert_eq!(
+            gao_decoding(&points, &values, K, MAX_ERRORS).unwrap(),
+            message
+        );
+        assert_eq!(
+            gao_decoding_with_field_hints(
+                &points,
+                &values,
+                K,
+                MAX_ERRORS,
+                &lagrange_polys,
+                &vanishing_poly,
+            )
+            .unwrap(),
+            message
+        );
+
+        group.bench_function(
+            BenchmarkId::new("without_hints", format!("e{error_count}")),
+            |b| {
+                b.iter(|| {
+                    black_box(
+                        gao_decoding(black_box(&points), black_box(&values), K, MAX_ERRORS)
+                            .unwrap(),
+                    )
+                });
+            },
+        );
+        group.bench_function(
+            BenchmarkId::new("with_hints", format!("e{error_count}")),
+            |b| {
+                b.iter(|| {
+                    black_box(
+                        gao_decoding_with_field_hints(
+                            black_box(&points),
+                            black_box(&values),
+                            K,
+                            MAX_ERRORS,
+                            black_box(&lagrange_polys),
+                            black_box(&vanishing_poly),
+                        )
+                        .unwrap(),
+                    )
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(gao_decoding_benches, bench_gao_decoding);
+criterion_main!(gao_decoding_benches);

--- a/core/threshold-algebra/benches/gao_decoding.rs
+++ b/core/threshold-algebra/benches/gao_decoding.rs
@@ -41,13 +41,13 @@ fn bench_gao_decoding(c: &mut Criterion) {
         }
 
         assert_eq!(
-            gao_decoding(&points, &values, K, MAX_ERRORS).unwrap(),
+            gao_decoding(&points, values.iter().copied(), K, MAX_ERRORS).unwrap(),
             message
         );
         assert_eq!(
             gao_decoding_with_field_hints(
                 &points,
-                &values,
+                values.iter().copied(),
                 K,
                 MAX_ERRORS,
                 &lagrange_polys,
@@ -62,8 +62,13 @@ fn bench_gao_decoding(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     black_box(
-                        gao_decoding(black_box(&points), black_box(&values), K, MAX_ERRORS)
-                            .unwrap(),
+                        gao_decoding(
+                            black_box(&points),
+                            black_box(&values).iter().copied(),
+                            K,
+                            MAX_ERRORS,
+                        )
+                        .unwrap(),
                     )
                 });
             },
@@ -75,7 +80,7 @@ fn bench_gao_decoding(c: &mut Criterion) {
                     black_box(
                         gao_decoding_with_field_hints(
                             black_box(&points),
-                            black_box(&values),
+                            black_box(&values).iter().copied(),
                             K,
                             MAX_ERRORS,
                             black_box(&lagrange_polys),

--- a/core/threshold-algebra/benches/reconstruction.rs
+++ b/core/threshold-algebra/benches/reconstruction.rs
@@ -1,0 +1,147 @@
+//! Benchmarks Galois-ring reconstruction across every supported extension degree.
+//!
+//! Run with `cargo bench -p threshold-algebra --bench reconstruction`.
+
+use aes_prng::AesRng;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use rand::SeedableRng;
+use std::hint::black_box;
+use threshold_algebra::{
+    error_correction::ReconstructionHints,
+    galois_rings::{
+        degree_3::{ResiduePolyF3Z64, ResiduePolyF3Z128},
+        degree_4::{ResiduePolyF4Z64, ResiduePolyF4Z128},
+        degree_5::{ResiduePolyF5Z64, ResiduePolyF5Z128},
+        degree_6::{ResiduePolyF6Z64, ResiduePolyF6Z128},
+        degree_7::{ResiduePolyF7Z64, ResiduePolyF7Z128},
+        degree_8::{ResiduePolyF8Z64, ResiduePolyF8Z128},
+    },
+    sharing::shamir::{InputOp, RevealOp, ShamirSharings},
+    structure_traits::Sample,
+};
+
+macro_rules! benchmark_honest_reconstruction {
+    ($group:expr, $ring:ty, $ring_name:literal, $parameters:expr) => {
+        for &(num_parties, threshold) in $parameters {
+            let mut rng = AesRng::seed_from_u64(42);
+            let secret = <$ring>::sample(&mut rng);
+            let sharing = ShamirSharings::share(&mut rng, secret, num_parties, threshold).unwrap();
+            let hints = ReconstructionHints::new(&sharing, threshold).unwrap();
+
+            assert_eq!(
+                sharing
+                    .error_reconstruct_with_hints(threshold, threshold, &hints)
+                    .unwrap(),
+                secret
+            );
+
+            $group.bench_function(
+                BenchmarkId::new($ring_name, format!("n{num_parties}_t{threshold}")),
+                |b| {
+                    b.iter(|| {
+                        black_box(
+                            sharing
+                                .error_reconstruct_with_hints(
+                                    threshold,
+                                    threshold,
+                                    black_box(&hints),
+                                )
+                                .unwrap(),
+                        )
+                    });
+                },
+            );
+        }
+    };
+}
+
+fn bench_honest_reconstruction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("reconstruction_with_hints");
+
+    // Four parties fit every exceptional sequence, including GF(2^3). This gives each specialized
+    // BitWiseEval implementation a directly comparable benchmark for both base-ring sizes.
+    let small = &[(4, 1)];
+    benchmark_honest_reconstruction!(group, ResiduePolyF3Z64, "f3z64", small);
+    benchmark_honest_reconstruction!(group, ResiduePolyF3Z128, "f3z128", small);
+    benchmark_honest_reconstruction!(group, ResiduePolyF4Z64, "f4z64", small);
+    benchmark_honest_reconstruction!(group, ResiduePolyF4Z128, "f4z128", small);
+    benchmark_honest_reconstruction!(group, ResiduePolyF5Z64, "f5z64", small);
+    benchmark_honest_reconstruction!(group, ResiduePolyF5Z128, "f5z128", small);
+    benchmark_honest_reconstruction!(group, ResiduePolyF6Z64, "f6z64", small);
+    benchmark_honest_reconstruction!(group, ResiduePolyF6Z128, "f6z128", small);
+    benchmark_honest_reconstruction!(group, ResiduePolyF7Z64, "f7z64", small);
+    benchmark_honest_reconstruction!(group, ResiduePolyF7Z128, "f7z128", small);
+    benchmark_honest_reconstruction!(group, ResiduePolyF8Z64, "f8z64", small);
+    benchmark_honest_reconstruction!(group, ResiduePolyF8Z128, "f8z128", small);
+
+    // Keep the original production-sized F4Z128 case from PR #650 and cover both word sizes for
+    // F8, which previously lived only in the experiments crate.
+    let production_sized = &[(13, 4)];
+    benchmark_honest_reconstruction!(group, ResiduePolyF4Z128, "f4z128", production_sized);
+    benchmark_honest_reconstruction!(group, ResiduePolyF8Z64, "f8z64", production_sized);
+    benchmark_honest_reconstruction!(group, ResiduePolyF8Z128, "f8z128", production_sized);
+
+    group.finish();
+}
+
+fn bench_reconstruction_with_errors(c: &mut Criterion) {
+    const NUM_PARTIES: usize = 13;
+    const THRESHOLD: usize = 4;
+
+    let mut group = c.benchmark_group("reconstruction_with_errors/f4z128/n13_t4");
+
+    for error_count in [1, THRESHOLD] {
+        let mut rng = AesRng::seed_from_u64(42);
+        let secret = ResiduePolyF4Z128::sample(&mut rng);
+        let mut sharing = ShamirSharings::share(&mut rng, secret, NUM_PARTIES, THRESHOLD).unwrap();
+        for share in sharing.shares.iter_mut().take(error_count) {
+            *share += ResiduePolyF4Z128::sample(&mut rng);
+        }
+        let hints = ReconstructionHints::new(&sharing, THRESHOLD).unwrap();
+
+        assert_eq!(
+            sharing.error_reconstruct(THRESHOLD, THRESHOLD).unwrap(),
+            secret
+        );
+        assert_eq!(
+            sharing
+                .error_reconstruct_with_hints(THRESHOLD, THRESHOLD, &hints)
+                .unwrap(),
+            secret
+        );
+
+        group.bench_function(
+            BenchmarkId::new("without_hints", format!("e{error_count}")),
+            |b| {
+                b.iter(|| {
+                    black_box(
+                        black_box(&sharing)
+                            .error_reconstruct(THRESHOLD, THRESHOLD)
+                            .unwrap(),
+                    )
+                });
+            },
+        );
+        group.bench_function(
+            BenchmarkId::new("with_hints", format!("e{error_count}")),
+            |b| {
+                b.iter(|| {
+                    black_box(
+                        black_box(&sharing)
+                            .error_reconstruct_with_hints(THRESHOLD, THRESHOLD, black_box(&hints))
+                            .unwrap(),
+                    )
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    reconstruction,
+    bench_honest_reconstruction,
+    bench_reconstruction_with_errors
+);
+criterion_main!(reconstruction);

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -292,13 +292,18 @@ where
             }
         }
         let num_new_bot = initial_length - xs.len();
+        let remaining_max_errors = max_errorsors.checked_sub(num_new_bot).ok_or_else(|| {
+            anyhow_error_and_log(format!(
+                "Too many shares evicted during error correction: {num_new_bot} evicted at iteration {bit_idx} exceeds the maximum of {max_errorsors} correctable errors"
+            ))
+        })?;
 
         // fi(X) = a0 + ... a_t * X^t where a0 is the secret bit corresponding to position i.
         let fi_mod2 = gao_decoding_from_values(
             &xs,
             binary_share_values(&shares_with_validity, bit_idx),
             degree + 1,
-            max_errorsors - num_new_bot,
+            remaining_max_errors,
         )?;
 
         let _evicted = apply_bit_correction(
@@ -388,6 +393,11 @@ where
             .filter(|(_, is_valid)| *is_valid)
             .count();
         let num_new_bot = initial_length - num_valid;
+        let remaining_max_errors = max_errorsors.checked_sub(num_new_bot).ok_or_else(|| {
+            anyhow_error_and_log(format!(
+                "Too many shares evicted during error correction: {num_new_bot} evicted at iteration {bit_idx} exceeds the maximum of {max_errorsors} correctable errors"
+            ))
+        })?;
 
         let fi_mod2 = if !validity_changed {
             // All parties still valid — use the precomputed field hints.
@@ -395,7 +405,7 @@ where
                 &hints.field_hints.embedded_points,
                 binary_share_values(&shares_with_validity, bit_idx),
                 degree + 1,
-                max_errorsors - num_new_bot,
+                remaining_max_errors,
                 &hints.field_hints.lagrange_polys,
                 &hints.field_hints.vanishing_poly,
             )?
@@ -414,7 +424,7 @@ where
                 &fallback_field_hints.embedded_points,
                 binary_share_values(&shares_with_validity, bit_idx),
                 degree + 1,
-                max_errorsors - num_new_bot,
+                remaining_max_errors,
                 &fallback_field_hints.lagrange_polys,
                 &fallback_field_hints.vanishing_poly,
             )?

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -1,8 +1,8 @@
 use super::{
     galois_rings::common::{LutMulReduction, ResiduePoly},
     poly::{
-        BitWiseEval, BitWisePoly, Poly, gao_decoding_from_values,
-        gao_decoding_with_field_hints_from_values, lagrange_polynomials, vanishing_poly,
+        BitWiseEval, BitWisePoly, Poly, gao_decoding, gao_decoding_with_field_hints,
+        lagrange_polynomials, vanishing_poly,
     },
     structure_traits::{
         BaseRing, ErrorCorrect, Field, QuotientMaximalIdeal, RingWithExceptionalSequence,
@@ -299,7 +299,7 @@ where
         })?;
 
         // fi(X) = a0 + ... a_t * X^t where a0 is the secret bit corresponding to position i.
-        let fi_mod2 = gao_decoding_from_values(
+        let fi_mod2 = gao_decoding(
             &xs,
             binary_share_values(&shares_with_validity, bit_idx),
             degree + 1,
@@ -401,7 +401,7 @@ where
 
         let fi_mod2 = if !validity_changed {
             // All parties still valid — use the precomputed field hints.
-            gao_decoding_with_field_hints_from_values(
+            gao_decoding_with_field_hints(
                 &hints.field_hints.embedded_points,
                 binary_share_values(&shares_with_validity, bit_idx),
                 degree + 1,
@@ -420,7 +420,7 @@ where
                 fallback_field_hints = Some(FieldHints::new(&valid_parties)?);
             }
             let fallback_field_hints = fallback_field_hints.as_ref().unwrap();
-            gao_decoding_with_field_hints_from_values(
+            gao_decoding_with_field_hints(
                 &fallback_field_hints.embedded_points,
                 binary_share_values(&shares_with_validity, bit_idx),
                 degree + 1,
@@ -502,7 +502,7 @@ pub fn error_correction<F: Field>(
         .map(|s| F::embed_role_to_exceptional_sequence(&s.owner()))
         .try_collect()?;
     // call Gao decoding with the shares as points/values, set Gao parameter k = v = degree+1
-    gao_decoding_from_values(
+    gao_decoding(
         &xs,
         shares.into_iter().map(Share::take_value),
         degree + 1,
@@ -520,7 +520,7 @@ pub fn error_correction_with_field_hints<F: Field>(
     max_errorsors: usize,
     field_hints: &FieldHints<F>,
 ) -> anyhow::Result<ShamirFieldPoly<F>> {
-    gao_decoding_with_field_hints_from_values(
+    gao_decoding_with_field_hints(
         &field_hints.embedded_points,
         shares.iter().map(Share::value),
         degree + 1,

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -1,8 +1,8 @@
 use super::{
     galois_rings::common::{LutMulReduction, ResiduePoly},
     poly::{
-        BitWiseEval, Poly, gao_decoding, gao_decoding_with_field_hints, lagrange_polynomials,
-        vanishing_poly,
+        BitWiseEval, BitWisePoly, Poly, gao_decoding_from_values,
+        gao_decoding_with_field_hints_from_values, lagrange_polynomials, vanishing_poly,
     },
     structure_traits::{
         BaseRing, ErrorCorrect, Field, QuotientMaximalIdeal, RingWithExceptionalSequence,
@@ -13,7 +13,7 @@ use error_utils::anyhow_error_and_log;
 use super::sharing::shamir::ShamirFieldPoly;
 use super::sharing::shamir::ShamirSharings;
 use super::sharing::share::Share;
-use crate::{matrix::compute_powers_list, poly::BitwisePoly};
+use crate::matrix::compute_powers_list;
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::sync::RwLock;
@@ -155,31 +155,6 @@ impl<Z: ErrorCorrect> ReconstructionHints<Z> {
     }
 }
 
-/// Per-value scratch buffers reused across the Hensel-lift bit-loop of `shamir_error_correct*`.
-///
-/// The loop runs `Z::BIT_LENGTH` (64/128) iterations per reconstructed value, each rebuilding the
-/// same-shaped temporaries. Allocating these once per value and `clear`ing (not freeing) between
-/// bits keeps each buffer's capacity warm, turning per-bit allocations into per-value ones.
-struct ReconScratch<F: Field> {
-    /// `compute_binary_shares` output: the bit-`i` projection of every still-valid share.
-    binary_shares: Vec<Share<F>>,
-    /// `error_correction_with_field_hints` y-values (share values fed to Gao decoding).
-    ys: Vec<F>,
-    /// `apply_bit_correction` byte view of the error-corrected bit polynomial.
-    bitwise: BitwisePoly,
-}
-
-impl<F: Field> ReconScratch<F> {
-    /// Empty buffers; each grows to its working size on the first bit and is reused thereafter.
-    fn new() -> Self {
-        Self {
-            binary_shares: Vec::new(),
-            ys: Vec::new(),
-            bitwise: BitwisePoly::default(),
-        }
-    }
-}
-
 /// Lifts binary polynomial p to the big ring and accumulates 2^amount * p into res
 fn accumulate_and_lift_bitwise_poly<Z: BaseRing, const EXTENSION_DEGREE: usize>(
     res: &mut Poly<ResiduePoly<Z, EXTENSION_DEGREE>>,
@@ -199,26 +174,23 @@ fn accumulate_and_lift_bitwise_poly<Z: BaseRing, const EXTENSION_DEGREE: usize>(
     }
 }
 
-/// Compose the `bit_idx`-th bit of every still-valid share into the reconstruction
-/// (quotient) field, writing the result into `out` (cleared first, capacity reused).
-/// Shared by the hinted and non-hinted Hensel lift.
-fn compute_binary_shares<Z: BaseRing, const EXTENSION_DEGREE: usize>(
-    shares_with_validity: &[(Share<ResiduePoly<Z, EXTENSION_DEGREE>>, bool)],
+/// Stream the `bit_idx`-th bit of every still-valid share into the quotient field.
+fn binary_share_values<'a, Z: BaseRing, const EXTENSION_DEGREE: usize>(
+    shares_with_validity: &'a [(Share<ResiduePoly<Z, EXTENSION_DEGREE>>, bool)],
     bit_idx: usize,
-    out: &mut Vec<
-        Share<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>,
-    >,
-) where
+) -> impl Iterator<Item = <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput> + 'a
+where
     ResiduePoly<Z, EXTENSION_DEGREE>: QuotientMaximalIdeal,
 {
-    out.clear();
-    out.extend(shares_with_validity.iter().filter_map(|(sh, is_valid)| {
-        if *is_valid {
-            Some(Share::new(sh.owner(), sh.value().bit_compose(bit_idx)))
-        } else {
-            None
-        }
-    }));
+    shares_with_validity
+        .iter()
+        .filter_map(move |(sh, is_valid)| {
+            if *is_valid {
+                Some(sh.value().bit_compose(bit_idx))
+            } else {
+                None
+            }
+        })
 }
 
 /// One Hensel-lift correction step shared by the hinted and non-hinted reconstruction:
@@ -232,17 +204,16 @@ fn apply_bit_correction<Z: BaseRing, const EXTENSION_DEGREE: usize>(
     fi_mod2: &Poly<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>,
     bit_idx: usize,
     res: &mut Poly<ResiduePoly<Z, EXTENSION_DEGREE>>,
-    bitwise: &mut BitwisePoly,
 ) -> Vec<Role>
 where
     ResiduePoly<Z, EXTENSION_DEGREE>: MemoizedExceptionals,
     ResiduePoly<Z, EXTENSION_DEGREE>: RingWithExceptionalSequence,
     ResiduePoly<Z, EXTENSION_DEGREE>: QuotientMaximalIdeal,
     ResiduePoly<Z, EXTENSION_DEGREE>: LutMulReduction<Z>,
-    BitwisePoly: BitWiseEval<Z, EXTENSION_DEGREE>,
+    for<'a> BitWisePoly<'a, <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>:
+        BitWiseEval<Z, EXTENSION_DEGREE>,
 {
-    // Reuse the caller's scratch buffer
-    bitwise.overwrite_from_poly(fi_mod2);
+    let bitwise = BitWisePoly::from(fi_mod2);
     let mut evicted = Vec::new();
     // remove the LSBs computed from error correction in the quotient field
     for (j, (share, is_valid)) in shares_with_validity.iter_mut().enumerate() {
@@ -276,7 +247,8 @@ where
     ResiduePoly<Z, EXTENSION_DEGREE>: RingWithExceptionalSequence,
     ResiduePoly<Z, EXTENSION_DEGREE>: QuotientMaximalIdeal,
     ResiduePoly<Z, EXTENSION_DEGREE>: LutMulReduction<Z>,
-    BitwisePoly: BitWiseEval<Z, EXTENSION_DEGREE>,
+    for<'a> BitWisePoly<'a, <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>:
+        BitWiseEval<Z, EXTENSION_DEGREE>,
 {
     let ring_size: usize = Z::BIT_LENGTH;
 
@@ -284,16 +256,15 @@ where
     let mut shares_with_validity = sharing
         .shares
         .iter()
-        .map(|x| (*x, true))
+        .map(|share| (*share, true))
         .collect::<Vec<_>>();
 
     let initial_length = shares_with_validity.len();
 
     // Exceptional powers fetched (per party) from the memoized store.
-    let parties: Vec<_> = sharing
-        .shares
+    let parties: Vec<_> = shares_with_validity
         .iter()
-        .map(|x| x.owner().one_based())
+        .map(|(share, _)| share.owner().one_based())
         .collect();
     let ordered_powers: Vec<Vec<ResiduePoly<Z, EXTENSION_DEGREE>>> = parties
         .iter()
@@ -305,20 +276,28 @@ where
     #[cfg(test)]
     let mut all_evicted: Vec<(Role, usize)> = Vec::new();
 
-    // Buffers reused across every bit of this reconstruction (see `ReconScratch`). The
-    // non-hinted path doesn't use `scratch.ys` (it calls the owned-`Vec` `error_correction`).
-    let mut scratch = ReconScratch::new();
+    // Only the public evaluation points are materialized. Secret bit projections stream directly
+    // from the residual shares into interpolation.
+    let mut xs = Vec::with_capacity(initial_length);
 
     for bit_idx in 0..ring_size {
-        // z = pi(y/2^i), Bots filtered out
-        compute_binary_shares(&shares_with_validity, bit_idx, &mut scratch.binary_shares);
-        let num_new_bot = initial_length - scratch.binary_shares.len();
+        xs.clear();
+        for (share, is_valid) in &shares_with_validity {
+            if *is_valid {
+                xs.push(
+                    <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput::embed_role_to_exceptional_sequence(
+                        &share.owner(),
+                    )?,
+                );
+            }
+        }
+        let num_new_bot = initial_length - xs.len();
 
         // fi(X) = a0 + ... a_t * X^t where a0 is the secret bit corresponding to position i.
-        // Cold path: `error_correction` consumes an owned `Vec`, so we clone the scratch buffer.
-        let fi_mod2 = error_correction(
-            scratch.binary_shares.clone(),
-            degree,
+        let fi_mod2 = gao_decoding_from_values(
+            &xs,
+            binary_share_values(&shares_with_validity, bit_idx),
+            degree + 1,
             max_errorsors - num_new_bot,
         )?;
 
@@ -328,7 +307,6 @@ where
             &fi_mod2,
             bit_idx,
             &mut res,
-            &mut scratch.bitwise,
         );
         #[cfg(test)]
         all_evicted.extend(_evicted.into_iter().map(|owner| (owner, bit_idx)));
@@ -360,7 +338,10 @@ where
     ResiduePoly<Z, EXTENSION_DEGREE>: RingWithExceptionalSequence,
     ResiduePoly<Z, EXTENSION_DEGREE>: QuotientMaximalIdeal,
     ResiduePoly<Z, EXTENSION_DEGREE>: LutMulReduction<Z>,
-    BitwisePoly: BitWiseEval<Z, EXTENSION_DEGREE>,
+    for<'a> BitWisePoly<
+        'a,
+        <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput,
+    >: BitWiseEval<Z, EXTENSION_DEGREE>,
 {
     if hints.degree != degree {
         return Err(anyhow_error_and_log(format!(
@@ -382,7 +363,7 @@ where
     let mut shares_with_validity = sharing
         .shares
         .iter()
-        .map(|x| (*x, true))
+        .map(|share| (*share, true))
         .collect::<Vec<_>>();
 
     let initial_length = shares_with_validity.len();
@@ -400,22 +381,23 @@ where
         FieldHints<<ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>,
     > = None;
 
-    // Buffers reused across every bit of this reconstruction (see `ReconScratch`).
-    let mut scratch = ReconScratch::new();
-
     // Loop over each bit (64 or 128, depending on the Ring)
     for bit_idx in 0..ring_size {
-        compute_binary_shares(&shares_with_validity, bit_idx, &mut scratch.binary_shares);
-        let num_new_bot = initial_length - scratch.binary_shares.len();
+        let num_valid = shares_with_validity
+            .iter()
+            .filter(|(_, is_valid)| *is_valid)
+            .count();
+        let num_new_bot = initial_length - num_valid;
 
         let fi_mod2 = if !validity_changed {
             // All parties still valid — use the precomputed field hints.
-            error_correction_with_field_hints(
-                &scratch.binary_shares,
-                degree,
+            gao_decoding_with_field_hints_from_values(
+                &hints.field_hints.embedded_points,
+                binary_share_values(&shares_with_validity, bit_idx),
+                degree + 1,
                 max_errorsors - num_new_bot,
-                &hints.field_hints,
-                &mut scratch.ys,
+                &hints.field_hints.lagrange_polys,
+                &hints.field_hints.vanishing_poly,
             )?
         } else {
             // Some parties were evicted — recompute field hints for the new valid set
@@ -427,12 +409,14 @@ where
                     .collect();
                 fallback_field_hints = Some(FieldHints::new(&valid_parties)?);
             }
-            error_correction_with_field_hints(
-                &scratch.binary_shares,
-                degree,
+            let fallback_field_hints = fallback_field_hints.as_ref().unwrap();
+            gao_decoding_with_field_hints_from_values(
+                &fallback_field_hints.embedded_points,
+                binary_share_values(&shares_with_validity, bit_idx),
+                degree + 1,
                 max_errorsors - num_new_bot,
-                fallback_field_hints.as_ref().unwrap(),
-                &mut scratch.ys,
+                &fallback_field_hints.lagrange_polys,
+                &fallback_field_hints.vanishing_poly,
             )?
         };
 
@@ -442,7 +426,6 @@ where
             &fi_mod2,
             bit_idx,
             &mut res,
-            &mut scratch.bitwise,
         );
         if !evicted.is_empty() {
             validity_changed = true;
@@ -460,7 +443,8 @@ where
     ResiduePoly<Z, EXTENSION_DEGREE>: RingWithExceptionalSequence,
     ResiduePoly<Z, EXTENSION_DEGREE>: QuotientMaximalIdeal,
     ResiduePoly<Z, EXTENSION_DEGREE>: LutMulReduction<Z>,
-    BitwisePoly: BitWiseEval<Z, EXTENSION_DEGREE>,
+    for<'a> BitWisePoly<'a, <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput>:
+        BitWiseEval<Z, EXTENSION_DEGREE>,
 {
     type ReconstructionField =
         <ResiduePoly<Z, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput;
@@ -507,32 +491,28 @@ pub fn error_correction<F: Field>(
         .iter()
         .map(|s| F::embed_role_to_exceptional_sequence(&s.owner()))
         .try_collect()?;
-    let ys: Vec<F> = shares.into_iter().map(|s| s.take_value()).collect();
-
     // call Gao decoding with the shares as points/values, set Gao parameter k = v = degree+1
-    gao_decoding(&xs, &ys, degree + 1, max_errorsors)
+    gao_decoding_from_values(
+        &xs,
+        shares.into_iter().map(Share::take_value),
+        degree + 1,
+        max_errorsors,
+    )
 }
 
 /// Like [`error_correction`] but reuses precomputed [`FieldHints`] to avoid redundant
 /// embedding, Lagrange polynomial, and vanishing polynomial computations.
 ///
 /// `field_hints` must have been built from the same __ordered list__ of parties that own the `shares`.
-// `ys` is a scratch buffer only. If decoding fails, callers must not rely on its contents.
-#[allow(unknown_lints)] // `non_local_effect_before_error_return` is a dylint-only lint
-#[allow(non_local_effect_before_error_return)]
 pub fn error_correction_with_field_hints<F: Field>(
     shares: &[Share<F>],
     degree: usize,
     max_errorsors: usize,
     field_hints: &FieldHints<F>,
-    ys: &mut Vec<F>,
 ) -> anyhow::Result<ShamirFieldPoly<F>> {
-    ys.clear();
-    ys.extend(shares.iter().map(|s| s.value()));
-
-    gao_decoding_with_field_hints(
+    gao_decoding_with_field_hints_from_values(
         &field_hints.embedded_points,
-        ys,
+        shares.iter().map(Share::value),
         degree + 1,
         max_errorsors,
         &field_hints.lagrange_polys,
@@ -564,7 +544,7 @@ mod tests {
         error_correction::{error_correction, shamir_error_correct},
         galois_fields::gf16::GF16,
         galois_rings::common::{LutMulReduction, ResiduePoly},
-        poly::{BitWiseEval, BitwisePoly},
+        poly::{BitWiseEval, BitWisePoly},
         sharing::{
             shamir::{InputOp, ShamirFieldPoly, ShamirSharings},
             share::Share,
@@ -612,7 +592,10 @@ mod tests {
         ResiduePoly<Z64, EXTENSION_DEGREE>: RingWithExceptionalSequence,
         ResiduePoly<Z64, EXTENSION_DEGREE>: QuotientMaximalIdeal,
         ResiduePoly<Z64, EXTENSION_DEGREE>: LutMulReduction<Z64>,
-        BitwisePoly: BitWiseEval<Z64, EXTENSION_DEGREE>,
+        for<'a> BitWisePoly<
+            'a,
+            <ResiduePoly<Z64, EXTENSION_DEGREE> as QuotientMaximalIdeal>::QuotientOutput,
+        >: BitWiseEval<Z64, EXTENSION_DEGREE>,
     {
         let num_parties = 4;
         let threshold = 1;
@@ -709,10 +692,8 @@ mod tests {
 
         let parties = shares.iter().map(|s| s.owner()).collect::<Vec<_>>();
         let hints = FieldHints::new(&parties).unwrap();
-        let mut ys = Vec::new();
         let secret_poly_with_hints =
-            error_correction_with_field_hints(&shares, threshold, max_errors, &hints, &mut ys)
-                .unwrap();
+            error_correction_with_field_hints(&shares, threshold, max_errors, &hints).unwrap();
         assert_eq!(secret_poly_with_hints, f);
     }
 

--- a/core/threshold-algebra/src/galois_rings/degree_3.rs
+++ b/core/threshold-algebra/src/galois_rings/degree_3.rs
@@ -1,6 +1,4 @@
 use anyhow::anyhow;
-use itertools::EitherOrBoth::{Both, Left, Right};
-use itertools::Itertools;
 use std::{
     collections::HashMap,
     num::Wrapping,
@@ -14,7 +12,7 @@ use crate::{
     error_correction::MemoizedExceptionals,
     galois_fields::gf8::{GF8, GF8_FROM_GENERATOR},
     matrix::compute_powers,
-    poly::{BitWiseEval, BitwisePoly},
+    poly::{BitWiseEval, BitWisePoly, bitwise_eval_coefficients},
     structure_traits::{
         BaseRing, One, QuotientMaximalIdeal, Ring, RingWithExceptionalSequence, Solve1, ZConsts,
         Zero,
@@ -265,38 +263,14 @@ impl MemoizedExceptionals for ResiduePolyF3Z128 {
     }
 }
 
-impl<Z> BitWiseEval<Z, 3> for BitwisePoly
+impl<Z, F> BitWiseEval<Z, 3> for BitWisePoly<'_, F>
 where
     Z: Zero + for<'a> AddAssign<&'a Z> + Copy + Clone,
+    F: Copy + Into<u8>,
     ResiduePoly<Z, 3>: LutMulReduction<Z>,
 {
     fn lazy_eval(&self, powers: &[ResiduePolyF3<Z>]) -> ResiduePolyF3<Z> {
-        let mut res_coefs = [Z::ZERO; 5];
-        // now we go through each
-        for pair in self.coefs().iter().zip_longest(powers) {
-            match pair {
-                Both(coef_2, coef_r) => {
-                    for bit_idx in 0..3 {
-                        if ((coef_2 >> bit_idx) & 1) == 1 {
-                            for (j, cr) in coef_r.coefs.iter().enumerate() {
-                                res_coefs[j + bit_idx] += cr;
-                            }
-                        }
-                    }
-                }
-                Right(_coef_r) => {
-                    // The coefficient is 0 so the result will not change
-                }
-                Left(_coef_2) => {
-                    // There are not enough powers supplied in the call, this can only happen in case of a bug
-                    panic!(
-                        "Not enough powers supplied for bitwise evaluation. Only {:?} are supplied but {:?} are needed.",
-                        powers.len(),
-                        self.coefs().len()
-                    );
-                }
-            }
-        }
+        let res_coefs = bitwise_eval_coefficients::<Z, _, 3, 5>(self.coefs(), powers);
         ResiduePolyF3::<Z>::reduce_mul(&res_coefs)
     }
 }

--- a/core/threshold-algebra/src/galois_rings/degree_4.rs
+++ b/core/threshold-algebra/src/galois_rings/degree_4.rs
@@ -1,6 +1,4 @@
 use anyhow::anyhow;
-use itertools::EitherOrBoth::{Both, Left, Right};
-use itertools::Itertools;
 use std::{
     collections::HashMap,
     num::Wrapping,
@@ -14,7 +12,7 @@ use crate::{
     error_correction::MemoizedExceptionals,
     galois_fields::gf16::{GF16, GF16_FROM_GENERATOR, GF16_NEWTON_INNER_LOOP, two_powers},
     matrix::compute_powers,
-    poly::{BitWiseEval, BitwisePoly},
+    poly::{BitWiseEval, BitWisePoly, bitwise_eval_coefficients},
     structure_traits::{
         BaseRing, One, QuotientMaximalIdeal, Ring, RingWithExceptionalSequence, Solve1, ZConsts,
         Zero,
@@ -269,38 +267,14 @@ impl MemoizedExceptionals for ResiduePolyF4Z128 {
     }
 }
 
-impl<Z> BitWiseEval<Z, 4> for BitwisePoly
+impl<Z, F> BitWiseEval<Z, 4> for BitWisePoly<'_, F>
 where
     Z: Zero + for<'a> AddAssign<&'a Z> + Copy + Clone,
+    F: Copy + Into<u8>,
     ResiduePoly<Z, 4>: LutMulReduction<Z>,
 {
     fn lazy_eval(&self, powers: &[ResiduePolyF4<Z>]) -> ResiduePolyF4<Z> {
-        let mut res_coefs = [Z::ZERO; 7];
-        // now we go through each
-        for pair in self.coefs().iter().zip_longest(powers) {
-            match pair {
-                Both(coef_2, coef_r) => {
-                    for bit_idx in 0..4 {
-                        if ((coef_2 >> bit_idx) & 1) == 1 {
-                            for (j, cr) in coef_r.coefs.iter().enumerate() {
-                                res_coefs[j + bit_idx] += cr;
-                            }
-                        }
-                    }
-                }
-                Right(_coef_r) => {
-                    // The coefficient is 0 so the result will not change
-                }
-                Left(_coef_2) => {
-                    // There are not enough powers supplied in the call, this can only happen in case of a bug
-                    panic!(
-                        "Not enough powers supplied for bitwise evaluation. Only {:?} are supplied but {:?} are needed.",
-                        powers.len(),
-                        self.coefs().len()
-                    );
-                }
-            }
-        }
+        let res_coefs = bitwise_eval_coefficients::<Z, _, 4, 7>(self.coefs(), powers);
         ResiduePolyF4::<Z>::reduce_mul(&res_coefs)
     }
 }

--- a/core/threshold-algebra/src/galois_rings/degree_5.rs
+++ b/core/threshold-algebra/src/galois_rings/degree_5.rs
@@ -1,6 +1,4 @@
 use anyhow::anyhow;
-use itertools::EitherOrBoth::{Both, Left, Right};
-use itertools::Itertools;
 use std::{
     collections::HashMap,
     num::Wrapping,
@@ -14,7 +12,7 @@ use crate::{
     error_correction::MemoizedExceptionals,
     galois_fields::gf32::{GF32, GF32_FROM_GENERATOR},
     matrix::compute_powers,
-    poly::{BitWiseEval, BitwisePoly},
+    poly::{BitWiseEval, BitWisePoly, bitwise_eval_coefficients},
     structure_traits::{
         BaseRing, One, QuotientMaximalIdeal, Ring, RingWithExceptionalSequence, Solve1, ZConsts,
         Zero,
@@ -274,38 +272,14 @@ impl MemoizedExceptionals for ResiduePolyF5Z128 {
     }
 }
 
-impl<Z> BitWiseEval<Z, 5> for BitwisePoly
+impl<Z, F> BitWiseEval<Z, 5> for BitWisePoly<'_, F>
 where
     Z: Zero + for<'a> AddAssign<&'a Z> + Copy + Clone,
+    F: Copy + Into<u8>,
     ResiduePoly<Z, 5>: LutMulReduction<Z>,
 {
     fn lazy_eval(&self, powers: &[ResiduePolyF5<Z>]) -> ResiduePolyF5<Z> {
-        let mut res_coefs = [Z::ZERO; 9];
-        // now we go through each
-        for pair in self.coefs().iter().zip_longest(powers) {
-            match pair {
-                Both(coef_2, coef_r) => {
-                    for bit_idx in 0..5 {
-                        if ((coef_2 >> bit_idx) & 1) == 1 {
-                            for (j, cr) in coef_r.coefs.iter().enumerate() {
-                                res_coefs[j + bit_idx] += cr;
-                            }
-                        }
-                    }
-                }
-                Right(_coef_r) => {
-                    // The coefficient is 0 so the result will not change
-                }
-                Left(_coef_2) => {
-                    // There are not enough powers supplied in the call, this can only happen in case of a bug
-                    panic!(
-                        "Not enough powers supplied for bitwise evaluation. Only {:?} are supplied but {:?} are needed.",
-                        powers.len(),
-                        self.coefs().len()
-                    );
-                }
-            }
-        }
+        let res_coefs = bitwise_eval_coefficients::<Z, _, 5, 9>(self.coefs(), powers);
         ResiduePolyF5::<Z>::reduce_mul(&res_coefs)
     }
 }

--- a/core/threshold-algebra/src/galois_rings/degree_6.rs
+++ b/core/threshold-algebra/src/galois_rings/degree_6.rs
@@ -1,6 +1,4 @@
 use anyhow::anyhow;
-use itertools::EitherOrBoth::{Both, Left, Right};
-use itertools::Itertools;
 use std::{
     collections::HashMap,
     num::Wrapping,
@@ -14,7 +12,7 @@ use crate::{
     error_correction::MemoizedExceptionals,
     galois_fields::gf64::{GF64, GF64_FROM_GENERATOR, GF64_NEWTON_INNER_LOOP, two_powers},
     matrix::compute_powers,
-    poly::{BitWiseEval, BitwisePoly},
+    poly::{BitWiseEval, BitWisePoly, bitwise_eval_coefficients},
     structure_traits::{
         BaseRing, One, QuotientMaximalIdeal, Ring, RingWithExceptionalSequence, Solve1, ZConsts,
         Zero,
@@ -278,38 +276,14 @@ impl MemoizedExceptionals for ResiduePolyF6Z128 {
     }
 }
 
-impl<Z> BitWiseEval<Z, 6> for BitwisePoly
+impl<Z, F> BitWiseEval<Z, 6> for BitWisePoly<'_, F>
 where
     Z: Zero + for<'a> AddAssign<&'a Z> + Copy + Clone,
+    F: Copy + Into<u8>,
     ResiduePoly<Z, 6>: LutMulReduction<Z>,
 {
     fn lazy_eval(&self, powers: &[ResiduePolyF6<Z>]) -> ResiduePolyF6<Z> {
-        let mut res_coefs = [Z::ZERO; 11];
-        // now we go through each
-        for pair in self.coefs().iter().zip_longest(powers) {
-            match pair {
-                Both(coef_2, coef_r) => {
-                    for bit_idx in 0..6 {
-                        if ((coef_2 >> bit_idx) & 1) == 1 {
-                            for (j, cr) in coef_r.coefs.iter().enumerate() {
-                                res_coefs[j + bit_idx] += cr;
-                            }
-                        }
-                    }
-                }
-                Right(_coef_r) => {
-                    // The coefficient is 0 so the result will not change
-                }
-                Left(_coef_2) => {
-                    // There are not enough powers supplied in the call, this can only happen in case of a bug
-                    panic!(
-                        "Not enough powers supplied for bitwise evaluation. Only {:?} are supplied but {:?} are needed.",
-                        powers.len(),
-                        self.coefs().len()
-                    );
-                }
-            }
-        }
+        let res_coefs = bitwise_eval_coefficients::<Z, _, 6, 11>(self.coefs(), powers);
         ResiduePolyF6::<Z>::reduce_mul(&res_coefs)
     }
 }

--- a/core/threshold-algebra/src/galois_rings/degree_7.rs
+++ b/core/threshold-algebra/src/galois_rings/degree_7.rs
@@ -1,6 +1,4 @@
 use anyhow::anyhow;
-use itertools::EitherOrBoth::{Both, Left, Right};
-use itertools::Itertools;
 use std::{
     collections::HashMap,
     num::Wrapping,
@@ -14,7 +12,7 @@ use crate::{
     error_correction::MemoizedExceptionals,
     galois_fields::gf128::{GF128, GF128_FROM_GENERATOR},
     matrix::compute_powers,
-    poly::{BitWiseEval, BitwisePoly},
+    poly::{BitWiseEval, BitWisePoly, bitwise_eval_coefficients},
     structure_traits::{
         BaseRing, One, QuotientMaximalIdeal, Ring, RingWithExceptionalSequence, Solve1, ZConsts,
         Zero,
@@ -284,38 +282,14 @@ impl MemoizedExceptionals for ResiduePolyF7Z128 {
     }
 }
 
-impl<Z> BitWiseEval<Z, 7> for BitwisePoly
+impl<Z, F> BitWiseEval<Z, 7> for BitWisePoly<'_, F>
 where
     Z: Zero + for<'a> AddAssign<&'a Z> + Copy + Clone,
+    F: Copy + Into<u8>,
     ResiduePoly<Z, 7>: LutMulReduction<Z>,
 {
     fn lazy_eval(&self, powers: &[ResiduePolyF7<Z>]) -> ResiduePolyF7<Z> {
-        let mut res_coefs = [Z::ZERO; 13];
-        // now we go through each
-        for pair in self.coefs().iter().zip_longest(powers) {
-            match pair {
-                Both(coef_2, coef_r) => {
-                    for bit_idx in 0..7 {
-                        if ((coef_2 >> bit_idx) & 1) == 1 {
-                            for (j, cr) in coef_r.coefs.iter().enumerate() {
-                                res_coefs[j + bit_idx] += cr;
-                            }
-                        }
-                    }
-                }
-                Right(_coef_r) => {
-                    // The coefficient is 0 so the result will not change
-                }
-                Left(_coef_2) => {
-                    // There are not enough powers supplied in the call, this can only happen in case of a bug
-                    panic!(
-                        "Not enough powers supplied for bitwise evaluation. Only {:?} are supplied but {:?} are needed.",
-                        powers.len(),
-                        self.coefs().len()
-                    );
-                }
-            }
-        }
+        let res_coefs = bitwise_eval_coefficients::<Z, _, 7, 13>(self.coefs(), powers);
         ResiduePolyF7::<Z>::reduce_mul(&res_coefs)
     }
 }

--- a/core/threshold-algebra/src/galois_rings/degree_8.rs
+++ b/core/threshold-algebra/src/galois_rings/degree_8.rs
@@ -1,6 +1,4 @@
 use anyhow::anyhow;
-use itertools::EitherOrBoth::{Both, Left, Right};
-use itertools::Itertools;
 use std::{
     collections::HashMap,
     num::Wrapping,
@@ -14,7 +12,7 @@ use crate::{
     error_correction::MemoizedExceptionals,
     galois_fields::gf256::{GF256, GF256_FROM_GENERATOR, GF256_NEWTON_INNER_LOOP, two_powers},
     matrix::compute_powers,
-    poly::{BitWiseEval, BitwisePoly},
+    poly::{BitWiseEval, BitWisePoly, bitwise_eval_coefficients},
     structure_traits::{
         BaseRing, One, QuotientMaximalIdeal, Ring, RingWithExceptionalSequence, Solve1, ZConsts,
         Zero,
@@ -360,38 +358,14 @@ impl MemoizedExceptionals for ResiduePolyF8Z128 {
     }
 }
 
-impl<Z> BitWiseEval<Z, 8> for BitwisePoly
+impl<Z, F> BitWiseEval<Z, 8> for BitWisePoly<'_, F>
 where
     Z: Zero + for<'a> AddAssign<&'a Z> + Copy + Clone,
+    F: Copy + Into<u8>,
     ResiduePoly<Z, 8>: LutMulReduction<Z>,
 {
     fn lazy_eval(&self, powers: &[ResiduePolyF8<Z>]) -> ResiduePolyF8<Z> {
-        let mut res_coefs = [Z::ZERO; 15];
-        // now we go through each
-        for pair in self.coefs().iter().zip_longest(powers) {
-            match pair {
-                Both(coef_2, coef_r) => {
-                    for bit_idx in 0..8 {
-                        if ((coef_2 >> bit_idx) & 1) == 1 {
-                            for (j, cr) in coef_r.coefs.iter().enumerate() {
-                                res_coefs[j + bit_idx] += cr;
-                            }
-                        }
-                    }
-                }
-                Right(_coef_r) => {
-                    // The coefficient is 0 so the result will not change
-                }
-                Left(_coef_2) => {
-                    // There are not enough powers supplied in the call, this can only happen in case of a bug
-                    panic!(
-                        "Not enough powers supplied for bitwise evaluation. Only {:?} are supplied but {:?} are needed.",
-                        powers.len(),
-                        self.coefs().len()
-                    );
-                }
-            }
-        }
+        let res_coefs = bitwise_eval_coefficients::<Z, _, 8, 15>(self.coefs(), powers);
         ResiduePolyF8::<Z>::reduce_mul(&res_coefs)
     }
 }

--- a/core/threshold-algebra/src/poly.rs
+++ b/core/threshold-algebra/src/poly.rs
@@ -48,6 +48,11 @@ where
 }
 
 /// Generic implementation of [BitWiseEval::lazy_eval].
+///
+/// Each coefficient is a `GF(2^EXTENSION_DEGREE)` element packed into a `u8`, so `EXTENSION_DEGREE`
+/// is at most 8. The result is the unreduced product of two polynomials with `EXTENSION_DEGREE`
+/// coefficients each, so `PRODUCT_LENGTH` is at least `2 * EXTENSION_DEGREE - 1`. Both bounds are
+/// checked at compile time.
 pub(crate) fn bitwise_eval_coefficients<
     Z,
     F,
@@ -70,10 +75,18 @@ where
         coefs.len()
     );
 
-    debug_assert!(
-        EXTENSION_DEGREE <= u8::BITS as usize,
-        "bitwise_eval_coefficients requires EXTENSION_DEGREE <= 8 (coefficients are stored in a u8)"
-    );
+    const {
+        assert!(
+            EXTENSION_DEGREE <= u8::BITS as usize,
+            "bitwise_eval_coefficients requires EXTENSION_DEGREE <= 8 (coefficients are stored in a u8)"
+        );
+        // `result[power_idx + bit_idx]` below reaches index `2 * EXTENSION_DEGREE - 2` at most,
+        // because both `power_idx` and `bit_idx` are below `EXTENSION_DEGREE`.
+        assert!(
+            PRODUCT_LENGTH >= 2 * EXTENSION_DEGREE - 1,
+            "bitwise_eval_coefficients requires PRODUCT_LENGTH >= 2 * EXTENSION_DEGREE - 1"
+        );
+    }
 
     let mut result = [Z::ZERO; PRODUCT_LENGTH];
     for (coef, power) in coefs.iter().zip(powers) {
@@ -298,6 +311,16 @@ where
         Poly {
             // an empty polynomial is considered zero
             coefs: vec![],
+        }
+    }
+
+    /// Returns the zero polynomial with space reserved for `capacity` coefficients.
+    ///
+    /// Unlike [`Poly::zeros`], the result is compressed. The reserved space lets in-place updates
+    /// grow the polynomial up to `capacity` coefficients without a reallocation.
+    pub(crate) fn zero_with_capacity(capacity: usize) -> Self {
+        Poly {
+            coefs: Vec::with_capacity(capacity),
         }
     }
 
@@ -574,33 +597,36 @@ fn quo_rem<F: Field>(a: Poly<F>, b: &Poly<F>) -> (Poly<F>, Poly<F>) {
 
 /// Replace `remainder` with `remainder mod divisor` and write the corresponding quotient into
 /// `quotient`, reusing both allocations.
+///
+/// Panics when `divisor` is zero, which is a bug in the caller.
 fn quo_rem_assign<F: Field>(remainder: &mut Poly<F>, divisor: &Poly<F>, quotient: &mut Poly<F>) {
+    assert!(!divisor.is_zero(), "division by 0 in quo_rem");
+
     let remainder_len = remainder.deg() + 1;
     let divisor_len = divisor.deg() + 1;
 
-    if divisor_len == 1 && divisor.coef(0) == F::ZERO {
-        panic!("division by 0 in quo_rem");
-    }
-
-    // Clear every previously live quotient coefficient before changing its logical length. This
-    // also ensures stale coefficients cannot affect a shorter quotient in a later EEA round.
-    quotient.coefs.fill(F::ZERO);
-    if remainder_len == 1 && remainder.coef(0) == F::ZERO {
+    // A zero remainder, or one of lower degree than the divisor, is already reduced and has a zero
+    // quotient. The zero remainder needs its own check because its `coefs` can be empty, which the
+    // loop below cannot index.
+    let remainder_is_zero = remainder_len == 1 && remainder.coef(0) == F::ZERO;
+    if remainder_is_zero || remainder_len < divisor_len {
         quotient.coefs.clear();
-        remainder.coefs.clear();
+        remainder.compress();
         return;
     }
 
-    let quotient_len = remainder_len.saturating_sub(divisor_len) + 1;
+    // Schoolbook long division, from the highest quotient coefficient down. In round `i` the leading
+    // term of the remainder is `remainder[i + deg(divisor)] * X^(i + deg(divisor))`. Dividing that
+    // coefficient by the leading coefficient of the divisor gives `quotient[i]`, and subtracting
+    // `quotient[i] * X^i * divisor` cancels the leading term. Every quotient coefficient is written,
+    // so no stale value from a previous call survives.
+    let quotient_len = remainder_len - divisor_len + 1;
     quotient.coefs.resize(quotient_len, F::ZERO);
-
-    if remainder_len >= divisor_len {
-        let inverse_leading = divisor.highest_coefficient().invert();
-        for i in (0..=(remainder_len - divisor_len)).rev() {
-            quotient.coefs[i] = remainder.coefs[i + divisor_len - 1] * inverse_leading;
-            for j in 0..divisor_len {
-                remainder.coefs[i + j] -= quotient.coefs[i] * divisor.coefs[j];
-            }
+    let inverse_leading = divisor.highest_coefficient().invert();
+    for i in (0..quotient_len).rev() {
+        quotient.coefs[i] = remainder.coefs[i + divisor_len - 1] * inverse_leading;
+        for j in 0..divisor_len {
+            remainder.coefs[i + j] -= quotient.coefs[i] * divisor.coefs[j];
         }
     }
     quotient.compress();
@@ -723,44 +749,28 @@ mod lagrange_basis_tests {
     }
 }
 
-/// interpolate a polynomial through coordinates where points holds the x-coordinates and values holds the y-coordinates
-pub fn lagrange_interpolation<F: Field>(points: &[F], values: &[F]) -> anyhow::Result<Poly<F>> {
-    lagrange_interpolation_from_values(points, values.iter().copied())
-}
-
-/// Like [`lagrange_interpolation`] but with the y-coordinates streamed instead of materialized.
+/// Interpolates the polynomial through the x-coordinates `points` and the y-coordinates `values`.
 ///
-/// Uses the memoized Lagrange basis for `points` when one is available, otherwise builds it.
-pub(crate) fn lagrange_interpolation_from_values<F, I>(
-    points: &[F],
-    values: I,
-) -> anyhow::Result<Poly<F>>
+/// `values` is consumed as a stream and must yield exactly one value per point. Uses the memoized
+/// Lagrange basis for `points` when one is available, otherwise builds it.
+pub fn lagrange_interpolation<F, I>(points: &[F], values: I) -> anyhow::Result<Poly<F>>
 where
     F: Field,
     I: IntoIterator<Item = F>,
 {
     if let Some(cached) = F::cached_lagrange_polys(points) {
-        lagrange_interpolation_with_polys_from_values(cached, values)
+        lagrange_interpolation_with_polys(cached, values)
     } else {
-        lagrange_interpolation_with_polys_from_values(lagrange_polynomials(points), values)
+        lagrange_interpolation_with_polys(lagrange_polynomials(points), values)
     }
 }
 
-/// interpolate a polynomial using pre-computed Lagrange basis polynomials and y-coordinates
-pub fn lagrange_interpolation_with_polys<F: Field>(
-    lagrange_polys: impl AsRef<[Poly<F>]>,
-    values: &[F],
-) -> anyhow::Result<Poly<F>> {
-    lagrange_interpolation_with_polys_from_values(lagrange_polys, values.iter().copied())
-}
-
-/// Interpolate a polynomial using pre-computed Lagrange basis polynomials and a stream of
-/// y-coordinates.
+/// Interpolates a polynomial from pre-computed Lagrange basis polynomials and the y-coordinates
+/// `values`.
 ///
-/// Unlike [`lagrange_interpolation_with_polys`], this does not require the y-coordinates to be
-/// materialized in a separate buffer. The iterator must yield exactly one value per basis
-/// polynomial.
-pub(crate) fn lagrange_interpolation_with_polys_from_values<F, I>(
+/// `values` is consumed as a stream, so callers do not need to collect the y-coordinates into a
+/// buffer. It must yield exactly one value per basis polynomial.
+pub fn lagrange_interpolation_with_polys<F, I>(
     lagrange_polys: impl AsRef<[Poly<F>]>,
     values: I,
 ) -> anyhow::Result<Poly<F>>
@@ -799,8 +809,9 @@ where
 
 /// Runs the extended Euclidean algorithm for `a` and `b` until `deg(r1) < stop`.
 ///
-/// Precondition: `deg(b) >= stop`. Callers ensure this code runs the loop at least once, and `a`
-/// is always read — hence `a` is cloned up front.
+/// Precondition: `deg(b) >= stop`. The loop then runs at least once and reads `a`, which is why
+/// `a` is cloned up front. When `deg(b) < stop` the result is `(b, 1)`, and the caller returns
+/// that without calling this function.
 ///
 /// Returns the low-degree remainder `r1` and its Bézout cofactor `t1` with
 /// respect to the original `b`.
@@ -808,18 +819,14 @@ fn partial_xgcd<F: Field>(a: &Poly<F>, b: Poly<F>, stop: usize) -> (Poly<F>, Pol
     let mut r0 = a.clone();
     let mut r1 = b;
 
-    // Invariant: each remainder is `a * s + b * t`; we only track `t`.
+    // Invariant: each remainder is `a * s + b * t`; we only track `t`. The cofactors and the
+    // quotient are updated in place, so they are allocated once with room for `deg(a) + 1`
+    // coefficients.
     let capacity = a.coefs.len();
-    let mut t0 = Poly {
-        coefs: Vec::with_capacity(capacity),
-    };
-    let mut t1 = Poly {
-        coefs: Vec::with_capacity(capacity),
-    };
+    let mut t0 = Poly::zero_with_capacity(capacity);
+    let mut t1 = Poly::zero_with_capacity(capacity);
     t1.coefs.push(F::ONE);
-    let mut q = Poly {
-        coefs: Vec::with_capacity(capacity),
-    };
+    let mut q = Poly::zero_with_capacity(capacity);
 
     while r1.deg() >= stop {
         // Turn r0 into the next remainder and reuse q's allocation across every EEA round.
@@ -920,36 +927,13 @@ fn gao_decoding_common<F: Field>(
 /// Runs Gao decoding algorithm.
 ///
 /// - `points` holds the x-coordinates
-/// - `values` holds the y-coordinates
+/// - `values` yields the y-coordinates, exactly one per point
 /// - `k` such that we apply error correction to a polynomial of degree < k
 ///   (usually degree = threshold in our scheme, but it can be 2*threshold in some cases)
 /// - `max_errors` is the maximum number of errors we try to correct for (most often threshold - len(corrupt_set), but can be less than this if degree is 2*threshold)
 ///
 /// __NOTE__ : We assume values already identified as errors have been excluded by the caller (i.e. values denoted Bot in NIST doc)
-pub fn gao_decoding<F: Field>(
-    points: &[F],
-    values: &[F],
-    k: usize,
-    max_errors: usize,
-) -> anyhow::Result<Poly<F>> {
-    // in the literature we find (n, k, d) codes
-    // parameter k is called v in the NIST doc (the RS dimension)
-    // this means that n is the number of points xi for which we have some values yi
-    // yi ~= G(xi)), where deg(G) <= k-1
-    // sanity check for parameter sizes
-    if values.len() != points.len() {
-        return Err(anyhow_error_and_log(
-            "Gao decoding failure: mismatch between number of values and points".to_string(),
-        ));
-    }
-
-    gao_decoding_from_values(points, values.iter().copied(), k, max_errors)
-}
-
-/// Run Gao decoding with streamed y-coordinates, avoiding a separate values buffer.
-///
-/// The iterator must yield exactly one value per point.
-pub(crate) fn gao_decoding_from_values<F, I>(
+pub fn gao_decoding<F, I>(
     points: &[F],
     values: I,
     k: usize,
@@ -959,10 +943,15 @@ where
     F: Field,
     I: IntoIterator<Item = F>,
 {
+    // in the literature we find (n, k, d) codes
+    // parameter k is called v in the NIST doc (the RS dimension)
+    // this means that n is the number of points xi for which we have some values yi
+    // yi ~= G(xi)), where deg(G) <= k-1
     let n = points.len();
 
     // R \in F[X] such that R(xi) = yi. Called g_1(x) in the Gao paper.
-    let r = lagrange_interpolation_from_values(points, values)?;
+    // The interpolation fails when `values` does not yield exactly one value per point.
+    let r = lagrange_interpolation(points, values)?;
 
     // G = prod(X - xi) where xi is party i's index. Called g_0(x) in the Gao paper.
     // note that deg(G) >= deg(R)
@@ -975,35 +964,8 @@ where
 /// from [`FieldHints`](crate::error_correction::FieldHints).
 ///
 /// The caller must ensure that `lagrange_polys` and `vanishing_poly` were built from the same
-/// `points` slice passed here.
-pub fn gao_decoding_with_field_hints<F: Field>(
-    points: &[F],
-    values: &[F],
-    k: usize,
-    max_errors: usize,
-    lagrange_polys: &[Poly<F>],
-    vanishing_poly: &Poly<F>,
-) -> anyhow::Result<Poly<F>> {
-    if values.len() != points.len() {
-        return Err(anyhow_error_and_log(
-            "Gao decoding failure: mismatch between number of values and points".to_string(),
-        ));
-    }
-
-    gao_decoding_with_field_hints_from_values(
-        points,
-        values.iter().copied(),
-        k,
-        max_errors,
-        lagrange_polys,
-        vanishing_poly,
-    )
-}
-
-/// Run Gao decoding with precomputed field hints and streamed y-coordinates.
-///
-/// The iterator must yield exactly one value per point and basis polynomial.
-pub(crate) fn gao_decoding_with_field_hints_from_values<F, I>(
+/// `points` slice passed here. `values` must yield exactly one value per point.
+pub fn gao_decoding_with_field_hints<F, I>(
     points: &[F],
     values: I,
     k: usize,
@@ -1018,7 +980,8 @@ where
     let n = points.len();
 
     // R = interpolation polynomial through (points, values), using the precomputed Lagrange basis.
-    let r = lagrange_interpolation_with_polys_from_values(lagrange_polys, values)?;
+    // The interpolation fails when `values` does not yield exactly one value per basis polynomial.
+    let r = lagrange_interpolation_with_polys(lagrange_polys, values)?;
 
     // partial_xgcd only clones "G" if the EEA loop actually runs, which is quite rare.
     gao_decoding_common(n, k, max_errors, r, vanishing_poly)
@@ -1057,17 +1020,15 @@ mod tests {
         assert!(xs.len() > poly.deg());
 
         let ys: Vec<_> = xs.iter().map(|x| poly.eval(x)).collect();
-        let interpolated = lagrange_interpolation(&xs, &ys);
+        let interpolated = lagrange_interpolation(&xs, ys.iter().copied());
         assert_eq!(poly, interpolated.unwrap());
 
-        let streamed = lagrange_interpolation_with_polys_from_values(
-            lagrange_polynomials(&xs),
-            ys.iter().copied(),
-        )
-        .unwrap();
-        assert_eq!(poly, streamed);
+        let with_polys =
+            lagrange_interpolation_with_polys(lagrange_polynomials(&xs), ys.iter().copied())
+                .unwrap();
+        assert_eq!(poly, with_polys);
 
-        let mismatch = lagrange_interpolation_with_polys_from_values(
+        let mismatch = lagrange_interpolation_with_polys(
             lagrange_polynomials(&xs),
             ys.iter().copied().take(ys.len() - 1),
         )
@@ -1200,13 +1161,13 @@ mod tests {
         // add an error
         ys[0] += GF16::from(3);
         ys[1] += GF16::from(4);
-        let polynomial = gao_decoding(&xs, &ys, f.coefs.len(), 2).unwrap();
+        let polynomial = gao_decoding(&xs, ys.iter().copied(), f.coefs.len(), 2).unwrap();
         assert_eq!(polynomial.eval(&GF16::from(0)), GF16::from(7));
 
         let field_hint = FieldHints::new(&roles).unwrap();
         let polynomial_with_hint = gao_decoding_with_field_hints(
             &xs,
-            &ys,
+            ys.iter().copied(),
             f.coefs.len(),
             2,
             &field_hint.lagrange_polys,
@@ -1239,7 +1200,9 @@ mod tests {
         // adding two errors
         ys[0] += GF16::from(2);
         ys[1] += GF16::from(5);
-        let r = gao_decoding(&xs, &ys, 3, 1).unwrap_err().to_string();
+        let r = gao_decoding(&xs, ys.iter().copied(), 3, 1)
+            .unwrap_err()
+            .to_string();
         assert!(r.contains(
             "Gao decoding failure: Allowed at most 1 errors but xgcd factor degree indicates 2."
         ));
@@ -1247,7 +1210,7 @@ mod tests {
         let field_hint = FieldHints::new(&roles).unwrap();
         let r_with_hint = gao_decoding_with_field_hints(
             &xs,
-            &ys,
+            ys.iter().copied(),
             3,
             1,
             &field_hint.lagrange_polys,

--- a/core/threshold-algebra/src/poly.rs
+++ b/core/threshold-algebra/src/poly.rs
@@ -595,8 +595,8 @@ fn quo_rem<F: Field>(a: Poly<F>, b: &Poly<F>) -> (Poly<F>, Poly<F>) {
     (q, r)
 }
 
-/// Replace `remainder` with `remainder mod divisor` and write the corresponding quotient into
-/// `quotient`, reusing both allocations.
+/// Computes `(quotient, remainder) = remainder / divisor`, reusing the `quotient` and `remainder`
+/// allocations.
 ///
 /// Panics when `divisor` is zero, which is a bug in the caller.
 fn quo_rem_assign<F: Field>(remainder: &mut Poly<F>, divisor: &Poly<F>, quotient: &mut Poly<F>) {

--- a/core/threshold-algebra/src/poly.rs
+++ b/core/threshold-algebra/src/poly.rs
@@ -3,7 +3,6 @@ use super::{
     structure_traits::{Field, Invert, One, Ring, RingWithExceptionalSequence, Sample, Zero},
 };
 use error_utils::anyhow_error_and_log;
-use itertools::Itertools;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
@@ -16,56 +15,27 @@ pub struct Poly<F> {
     coefs: Vec<F>,
 }
 
-/// Polynomial struct where all coefficients are bit-strings.
-/// We use this as a helper to optimize the reconstruction algorithms
-/// where we need to lift binary polynomials into the full ring domain.
-#[derive(Serialize, Deserialize, Hash, Clone, Default, Debug)]
-pub struct BitwisePoly {
-    coefs: Vec<u8>,
+/// A borrowed view of a polynomial whose coefficients are interpreted as bit strings.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct BitWisePoly<'a, F> {
+    poly: &'a Poly<F>,
 }
 
-impl From<Poly<super::galois_fields::gf8::GF8>> for BitwisePoly {
-    fn from(poly: Poly<super::galois_fields::gf8::GF8>) -> BitwisePoly {
-        let coefs: Vec<u8> = poly.coefs.iter().map(|coef_2| coef_2.0).collect();
-        BitwisePoly { coefs }
+impl<'a, F> From<&'a Poly<F>> for BitWisePoly<'a, F> {
+    fn from(poly: &'a Poly<F>) -> Self {
+        Self { poly }
     }
 }
 
-impl From<Poly<super::galois_fields::gf16::GF16>> for BitwisePoly {
-    fn from(poly: Poly<super::galois_fields::gf16::GF16>) -> BitwisePoly {
-        let coefs: Vec<u8> = poly.coefs.iter().map(|coef_2| coef_2.0).collect();
-        BitwisePoly { coefs }
+impl<F> BitWisePoly<'_, F> {
+    /// Return the borrowed field coefficients.
+    pub(crate) fn coefs(&self) -> &[F] {
+        self.poly.coefs()
     }
 }
 
-impl From<Poly<super::galois_fields::gf32::GF32>> for BitwisePoly {
-    fn from(poly: Poly<super::galois_fields::gf32::GF32>) -> BitwisePoly {
-        let coefs: Vec<u8> = poly.coefs.iter().map(|coef_2| coef_2.0).collect();
-        BitwisePoly { coefs }
-    }
-}
-
-impl From<Poly<super::galois_fields::gf64::GF64>> for BitwisePoly {
-    fn from(poly: Poly<super::galois_fields::gf64::GF64>) -> BitwisePoly {
-        let coefs: Vec<u8> = poly.coefs.iter().map(|coef_2| coef_2.0).collect();
-        BitwisePoly { coefs }
-    }
-}
-
-impl From<Poly<super::galois_fields::gf128::GF128>> for BitwisePoly {
-    fn from(poly: Poly<super::galois_fields::gf128::GF128>) -> BitwisePoly {
-        let coefs: Vec<u8> = poly.coefs.iter().map(|coef_2| coef_2.0).collect();
-        BitwisePoly { coefs }
-    }
-}
-
-impl From<Poly<super::galois_fields::gf256::GF256>> for BitwisePoly {
-    fn from(poly: Poly<super::galois_fields::gf256::GF256>) -> BitwisePoly {
-        let coefs: Vec<u8> = poly.coefs.iter().map(|coef_2| coef_2.0).collect();
-        BitwisePoly { coefs }
-    }
-}
-
+/// Evaluate a bitwise polynomial over `GF(2^EXTENSION_DEGREE)` at a Galois-ring point.
+/// The evaluation lifts each coefficient to `GR(2^k, EXTENSION_DEGREE)` on demand.
 pub trait BitWiseEval<Z, const EXTENSION_DEGREE: usize>
 where
     Z: Zero + for<'a> AddAssign<&'a Z> + Copy + Clone,
@@ -75,6 +45,46 @@ where
         &self,
         powers: &[ResiduePoly<Z, EXTENSION_DEGREE>],
     ) -> ResiduePoly<Z, EXTENSION_DEGREE>;
+}
+
+/// Generic implementation of [BitWiseEval::lazy_eval].
+pub(crate) fn bitwise_eval_coefficients<
+    Z,
+    F,
+    const EXTENSION_DEGREE: usize,
+    const PRODUCT_LENGTH: usize,
+>(
+    coefs: &[F],
+    powers: &[ResiduePoly<Z, EXTENSION_DEGREE>],
+) -> [Z; PRODUCT_LENGTH]
+where
+    Z: Zero + for<'a> AddAssign<&'a Z> + Copy + Clone,
+    F: Copy + Into<u8>,
+{
+    // Surplus powers are harmless (the missing high coefficients are zero and contribute nothing),
+    // so only the other direction is an error — and it can only be a bug.
+    assert!(
+        coefs.len() <= powers.len(),
+        "Not enough powers supplied for bitwise evaluation. Only {:?} are supplied but {:?} are needed.",
+        powers.len(),
+        coefs.len()
+    );
+
+    let mut result = [Z::ZERO; PRODUCT_LENGTH];
+    for (coef, power) in coefs.iter().zip(powers) {
+        // Bit b of this byte is the lifted ring coefficient of X^b; bits >= D are always clear.
+        let coef: u8 = (*coef).into();
+        for bit_idx in 0..EXTENSION_DEGREE {
+            if ((coef >> bit_idx) & 1) == 1 {
+                // Multiplying by a 1 bit is a shift by X^bit_idx, i.e. add `power` into `result`
+                // offset by bit_idx. A 0 bit contributes nothing, so it is simply skipped.
+                for (power_idx, power_coef) in power.coefs.iter().enumerate() {
+                    result[power_idx + bit_idx] += power_coef;
+                }
+            }
+        }
+    }
+    result
 }
 
 impl<Z> Poly<Z> {
@@ -126,41 +136,6 @@ impl<Z> Poly<Z> {
 
     pub fn into_container(self) -> Vec<Z> {
         self.coefs
-    }
-}
-
-impl BitwisePoly {
-    pub fn coef(&self, idx: usize) -> u8 {
-        if idx < self.coefs.len() {
-            self.coefs[idx]
-        } else {
-            0
-        }
-    }
-
-    pub fn coefs(&self) -> &[u8] {
-        &self.coefs
-    }
-
-    pub fn set_coef(&mut self, idx: usize, value: u8) {
-        if idx < self.coefs.len() {
-            self.coefs[idx] = value;
-        } else {
-            // extend the coefficients vector with zeros if needed
-            self.coefs.resize(idx + 1, 0);
-            self.coefs[idx] = value;
-        }
-    }
-
-    /// Overwrite the coefficients from `poly`, reusing this buffer's existing allocation.
-    ///
-    /// Each field coefficient is reduced to its byte representation — the same value the
-    /// `From<Poly<GFx>>` impls produce (those map `coef.0`; `Into<u8>` is the identity on the
-    /// stored byte) — but `clear` + `extend` keeps the `Vec`'s capacity, so the hot reconstruction
-    /// loop reuses one buffer across all bits instead of allocating a fresh `BitwisePoly` per bit.
-    pub fn overwrite_from_poly<F: Into<u8> + Copy>(&mut self, poly: &Poly<F>) {
-        self.coefs.clear();
-        self.coefs.extend(poly.coefs().iter().map(|c| (*c).into()));
     }
 }
 
@@ -592,6 +567,58 @@ fn quo_rem<F: Field>(a: Poly<F>, b: &Poly<F>) -> (Poly<F>, Poly<F>) {
     (q, r)
 }
 
+/// Replace `remainder` with `remainder mod divisor` and write the corresponding quotient into
+/// `quotient`, reusing both allocations.
+fn quo_rem_assign<F: Field>(remainder: &mut Poly<F>, divisor: &Poly<F>, quotient: &mut Poly<F>) {
+    let remainder_len = remainder.deg() + 1;
+    let divisor_len = divisor.deg() + 1;
+
+    if divisor_len == 1 && divisor.coef(0) == F::ZERO {
+        panic!("division by 0 in quo_rem");
+    }
+
+    // Clear every previously live quotient coefficient before changing its logical length. This
+    // also ensures stale coefficients cannot affect a shorter quotient in a later EEA round.
+    quotient.coefs.fill(F::ZERO);
+    if remainder_len == 1 && remainder.coef(0) == F::ZERO {
+        quotient.coefs.clear();
+        return;
+    }
+
+    let quotient_len = remainder_len.saturating_sub(divisor_len) + 1;
+    quotient.coefs.resize(quotient_len, F::ZERO);
+
+    if remainder_len >= divisor_len {
+        let inverse_leading = divisor.highest_coefficient().invert();
+        for i in (0..=(remainder_len - divisor_len)).rev() {
+            quotient.coefs[i] = remainder.coefs[i + divisor_len - 1] * inverse_leading;
+            for j in 0..divisor_len {
+                remainder.coefs[i + j] -= quotient.coefs[i] * divisor.coefs[j];
+            }
+        }
+    }
+    quotient.compress();
+    remainder.compress();
+}
+
+/// Compute `target -= lhs * rhs` coefficient-wise without allocating the product polynomial.
+fn sub_mul_assign<F: Field>(target: &mut Poly<F>, lhs: &Poly<F>, rhs: &Poly<F>) {
+    if lhs.is_zero() || rhs.is_zero() {
+        return;
+    }
+
+    let product_len = lhs.coefs.len() + rhs.coefs.len() - 1;
+    if target.coefs.len() < product_len {
+        target.coefs.resize(product_len, F::ZERO);
+    }
+    for (i, lhs_coef) in lhs.coefs.iter().enumerate() {
+        for (j, rhs_coef) in rhs.coefs.iter().enumerate() {
+            target.coefs[i + j] -= *lhs_coef * *rhs_coef;
+        }
+    }
+    target.compress();
+}
+
 /// Build the vanishing polynomial `V(Z) = ∏_j (Z - points[j])` (monic, degree `points.len()`).
 /// We do so iteratively, starting from the low to the high coefficients, so that the leading coefficient is always 1 (monic).
 /// Then for each subsequent point, we multiply the running product by `(Z - alpha)`.
@@ -641,7 +668,7 @@ pub(crate) fn deflate_root<F: Ring>(v: &Poly<F>, root: F) -> Poly<F> {
     qc[deg - 1] = vc[deg]; // leading coefficient drops straight down since the result, q(Z), is one degree lower than the input v(Z)
     for k in (0..deg - 1).rev() {
         // iterate from highest coefficients to lowest in the incremental result since qc[k+1] has already been fully computed
-        qc[k] = vc[k + 1] + root * qc[k + 1]; // I.e. q_{k−1} = v_k + root * q_k  
+        qc[k] = vc[k + 1] + root * qc[k + 1]; // I.e. q_{k−1} = v_k + root * q_k
     }
     assert!(vc[0] + root * qc[0] == F::ZERO, "remainder must vanish");
     // Invariant: coefs is canonical because the leading coef == vc[deg] (nonzero)
@@ -692,10 +719,24 @@ mod lagrange_basis_tests {
 
 /// interpolate a polynomial through coordinates where points holds the x-coordinates and values holds the y-coordinates
 pub fn lagrange_interpolation<F: Field>(points: &[F], values: &[F]) -> anyhow::Result<Poly<F>> {
+    lagrange_interpolation_from_values(points, values.iter().copied())
+}
+
+/// Like [`lagrange_interpolation`] but with the y-coordinates streamed instead of materialized.
+///
+/// Uses the memoized Lagrange basis for `points` when one is available, otherwise builds it.
+pub(crate) fn lagrange_interpolation_from_values<F, I>(
+    points: &[F],
+    values: I,
+) -> anyhow::Result<Poly<F>>
+where
+    F: Field,
+    I: IntoIterator<Item = F>,
+{
     if let Some(cached) = F::cached_lagrange_polys(points) {
-        lagrange_interpolation_with_polys(cached, values)
+        lagrange_interpolation_with_polys_from_values(cached, values)
     } else {
-        lagrange_interpolation_with_polys(lagrange_polynomials(points), values)
+        lagrange_interpolation_with_polys_from_values(lagrange_polynomials(points), values)
     }
 }
 
@@ -704,13 +745,25 @@ pub fn lagrange_interpolation_with_polys<F: Field>(
     lagrange_polys: impl AsRef<[Poly<F>]>,
     values: &[F],
 ) -> anyhow::Result<Poly<F>> {
+    lagrange_interpolation_with_polys_from_values(lagrange_polys, values.iter().copied())
+}
+
+/// Interpolate a polynomial using pre-computed Lagrange basis polynomials and a stream of
+/// y-coordinates.
+///
+/// Unlike [`lagrange_interpolation_with_polys`], this does not require the y-coordinates to be
+/// materialized in a separate buffer. The iterator must yield exactly one value per basis
+/// polynomial.
+pub(crate) fn lagrange_interpolation_with_polys_from_values<F, I>(
+    lagrange_polys: impl AsRef<[Poly<F>]>,
+    values: I,
+) -> anyhow::Result<Poly<F>>
+where
+    F: Field,
+    I: IntoIterator<Item = F>,
+{
     let lagrange_polys = lagrange_polys.as_ref();
-    if lagrange_polys.len() != values.len() {
-        return Err(anyhow_error_and_log(
-            "Lagrange interpolation failure: mismatch between number of points and values"
-                .to_string(),
-        ));
-    }
+    let mut values = values.into_iter();
 
     // res = Σ_i lagrange_polys[i] * values[i], accumulated coefficient-wise into a single buffer. This function runs
     // once per bit, ring_size times per opened value, so this is a hot spot for reconstruction.
@@ -718,17 +771,29 @@ pub fn lagrange_interpolation_with_polys<F: Field>(
     // Each Lagrange basis poly over these `n` points has degree exactly n-1 (n coefficients), so the interpolant has at
     // most `n` coefficients.
     let mut coefs = vec![F::ZERO; lagrange_polys.len()];
-    for (li, vi) in lagrange_polys.iter().zip_eq(values.iter()) {
+    for li in lagrange_polys {
+        let Some(vi) = values.next() else {
+            return Err(anyhow_error_and_log(
+                "Lagrange interpolation failure: mismatch between number of points and values"
+                    .to_string(),
+            ));
+        };
         for (acc, lc) in coefs.iter_mut().zip(li.coefs.iter()) {
-            *acc += *lc * *vi;
+            *acc += *lc * vi;
         }
+    }
+    if values.next().is_some() {
+        return Err(anyhow_error_and_log(
+            "Lagrange interpolation failure: mismatch between number of points and values"
+                .to_string(),
+        ));
     }
     Ok(Poly::from_coefs(coefs))
 }
 
 /// Runs the extended Euclidean algorithm for `a` and `b` until `deg(r1) < stop`.
 ///
-/// Precondition: `deg(b) >= stop`. Callers should ensure `deg(b) < stop`. This code runs the loop at least once and `a`
+/// Precondition: `deg(b) >= stop`. Callers ensure this code runs the loop at least once, and `a`
 /// is always read — hence `a` is cloned up front.
 ///
 /// Returns the low-degree remainder `r1` and its Bézout cofactor `t1` with
@@ -738,18 +803,26 @@ fn partial_xgcd<F: Field>(a: &Poly<F>, b: Poly<F>, stop: usize) -> (Poly<F>, Pol
     let mut r1 = b;
 
     // Invariant: each remainder is `a * s + b * t`; we only track `t`.
-    let mut t0 = Poly::zero();
-    let mut t1 = Poly::one();
+    let capacity = a.coefs.len();
+    let mut t0 = Poly {
+        coefs: Vec::with_capacity(capacity),
+    };
+    let mut t1 = Poly {
+        coefs: Vec::with_capacity(capacity),
+    };
+    t1.coefs.push(F::ONE);
+    let mut q = Poly {
+        coefs: Vec::with_capacity(capacity),
+    };
 
     while r1.deg() >= stop {
-        let (q, r2) = &r0 / &r1;
-        let t2 = t0 - (&q * &t1);
+        // Turn r0 into the next remainder and reuse q's allocation across every EEA round.
+        quo_rem_assign(&mut r0, &r1, &mut q);
+        // Turn t0 into the next cofactor directly, without materializing q * t1 or t2.
+        sub_mul_assign(&mut t0, &q, &t1);
 
-        r0 = r1;
-        r1 = r2;
-
-        t0 = t1;
-        t1 = t2;
+        std::mem::swap(&mut r0, &mut r1);
+        std::mem::swap(&mut t0, &mut t1);
     }
 
     (r1, t1)
@@ -857,8 +930,6 @@ pub fn gao_decoding<F: Field>(
     // parameter k is called v in the NIST doc (the RS dimension)
     // this means that n is the number of points xi for which we have some values yi
     // yi ~= G(xi)), where deg(G) <= k-1
-    let n = points.len();
-
     // sanity check for parameter sizes
     if values.len() != points.len() {
         return Err(anyhow_error_and_log(
@@ -866,8 +937,26 @@ pub fn gao_decoding<F: Field>(
         ));
     }
 
+    gao_decoding_from_values(points, values.iter().copied(), k, max_errors)
+}
+
+/// Run Gao decoding with streamed y-coordinates, avoiding a separate values buffer.
+///
+/// The iterator must yield exactly one value per point.
+pub(crate) fn gao_decoding_from_values<F, I>(
+    points: &[F],
+    values: I,
+    k: usize,
+    max_errors: usize,
+) -> anyhow::Result<Poly<F>>
+where
+    F: Field,
+    I: IntoIterator<Item = F>,
+{
+    let n = points.len();
+
     // R \in F[X] such that R(xi) = yi. Called g_1(x) in the Gao paper.
-    let r = lagrange_interpolation(points, values)?;
+    let r = lagrange_interpolation_from_values(points, values)?;
 
     // G = prod(X - xi) where xi is party i's index. Called g_0(x) in the Gao paper.
     // note that deg(G) >= deg(R)
@@ -889,16 +978,41 @@ pub fn gao_decoding_with_field_hints<F: Field>(
     lagrange_polys: &[Poly<F>],
     vanishing_poly: &Poly<F>,
 ) -> anyhow::Result<Poly<F>> {
-    let n = points.len();
-
     if values.len() != points.len() {
         return Err(anyhow_error_and_log(
             "Gao decoding failure: mismatch between number of values and points".to_string(),
         ));
     }
 
+    gao_decoding_with_field_hints_from_values(
+        points,
+        values.iter().copied(),
+        k,
+        max_errors,
+        lagrange_polys,
+        vanishing_poly,
+    )
+}
+
+/// Run Gao decoding with precomputed field hints and streamed y-coordinates.
+///
+/// The iterator must yield exactly one value per point and basis polynomial.
+pub(crate) fn gao_decoding_with_field_hints_from_values<F, I>(
+    points: &[F],
+    values: I,
+    k: usize,
+    max_errors: usize,
+    lagrange_polys: &[Poly<F>],
+    vanishing_poly: &Poly<F>,
+) -> anyhow::Result<Poly<F>>
+where
+    F: Field,
+    I: IntoIterator<Item = F>,
+{
+    let n = points.len();
+
     // R = interpolation polynomial through (points, values), using the precomputed Lagrange basis.
-    let r = lagrange_interpolation_with_polys(lagrange_polys, values)?;
+    let r = lagrange_interpolation_with_polys_from_values(lagrange_polys, values)?;
 
     // partial_xgcd only clones "G" if the EEA loop actually runs, which is quite rare.
     gao_decoding_common(n, k, max_errors, r, vanishing_poly)
@@ -939,6 +1053,22 @@ mod tests {
         let ys: Vec<_> = xs.iter().map(|x| poly.eval(x)).collect();
         let interpolated = lagrange_interpolation(&xs, &ys);
         assert_eq!(poly, interpolated.unwrap());
+
+        let streamed = lagrange_interpolation_with_polys_from_values(
+            lagrange_polynomials(&xs),
+            ys.iter().copied(),
+        )
+        .unwrap();
+        assert_eq!(poly, streamed);
+
+        let mismatch = lagrange_interpolation_with_polys_from_values(
+            lagrange_polynomials(&xs),
+            ys.iter().copied().take(ys.len() - 1),
+        )
+        .unwrap_err();
+        assert!(mismatch.to_string().contains(
+            "Lagrange interpolation failure: mismatch between number of points and values"
+        ));
     }
 
     #[rstest]
@@ -971,9 +1101,55 @@ mod tests {
 
             if !b.is_zero() {
                 let (q, r) = a.clone() / b.clone();
-                assert_eq!(q * b + r, a);
+                assert_eq!(q.clone() * b.clone() + r.clone(), a);
+
+                let mut in_place_r = a.clone();
+                let mut in_place_q = Poly::zero();
+                quo_rem_assign(&mut in_place_r, &b, &mut in_place_q);
+                assert_eq!(in_place_q, q);
+                assert_eq!(in_place_r, r);
             }
 
+        }
+    }
+
+    fn partial_xgcd_allocating<F: Field>(
+        a: &Poly<F>,
+        b: Poly<F>,
+        stop: usize,
+    ) -> (Poly<F>, Poly<F>) {
+        let mut r0 = a.clone();
+        let mut r1 = b;
+        let mut t0 = Poly::zero();
+        let mut t1 = Poly::one();
+
+        while r1.deg() >= stop {
+            let (q, r2) = &r0 / &r1;
+            let t2 = t0 - (&q * &t1);
+            r0 = r1;
+            r1 = r2;
+            t0 = t1;
+            t1 = t2;
+        }
+        (r1, t1)
+    }
+
+    proptest! {
+        #[test]
+        fn in_place_partial_xgcd_matches_allocating_version(
+            coefs_a in proptest::collection::vec(any::<u8>().prop_map(GF16::from), 2..10),
+            coefs_b in proptest::collection::vec(any::<u8>().prop_map(GF16::from), 2..9),
+            stop in 1usize..8,
+        ) {
+            let a = Poly::from_coefs(coefs_a);
+            let b = Poly::from_coefs(coefs_b);
+            prop_assume!(!b.is_zero());
+            prop_assume!(a.deg() >= b.deg());
+            prop_assume!(b.deg() >= stop);
+
+            let expected = partial_xgcd_allocating(&a, b.clone(), stop);
+            let actual = partial_xgcd(&a, b, stop);
+            prop_assert_eq!(actual, expected);
         }
     }
 
@@ -1099,10 +1275,11 @@ mod tests {
     }
 
     #[test]
-    fn test_bitwise_poly() {
+    fn test_polynomial_bitwise_eval() {
         let f = Poly {
             coefs: vec![GF16::from(7), GF16::from(3), GF16::from(8)],
         };
+        let bitwise = BitWisePoly::from(&f);
         let degree = f.coefs.len();
 
         let shifted_pos = 10;
@@ -1117,8 +1294,6 @@ mod tests {
             })
             .collect::<anyhow::Result<Vec<_>>>()
             .unwrap();
-
-        let bitwise = BitwisePoly::from(f);
 
         for party_id in party_ids {
             assert_eq!(

--- a/core/threshold-algebra/src/poly.rs
+++ b/core/threshold-algebra/src/poly.rs
@@ -70,6 +70,11 @@ where
         coefs.len()
     );
 
+    debug_assert!(
+        EXTENSION_DEGREE <= u8::BITS as usize,
+        "bitwise_eval_coefficients requires EXTENSION_DEGREE <= 8 (coefficients are stored in a u8)"
+    );
+
     let mut result = [Z::ZERO; PRODUCT_LENGTH];
     for (coef, power) in coefs.iter().zip(powers) {
         // Bit b of this byte is the lifted ring coefficient of X^b; bits >= D are always clear.

--- a/core/threshold-algebra/src/poly.rs
+++ b/core/threshold-algebra/src/poly.rs
@@ -587,6 +587,7 @@ fn quo_rem_assign<F: Field>(remainder: &mut Poly<F>, divisor: &Poly<F>, quotient
     quotient.coefs.fill(F::ZERO);
     if remainder_len == 1 && remainder.coef(0) == F::ZERO {
         quotient.coefs.clear();
+        remainder.coefs.clear();
         return;
     }
 

--- a/core/threshold-algebra/src/syndrome.rs
+++ b/core/threshold-algebra/src/syndrome.rs
@@ -252,7 +252,7 @@ mod tests {
         assert!(syndrome.is_zero());
 
         // with no errors we can just do plain Lagrange interpolation
-        let l_poly = lagrange_interpolation(&xs, &ys).unwrap();
+        let l_poly = lagrange_interpolation(&xs, ys.iter().copied()).unwrap();
         for i in 1..=n {
             let l_i = l_poly.eval(&BaseField::from_u128(i));
             tracing::info!("interpolated L({i}) = {l_i:?}",);
@@ -264,7 +264,7 @@ mod tests {
         tracing::info!("cis ERROR: {:?}", ys);
 
         // check that we can correct with one error
-        let polynomial = gao_decoding(&xs, &ys, v, 1).unwrap();
+        let polynomial = gao_decoding(&xs, ys.iter().copied(), v, 1).unwrap();
         assert_eq!(
             polynomial.eval(&BaseField::from_u128(0)),
             BaseField::from_u128(7)

--- a/core/threshold-bgv/src/algebra/levels.rs
+++ b/core/threshold-bgv/src/algebra/levels.rs
@@ -1548,7 +1548,7 @@ mod tests {
         assert!(xs.len() > poly.deg());
 
         let ys: Vec<_> = xs.iter().map(|x| poly.eval(x)).collect();
-        let interpolated = lagrange_interpolation(&xs, &ys);
+        let interpolated = lagrange_interpolation(&xs, ys.iter().copied());
         assert_eq!(poly, interpolated.unwrap());
     }
 


### PR DESCRIPTION
## Description

This PR reduces allocation in the algebra crate. This is useful because when we want to add zeroization, we will have fewer intermediate values to worry about.

- `BitWisePoly { coefs: Vec<u8> }` is no more since it keeps a copy, the new version keeps a reference
- `ReconScratch { binary_shares, ys, bitwise }` also is no more since we want to avoid scratch buffers
- `partial_xgcd` previously allocated a bunch of intermediate values, use `quo_rem_assign` and `sub_mul_assign` instead

Below are the new allocation numbers


```
+--------+----+-----------+--------+---------------+--------------+------------+-----------+
| path   | n  | threshold | errors | allocs_before | bytes_before | allocs_now | bytes_now |
+--------+----+-----------+--------+---------------+--------------+------------+-----------+
| plain  | 13 | 4         | 0      | 408.0         | 21728.0      | 149.0      | 5605.0    |
+--------+----+-----------+--------+---------------+--------------+------------+-----------+
| hinted | 13 | 4         | 0      | 73.0          | 2413.0       | 68.0       | 1944.0    |
+--------+----+-----------+--------+---------------+--------------+------------+-----------+
| plain  | 13 | 4         | 2      | 422.8         | 19530.4      | 158.2      | 5530.1    |
+--------+----+-----------+--------+---------------+--------------+------------+-----------+
| hinted | 13 | 4         | 2      | 108.0         | 3222.3       | 97.8       | 2739.3    |
+--------+----+-----------+--------+---------------+--------------+------------+-----------+
| plain  | 4  | 1         | 0      | 330.0         | 6216.0       | 137.0      | 1284.0    |
+--------+----+-----------+--------+---------------+--------------+------------+-----------+
| hinted | 4  | 1         | 0      | 70.0          | 688.0        | 67.0       | 608.0     |
+--------+----+-----------+--------+---------------+--------------+------------+-----------+
| plain  | 4  | 1         | 1      | 339.0         | 5106.9       | 144.0      | 1245.1    |
+--------+----+-----------+--------+---------------+--------------+------------+-----------+
| hinted | 4  | 1         | 1      | 86.0          | 836.9        | 81.0       | 756.9     |
+--------+----+-----------+--------+---------------+--------------+------------+-----------+
```


### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
