### PR TITLE
A broken test on main slipped through

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,10 +235,8 @@ jobs:
       matrix:
         include:
 
-          # "Normal" crates and small utilities; default features only.
-          # threshold-execution / threshold-bgv / threshold-networking are
-          # intentionally excluded — heavy-1 / heavy-2 already run them with
-          # `*/slow_tests`, which is a *superset* of the default test set.
+          # "Normal" crates and small utilities; default features only. threshold-execution / threshold-bgv /
+          # threshold-networking are intentionally excluded. The heavy groups run their test sets.
           - group: crates-normies
             crates: '-p threshold-types -p threshold-hashing -p threshold-algebra -p bc2wrap -p error-utils -p thread-handles -p test-utils -p observability'
             features: ''
@@ -267,11 +265,11 @@ jobs:
             threads: '8'
             runs-on: '64cpu-linux-x64'
 
-          # Slow/heavy tests, 2/2. Big iron, lots of RAM.
-          # The `threshold-bgv` tests all use N65536 and is inherently RAM-heavy, so gets own runner.
+          # Slow/heavy tests, 2/2. Big iron, lots of RAM. The threshold-bgv tests use N65536 and need a large runner.
+          # threshold-networking shares the fast job and its build artifacts. 
           # TODO(dp): discuss making this non-required so failures here do not impeed PR merge?
           - group: crates-heavy-2-fast
-            crates: '-p threshold-bgv'
+            crates: '-p threshold-bgv -p threshold-networking'
             features: '-F threshold-bgv/slow_tests'
             partition: '-- --skip test_dkg_with_offline --skip test_dkg_dummy_preproc'
             threads: '8'

--- a/core/threshold-networking/src/constants.rs
+++ b/core/threshold-networking/src/constants.rs
@@ -54,6 +54,8 @@ pub(crate) static NETWORK_TIMEOUT_BK_SNS: Duration = Duration::from_secs(1200);
 // max message size for decoding - encoding message on gRPC protocol
 pub static MAX_EN_DECODE_MESSAGE_SIZE: LazyLock<usize> = LazyLock::new(|| 2 * 1024 * 1024 * 1024);
 
+/// Maximum number of rounds ahead that a future message can be buffered.
+pub(crate) const MAX_FUTURE_ROUNDS: usize = 16;
+
 /// Hard cap on the number of distinct future-round messages buffered per sender.
-/// Since we only ever have one message per round, this is also the cap on highest round number we buffer.
 pub(crate) const MAX_BUFFERED_FUTURE_MSGS: usize = 32;

--- a/core/threshold-networking/src/grpc/config.rs
+++ b/core/threshold-networking/src/grpc/config.rs
@@ -2,7 +2,7 @@
 
 use crate::constants::{
     DISCARD_INACTIVE_SESSION_INTERVAL_SECS, INITIAL_INTERVAL_MS, MAX_BUFFERED_FUTURE_MSGS,
-    MAX_ELAPSED_TIME, MAX_EN_DECODE_MESSAGE_SIZE, MAX_INTERVAL,
+    MAX_ELAPSED_TIME, MAX_EN_DECODE_MESSAGE_SIZE, MAX_FUTURE_ROUNDS, MAX_INTERVAL,
     MAX_OPENED_INACTIVE_SESSIONS_PER_PARTY, MAX_WAITING_TIME_MESSAGE_QUEUE, MESSAGE_LIMIT,
     MULTIPLIER, NETWORK_TIMEOUT_BK, NETWORK_TIMEOUT_BK_SNS, NETWORK_TIMEOUT_LONG,
     SESSION_CLEANUP_INTERVAL_SECS, SESSION_STATUS_UPDATE_INTERVAL_SECS,
@@ -174,5 +174,11 @@ impl CoreToCoreNetworkConfig {
         self.max_buffered_future_msgs
             .map(|v| v as usize)
             .unwrap_or(MAX_BUFFERED_FUTURE_MSGS)
+    }
+
+    pub fn get_max_future_rounds(&self) -> usize {
+        self.max_future_rounds
+            .map(|v| v as usize)
+            .unwrap_or(MAX_FUTURE_ROUNDS)
     }
 }

