### PR TITLE
chore: backward compatibility test for StoredEip712Domain

### DIFF
--- a/backward-compatibility/data/0_15_0/kms/crs_gen_metadata.bcode
+++ b/backward-compatibility/data/0_15_0/kms/crs_gen_metadata.bcode
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ba0d68b4e59d2b44956bf10fce5995c220ef17f91ecac79c22b97f5b1d33ad5
-size 170
+oid sha256:0f5c898569c8ab08a0768b6e75caf8702a6ddcd00a73c18087713dbfade6c4e1
+size 171

--- a/backward-compatibility/data/0_15_0/kms/crs_gen_metadata_with_extra_data.bcode
+++ b/backward-compatibility/data/0_15_0/kms/crs_gen_metadata_with_extra_data.bcode
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28d1aad844712dc58903acb790c8ea5fd3568026467fe10b45a44a668d9616c2
-size 182
+oid sha256:03cb29142abc4fc4a8b75a3e6c1b91646c3396874138ee9dbb1d2c621c01ce85
+size 183

--- a/backward-compatibility/data/0_15_0/kms/key_gen_metadata.bcode
+++ b/backward-compatibility/data/0_15_0/kms/key_gen_metadata.bcode
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3009eaffbaba3d20748d6a1eb230d53621a54474d0f4e3803e603b940f36bc2
-size 254
+oid sha256:9c7492787108a947da3253f7a7523c6828e7567c6abbf83a0821853138073db8
+size 255

--- a/backward-compatibility/data/0_15_0/kms/key_gen_metadata_with_extra_data.bcode
+++ b/backward-compatibility/data/0_15_0/kms/key_gen_metadata_with_extra_data.bcode
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:132dd4e00d69f70451e72ae04ef6efaad48b16dc31313ebdff37cc15165b2371
-size 266
+oid sha256:5ea000d06bea9c72ba4f33625a3320f0f6cdc049f8fad7d50c3f9b1d5ec8d3f5
+size 267

--- a/backward-compatibility/data/0_15_0/kms/key_gen_metadata_with_extra_data.bcode
+++ b/backward-compatibility/data/0_15_0/kms/key_gen_metadata_with_extra_data.bcode
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ea000d06bea9c72ba4f33625a3320f0f6cdc049f8fad7d50c3f9b1d5ec8d3f5
-size 267
+oid sha256:058945742e90a9627743fd17bae051f105cb577f4ff89f4819e8c7394ab111eb
+size 383

--- a/backward-compatibility/data/0_15_0/kms/kms_fhe_key_handles.bcode
+++ b/backward-compatibility/data/0_15_0/kms/kms_fhe_key_handles.bcode
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1844cd50a2f0b4e0f41afd632ed26a888f6562489fb3f146c27699db98cf1307
-size 11411
+oid sha256:2463be78907bb95da36b2ba6ce9ac72e6571fa2f417b2c6b0edda55c236587af
+size 11525

--- a/backward-compatibility/data/0_15_0/kms/stored_eip712_domain.bcode
+++ b/backward-compatibility/data/0_15_0/kms/stored_eip712_domain.bcode
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:371c6011615973719661ab4dd9a9ce82c8209102ea498538fe478940e70481ae
+size 153

--- a/backward-compatibility/data/kms.ron
+++ b/backward-compatibility/data/kms.ron
@@ -1824,6 +1824,18 @@
     (
         kms_core_version_min: "0.15.0",
         kms_core_module: "kms",
+        metadata: StoredEip712Domain((
+            test_filename: "stored_eip712_domain",
+            name: "Authorization token",
+            version: "1",
+            chain_id: 8006,
+            verifying_contract: (102, 249, 102, 79, 151, 242, 181, 15, 98, 209, 62, 160, 100, 152, 47, 147, 109, 231, 102, 87),
+            salt: (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31),
+        )),
+    ),
+    (
+        kms_core_version_min: "0.15.0",
+        kms_core_module: "kms",
         metadata: TypedPlaintext((
             test_filename: "typed_plaintext",
             plaintext_bytes: [

--- a/backward-compatibility/data/kms.ron
+++ b/backward-compatibility/data/kms.ron
@@ -1046,6 +1046,7 @@
                 187,
                 204,
             ],
+            eip712_domain: None,
         )),
     ),
     (
@@ -1391,6 +1392,7 @@
                 187,
                 204,
             ],
+            eip712_domain: None,
         )),
     ),
     (
@@ -1804,6 +1806,13 @@
                 187,
                 204,
             ],
