### PR TITLE
fix: put legacyPrssMask into threshold section of charts

### DIFF
--- a/charts/kms-core/Chart.yaml
+++ b/charts/kms-core/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-core
 description: A helm chart to distribute and deploy the Zama KMS core service.
-version: 1.6.1
+version: 1.6.2
 appVersion: 0.13.22   # Minimum kms version to run this chart
 apiVersion: v2
 keywords:

--- a/charts/kms-core/templates/kms-core-configmap.yaml
+++ b/charts/kms-core/templates/kms-core-configmap.yaml
@@ -1,6 +1,20 @@
 {{- if or .Values.kmsCore.enabled .Values.kmsGenCertAndKeys.enabled -}}
 {{- $kmsCoreName := include "kmsCoreName" . }}
 {{- $peersIDList := untilStep (include "kmsPeersStartID" . | int) (.Values.kmsPeers.count | add1 | int) 1  }}
+{{- /* Issue#3089: the PRSS-Mask activation thresholds render into the [threshold] config
+       section, so as of chart 1.6.2 they live with the rest of that section under
+       kmsCore.thresholdMode instead of at the top-level kmsCore.legacyPrssMask used by chart
+       <=1.6.1. Reject the old path loudly: Helm drops misplaced keys without error and the
+       server config defaults the fields to "0", so a wrongly-nested threshold is invisible —
+       the party runs the fixed schedule while unpatched peers run the legacy one, and
+       decryption keeps passing because the divergence sits inside the fault budget.
+       Only non-empty values are rejected, since `helm upgrade --reuse-values` from chart
+       <=1.6.1 carries the old empty defaults forward and those mean "unset". */}}
+{{- with (.Values.kmsCore).legacyPrssMask }}
+  {{- if or .beforePublicDecryptId .beforeUserDecryptId }}
+    {{- fail "kmsCore.legacyPrssMask moved to kmsCore.thresholdMode.legacyPrssMask in chart 1.6.2. Set kmsCore.thresholdMode.legacyPrssMask.beforePublicDecryptId and .beforeUserDecryptId instead, and remove kmsCore.legacyPrssMask: at the old path the value is silently ignored." }}
+  {{- end }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -114,13 +128,13 @@ data:
 
     {{- /* Issue#3089: temporary PRSS-Mask schedule activation thresholds, see values.yaml.
            Safe navigation (parenthesized) so the traversal returns nil rather than erroring when
-           legacyPrssMask is absent — e.g. on a `helm upgrade --reuse-values` from a pre-1.6.1
+           legacyPrssMask is absent — e.g. on a `helm upgrade --reuse-values` from a pre-1.6.2
            release, where the reused values snapshot has no legacyPrssMask key and chart defaults
            are not re-merged. */}}
-    {{- with ((.Values.kmsCore).legacyPrssMask).beforePublicDecryptId }}
+    {{- with ((.Values.kmsCore.thresholdMode).legacyPrssMask).beforePublicDecryptId }}
     legacy_prss_mask_before_public_decrypt_id = {{ . | quote }}
     {{- end }}
-    {{- with ((.Values.kmsCore).legacyPrssMask).beforeUserDecryptId }}
+    {{- with ((.Values.kmsCore.thresholdMode).legacyPrssMask).beforeUserDecryptId }}
     legacy_prss_mask_before_user_decrypt_id = {{ . | quote }}
     {{- end }}
 

--- a/charts/kms-core/values.yaml
+++ b/charts/kms-core/values.yaml
@@ -42,24 +42,6 @@ kmsCore:
         backupVaultKeychainAWSKMSRootKeyID: KMS_CORE__BACKUP_VAULT__KEYCHAIN__AWS_KMS__ROOT_KEY_ID
   rateLimiter:
     bucketSize: 50000
-  # Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
-  # fix (#663). Requests with an ID strictly below the configured value run the legacy
-  # (pre-#663) schedule for interop with unpatched peers; requests at or above it run the
-  # fixed schedule. MANDATORY fields of the server config (chart rendering fails if nulled);
-  # "0" means the fixed schedule is always used.
-  #
-  # ALL MPC parties MUST configure identical values, chosen
-  # with enough margin for the slowest party to upgrade before the counters reach
-  # them. ALWAYS quote the values (they are 256-bit integers, decimal or 0x-prefixed hex;
-  # unquoted large YAML numbers get mangled). Remove once the migration is complete.
-  # PRSS-Mask legacy-schedule activation thresholds (Issue#3089). Left EMPTY by default so the
-  # config omits the fields entirely — pre-#663 binaries reject unknown config keys, so during a
-  # rolling upgrade these must stay unset until every party runs the new binary, then be enabled
-  # in a second pass (see ci/scripts/rolling_upgrade.sh). Empty => new binary defaults to "0"
-  # (always the fixed schedule). Set to a decimal/0x-hex request-ID threshold to activate.
-  legacyPrssMask:
-    beforePublicDecryptId: ""
-    beforeUserDecryptId: ""
   # Add the following to enable threshold mode:
   thresholdMode:
     enabled: false
@@ -127,6 +109,32 @@ kmsCore:
     # Number of sessions to pre-process should be equal to number of vCPUs
     numSessionsPreproc: 100
     decryptionMode: "NoiseFloodSmall"
+    # Issue#3089: temporary request-ID activation thresholds for the PRSS-Mask counter-schedule
+    # fix (#663). A decryption request whose ID, read as a big-endian integer, is strictly below
+    # the configured value runs the legacy (pre-#663) schedule for interop with unpatched peers;
+    # requests at or above it run the fixed schedule. Public and user decryption request IDs come
+    # from separate counters, hence one threshold each.
+    #
+    # These render into the [threshold] section of kms-server.toml, so they MUST stay nested here
+    # under thresholdMode. Set anywhere else — in particular at the old kmsCore.legacyPrssMask
+    # path used by chart <=1.6.1 — Helm ignores them without error and the party silently runs the
+    # fixed schedule against legacy-schedule peers. The chart hard-fails on that old path.
+    #
+    # Left EMPTY by default so the rendered config omits the fields entirely: pre-#663 binaries
+    # reject unknown config keys, so during a rolling upgrade these must stay unset until every
+    # party runs the new binary, then be enabled in a second pass (see
+    # ci/scripts/rolling_upgrade.sh). Omitted => the new binary defaults to "0", i.e. always the
+    # fixed schedule.
+    #
+    # ALL MPC parties MUST configure identical values, chosen with enough margin for the slowest
+    # party to upgrade before the counters reach them. ALWAYS quote the values (they are 256-bit
+    # integers, decimal or 0x-prefixed hex; unquoted large YAML numbers get mangled). After each
+    # party restarts, confirm the "PRSS-Mask legacy schedule activation thresholds configured"
+    # startup line in its log — that line is the only signal the value took effect. Remove this
+    # whole block once the migration is complete.
+    legacyPrssMask:
+      beforePublicDecryptId: ""
+      beforeUserDecryptId: ""
   # Add the following to enable nitro enclave:
   # Nitro enclave needs specific instance types
   nitroEnclave:

--- a/ci/scripts/rolling_upgrade.sh
+++ b/ci/scripts/rolling_upgrade.sh
@@ -227,7 +227,20 @@ main() {
     # bumps `checksum/config`, restarting the (already-new) pod to pick it up.
     # Non-upgraded (old) parties are never touched, so no old binary ever sees it.
     #=========================================================================
+    # The server parses the threshold as a U256 and logs it back in canonical decimal, and the
+    # confirmation below gates the wave on that log line. An input that differs from its own
+    # canonical form could never match it, so restrict this script to decimal and strip leading
+    # zeros. 0x-prefixed hex remains valid for the chart value and the server config; only this
+    # script's automated comparison requires decimal.
     local threshold="${LEGACY_PRSS_MASK_THRESHOLD:-100}"
+    if [[ ! "${threshold}" =~ ^[0-9]+$ ]]; then
+        log_error "LEGACY_PRSS_MASK_THRESHOLD must be a decimal integer, got '${threshold}'."
+        log_error "0x-prefixed hex is accepted by the chart value but not by this script; convert it to decimal."
+        exit 1
+    fi
+    threshold="$(echo "${threshold}" | sed 's/^0*//')"
+    threshold="${threshold:-0}"
+
     log_info "Step 4: Enabling PRSS-Mask threshold=${threshold} on upgraded parties [${ALL_UPGRADED_PARTIES}]..."
 
     local new_chart_loc="${REPO_ROOT}/charts/kms-core"
@@ -273,34 +286,54 @@ main() {
     # reached the core config: a misplaced value is dropped without error and the server then
     # defaults to "0" (fixed schedule). The startup line below is the only signal that the value
     # took effect, so gate the wave on it per party rather than trusting the upgrade exit status.
-    local _prss_unconfirmed=()
-    for _id in "${_prss_ids[@]}"; do
-        local i; i="$(echo "${_id}" | tr -d ' ')"
-        [[ -z "${i}" ]] && continue
-        local _pod; _pod="$(get_party_pod_name "${i}")"
-        local _confirmed="false"
-        for _attempt in 1 2 3 4 5 6; do
-            if kubectl logs "${_pod}" -n "${NAMESPACE}" --all-containers=true 2>/dev/null \
-                | grep -qF "PRSS-Mask legacy schedule activation thresholds configured: requests with ID strictly below public=${threshold} / user=${threshold}"; then
-                _confirmed="true"
-                break
+    #
+    # A threshold of 0 is the one value that cannot be confirmed this way: it means "no legacy
+    # window" (no request ID is strictly below 0), which is already the default, so the server
+    # emits no line at all. Skip the gate rather than fail it, and say so loudly — running this
+    # step with 0 configures nothing.
+    if [[ "${threshold}" == "0" ]]; then
+        log_warn "PRSS-Mask threshold is 0: no legacy-schedule window is configured and the server"
+        log_warn "logs no activation line, so there is nothing to confirm. Skipping the startup check."
+        log_warn "If you meant to enable a legacy window, set LEGACY_PRSS_MASK_THRESHOLD to a non-zero value."
+    else
+        local _prss_unconfirmed=()
+        local _expected="PRSS-Mask legacy schedule activation thresholds configured: requests with ID strictly below public=${threshold} / user=${threshold}"
+        local _max_attempts=6
+        for _id in "${_prss_ids[@]}"; do
+            local i; i="$(echo "${_id}" | tr -d ' ')"
+            [[ -z "${i}" ]] && continue
+            local _pod; _pod="$(get_party_pod_name "${i}")"
+            local _confirmed="false"
+            local _logs _attempt
+            for ((_attempt = 1; _attempt <= _max_attempts; _attempt++)); do
+                # Read the whole stream into a variable and match in-shell. Piping into `grep -q`
+                # would let grep exit on the first match and SIGPIPE `kubectl logs`, which under
+                # this script's `set -o pipefail` makes the pipeline fail — turning a successful
+                # match into a reported failure.
+                _logs="$(kubectl logs "${_pod}" -n "${NAMESPACE}" --all-containers=true 2>/dev/null || true)"
+                if [[ "${_logs}" == *"${_expected}"* ]]; then
+                    _confirmed="true"
+                    break
+                fi
+                if [[ "${_attempt}" -lt "${_max_attempts}" ]]; then
+                    log_info "  Party ${i}: threshold startup line not present yet (attempt ${_attempt}/${_max_attempts})..."
+                    sleep 10
+                fi
+            done
+            if [[ "${_confirmed}" == "true" ]]; then
+                log_info "  Party ${i}: PRSS-Mask threshold=${threshold} confirmed in startup log."
+            else
+                _prss_unconfirmed+=("${i}")
             fi
-            log_info "  Party ${i}: threshold startup line not present yet (attempt ${_attempt}/6)..."
-            sleep 10
         done
-        if [[ "${_confirmed}" == "true" ]]; then
-            log_info "  Party ${i}: PRSS-Mask threshold=${threshold} confirmed in startup log."
-        else
-            _prss_unconfirmed+=("${i}")
+        if [[ "${#_prss_unconfirmed[@]}" -gt 0 ]]; then
+            log_error "PRSS-Mask threshold=${threshold} never appeared in the startup log of parties: ${_prss_unconfirmed[*]}"
+            log_error "Those parties are running the fixed schedule while unpatched peers run the legacy one."
+            log_error "Check that the value is set at kmsCore.thresholdMode.legacyPrssMask (not kmsCore.legacyPrssMask)."
+            exit 1
         fi
-    done
-    if [[ "${#_prss_unconfirmed[@]}" -gt 0 ]]; then
-        log_error "PRSS-Mask threshold=${threshold} never appeared in the startup log of parties: ${_prss_unconfirmed[*]}"
-        log_error "Those parties are running the fixed schedule while unpatched peers run the legacy one."
-        log_error "Check that the value is set at kmsCore.thresholdMode.legacyPrssMask (not kmsCore.legacyPrssMask)."
-        exit 1
+        log_info "PRSS-Mask threshold enabled and confirmed on all upgraded parties."
     fi
-    log_info "PRSS-Mask threshold enabled and confirmed on all upgraded parties."
 
     log_info "========================================="
     log_info "Rolling Upgrade Complete!"

--- a/ci/scripts/rolling_upgrade.sh
+++ b/ci/scripts/rolling_upgrade.sh
@@ -251,8 +251,8 @@ main() {
             --namespace "${NAMESPACE}" \
             --reuse-values \
             --set kmsGenCertAndKeys.enabled=false \
-            --set "kmsCore.legacyPrssMask.beforePublicDecryptId=${threshold}" \
-            --set "kmsCore.legacyPrssMask.beforeUserDecryptId=${threshold}" \
+            --set "kmsCore.thresholdMode.legacyPrssMask.beforePublicDecryptId=${threshold}" \
+            --set "kmsCore.thresholdMode.legacyPrssMask.beforeUserDecryptId=${threshold}" \
             --wait --wait-for-jobs --timeout=1200s &
         _prss_pids+=("$!")
         _prss_parties+=("${i}")
@@ -268,7 +268,39 @@ main() {
         log_error "PRSS-Mask threshold rollout failed for parties: ${_prss_failed[*]}"
         exit 1
     fi
-    log_info "PRSS-Mask threshold enabled on all upgraded parties."
+
+    # A successful helm upgrade only proves Helm accepted the values, not that the threshold
+    # reached the core config: a misplaced value is dropped without error and the server then
+    # defaults to "0" (fixed schedule). The startup line below is the only signal that the value
+    # took effect, so gate the wave on it per party rather than trusting the upgrade exit status.
+    local _prss_unconfirmed=()
+    for _id in "${_prss_ids[@]}"; do
+        local i; i="$(echo "${_id}" | tr -d ' ')"
+        [[ -z "${i}" ]] && continue
+        local _pod; _pod="$(get_party_pod_name "${i}")"
+        local _confirmed="false"
+        for _attempt in 1 2 3 4 5 6; do
+            if kubectl logs "${_pod}" -n "${NAMESPACE}" --all-containers=true 2>/dev/null \
+                | grep -qF "PRSS-Mask legacy schedule activation thresholds configured: requests with ID strictly below public=${threshold} / user=${threshold}"; then
+                _confirmed="true"
+                break
+            fi
+            log_info "  Party ${i}: threshold startup line not present yet (attempt ${_attempt}/6)..."
+            sleep 10
+        done
+        if [[ "${_confirmed}" == "true" ]]; then
+            log_info "  Party ${i}: PRSS-Mask threshold=${threshold} confirmed in startup log."
+        else
+            _prss_unconfirmed+=("${i}")
+        fi
+    done
+    if [[ "${#_prss_unconfirmed[@]}" -gt 0 ]]; then
+        log_error "PRSS-Mask threshold=${threshold} never appeared in the startup log of parties: ${_prss_unconfirmed[*]}"
+        log_error "Those parties are running the fixed schedule while unpatched peers run the legacy one."
+        log_error "Check that the value is set at kmsCore.thresholdMode.legacyPrssMask (not kmsCore.legacyPrssMask)."
+        exit 1
+    fi
+    log_info "PRSS-Mask threshold enabled and confirmed on all upgraded parties."
 
     log_info "========================================="
     log_info "Rolling Upgrade Complete!"


### PR DESCRIPTION
## Description
In charts v1.6.1 the `legacyPrssMask` was put outside the `thresholdMode` section, which could lead to the value being ignored.
This update to charts v1.6.2 moves the values to the `thresholdMode` section, where they belong.

### Related issue(s)
https://github.com/zama-ai/planning-blockchain/issues/1322

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

