### PR TITLE
chore: prevent debug logging of TLS or ECDSA keys

### DIFF
--- a/core/service/src/conf/threshold.rs
+++ b/core/service/src/conf/threshold.rs
@@ -184,7 +184,7 @@ impl TlsCert {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum TlsKey {
     Path(PathBuf),
@@ -194,6 +194,15 @@ pub enum TlsKey {
 impl Default for TlsKey {
     fn default() -> Self {
         TlsKey::Pem("REDACTED".to_string())
+    }
+}
+
+impl std::fmt::Debug for TlsKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TlsKey::Path(path) => write!(f, "TlsKey::Path({})", path.display()),
+            TlsKey::Pem(_) => write!(f, "TlsKey::Pem(REDACTED)"),
+        }
     }
 }
 

--- a/core/service/src/conf/threshold.rs
+++ b/core/service/src/conf/threshold.rs
@@ -1,6 +1,4 @@
-use crate::engine::base::derive_request_id;
 use alloy_primitives::Address;
-use kms_grpc::RequestId;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use strum_macros::EnumIs;
@@ -210,12 +208,6 @@ impl TlsKey {
     pub fn into_pem(&self) -> anyhow::Result<Pem> {
         let key_bytes = self.to_string()?;
         Ok(parse_x509_pem(key_bytes.as_ref())?.1)
-    }
-
-    pub fn into_request_id(&self) -> anyhow::Result<RequestId> {
-        let key_bytes = self.to_string()?;
-        derive_request_id(key_bytes.as_ref())
-            .map_err(|e| anyhow::anyhow!("Failed to derive request ID from TLS key: {}", e))
     }
 
     fn to_string(&self) -> anyhow::Result<String> {

--- a/core/service/src/conf/threshold.rs
+++ b/core/service/src/conf/threshold.rs
@@ -195,6 +195,7 @@ impl Default for TlsKey {
     }
 }
 
+// Deliberately never render secret-key material to avoid it accidentally leaking in logs or debug output.
 impl std::fmt::Debug for TlsKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/core/service/src/cryptography/signing/ecdsa.rs
+++ b/core/service/src/cryptography/signing/ecdsa.rs
@@ -264,9 +264,16 @@ impl HasSigningScheme for PrivateSigKey {
 // (this is why the zeroizing `Drop` lives on the `WrappedSigningKey` newtype).
 impl ZeroizeOnDrop for PrivateSigKey {}
 
-#[derive(Clone, PartialEq, Eq, Debug, ZeroizeOnDrop)]
+#[derive(Clone, PartialEq, Eq, ZeroizeOnDrop)]
 struct WrappedSigningKey(k256::ecdsa::SigningKey);
 impl_generic_versionize!(WrappedSigningKey);
+
+// Deliberately never render secret-key material to avoid it accidentally leaking in logs or debug output.
+impl std::fmt::Debug for WrappedSigningKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("WrappedSigningKey(REDACTED)")
+    }
+}
 
 /// Per-scheme cache of signing keys derived from a [`PrivateSigKey`].
 ///


### PR DESCRIPTION
## Description
Prevent accidental logging of TLS keys or ECDSA signing keys.
These particular code paths are not used in production (due to how things are configured), but still worth fixing. 

### Related issue(s)
https://github.com/zama-ai/kms-internal/issues/3191

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