+            eip712_domain: Some((
+                name: "Keygen metadata domain",
+                version: "2",
+                chain_id: 70001,
+                verifying_contract: (30, 47, 58, 75, 92, 109, 126, 143, 144, 161, 178, 195, 212, 229, 246, 7, 24, 41, 58, 75),
+                salt: None,
+            )),
         )),
     ),
     (

--- a/backward-compatibility/generate-v0.13.20/src/data_0_13.rs
+++ b/backward-compatibility/generate-v0.13.20/src/data_0_13.rs
@@ -345,6 +345,7 @@ const KEY_GEN_METADATA_WITH_EXTRA_DATA_TEST: KeyGenMetadataWithExtraDataTest =
         test_filename: Cow::Borrowed("key_gen_metadata_with_extra_data"),
         state: 101,
         extra_data: Cow::Borrowed(&[0x02, 0xAA, 0xBB, 0xCC]),
+        eip712_domain: None,
     };
 
 const CRS_GEN_METADATA_WITH_EXTRA_DATA_TEST: CrsGenMetadataWithExtraDataTest =

--- a/backward-compatibility/generate-v0.14.0/src/data_0_14.rs
+++ b/backward-compatibility/generate-v0.14.0/src/data_0_14.rs
@@ -367,6 +367,7 @@ const KEY_GEN_METADATA_WITH_EXTRA_DATA_TEST: KeyGenMetadataWithExtraDataTest =
         test_filename: Cow::Borrowed("key_gen_metadata_with_extra_data"),
         state: 101,
         extra_data: Cow::Borrowed(&[0x02, 0xAA, 0xBB, 0xCC]),
+        eip712_domain: None,
     };
 
 const CRS_GEN_METADATA_WITH_EXTRA_DATA_TEST: CrsGenMetadataWithExtraDataTest =

--- a/backward-compatibility/generate-v0.15.0/Cargo.lock
+++ b/backward-compatibility/generate-v0.15.0/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "cfg-if",
  "cipher 0.4.4",
  "cpufeatures 0.2.17",
+ "zeroize",
 ]
 
 [[package]]
@@ -46,6 +47,7 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1169,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -1180,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -1800,7 +1802,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bc2wrap"
 version = "2.0.1"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "bincode 2.0.1",
  "serde",
@@ -2967,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "error-utils"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "anyhow",
  "tracing",
@@ -3516,6 +3518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
 dependencies = [
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -3955,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -3985,6 +3988,7 @@ dependencies = [
  "enum_dispatch",
  "futures-util",
  "hex",
+ "hybrid-array 0.2.3",
  "iam-rs",
  "itertools 0.14.0",
  "k256",
@@ -4039,7 +4043,7 @@ dependencies = [
 [[package]]
 name = "kms-grpc"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4063,6 +4067,7 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]
@@ -4478,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "observability"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "anyhow",
  "axum",
@@ -5758,8 +5763,8 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
-source = "git+https://github.com/zama-ai/rustls.git?branch=rel-0.23#49aa4091eae6a73f575bebeae28d370acd74f8b6"
+version = "0.23.43"
+source = "git+https://github.com/zama-ai/rustls.git?branch=rel-0.23#0af4c54c15d5955d268079989afaf031e0008509"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5794,8 +5799,8 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
-source = "git+https://github.com/zama-ai/webpki.git?branch=rel-0.103#9558707f39b97060b527966de76943e7ed40a022"
+version = "0.103.14"
+source = "git+https://github.com/zama-ai/webpki.git?branch=rel-0.103#16364610f182aae5764d3106bcdcc61e6a85cda8"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6586,7 +6591,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test-utils"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -6761,7 +6766,7 @@ dependencies = [
 [[package]]
 name = "thread-handles"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "anyhow",
  "error-utils",
@@ -6792,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "threshold-algebra"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "anyhow",
  "error-utils",
@@ -6813,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "threshold-execution"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "aes 0.9.1",
  "aes-prng",
@@ -6856,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "threshold-hashing"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -6869,7 +6874,7 @@ dependencies = [
 [[package]]
 name = "threshold-networking"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6899,13 +6904,14 @@ dependencies = [
  "tonic-tls",
  "tower",
  "tracing",
+ "validator",
  "x509-parser 0.18.1",
 ]
 
 [[package]]
 name = "threshold-types"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=8a9ebb163a8d480e23859faa7456305a2fa96f7a#8a9ebb163a8d480e23859faa7456305a2fa96f7a"
+source = "git+https://github.com/zama-ai/kms.git?rev=1a16d5fc37f629f51bf7a3a2729a9d0ac428570a#1a16d5fc37f629f51bf7a3a2729a9d0ac428570a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/backward-compatibility/generate-v0.15.0/Cargo.toml
+++ b/backward-compatibility/generate-v0.15.0/Cargo.toml
@@ -9,23 +9,23 @@ license = "BSD-3-Clause-Clear"
 [dependencies]
 # Import the base backward-compatibility crate for shared types and utilities
 backward-compatibility = { path = ".." }
-bc2wrap = { git = "https://github.com/zama-ai/kms.git", package = "bc2wrap", rev = "8a9ebb163a8d480e23859faa7456305a2fa96f7a" }
+bc2wrap = { git = "https://github.com/zama-ai/kms.git", package = "bc2wrap", rev = "1a16d5fc37f629f51bf7a3a2729a9d0ac428570a" }
 
 # NOTE: Some dependencies below are duplicated from ../Cargo.toml
 # This is intentional - these crates are excluded from the workspace for isolation.
 # Each generator may need different versions to match its target KMS version.
 
 # All dependencies below target the v0.15.0 release.
-# NOTE: v0.15.0 is not tagged yet, so we pin a commit rev on this branch. This rev
-# MUST be updated to the commit that introduces the `EpochData` type (and its public
-# re-export) once these changes are pushed, otherwise the generator will not compile.
-kms_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "kms", rev = "8a9ebb163a8d480e23859faa7456305a2fa96f7a" }
-kms_grpc_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "kms-grpc", rev = "8a9ebb163a8d480e23859faa7456305a2fa96f7a" }
-algebra_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-algebra", default-features = false, rev = "8a9ebb163a8d480e23859faa7456305a2fa96f7a" }
-threshold_execution_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-execution", default-features = false, rev = "8a9ebb163a8d480e23859faa7456305a2fa96f7a", features = ["testing"] }
-threshold_networking_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-networking", default-features = false, rev = "8a9ebb163a8d480e23859faa7456305a2fa96f7a" }
-threshold_types_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-types", default-features = false, rev = "8a9ebb163a8d480e23859faa7456305a2fa96f7a" }
-hashing_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-hashing", default-features = false, rev = "8a9ebb163a8d480e23859faa7456305a2fa96f7a" }
+# NOTE: v0.15.0 is not tagged yet, so we pin a commit rev on `main`. Bump this rev to a
+# commit that contains every type this generator serializes, otherwise the generator will
+# not compile.
+kms_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "kms", rev = "1a16d5fc37f629f51bf7a3a2729a9d0ac428570a" }
+kms_grpc_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "kms-grpc", rev = "1a16d5fc37f629f51bf7a3a2729a9d0ac428570a" }
+algebra_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-algebra", default-features = false, rev = "1a16d5fc37f629f51bf7a3a2729a9d0ac428570a" }
+threshold_execution_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-execution", default-features = false, rev = "1a16d5fc37f629f51bf7a3a2729a9d0ac428570a", features = ["testing"] }
+threshold_networking_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-networking", default-features = false, rev = "1a16d5fc37f629f51bf7a3a2729a9d0ac428570a" }
+threshold_types_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-types", default-features = false, rev = "1a16d5fc37f629f51bf7a3a2729a9d0ac428570a" }
+hashing_0_15_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-hashing", default-features = false, rev = "1a16d5fc37f629f51bf7a3a2729a9d0ac428570a" }
 #error-utils_0_15_0 = { path = "./core/error-utils", default-features = false }
 #thread-handles_0_15_0 = { path = "./core/thread-handles" }
 

