### PR TITLE
chore: bump to v0.14.1 stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "backward-compatibility"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bincode 1.3.3",
  "ron 0.10.1",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "error-utils"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "tracing",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "experiments"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "aes-prng",
  "anyhow",
@@ -3487,7 +3487,7 @@ checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
 
 [[package]]
 name = "generate-test-material"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4268,7 +4268,7 @@ dependencies = [
 
 [[package]]
 name = "kms"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "kms-core-client"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "aes-prng",
  "alloy-primitives",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "kms-grpc"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "kms-health-check"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4921,7 +4921,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -7260,7 +7260,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -7271,11 +7271,11 @@ dependencies = [
 
 [[package]]
 name = "test-utils-cc"
-version = "0.14.1-1"
+version = "0.14.1"
 
 [[package]]
 name = "test-utils-service"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -7446,7 +7446,7 @@ dependencies = [
 
 [[package]]
 name = "thread-handles"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "error-utils",
@@ -7476,7 +7476,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-algebra"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "aes-prng",
  "anyhow",
@@ -7503,7 +7503,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-bgv"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "aes-prng",
  "anyhow",
@@ -7531,7 +7531,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-execution"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "aes 0.9.1",
  "aes-prng",
@@ -7577,7 +7577,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-hashing"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -7589,7 +7589,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-networking"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7627,7 +7627,7 @@ dependencies = [
 
 [[package]]
 name = "threshold-types"
-version = "0.14.1-1"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ authors = ["Zama"]
 publish = true
 edition = "2024"
 license = "BSD-3-Clause-Clear"
-version = "0.14.1-1"
+version = "0.14.1"
 repository = "https://github.com/zama-ai/kms"
 description = "Key Management System for the Zama Protocol."
 

--- a/backward-compatibility/Cargo.toml
+++ b/backward-compatibility/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backward-compatibility"
-version = "0.14.0"
+version = "0.14.1"
 publish = false
 authors = ["Zama"]
 edition = "2021"

--- a/backward-compatibility/generate-v0.14.0/Cargo.toml
+++ b/backward-compatibility/generate-v0.14.0/Cargo.toml
@@ -9,20 +9,20 @@ license = "BSD-3-Clause-Clear"
 [dependencies]
 # Import the base backward-compatibility crate for shared types and utilities
 backward-compatibility = { path = ".." }
-bc2wrap = { git = "https://github.com/zama-ai/kms.git", package = "bc2wrap", tag = "v0.14.0-0" }
+bc2wrap = { git = "https://github.com/zama-ai/kms.git", package = "bc2wrap", tag = "v0.14.1-1" }
 
 # NOTE: Some dependencies below are duplicated from ../Cargo.toml
 # This is intentional - these crates are excluded from the workspace for isolation.
 # Each generator may need different versions to match its target KMS version.
 
-# All dependencies below target tag v0.14.0-0 (for now just using a commit from main until tag is made).
-kms_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "kms", tag = "v0.14.0-0" }
-kms_grpc_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "kms-grpc", tag = "v0.14.0-0" }
-algebra_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-algebra", default-features = false, tag = "v0.14.0-0" }
-threshold_execution_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-execution", default-features = false, tag = "v0.14.0-0", features = ["testing"] }
-threshold_networking_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-networking", default-features = false, tag = "v0.14.0-0" }
-threshold_types_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-types", default-features = false, tag = "v0.14.0-0" }
-hashing_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-hashing", default-features = false, tag = "v0.14.0-0" }
+# All dependencies below target tag v0.14.1-1 (for now just using a commit from main until tag is made).
+kms_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "kms", tag = "v0.14.1-1" }
+kms_grpc_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "kms-grpc", tag = "v0.14.1-1" }
+algebra_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-algebra", default-features = false, tag = "v0.14.1-1" }
+threshold_execution_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-execution", default-features = false, tag = "v0.14.1-1", features = ["testing"] }
+threshold_networking_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-networking", default-features = false, tag = "v0.14.1-1" }
+threshold_types_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-types", default-features = false, tag = "v0.14.1-1" }
+hashing_0_14_0 = { git = "https://github.com/zama-ai/kms.git", package = "threshold-hashing", default-features = false, tag = "v0.14.1-1" }
 #error-utils_0_14_0 = { path = "./core/error-utils", default-features = false }
 #thread-handles_0_14_0 = { path = "./core/thread-handles" }
 


### PR DESCRIPTION
## Description
sets the version to v0.14.1 stable for the release.


## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