--- a/core/threshold-networking/src/grpc/message_queue.rs
+++ b/core/threshold-networking/src/grpc/message_queue.rs
@@ -57,7 +57,7 @@ impl ReceiverState {
     /// Buffer a strictly-future-round message, enforcing the reordering-buffer
     /// bounds. Returns `true` if the message was buffered, `false` if it was
     /// dropped for being outside the `max_future_rounds` look-ahead window or
-    /// over the per-sender `max_buffered` cap.
+    /// over the per-sender `max_buffered_msgs` cap.
     ///
     /// At most one value is kept per round: a duplicate for an already-buffered
     /// round is discarded (first one wins) so a malicious peer cannot clobber a
@@ -67,17 +67,19 @@ impl ReceiverState {
         round: usize,
         value: Vec<u8>,
         current: usize,
-        max_buffered: usize,
+        max_future_rounds: usize,
+        max_buffered_msgs: usize,
     ) -> bool {
-        if round > current
-            && round <= current.saturating_add(max_buffered)
-            && self.future.len() < max_buffered
+        if round <= current
+            || round > current.saturating_add(max_future_rounds)
+            || self.future.len() >= max_buffered_msgs
+            || self.future.contains_key(&round)
         {
-            self.future.entry(round).or_insert(value);
-            true
-        } else {
-            false
+            return false;
         }
+
+        self.future.insert(round, value);
+        true
     }
 }
 
@@ -233,7 +235,13 @@ mod tests {
         let mut current_round = 2;
         let window_size = 5;
         for i in 0..10 {
-            let res = receiver_state.buffer_future(i, vec![i as u8], current_round, window_size);
+            let res = receiver_state.buffer_future(
+                i,
+                vec![i as u8],
+                current_round,
+                window_size,
+                window_size,
+            );
 
             // Check that messages for rounds outside the window are dropped, and those within the window are buffered.
             if i <= current_round || i > current_round + 5 {
@@ -255,5 +263,32 @@ mod tests {
             );
             current_round += 1;
         }
+    }
+
+    #[test]
+    fn test_buffer_future_enforces_independent_bounds() {
+        let (_, rx) = channel::<NetworkRoundValue>(10);
+        let mut receiver_state = ReceiverState::new(rx);
+
+        assert!(receiver_state.buffer_future(1, vec![1], 0, 2, 10));
+        assert!(receiver_state.buffer_future(2, vec![2], 0, 2, 10));
+        assert!(!receiver_state.buffer_future(3, vec![3], 0, 2, 10));
+
+        let (_, rx) = channel::<NetworkRoundValue>(10);
+        let mut receiver_state = ReceiverState::new(rx);
+
+        assert!(receiver_state.buffer_future(1, vec![1], 0, 10, 2));
+        assert!(receiver_state.buffer_future(2, vec![2], 0, 10, 2));
+        assert!(!receiver_state.buffer_future(3, vec![3], 0, 10, 2));
+    }
+
+    #[test]
+    fn test_buffer_future_rejects_duplicate_round() {
+        let (_, rx) = channel::<NetworkRoundValue>(10);
+        let mut receiver_state = ReceiverState::new(rx);
+
+        assert!(receiver_state.buffer_future(1, vec![1], 0, 10, 10));
+        assert!(!receiver_state.buffer_future(1, vec![2], 0, 10, 10));
+        assert_eq!(receiver_state.future.get(&1), Some(&vec![1]));
     }
 }

--- a/core/threshold-networking/src/sending_service/session.rs
+++ b/core/threshold-networking/src/sending_service/session.rs
@@ -237,6 +237,7 @@ impl<R: RoleTrait> Networking<R> for NetworkSession {
                         round,
                         packet.value,
                         network_round,
+                        self.conf.get_max_future_rounds(),
                         self.conf.get_max_buffered_future_msgs(),
                     ) {
                         // Note that the sender is never warned of this failure, so a honest party
@@ -1020,6 +1021,8 @@ mod tests {
                 .unwrap()
                 .unwrap();
             let state = rx.lock().await;
+
+            // Keep the round 2 message, but drop round 5's: it is outside the configured window.
             assert!(
                 state.future.contains_key(&2),
                 "round 2 is within the configured window and must be buffered"


### PR DESCRIPTION
At some point this spring/summer we removed `threshold-networking` from the CI testing jobs.

This PR revives the tests in CI and fixes a test that was failing.