--- a/backward-compatibility/generate-v0.15.0/src/data_0_15.rs
+++ b/backward-compatibility/generate-v0.15.0/src/data_0_15.rs
@@ -98,8 +98,8 @@ use backward_compatibility::parameters::{
 };
 use backward_compatibility::{
     AppKeyBlobTest, BackupCiphertextTest, ContextInfoTest, CrsGenMetadataTest,
-    CrsGenMetadataWithExtraDataTest, CrsSignedPayloadTest, EpochDataTest, HybridKemCtTest,
-    InternalCustodianContextTest, InternalCustodianRecoveryOutputTest,
+    CrsGenMetadataWithExtraDataTest, CrsSignedPayloadTest, Eip712DomainTest, EpochDataTest,
+    HybridKemCtTest, InternalCustodianContextTest, InternalCustodianRecoveryOutputTest,
     InternalCustodianSetupMessageTest, InternalRecoveryRequestTest, KeyGenMetadataTest,
     KeyGenMetadataWithExtraDataTest, KeygenSignedPayloadTest, KmsFheKeyHandlesTest, NodeInfoTest,
     OperatorBackupOutputTest, PRSSSetupTest, PrepKeygenSignedPayloadTest, PrfKeyTest,
@@ -383,7 +383,22 @@ const KEY_GEN_METADATA_WITH_EXTRA_DATA_TEST: KeyGenMetadataWithExtraDataTest =
         test_filename: Cow::Borrowed("key_gen_metadata_with_extra_data"),
         state: 101,
         extra_data: Cow::Borrowed(&[0x02, 0xAA, 0xBB, 0xCC]),
+        eip712_domain: Some(KEY_GEN_METADATA_DOMAIN),
     };
+
+// KMS test — the domain of the keygen metadata fixture above. The values differ from
+// `dummy_domain`, so a loader that rebuilds the metadata must read the domain from
+// this entry. The salt is unset, because the KMS also stores domains without a salt.
+const KEY_GEN_METADATA_DOMAIN: Eip712DomainTest = Eip712DomainTest {
+    name: Cow::Borrowed("Keygen metadata domain"),
+    version: Cow::Borrowed("2"),
+    chain_id: 70001,
+    verifying_contract: [
+        0x1e, 0x2f, 0x3a, 0x4b, 0x5c, 0x6d, 0x7e, 0x8f, 0x90, 0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6,
+        0x07, 0x18, 0x29, 0x3a, 0x4b,
+    ],
+    salt: None,
+};
 
 const CRS_GEN_METADATA_WITH_EXTRA_DATA_TEST: CrsGenMetadataWithExtraDataTest =
     CrsGenMetadataWithExtraDataTest {
@@ -664,6 +679,19 @@ fn dummy_domain() -> alloy_sol_types_1_6_0::Eip712Domain {
     )
 }
 
+/// Rebuilds the EIP-712 domain that `test` describes.
+fn domain_from_test(test: &Eip712DomainTest) -> alloy_sol_types_1_6_0::Eip712Domain {
+    alloy_sol_types_1_6_0::Eip712Domain::new(
+        Some(test.name.to_string().into()),
+        Some(test.version.to_string().into()),
+        Some(alloy_primitives_1_6_0::U256::from(test.chain_id)),
+        Some(alloy_primitives_1_6_0::Address::from(
+            test.verifying_contract,
+        )),
+        test.salt.map(alloy_primitives_1_6_0::B256::from),
+    )
+}
+
 pub struct V0_15_0;
 
 struct KmsV0_15_0;
@@ -846,7 +874,8 @@ impl KmsV0_15_0 {
         TestMetadataKMS::CrsGenMetadata(CRS_GEN_METADATA_TEST)
     }
 
-    /// Twin of `gen_key_gen_metadata` for version 15.0 (with extra_data).
+    /// Twin of `gen_key_gen_metadata` for version 15.0, with extra data and the
+    /// stored EIP-712 domain.
     fn gen_key_gen_metadata_with_extra_data(dir: &PathBuf) -> TestMetadataKMS {
         let mut rng = AesRng::seed_from_u64(KEY_GEN_METADATA_WITH_EXTRA_DATA_TEST.state);
         let (_verf_key, sig_key) = gen_sig_keys(&mut rng);
@@ -867,14 +896,14 @@ impl KmsV0_15_0 {
         );
         key_digest_map.insert(PubDataType::ServerKey, server_key_digest);
         key_digest_map.insert(PubDataType::PublicKey, pub_key_digest);
-        let external_signature =
-            compute_eip712_signature(&sig_key, &sol_type, &dummy_domain()).unwrap();
+        let domain = domain_from_test(&KEY_GEN_METADATA_DOMAIN);
+        let external_signature = compute_eip712_signature(&sig_key, &sol_type, &domain).unwrap();
 
         let current = KeyGenMetadataInner {
             key_id,
             preprocessing_id,
             key_digest_map,
-            eip712_domain: None, // Legacy (before the domain was stored)
+            eip712_domain: Some(StoredEip712Domain::from(&domain)),
             external_signature,
             signatures: Vec::new(), // Legacy (before multiple signing key support)
             extra_data: Some(extra_data),

--- a/backward-compatibility/generate-v0.15.0/src/data_0_15.rs
+++ b/backward-compatibility/generate-v0.15.0/src/data_0_15.rs
@@ -28,8 +28,9 @@ use kms_0_15_0::cryptography::{
     },
 };
 use kms_0_15_0::engine::base::{
-    CrsGenMetadata, CrsSignedPayload, KeyGenMetadataInner, KeygenSignedPayload, KmsFheKeyHandles,
-    PrepKeygenSignedPayload, StoredTypedSignature,
+    CrsGenMetadata, CrsGenMetadataInner, CrsGenMetadataInnerV2, CrsSignedPayload,
+    KeyGenMetadataInner, KeygenSignedPayload, KmsFheKeyHandles, PrepKeygenSignedPayload,
+    StoredEip712Domain, StoredTypedSignature,
 };
 use kms_0_15_0::engine::centralized::central_kms::generate_client_fhe_key;
 use kms_0_15_0::engine::context::{
@@ -105,10 +106,11 @@ use backward_compatibility::{
     PrivDataTypeTest, PrivateSigKeyTest, PrssSetTest, PrssSetupCombinedTest, PubDataTypeTest,
     PublicSigKeyTest, RecoveryValidationMaterialTest, ReleasePCRValuesTest, SchemeDigestsTest,
     ShareTest, SigncryptionPayloadTest, SignedPubDataHandleInternalTest, SoftwareVersionTest,
-    StoredTypedSignatureTest, TestMetadataDD, TestMetadataKMS, TestMetadataKmsGrpc,
-    ThresholdFheKeysTest, TypedPlaintextTest, UnifiedCipherTest, UnifiedPublicSigKeyTest,
-    UnifiedSigncryptionKeyTest, UnifiedSigncryptionTest, UnifiedUnsigncryptionKeyTest,
-    DISTRIBUTED_DECRYPTION_MODULE_NAME, KMS_GRPC_MODULE_NAME, KMS_MODULE_NAME,
+    StoredEip712DomainTest, StoredTypedSignatureTest, TestMetadataDD, TestMetadataKMS,
+    TestMetadataKmsGrpc, ThresholdFheKeysTest, TypedPlaintextTest, UnifiedCipherTest,
+    UnifiedPublicSigKeyTest, UnifiedSigncryptionKeyTest, UnifiedSigncryptionTest,
+    UnifiedUnsigncryptionKeyTest, DISTRIBUTED_DECRYPTION_MODULE_NAME, KMS_GRPC_MODULE_NAME,
+    KMS_MODULE_NAME,
 };
 use hashing_0_15_0::hash_versioned;
 use kms_0_15_0::cryptography::signcryption::SigncryptionPayload;
@@ -390,6 +392,25 @@ const CRS_GEN_METADATA_WITH_EXTRA_DATA_TEST: CrsGenMetadataWithExtraDataTest =
         max_num_bits: 2048,
         extra_data: Cow::Borrowed(&[0x02, 0xDD, 0xEE, 0xFF]),
     };
+
+// KMS test — the EIP-712 domain retained in keygen and CRS metadata, with every
+// optional field set. The chain ID exceeds one byte so the fixture also pins the
+// big-endian widening to 32 bytes.
+const STORED_EIP712_DOMAIN_TEST: StoredEip712DomainTest = StoredEip712DomainTest {
+    test_filename: Cow::Borrowed("stored_eip712_domain"),
+    name: Cow::Borrowed("Authorization token"),
+    version: Cow::Borrowed("1"),
+    chain_id: 8006,
+    verifying_contract: [
+        0x66, 0xf9, 0x66, 0x4f, 0x97, 0xf2, 0xb5, 0x0f, 0x62, 0xd1, 0x3e, 0xa0, 0x64, 0x98, 0x2f,
+        0x93, 0x6d, 0xe7, 0x66, 0x57,
+    ],
+    salt: [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f,
+    ],
+};
 
 // KMS test
 const APP_KEY_BLOB_TEST: AppKeyBlobTest = AppKeyBlobTest {
@@ -765,6 +786,7 @@ impl KmsV0_15_0 {
             key_id,
             preprocessing_id,
             key_digest_map,
+            eip712_domain: None,
             external_signature,
             signatures: Vec::new(),
             extra_data: None,
@@ -789,14 +811,19 @@ impl KmsV0_15_0 {
         let sol_type = CrsgenVerificationQ126::new(&crs_id, max_num_bits as usize, digest.clone());
         let external_signature =
             compute_eip712_signature(&sig_key, &sol_type, &dummy_domain()).unwrap();
-        let current_crs_meta_data = CrsGenMetadata::new(
+        // Legacy layout (before the domain was stored), upgraded the way the KMS
+        // upgrades it on load.
+        let current_inner: CrsGenMetadataInner = CrsGenMetadataInnerV2 {
             crs_id,
-            digest,
+            crs_digest: digest,
             max_num_bits,
-            external_signature.clone(),
-            vec![], // Empty signatures to signal legacy
-            vec![], // Empty extra data to signal legacy
-        );
+            extra_data: None, // Empty extra data to signal legacy
+            external_signature: external_signature.clone(),
+            signatures: vec![], // Empty signatures to signal legacy
+        }
+        .upgrade()
+        .unwrap();
+        let current_crs_meta_data = CrsGenMetadata::Current(current_inner);
 
         let legacy_crs_meta_data = SignedPubDataHandleInternal::new(
             crs_id.to_string(),
@@ -847,6 +874,7 @@ impl KmsV0_15_0 {
             key_id,
             preprocessing_id,
             key_digest_map,
+            eip712_domain: None, // Legacy (before the domain was stored)
             external_signature,
             signatures: Vec::new(), // Legacy (before multiple signing key support)
             extra_data: Some(extra_data),
@@ -876,14 +904,19 @@ impl KmsV0_15_0 {
         );
         let external_signature =
             compute_eip712_signature(&sig_key, &sol_type, &dummy_domain()).unwrap();
-        let current_crs_meta_data = CrsGenMetadata::new(
+        // Legacy layout (before the domain was stored), upgraded the way the KMS
+        // upgrades it on load.
+        let current_inner: CrsGenMetadataInner = CrsGenMetadataInnerV2 {
             crs_id,
-            digest,
+            crs_digest: digest,
             max_num_bits,
-            external_signature.clone(),
-            Vec::new(), // Legacy (before multiple signing key support)
-            extra_data,
-        );
+            extra_data: Some(extra_data),
+            external_signature: external_signature.clone(),
+            signatures: Vec::new(), // Legacy (before multiple signing key support)
+        }
+        .upgrade()
+        .unwrap();
+        let current_crs_meta_data = CrsGenMetadata::Current(current_inner);
 
         store_versioned_test!(
             &current_crs_meta_data,
@@ -892,6 +925,27 @@ impl KmsV0_15_0 {
         );
 
         TestMetadataKMS::CrsGenMetadataWithExtraData(CRS_GEN_METADATA_WITH_EXTRA_DATA_TEST)
+    }
+
+    fn gen_stored_eip712_domain(dir: &PathBuf) -> TestMetadataKMS {
+        let domain = alloy_sol_types_1_6_0::Eip712Domain::new(
+            Some(STORED_EIP712_DOMAIN_TEST.name.to_string().into()),
+            Some(STORED_EIP712_DOMAIN_TEST.version.to_string().into()),
+            Some(alloy_primitives_1_6_0::U256::from(
+                STORED_EIP712_DOMAIN_TEST.chain_id,
+            )),
+            Some(alloy_primitives_1_6_0::Address::from(
+                STORED_EIP712_DOMAIN_TEST.verifying_contract,
+            )),
+            Some(alloy_primitives_1_6_0::B256::from(
+                STORED_EIP712_DOMAIN_TEST.salt,
+            )),
+        );
+        let stored = StoredEip712Domain::from(&domain);
+
+        store_versioned_test!(&stored, dir, &STORED_EIP712_DOMAIN_TEST.test_filename);
+
+        TestMetadataKMS::StoredEip712Domain(STORED_EIP712_DOMAIN_TEST)
     }
 
     #[expect(clippy::ptr_arg)]
@@ -1951,6 +2005,7 @@ impl KMSCoreVersion for V0_15_0 {
             KmsV0_15_0::gen_crs_metadata(&dir),
             KmsV0_15_0::gen_key_gen_metadata_with_extra_data(&dir),
             KmsV0_15_0::gen_crs_metadata_with_extra_data(&dir),
+            KmsV0_15_0::gen_stored_eip712_domain(&dir),
             KmsV0_15_0::gen_typed_plaintext(&dir),
             KmsV0_15_0::gen_signcryption_payload(&dir),
             KmsV0_15_0::gen_signcryption_key(&dir),

--- a/backward-compatibility/src/lib.rs
+++ b/backward-compatibility/src/lib.rs
@@ -324,6 +324,12 @@ pub struct KeyGenMetadataWithExtraDataTest {
     pub test_filename: Cow<'static, str>,
     pub state: u64,
     pub extra_data: Cow<'static, [u8]>,
+    /// The EIP-712 domain that the metadata keeps, and that signs the external
+    /// signature in the same metadata. The versions that predate the stored
+    /// domain leave the field out of their manifest entry, so it defaults to
+    /// `None`.
+    #[serde(default)]
+    pub eip712_domain: Option<Eip712DomainTest>,
 }
 
 impl TestType for KeyGenMetadataWithExtraDataTest {
@@ -361,6 +367,22 @@ impl TestType for CrsGenMetadataWithExtraDataTest {
     fn test_filename(&self) -> String {
         self.test_filename.to_string()
     }
+}
+
+// KMS test — an EIP-712 domain that another fixture embeds. The type has no
+// fixture file of its own, so it has no filename.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Eip712DomainTest {
+    /// EIP-712 domain name.
+    pub name: Cow<'static, str>,
+    /// EIP-712 domain version.
+    pub version: Cow<'static, str>,
+    /// Chain ID. The stored form widens it to a 32-byte big-endian integer.
+    pub chain_id: u64,
+    /// Address of the verifying contract.
+    pub verifying_contract: [u8; 20],
+    /// Domain salt, if the domain has one.
+    pub salt: Option<[u8; 32]>,
 }
 
 // KMS test — the EIP-712 domain that keygen and CRS metadata retain. Every optional

--- a/backward-compatibility/src/lib.rs
+++ b/backward-compatibility/src/lib.rs
@@ -363,6 +363,37 @@ impl TestType for CrsGenMetadataWithExtraDataTest {
     }
 }
 
+// KMS test — the EIP-712 domain that keygen and CRS metadata retain. Every optional
+// field of the domain is set, so one fixture pins the byte layout of all of them.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct StoredEip712DomainTest {
+    pub test_filename: Cow<'static, str>,
+    /// EIP-712 domain name.
+    pub name: Cow<'static, str>,
+    /// EIP-712 domain version.
+    pub version: Cow<'static, str>,
+    /// Chain ID. The stored form widens it to a 32-byte big-endian integer.
+    pub chain_id: u64,
+    /// Address of the verifying contract.
+    pub verifying_contract: [u8; 20],
+    /// Domain salt.
+    pub salt: [u8; 32],
+}
+
+impl TestType for StoredEip712DomainTest {
+    fn module(&self) -> String {
+        KMS_MODULE_NAME.to_string()
+    }
+
+    fn target_type(&self) -> String {
+        "StoredEip712Domain".to_string()
+    }
+
+    fn test_filename(&self) -> String {
+        self.test_filename.to_string()
+    }
+}
+
 // KMS test
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AppKeyBlobTest {
@@ -1119,6 +1150,7 @@ pub enum TestMetadataKMS {
     KeyGenMetadata(KeyGenMetadataTest),
     CrsGenMetadataWithExtraData(CrsGenMetadataWithExtraDataTest),
     KeyGenMetadataWithExtraData(KeyGenMetadataWithExtraDataTest),
+    StoredEip712Domain(StoredEip712DomainTest),
     SigncryptionPayload(SigncryptionPayloadTest),
     PrssSetupCombined(PrssSetupCombinedTest),
     EpochData(EpochDataTest),

--- a/core/service/src/engine/storage_material_verification.rs
+++ b/core/service/src/engine/storage_material_verification.rs
@@ -344,7 +344,7 @@ fn verify_keygen_metadata_signature(
     metadata: &KeyGenMetadataInner,
     expected_address: Address,
 ) -> anyhow::Result<()> {
-    // TODO(github.com/zama-ai/kms-internal#3201)
+    // TODO(github.com/zama-ai/kms-internal/issues/3201)
     // After we upgrade to 0.16 (and have migrated keys in 0.15),
     // or after we retire the default epoch, then remove the backward compatibility support.
     // That is, we should always have a domain in the metadata that we can use to verify the signature.
@@ -390,7 +390,7 @@ fn verify_crs_metadata_signature(
     metadata: &CrsGenMetadataInner,
     expected_address: Address,
 ) -> anyhow::Result<()> {
-    // TODO(github.com/zama-ai/kms-internal#3201)
+    // TODO(github.com/zama-ai/kms-internal/issues/3201)
     // After we can retire the default epoch, we can remove the backward compatibility support
     // since new epochs will be re-signed using the more recent format.
     // That is, we should always have a domain in the metadata that we can use to verify the signature.

--- a/core/service/tests/backward_compatibility_kms.rs
+++ b/core/service/tests/backward_compatibility_kms.rs
@@ -15,10 +15,10 @@ use backward_compatibility::{
     KeyGenMetadataWithExtraDataTest, KeygenSignedPayloadTest, KmsFheKeyHandlesTest, NodeInfoTest,
     OperatorBackupOutputTest, PrepKeygenSignedPayloadTest, PrivateSigKeyTest,
     PrssSetupCombinedTest, PublicSigKeyTest, RecoveryValidationMaterialTest, SchemeDigestsTest,
-    SigncryptionPayloadTest, SoftwareVersionTest, StoredTypedSignatureTest, TestMetadataKMS,
-    TestType, Testcase, ThresholdFheKeysTest, TypedPlaintextTest, UnifiedCipherTest,
-    UnifiedPublicSigKeyTest, UnifiedSigncryptionKeyTest, UnifiedSigncryptionTest,
-    UnifiedUnsigncryptionKeyTest, data_dir,
+    SigncryptionPayloadTest, SoftwareVersionTest, StoredEip712DomainTest, StoredTypedSignatureTest,
+    TestMetadataKMS, TestType, Testcase, ThresholdFheKeysTest, TypedPlaintextTest,
+    UnifiedCipherTest, UnifiedPublicSigKeyTest, UnifiedSigncryptionKeyTest,
+    UnifiedSigncryptionTest, UnifiedUnsigncryptionKeyTest, data_dir,
     load::{DataFormat, TestFailure, TestResult, TestSuccess},
     tests::{TestedModule, run_all_tests},
 };
@@ -60,7 +60,7 @@ use kms_lib::{
         base::{
             CrsGenMetadata, CrsGenMetadataInner, CrsGenMetadataInnerV2, CrsSignedPayload,
             KeyGenMetadata, KeyGenMetadataInner, KeygenSignedPayload, KmsFheKeyHandles,
-            PrepKeygenSignedPayload, StoredTypedSignature,
+            PrepKeygenSignedPayload, StoredEip712Domain, StoredTypedSignature,
         },
         context::{ContextInfo, NodeInfo, SchemeDigests, SignerAddress, SoftwareVersion},
         threshold::service::{
@@ -1384,6 +1384,46 @@ fn scheme_from_name(name: &str) -> SigningSchemeType {
     }
 }
 
+fn test_stored_eip712_domain(
+    dir: &Path,
+    test: &StoredEip712DomainTest,
+    format: DataFormat,
+) -> Result<TestSuccess, TestFailure> {
+    let original_versionized: StoredEip712Domain = load_and_unversionize(dir, test, format)?;
+
+    let domain = alloy_sol_types::Eip712Domain::new(
+        Some(test.name.to_string().into()),
+        Some(test.version.to_string().into()),
+        Some(alloy_primitives::U256::from(test.chain_id)),
+        Some(alloy_primitives::Address::from(test.verifying_contract)),
+        Some(alloy_primitives::B256::from(test.salt)),
+    );
+    let new_versionized = StoredEip712Domain::from(&domain);
+
+    if original_versionized != new_versionized {
+        return Err(test.failure(
+            format!(
+                "Invalid StoredEip712Domain:\n Expected :\n{original_versionized:?}\nGot:\n{new_versionized:?}"
+            ),
+            format,
+        ));
+    }
+
+    // Boot-time signature verification runs on the domain converted back from
+    // storage, so the stored form must round-trip to the domain it was built from.
+    let round_trip = alloy_sol_types::Eip712Domain::from(&original_versionized);
+    if round_trip != domain {
+        Err(test.failure(
+            format!(
+                "StoredEip712Domain does not convert back to its domain:\n Expected :\n{domain:?}\nGot:\n{round_trip:?}"
+            ),
+            format,
+        ))
+    } else {
+        Ok(test.success(format))
+    }
+}
+
 fn test_stored_scheme_signature(
     dir: &Path,
     test: &StoredTypedSignatureTest,
@@ -1545,6 +1585,9 @@ impl TestedModule for KMS {
             }
             Self::Metadata::CrsGenMetadataWithExtraData(test) => {
                 test_crs_gen_metadata_with_extra_data(test_dir.as_ref(), test, format).into()
+            }
+            Self::Metadata::StoredEip712Domain(test) => {
+                test_stored_eip712_domain(test_dir.as_ref(), test, format).into()
             }
             Self::Metadata::SigncryptionPayload(test) => {
                 test_signcryption_payload(test_dir.as_ref(), test, format).into()

--- a/core/service/tests/backward_compatibility_kms.rs
+++ b/core/service/tests/backward_compatibility_kms.rs
@@ -9,8 +9,8 @@ use aes_prng::AesRng;
 use algebra::galois_rings::degree_4::{ResiduePolyF4Z64, ResiduePolyF4Z128};
 use backward_compatibility::{
     AppKeyBlobTest, BackupCiphertextTest, ContextInfoTest, CrsGenMetadataTest,
-    CrsGenMetadataWithExtraDataTest, CrsSignedPayloadTest, EpochDataTest, HybridKemCtTest,
-    InternalCustodianContextTest, InternalCustodianRecoveryOutputTest,
+    CrsGenMetadataWithExtraDataTest, CrsSignedPayloadTest, Eip712DomainTest, EpochDataTest,
+    HybridKemCtTest, InternalCustodianContextTest, InternalCustodianRecoveryOutputTest,
     InternalCustodianSetupMessageTest, InternalRecoveryRequestTest, KeyGenMetadataTest,
     KeyGenMetadataWithExtraDataTest, KeygenSignedPayloadTest, KmsFheKeyHandlesTest, NodeInfoTest,
     OperatorBackupOutputTest, PrepKeygenSignedPayloadTest, PrivateSigKeyTest,
@@ -94,6 +94,17 @@ fn dummy_domain() -> alloy_sol_types::Eip712Domain {
         version: "1",
         chain_id: 8006,
         verifying_contract: alloy_primitives::address!("66f9664f97F2b50F62D13eA064982f936dE76657"),
+    )
+}
+
+/// Rebuilds the EIP-712 domain that `test` describes.
+fn domain_from_test(test: &Eip712DomainTest) -> alloy_sol_types::Eip712Domain {
+    alloy_sol_types::Eip712Domain::new(
+        Some(test.name.to_string().into()),
+        Some(test.version.to_string().into()),
+        Some(alloy_primitives::U256::from(test.chain_id)),
+        Some(alloy_primitives::Address::from(test.verifying_contract)),
+        test.salt.map(alloy_primitives::B256::from),
     )
 }
 
@@ -380,15 +391,20 @@ fn test_key_gen_metadata_with_extra_data(
     );
     key_digest_map.insert(PubDataType::ServerKey, server_key_digest);
     key_digest_map.insert(PubDataType::PublicKey, pub_key_digest);
+    // The versions that predate the stored domain signed with `dummy_domain` and kept
+    // no domain. The later versions name their domain in the fixture metadata, and the
+    // same domain signs the external signature.
+    let stored_domain = test.eip712_domain.as_ref().map(domain_from_test);
+    let signing_domain = stored_domain.clone().unwrap_or_else(dummy_domain);
     let external_signature =
-        compute_eip712_signature(&sig_key, &sol_type, &dummy_domain()).unwrap();
+        compute_eip712_signature(&sig_key, &sol_type, &signing_domain).unwrap();
 
     let new_versionized = KeyGenMetadataInner {
         signatures: vec![],
         key_id,
         preprocessing_id,
         key_digest_map,
-        eip712_domain: None,
+        eip712_domain: stored_domain.as_ref().map(StoredEip712Domain::from),
         external_signature,
         extra_data: Some(extra_data),
     };

--- a/core/service/tests/versioned_enum_coverage.rs
+++ b/core/service/tests/versioned_enum_coverage.rs
@@ -78,9 +78,6 @@ const ALLOW_UNCOVERED: &[&str] = &[
     // Variant payload of CrsGenMetadata::Current.
     // Covered via CrsGenMetadataTest.
     "CrsGenMetadataInner",
-    // Field of KeyGenMetadataInner.eip712_domain.
-    // TODO(github.com/zama-ai/kms-internal/issues/3200)
-    "StoredEip712Domain",
     // Field of Share.
     // Covered via ShareTest.
     "Role",


### PR DESCRIPTION
## Description
Add backward compatibility tests for StoredEip712Domain, also re-generate backward compatibility data for 0.15.0. 

### Related issue(s)
Closes zama-ai/kms-internal#3200

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
