### PR TITLE
chore: migrate CRS to epoch storage

### DIFF
--- a/core/service/src/bin/kms-server.rs
+++ b/core/service/src/bin/kms-server.rs
@@ -21,7 +21,7 @@ use kms_lib::{
     engine::{
         base::BaseKmsStruct, centralized::central_kms::RealCentralizedKms,
         context::SoftwareVersion, context_manager::create_default_centralized_context_in_storage,
-        migration::migrate_to_0_13_20, run_server, threshold::service::new_real_threshold_kms,
+        migration::migrate_to_0_14_2, run_server, threshold::service::new_real_threshold_kms,
     },
     grpc::MetaStoreStatusServiceImpl,
     vault::{
@@ -545,7 +545,7 @@ async fn main_exec() -> anyhow::Result<()> {
         Some(_) => KMSType::Threshold,
         None => KMSType::Centralized,
     };
-    migrate_to_0_13_20(&mut private_vault, kms_type)
+    migrate_to_0_14_2(&mut private_vault, kms_type)
         .await
         .inspect_err(|e| tracing::error!("Could not complete migration: {e}"))?;
 

--- a/core/service/src/bin/kms-server.rs
+++ b/core/service/src/bin/kms-server.rs
@@ -539,12 +539,13 @@ async fn main_exec() -> anyhow::Result<()> {
         keychain: private_keychain,
     };
 
-    // Migrate legacy FHE keys to epoch-aware format.
-    // Must run after Vault init so the keychain can decrypt AppKeyBlob-wrapped data from older versions.
     let kms_type = match core_config.threshold {
         Some(_) => KMSType::Threshold,
         None => KMSType::Centralized,
     };
+
+    // Migrate legacy FHE keys and CRS files to epoch-aware format.
+    // Must run after Vault init so the keychain can decrypt AppKeyBlob-wrapped data from older versions.
     migrate_to_0_14_2(&mut private_vault, kms_type)
         .await
         .inspect_err(|e| tracing::error!("Could not complete migration: {e}"))?;

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -208,6 +208,7 @@ where
                 .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
                 .await?;
             if existing_data == legacy_data {
+                // Now that we know it's safe to do so, delete the legacy data      
                 priv_storage.delete_data(&crs_id, &data_type_str).await?;
                 tracing::info!(
                     "Legacy {data_type_str} {crs_id} was already migrated to epoch {target_epoch_id}, removed the flat copy"

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -2,7 +2,8 @@ use crate::consts::{DEFAULT_EPOCH_ID, DEFAULT_MPC_CONTEXT};
 use crate::engine::base::derive_request_id;
 use crate::engine::threshold::service::session::PRSSSetupCombined;
 use crate::vault::storage::{
-    StorageExt, read_context_at_id, read_versioned_at_request_id, store_versioned_at_request_id,
+    StorageExt, StoreWriteOutcome, read_context_at_id, read_versioned_at_request_id,
+    store_versioned_at_request_id,
 };
 use algebra::galois_rings::degree_4::{ResiduePolyF4Z64, ResiduePolyF4Z128};
 use kms_grpc::ContextId;
@@ -234,12 +235,23 @@ conflict needs manual resolution.",
             continue;
         }
 
-        priv_storage
+        let outcome = priv_storage
             .store_bytes_at_epoch(&legacy_data, &crs_id, &target_epoch_id, &data_type_str)
             .await?;
+        if outcome != StoreWriteOutcome::Created {
+            // The store declines to overwrite and reports `SkippedExisting` instead of failing, so
+            // an entry must have appeared between the existence check above and this write. Bail
+            // before the read-back: the rollback below deletes the epoch-scoped entry, and it must
+            // never delete one that this migration did not write.
+            anyhow::bail!(
+                "Storing {data_type_str} {crs_id} at epoch {target_epoch_id} reported {outcome:?} \
+instead of writing the data, so another entry appeared concurrently. Nothing was modified."
+            );
+        }
 
-        // Verify the copy by reading it back before removing anything. A silent short write here
-        // would otherwise destroy the only copy of the CRS metadata.
+        // Verify the copy by reading it back before removing anything. Guards against a write that
+        // reports success without persisting the expected bytes, which would otherwise leave the
+        // CRS metadata with no intact copy once the flat entry is deleted.
         let written_data = priv_storage
             .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
             .await?;
@@ -2583,9 +2595,10 @@ mod tests {
         test_migrate_crs_aborts_on_conflict(&mut storage).await;
     }
 
-    /// The copy must be verified before the flat entry is deleted. A silent short write on the
-    /// epoch-aware path must abort the migration, leave the legacy entry intact, and remove the
-    /// unverified copy so the next start does not read corrupt CRS metadata.
+    /// The copy must be verified before the flat entry is deleted. An epoch-aware write that
+    /// reports success without persisting the expected bytes must abort the migration, leave the
+    /// legacy entry intact, and remove the unverified copy so the next start does not read corrupt
+    /// CRS metadata.
     #[tokio::test]
     async fn test_migrate_crs_rejects_corrupted_copy() {
         let crs_id = crs_test_id("c7");
@@ -2645,6 +2658,43 @@ mod tests {
                 .await
                 .unwrap(),
             crs_data
+        );
+    }
+
+    /// The store declines to overwrite and reports `SkippedExisting` rather than failing, meaning
+    /// an entry raced in after the existence check. The migration must abort without deleting the
+    /// flat entry, and without rolling back an epoch-scoped entry it did not write.
+    #[tokio::test]
+    async fn test_migrate_crs_aborts_when_write_is_skipped() {
+        let crs_id = crs_test_id("cc");
+        let data_type = PrivDataType::CrsInfo.to_string();
+        let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+        let crs_data = vec![1, 6, 1, 8];
+
+        let mut storage = FailingRamStorage::new(100);
+        storage
+            .store_bytes(&crs_data, &crs_id, &data_type)
+            .await
+            .unwrap();
+        storage.set_skip_epoch_writes(true);
+
+        let err = migrate_crs_to_0_14_2(&mut storage)
+            .await
+            .expect_err("a skipped write must abort the migration");
+        assert!(
+            err.to_string().contains("Nothing was modified"),
+            "unexpected error: {err}"
+        );
+
+        assert_eq!(
+            storage.load_bytes(&crs_id, &data_type).await.unwrap(),
+            crs_data
+        );
+        assert!(
+            !storage
+                .data_exists_at_epoch(&crs_id, &target_epoch_id, &data_type)
+                .await
+                .unwrap()
         );
     }
 

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -730,6 +730,7 @@ mod tests {
         store_versioned_at_request_id,
     };
     use kms_grpc::RequestId;
+    use std::collections::HashSet;
     use std::str::FromStr;
 
     /// Test migration of threshold FHE keys (FheKeyInfo)
@@ -2459,6 +2460,61 @@ mod tests {
             storage.load_bytes(&data_id, &key_type).await.unwrap(),
             key_data
         );
+    }
+
+    /// The server startup loader enumerates CRS through `all_epoch_ids_for_data` +
+    /// `all_data_ids_at_epoch` (see `read_all_data_from_all_epochs_versioned`), which only ever
+    /// looks at epoch-scoped entries. A flat entry is therefore invisible to it; the migration is
+    /// what makes the CRS reachable at boot.
+    pub async fn test_migrate_crs_makes_crs_visible_to_startup_loader<
+        S: StorageExt + Sync + Send,
+    >(
+        storage: &mut S,
+    ) {
+        let crs_id = crs_test_id("cb");
+        let data_type = PrivDataType::CrsInfo.to_string();
+        let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+
+        storage
+            .store_bytes(&[1, 2, 3], &crs_id, &data_type)
+            .await
+            .unwrap();
+
+        // Before: the loader's enumeration finds nothing, even though the entry exists.
+        assert!(
+            storage
+                .all_epoch_ids_for_data(&data_type)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 1);
+
+        // After: the entry is enumerated under the default epoch.
+        assert_eq!(
+            storage.all_epoch_ids_for_data(&data_type).await.unwrap(),
+            HashSet::from([target_epoch_id])
+        );
+        assert_eq!(
+            storage
+                .all_data_ids_at_epoch(&target_epoch_id, &data_type)
+                .await
+                .unwrap(),
+            HashSet::from([crs_id])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_migrate_crs_makes_crs_visible_to_startup_loader_ram() {
+        test_migrate_crs_makes_crs_visible_to_startup_loader(&mut RamStorage::new()).await;
+    }
+
+    #[tokio::test]
+    async fn test_migrate_crs_makes_crs_visible_to_startup_loader_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut storage = FileStorage::new(Some(temp_dir.path()), StorageType::PRIV, None).unwrap();
+        test_migrate_crs_makes_crs_visible_to_startup_loader(&mut storage).await;
     }
 
     #[tokio::test]

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -258,8 +258,8 @@ instead of writing the data, so another entry appeared concurrently. Nothing was
         if written_data != legacy_data {
             // Roll the bad copy back while the flat source is still intact. Leaving it in place
             // would poison the storage: readers resolve CRS metadata from the epoch-scoped path,
-            // and the next run of this migration would classify the pair as a conflict and skip
-            // it forever. Abort so the operator sees the failure instead of a degraded start.
+            // and every later run of this migration would classify the pair as a conflict and
+            // refuse to start. Abort so the operator sees the failure on the first attempt.
             priv_storage
                 .delete_data_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
                 .await

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -745,15 +745,17 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::base::CrsGenMetadata;
     use crate::engine::context::{ContextInfo, NodeInfo, SoftwareVersion};
     use crate::vault::storage::file::FileStorage;
     use crate::vault::storage::ram::{self, FailingRamStorage, RamStorage};
     use crate::vault::storage::{
-        Storage, StorageExt, StorageReader, StorageReaderExt, StorageType, store_context_at_id,
+        Storage, StorageExt, StorageReader, StorageReaderExt, StorageType,
+        read_all_data_from_all_epochs_versioned, store_context_at_id,
         store_versioned_at_request_id,
     };
     use kms_grpc::RequestId;
-    use std::collections::HashSet;
+    use std::collections::HashMap;
     use std::str::FromStr;
 
     /// Test migration of threshold FHE keys (FheKeyInfo)
@@ -2501,34 +2503,43 @@ mod tests {
         let crs_id = crs_test_id("cb");
         let data_type = PrivDataType::CrsInfo.to_string();
         let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+        // A real, versioned `CrsGenMetadata`, so the assertions below cover deserialization and
+        // not just the presence of some bytes at the right path.
+        let crs_meta = CrsGenMetadata::new(
+            crs_id,
+            vec![7u8; 32],
+            128,
+            vec![9u8; 8],
+            b"startup-loader-fixture".to_vec(),
+        );
 
-        storage
-            .store_bytes(&[1, 2, 3], &crs_id, &data_type)
+        // Pre-0.13 layout: metadata directly under the data type, with no epoch component.
+        store_versioned_at_request_id(storage, &crs_id, &crs_meta, &data_type)
             .await
             .unwrap();
 
-        // Before: the loader's enumeration finds nothing, even though the entry exists.
-        assert!(
-            storage
-                .all_epoch_ids_for_data(&data_type)
+        // Before: the loader reads nothing at all, even though the entry exists on disk.
+        let before: HashMap<(RequestId, EpochId), CrsGenMetadata> =
+            read_all_data_from_all_epochs_versioned(storage, &data_type)
                 .await
-                .unwrap()
-                .is_empty()
+                .unwrap();
+        assert!(
+            before.is_empty(),
+            "the flat entry must be invisible to the startup loader before migrating"
         );
 
         assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 1);
 
-        // After: the entry is enumerated under the default epoch.
-        assert_eq!(
-            storage.all_epoch_ids_for_data(&data_type).await.unwrap(),
-            HashSet::from([target_epoch_id])
-        );
-        assert_eq!(
-            storage
-                .all_data_ids_at_epoch(&target_epoch_id, &data_type)
+        // After: the loader finds it under the default epoch and deserializes it unchanged.
+        let after: HashMap<(RequestId, EpochId), CrsGenMetadata> =
+            read_all_data_from_all_epochs_versioned(storage, &data_type)
                 .await
-                .unwrap(),
-            HashSet::from([crs_id])
+                .unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(
+            after.get(&(crs_id, target_epoch_id)),
+            Some(&crs_meta),
+            "migrated CRS metadata must round-trip byte-for-byte through the loader"
         );
     }
 

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -121,6 +121,155 @@ where
     Ok(())
 }
 
+/// Migrate to 0.14.2
+///
+/// This moves the private CRS metadata to the epoch-aware storage layout, which the 0.13
+/// migrations never covered. See [`migrate_crs_to_0_14_2`] for why this is required.
+pub async fn migrate_to_0_14_2<PrivS>(
+    priv_storage: &mut PrivS,
+    kms_type: KMSType,
+) -> anyhow::Result<()>
+where
+    PrivS: StorageExt + Sync + Send,
+{
+    // Ensure old migration is done
+    migrate_to_0_13_20(priv_storage, kms_type).await?;
+    migrate_crs_to_0_14_2(priv_storage).await?;
+    Ok(())
+}
+
+/// Migrate private CRS metadata from the legacy flat path to the epoch-aware path.
+///
+/// Before v0.13, private CRS metadata was stored at `<prefix>/CrsInfo/<crs_id>`, with no epoch
+/// component. The 0.13 migrations moved every other private data type to the epoch-aware layout
+/// `<prefix>/<data_type>/<epoch_id>/<data_id>` but never covered [`PrivDataType::CrsInfo`], so a
+/// storage created before v0.13 keeps a flat CRS entry indefinitely.
+///
+/// That leftover entry breaks resharing permanently. `write_all` rejects a write whose data id
+/// already exists at the flat path even when the write targets an epoch, so the reshared CRS write
+/// fails with `StorageError::Duplicate`, and a single failed storage task rolls back the whole new
+/// epoch on every node. Installations created on v0.13 or later are unaffected, because CRS
+/// generation has written epoch-scoped data since then and nothing is ever placed at the flat path.
+///
+/// Migrated entries are placed under [`DEFAULT_EPOCH_ID`], which is where the 0.13 migrations put
+/// the FHE key material.
+///
+/// The flat copy is only deleted after the epoch-aware copy has been written *and* read back
+/// byte-for-byte identical, so the metadata is never left without at least one intact copy.
+/// If the read-back does not match, the unverified copy is deleted again and the migration fails:
+/// leaving it behind would poison the storage, because readers resolve CRS metadata from the
+/// epoch-scoped path and a later run of this migration would classify the pair as a conflict and
+/// skip it indefinitely.
+///
+/// Public CRS material ([`kms_grpc::rpc_types::PubDataType::CRS`]) is deliberately left alone:
+/// public data is shared across epochs and is stored flat by design.
+///
+/// # Returns
+/// * `Ok(migrated_count)` - Number of CRS entries copied to the epoch-aware path and then removed
+///   from the flat path.
+/// * `Err(...)` - If reading the legacy entry, writing the copy, verifying the copy, or deleting
+///   the flat entry fails. The flat entry is always left intact when this happens.
+async fn migrate_crs_to_0_14_2<PrivS>(priv_storage: &mut PrivS) -> anyhow::Result<usize>
+where
+    PrivS: StorageExt + Sync + Send,
+{
+    let data_type_str = PrivDataType::CrsInfo.to_string();
+    let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+
+    // Only entries directly under the data type directory are legacy; epoch-scoped entries are
+    // already in the target layout.
+    let legacy_crs_ids = priv_storage.all_data_ids(&data_type_str).await?;
+
+    if legacy_crs_ids.is_empty() {
+        tracing::info!("No legacy {data_type_str} entries found to migrate");
+        return Ok(0);
+    }
+
+    tracing::info!(
+        "Found {} legacy {data_type_str} entries to migrate to epoch {target_epoch_id}",
+        legacy_crs_ids.len(),
+    );
+
+    let mut migrated_count = 0;
+
+    for crs_id in legacy_crs_ids {
+        // Read raw bytes to avoid type-specific deserialization issues, matching the FHE key
+        // migration above.
+        let legacy_data: Vec<u8> = priv_storage.load_bytes(&crs_id, &data_type_str).await?;
+
+        if priv_storage
+            .data_exists_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
+            .await?
+        {
+            // Something is already there, e.g. an earlier run of this migration that was
+            // interrupted between the write and the delete. Drop the flat copy only when the two
+            // agree; otherwise keep both, because deleting the flat copy cannot be undone.
+            let existing_data = priv_storage
+                .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
+                .await?;
+            if existing_data == legacy_data {
+                priv_storage.delete_data(&crs_id, &data_type_str).await?;
+                tracing::info!(
+                    "Legacy {data_type_str} {crs_id} was already migrated to epoch {target_epoch_id}, removed the flat copy"
+                );
+            } else {
+                tracing::error!(
+                    "Legacy {data_type_str} {crs_id} ({} bytes) differs from the entry already \
+stored at epoch {target_epoch_id} ({} bytes). Keeping both copies; this needs manual resolution.",
+                    legacy_data.len(),
+                    existing_data.len(),
+                );
+            }
+            continue;
+        }
+
+        priv_storage
+            .store_bytes_at_epoch(&legacy_data, &crs_id, &target_epoch_id, &data_type_str)
+            .await?;
+
+        // Verify the copy by reading it back before removing anything. A silent short write here
+        // would otherwise destroy the only copy of the CRS metadata.
+        let written_data = priv_storage
+            .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
+            .await?;
+        if written_data != legacy_data {
+            // Roll the bad copy back while the flat source is still intact. Leaving it in place
+            // would poison the storage: readers resolve CRS metadata from the epoch-scoped path,
+            // and the next run of this migration would classify the pair as a conflict and skip
+            // it forever. Abort so the operator sees the failure instead of a degraded start.
+            priv_storage
+                .delete_data_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
+                .await
+                .inspect_err(|e| {
+                    tracing::error!(
+                        "Could not remove the unverified copy of {data_type_str} {crs_id} at epoch \
+{target_epoch_id} ({e}). Storage now holds a corrupt epoch-scoped entry alongside the intact flat \
+entry and needs manual repair."
+                    )
+                })?;
+            anyhow::bail!(
+                "Verification of migrated {data_type_str} {crs_id} at epoch {target_epoch_id} \
+failed: read back {} bytes, expected {}. The unverified copy was removed and the flat entry kept.",
+                written_data.len(),
+                legacy_data.len(),
+            );
+        }
+
+        priv_storage.delete_data(&crs_id, &data_type_str).await?;
+        migrated_count += 1;
+
+        tracing::info!(
+            "Migrated {data_type_str} {crs_id} from the legacy flat path to epoch {target_epoch_id}"
+        );
+    }
+
+    tracing::info!(
+        "Successfully migrated {migrated_count} {data_type_str} entries to the epoch-aware format"
+    );
+
+    Ok(migrated_count)
+}
+
 /// Migrate FHE key material from legacy storage format to epoch-aware format.
 /// The migration should be applied to private storage created in v0.12.x,
 /// after the migration the private storage format should follow v0.13.x.
@@ -575,7 +724,7 @@ mod tests {
     use super::*;
     use crate::engine::context::{ContextInfo, NodeInfo, SoftwareVersion};
     use crate::vault::storage::file::FileStorage;
-    use crate::vault::storage::ram::{self, RamStorage};
+    use crate::vault::storage::ram::{self, FailingRamStorage, RamStorage};
     use crate::vault::storage::{
         Storage, StorageExt, StorageReader, StorageReaderExt, StorageType, store_context_at_id,
         store_versioned_at_request_id,
@@ -2139,6 +2288,365 @@ mod tests {
             .unwrap();
     }
 
+    // ── Tests for migrate_crs_to_0_14_2 ──
+
+    /// CRS id that does not collide with any epoch id, to avoid path conflicts.
+    fn crs_test_id(last_byte: &str) -> RequestId {
+        RequestId::from_str(&format!(
+            "0x00000000000000000000000000000000000000000000000000000000000000{last_byte}"
+        ))
+        .unwrap()
+    }
+
+    /// Two legacy CRS entries are copied to the default epoch and their flat copies removed.
+    pub async fn test_migrate_crs_flat_to_epoch<S: StorageExt + Sync + Send>(storage: &mut S) {
+        let crs_id_1 = crs_test_id("c1");
+        let crs_id_2 = crs_test_id("c2");
+        let data_type = PrivDataType::CrsInfo.to_string();
+        let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+
+        let crs_data_1 = vec![1, 2, 3, 4];
+        let crs_data_2 = vec![5, 6, 7];
+
+        storage
+            .store_bytes(&crs_data_1, &crs_id_1, &data_type)
+            .await
+            .unwrap();
+        storage
+            .store_bytes(&crs_data_2, &crs_id_2, &data_type)
+            .await
+            .unwrap();
+
+        let migrated_count = migrate_crs_to_0_14_2(storage).await.unwrap();
+        assert_eq!(migrated_count, 2);
+
+        for (crs_id, expected) in [(crs_id_1, crs_data_1), (crs_id_2, crs_data_2)] {
+            // The copy is present at the epoch-aware path and byte-identical.
+            assert!(
+                storage
+                    .data_exists_at_epoch(&crs_id, &target_epoch_id, &data_type)
+                    .await
+                    .unwrap()
+            );
+            assert_eq!(
+                storage
+                    .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type)
+                    .await
+                    .unwrap(),
+                expected
+            );
+            // The flat copy is gone, which is what unblocks resharing.
+            assert!(!storage.data_exists(&crs_id, &data_type).await.unwrap());
+        }
+    }
+
+    /// A storage with no legacy CRS entries is left untouched.
+    pub async fn test_migrate_crs_no_legacy_data<S: StorageExt + Sync + Send>(storage: &mut S) {
+        let migrated_count = migrate_crs_to_0_14_2(storage).await.unwrap();
+        assert_eq!(migrated_count, 0);
+    }
+
+    /// Running the migration twice is a no-op the second time.
+    pub async fn test_migrate_crs_idempotent<S: StorageExt + Sync + Send>(storage: &mut S) {
+        let crs_id = crs_test_id("c3");
+        let data_type = PrivDataType::CrsInfo.to_string();
+        let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+        let crs_data = vec![9, 9, 9];
+
+        storage
+            .store_bytes(&crs_data, &crs_id, &data_type)
+            .await
+            .unwrap();
+
+        assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 1);
+        assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 0);
+
+        assert_eq!(
+            storage
+                .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type)
+                .await
+                .unwrap(),
+            crs_data
+        );
+        assert!(!storage.data_exists(&crs_id, &data_type).await.unwrap());
+    }
+
+    /// An interrupted earlier run left an identical copy at the epoch: the flat copy is removed,
+    /// but it is not counted as a fresh migration.
+    pub async fn test_migrate_crs_removes_flat_when_identical_copy_exists<
+        S: StorageExt + Sync + Send,
+    >(
+        storage: &mut S,
+    ) {
+        let crs_id = crs_test_id("c4");
+        let data_type = PrivDataType::CrsInfo.to_string();
+        let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+        let crs_data = vec![4, 2];
+
+        storage
+            .store_bytes(&crs_data, &crs_id, &data_type)
+            .await
+            .unwrap();
+        storage
+            .store_bytes_at_epoch(&crs_data, &crs_id, &target_epoch_id, &data_type)
+            .await
+            .unwrap();
+
+        assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 0);
+
+        assert!(!storage.data_exists(&crs_id, &data_type).await.unwrap());
+        assert_eq!(
+            storage
+                .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type)
+                .await
+                .unwrap(),
+            crs_data
+        );
+    }
+
+    /// A *different* entry already sits at the epoch path: nothing is overwritten and, crucially,
+    /// the flat copy is kept.
+    pub async fn test_migrate_crs_keeps_both_on_conflict<S: StorageExt + Sync + Send>(
+        storage: &mut S,
+    ) {
+        let crs_id = crs_test_id("c5");
+        let data_type = PrivDataType::CrsInfo.to_string();
+        let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+        let legacy_data = vec![1, 1, 1];
+        let conflicting_data = vec![2, 2, 2];
+
+        storage
+            .store_bytes(&legacy_data, &crs_id, &data_type)
+            .await
+            .unwrap();
+        storage
+            .store_bytes_at_epoch(&conflicting_data, &crs_id, &target_epoch_id, &data_type)
+            .await
+            .unwrap();
+
+        assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 0);
+
+        // Both copies survive untouched so a human can resolve the conflict.
+        assert_eq!(
+            storage.load_bytes(&crs_id, &data_type).await.unwrap(),
+            legacy_data
+        );
+        assert_eq!(
+            storage
+                .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type)
+                .await
+                .unwrap(),
+            conflicting_data
+        );
+    }
+
+    /// Other private data types are not touched by the CRS migration.
+    pub async fn test_migrate_crs_leaves_other_types_alone<S: StorageExt + Sync + Send>(
+        storage: &mut S,
+    ) {
+        let data_id = crs_test_id("c6");
+        let key_type = PrivDataType::FheKeyInfo.to_string();
+        let key_data = vec![7, 7];
+
+        storage
+            .store_bytes(&key_data, &data_id, &key_type)
+            .await
+            .unwrap();
+
+        assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 0);
+
+        assert_eq!(
+            storage.load_bytes(&data_id, &key_type).await.unwrap(),
+            key_data
+        );
+    }
+
+    #[tokio::test]
+    async fn test_migrate_crs_flat_to_epoch_ram() {
+        test_migrate_crs_flat_to_epoch(&mut RamStorage::new()).await;
+    }
+
+    #[tokio::test]
+    async fn test_migrate_crs_no_legacy_data_ram() {
+        test_migrate_crs_no_legacy_data(&mut RamStorage::new()).await;
+    }
+
+    #[tokio::test]
+    async fn test_migrate_crs_idempotent_ram() {
+        test_migrate_crs_idempotent(&mut RamStorage::new()).await;
+    }
+
+    #[tokio::test]
+    async fn test_migrate_crs_removes_flat_when_identical_copy_exists_ram() {
+        test_migrate_crs_removes_flat_when_identical_copy_exists(&mut RamStorage::new()).await;
+    }
+
+    #[tokio::test]
+    async fn test_migrate_crs_keeps_both_on_conflict_ram() {
+        test_migrate_crs_keeps_both_on_conflict(&mut RamStorage::new()).await;
+    }
+
+    #[tokio::test]
+    async fn test_migrate_crs_leaves_other_types_alone_ram() {
+        test_migrate_crs_leaves_other_types_alone(&mut RamStorage::new()).await;
+    }
+
+    #[tokio::test]
+    async fn test_migrate_crs_flat_to_epoch_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut storage = FileStorage::new(Some(temp_dir.path()), StorageType::PRIV, None).unwrap();
+        test_migrate_crs_flat_to_epoch(&mut storage).await;
+    }
+
+    #[tokio::test]
+    async fn test_migrate_crs_idempotent_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut storage = FileStorage::new(Some(temp_dir.path()), StorageType::PRIV, None).unwrap();
+        test_migrate_crs_idempotent(&mut storage).await;
+    }
+
+    #[tokio::test]
+    async fn test_migrate_crs_keeps_both_on_conflict_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut storage = FileStorage::new(Some(temp_dir.path()), StorageType::PRIV, None).unwrap();
+        test_migrate_crs_keeps_both_on_conflict(&mut storage).await;
+    }
+
+    /// The copy must be verified before the flat entry is deleted. A silent short write on the
+    /// epoch-aware path must abort the migration, leave the legacy entry intact, and remove the
+    /// unverified copy so the next start does not read corrupt CRS metadata.
+    #[tokio::test]
+    async fn test_migrate_crs_rejects_corrupted_copy() {
+        let crs_id = crs_test_id("c7");
+        let data_type = PrivDataType::CrsInfo.to_string();
+        let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+        let crs_data = vec![3, 1, 4, 1, 5];
+
+        let mut storage = FailingRamStorage::new(100);
+        storage
+            .store_bytes(&crs_data, &crs_id, &data_type)
+            .await
+            .unwrap();
+        storage.set_corrupt_epoch_writes(true);
+
+        assert!(migrate_crs_to_0_14_2(&mut storage).await.is_err());
+
+        // The legacy entry survives, so nothing was lost.
+        assert_eq!(
+            storage.load_bytes(&crs_id, &data_type).await.unwrap(),
+            crs_data
+        );
+        // The corrupt copy is gone, so readers cannot pick it up and a retry starts from a clean
+        // state rather than hitting the conflict branch.
+        assert!(
+            !storage
+                .data_exists_at_epoch(&crs_id, &target_epoch_id, &data_type)
+                .await
+                .unwrap()
+        );
+    }
+
+    /// After a rejected copy has been rolled back, a retry against healthy storage succeeds.
+    #[tokio::test]
+    async fn test_migrate_crs_retry_succeeds_after_rejected_copy() {
+        let crs_id = crs_test_id("ca");
+        let data_type = PrivDataType::CrsInfo.to_string();
+        let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+        let crs_data = vec![8, 6, 7, 5, 3, 0, 9];
+
+        let mut storage = FailingRamStorage::new(100);
+        storage
+            .store_bytes(&crs_data, &crs_id, &data_type)
+            .await
+            .unwrap();
+
+        storage.set_corrupt_epoch_writes(true);
+        assert!(migrate_crs_to_0_14_2(&mut storage).await.is_err());
+
+        // Storage recovers; the retry must not be blocked by leftovers from the failed attempt.
+        storage.set_corrupt_epoch_writes(false);
+        assert_eq!(migrate_crs_to_0_14_2(&mut storage).await.unwrap(), 1);
+
+        assert!(!storage.data_exists(&crs_id, &data_type).await.unwrap());
+        assert_eq!(
+            storage
+                .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type)
+                .await
+                .unwrap(),
+            crs_data
+        );
+    }
+
+    /// A hard failure on the epoch-aware write aborts the migration without deleting anything.
+    #[tokio::test]
+    async fn test_migrate_crs_keeps_flat_when_copy_write_fails() {
+        let crs_id = crs_test_id("c8");
+        let data_type = PrivDataType::CrsInfo.to_string();
+        let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+        let crs_data = vec![2, 7, 1, 8];
+
+        let mut storage = FailingRamStorage::new(100);
+        storage
+            .store_bytes(&crs_data, &crs_id, &data_type)
+            .await
+            .unwrap();
+        storage.set_available_epoch_writes(Some(0));
+
+        assert!(migrate_crs_to_0_14_2(&mut storage).await.is_err());
+
+        // The legacy entry survives and no epoch-aware entry was created.
+        assert_eq!(
+            storage.load_bytes(&crs_id, &data_type).await.unwrap(),
+            crs_data
+        );
+        assert!(
+            !storage
+                .data_exists_at_epoch(&crs_id, &target_epoch_id, &data_type)
+                .await
+                .unwrap()
+        );
+    }
+
+    // ── Tests for migrate_to_0_14_2 (orchestrator) ──
+
+    #[tokio::test]
+    async fn test_migrate_to_0_14_2_migrates_crs() {
+        let crs_id = crs_test_id("c9");
+        let data_type = PrivDataType::CrsInfo.to_string();
+        let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+        let crs_data = vec![1, 4, 1, 4];
+
+        let mut storage = RamStorage::new();
+        storage
+            .store_bytes(&crs_data, &crs_id, &data_type)
+            .await
+            .unwrap();
+
+        migrate_to_0_14_2(&mut storage, KMSType::Threshold)
+            .await
+            .unwrap();
+
+        assert!(!storage.data_exists(&crs_id, &data_type).await.unwrap());
+        assert_eq!(
+            storage
+                .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type)
+                .await
+                .unwrap(),
+            crs_data
+        );
+    }
+
+    #[tokio::test]
+    async fn test_migrate_to_0_14_2_empty_storage() {
+        let mut storage = RamStorage::new();
+        migrate_to_0_14_2(&mut storage, KMSType::Threshold)
+            .await
+            .unwrap();
+        migrate_to_0_14_2(&mut storage, KMSType::Centralized)
+            .await
+            .unwrap();
+    }
+
     // S3 storage tests
     #[cfg(feature = "s3_tests")]
     mod s3_tests {
@@ -2153,6 +2661,26 @@ mod tests {
             )
             .await;
             test_migrate_legacy_fhe_keys_threshold(&mut storage).await;
+        }
+
+        #[tokio::test]
+        async fn test_migrate_crs_flat_to_epoch_s3() {
+            let mut storage = create_s3_storage(
+                StorageType::PRIV,
+                std::stringify!(test_migrate_crs_flat_to_epoch_s3),
+            )
+            .await;
+            test_migrate_crs_flat_to_epoch(&mut storage).await;
+        }
+
+        #[tokio::test]
+        async fn test_migrate_crs_keeps_both_on_conflict_s3() {
+            let mut storage = create_s3_storage(
+                StorageType::PRIV,
+                std::stringify!(test_migrate_crs_keeps_both_on_conflict_s3),
+            )
+            .await;
+            test_migrate_crs_keeps_both_on_conflict(&mut storage).await;
         }
 
         #[tokio::test]

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -2301,7 +2301,7 @@ mod tests {
         .unwrap()
     }
 
-    /// Two legacy CRS entries are copied to the default epoch and their flat copies removed.
+    /// Two legacy CRS entries are copied to the default epoch and their flat copies remain.
     pub async fn test_migrate_crs_flat_to_epoch<S: StorageExt + Sync + Send>(storage: &mut S) {
         let crs_id_1 = crs_test_id("c1");
         let crs_id_2 = crs_test_id("c2");
@@ -2553,7 +2553,7 @@ mod tests {
         test_migrate_crs_aborts_on_conflict(&mut storage).await;
     }
 
-    /// The copy must be verified before the flat entry is deleted. An epoch-aware write that
+    /// The copy must be verified after migration. An epoch-aware write that
     /// reports success without persisting the expected bytes must abort the migration, leave the
     /// legacy entry intact, and remove the unverified copy so the next start does not read corrupt
     /// CRS metadata.

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -139,43 +139,42 @@ where
     Ok(())
 }
 
-/// Migrate private CRS metadata from the legacy flat path to the epoch-aware path.
+/// Copy private CRS metadata from the legacy flat path to the epoch-aware path.
 ///
 /// Before v0.13, private CRS metadata was stored at `<prefix>/CrsInfo/<crs_id>`, with no epoch
 /// component. The 0.13 migrations moved every other private data type to the epoch-aware layout
 /// `<prefix>/<data_type>/<epoch_id>/<data_id>` but never covered [`PrivDataType::CrsInfo`], so a
-/// storage created before v0.13 keeps a flat CRS entry indefinitely.
+/// storage created before v0.13 keeps a flat CRS entry indefinitely. Without an epoch-scoped copy
+/// the CRS is invisible to the startup loader, which enumerates epochs only, and to
+/// `purge_epoch_material`. Installations created on v0.13 or later are unaffected, because CRS
+/// generation has written epoch-scoped data since then.
 ///
-/// That leftover entry breaks resharing permanently. `write_all` rejects a write whose data id
-/// already exists at the flat path even when the write targets an epoch, so the reshared CRS write
-/// fails with `StorageError::Duplicate`, and a single failed storage task rolls back the whole new
-/// epoch on every node. Installations created on v0.13 or later are unaffected, because CRS
-/// generation has written epoch-scoped data since then and nothing is ever placed at the flat path.
+/// Copies are placed under [`DEFAULT_EPOCH_ID`], which is where the 0.13 migrations put the FHE
+/// key material.
 ///
-/// Migrated entries are placed under [`DEFAULT_EPOCH_ID`], which is where the 0.13 migrations put
-/// the FHE key material.
+/// **The legacy entry is deliberately kept.** Leaving it in place means the node can still be
+/// downgraded to a release that reads the flat path; that older release then sees the CRS frozen
+/// as of this migration, which is accepted. Retaining it is only safe because `write_all` scopes
+/// its duplicate check to the path being written, so the legacy entry does not block later
+/// epoch-scoped writes such as resharing.
 ///
-/// The flat copy is only deleted after the epoch-aware copy has been written *and* read back
-/// byte-for-byte identical, so the metadata is never left without at least one intact copy.
-/// If the read-back does not match, the unverified copy is deleted again and the migration fails:
-/// leaving it behind would poison the storage, because readers resolve CRS metadata from the
-/// epoch-scoped path.
+/// The copy is read back byte-for-byte before it is accepted. If the read-back does not match, the
+/// unverified copy is deleted again and the migration fails: leaving it behind would poison the
+/// storage, because readers resolve CRS metadata from the epoch-scoped path.
 ///
-/// If an entry already exists at the target epoch and *differs* from the flat one, the migration
-/// fails without touching either copy. There is no way to tell which of the two is authoritative,
-/// and this runs at boot, so aborting is preferable to starting the node against whichever copy
-/// the readers happen to resolve. An identical entry is treated as a completed earlier run and the
-/// flat copy is removed.
+/// If an entry already exists at the target epoch and *differs* from the legacy one, the migration
+/// fails without touching either copy. There is no way to tell which is authoritative, and this
+/// runs at boot, so aborting is preferable to starting the node against whichever copy the readers
+/// happen to resolve. An identical entry means an earlier run already copied it, and is a no-op.
 ///
 /// Public CRS material ([`kms_grpc::rpc_types::PubDataType::CRS`]) is deliberately left alone:
 /// public data is shared across epochs and is stored flat by design.
 ///
 /// # Returns
-/// * `Ok(migrated_count)` - Number of CRS entries copied to the epoch-aware path and then removed
-///   from the flat path.
-/// * `Err(...)` - If reading the legacy entry, writing the copy, verifying the copy, or deleting
-///   the flat entry fails, or if a conflicting entry exists at the target epoch. The flat entry is
-///   always left intact when this happens.
+/// * `Ok(copied_count)` - Number of CRS entries newly copied to the epoch-aware path. Entries an
+///   earlier run already copied are not counted, so a repeat run on a migrated storage returns 0.
+/// * `Err(...)` - If reading the legacy entry, writing the copy or verifying the copy fails, or if
+///   a conflicting entry exists at the target epoch. The legacy entry is never modified.
 async fn migrate_crs_to_0_14_2<PrivS>(priv_storage: &mut PrivS) -> anyhow::Result<usize>
 where
     PrivS: StorageExt + Sync + Send,
@@ -221,16 +220,15 @@ where
                 // happen to resolve. Neither copy is touched, so the operator can inspect both.
                 anyhow::bail!(
                     "Legacy {data_type_str} {crs_id} ({} bytes) differs from the entry already \
-stored at epoch {target_epoch_id} ({} bytes). Refusing to start: both copies were kept and this \
-conflict needs manual resolution.",
+stored at epoch {target_epoch_id} ({} bytes). Refusing to start: this conflict needs manual \
+resolution.",
                     legacy_data.len(),
                     existing_data.len(),
                 );
             }
-            // Now that we know it's safe to do so, delete the legacy data
-            priv_storage.delete_data(&crs_id, &data_type_str).await?;
-            tracing::info!(
-                "Legacy {data_type_str} {crs_id} was already migrated to epoch {target_epoch_id}, removed the flat copy"
+            // An earlier run already made the copy and it still matches. Nothing to do.
+            tracing::debug!(
+                "{data_type_str} {crs_id} is already present at epoch {target_epoch_id}, nothing to copy"
             );
             continue;
         }
@@ -249,45 +247,44 @@ instead of writing the data, so another entry appeared concurrently. Nothing was
             );
         }
 
-        // Verify the copy by reading it back before removing anything. Guards against a write that
-        // reports success without persisting the expected bytes, which would otherwise leave the
-        // CRS metadata with no intact copy once the flat entry is deleted.
+        // Verify the copy by reading it back. Guards against a write that reports success without
+        // persisting the expected bytes, which would leave readers resolving corrupt metadata.
         let written_data = priv_storage
             .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
             .await?;
         if written_data != legacy_data {
-            // Roll the bad copy back while the flat source is still intact. Leaving it in place
-            // would poison the storage: readers resolve CRS metadata from the epoch-scoped path,
-            // and every later run of this migration would classify the pair as a conflict and
-            // refuse to start. Abort so the operator sees the failure on the first attempt.
+            // Roll the bad copy back. Leaving it in place would poison the storage: readers
+            // resolve CRS metadata from the epoch-scoped path, and every later run of this
+            // migration would classify the pair as a conflict and refuse to start. Abort so the
+            // operator sees the failure on the first attempt.
             priv_storage
                 .delete_data_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
                 .await
                 .inspect_err(|e| {
                     tracing::error!(
                         "Could not remove the unverified copy of {data_type_str} {crs_id} at epoch \
-{target_epoch_id} ({e}). Storage now holds a corrupt epoch-scoped entry alongside the intact flat \
-entry and needs manual repair."
+{target_epoch_id} ({e}). Storage now holds a corrupt epoch-scoped entry alongside the intact \
+legacy entry and needs manual repair."
                     )
                 })?;
             anyhow::bail!(
-                "Verification of migrated {data_type_str} {crs_id} at epoch {target_epoch_id} \
-failed: read back {} bytes, expected {}. The unverified copy was removed and the flat entry kept.",
+                "Verification of copied {data_type_str} {crs_id} at epoch {target_epoch_id} \
+failed: read back {} bytes, expected {}. The unverified copy was removed.",
                 written_data.len(),
                 legacy_data.len(),
             );
         }
 
-        priv_storage.delete_data(&crs_id, &data_type_str).await?;
         migrated_count += 1;
 
         tracing::info!(
-            "Migrated {data_type_str} {crs_id} from the legacy flat path to epoch {target_epoch_id}"
+            "Copied {data_type_str} {crs_id} from the legacy flat path to epoch {target_epoch_id}, \
+keeping the legacy entry"
         );
     }
 
     tracing::info!(
-        "Successfully migrated {migrated_count} {data_type_str} entries to the epoch-aware format"
+        "Successfully copied {migrated_count} {data_type_str} entries to the epoch-aware format"
     );
 
     Ok(migrated_count)
@@ -2361,8 +2358,11 @@ mod tests {
                     .unwrap(),
                 expected
             );
-            // The flat copy is gone, which is what unblocks resharing.
-            assert!(!storage.data_exists(&crs_id, &data_type).await.unwrap());
+            // The legacy entry is deliberately retained so the node stays downgradable.
+            assert_eq!(
+                storage.load_bytes(&crs_id, &data_type).await.unwrap(),
+                expected
+            );
         }
     }
 
@@ -2385,6 +2385,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 1);
+        // The legacy entry is still there, so the second run sees it again and must recognise the
+        // copy it made rather than counting or rewriting it.
         assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 0);
 
         assert_eq!(
@@ -2394,12 +2396,15 @@ mod tests {
                 .unwrap(),
             crs_data
         );
-        assert!(!storage.data_exists(&crs_id, &data_type).await.unwrap());
+        assert_eq!(
+            storage.load_bytes(&crs_id, &data_type).await.unwrap(),
+            crs_data
+        );
     }
 
-    /// An interrupted earlier run left an identical copy at the epoch: the flat copy is removed,
-    /// but it is not counted as a fresh migration.
-    pub async fn test_migrate_crs_removes_flat_when_identical_copy_exists<
+    /// An earlier run already made an identical copy at the epoch: nothing is written, nothing is
+    /// counted, and both entries stay in place.
+    pub async fn test_migrate_crs_is_noop_when_identical_copy_exists<
         S: StorageExt + Sync + Send,
     >(
         storage: &mut S,
@@ -2420,7 +2425,10 @@ mod tests {
 
         assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 0);
 
-        assert!(!storage.data_exists(&crs_id, &data_type).await.unwrap());
+        assert_eq!(
+            storage.load_bytes(&crs_id, &data_type).await.unwrap(),
+            crs_data
+        );
         assert_eq!(
             storage
                 .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type)
@@ -2571,8 +2579,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_migrate_crs_removes_flat_when_identical_copy_exists_ram() {
-        test_migrate_crs_removes_flat_when_identical_copy_exists(&mut RamStorage::new()).await;
+    async fn test_migrate_crs_is_noop_when_identical_copy_exists_ram() {
+        test_migrate_crs_is_noop_when_identical_copy_exists(&mut RamStorage::new()).await;
     }
 
     #[tokio::test]
@@ -2662,7 +2670,10 @@ mod tests {
         storage.set_corrupt_epoch_writes(false);
         assert_eq!(migrate_crs_to_0_14_2(&mut storage).await.unwrap(), 1);
 
-        assert!(!storage.data_exists(&crs_id, &data_type).await.unwrap());
+        assert_eq!(
+            storage.load_bytes(&crs_id, &data_type).await.unwrap(),
+            crs_data
+        );
         assert_eq!(
             storage
                 .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type)
@@ -2673,8 +2684,8 @@ mod tests {
     }
 
     /// The store declines to overwrite and reports `SkippedExisting` rather than failing, meaning
-    /// an entry raced in after the existence check. The migration must abort without deleting the
-    /// flat entry, and without rolling back an epoch-scoped entry it did not write.
+    /// an entry raced in after the existence check. The migration must abort without touching the
+    /// legacy entry, and without rolling back an epoch-scoped entry it did not write.
     #[tokio::test]
     async fn test_migrate_crs_aborts_when_write_is_skipped() {
         let crs_id = crs_test_id("cc");
@@ -2758,7 +2769,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(!storage.data_exists(&crs_id, &data_type).await.unwrap());
+        assert_eq!(
+            storage.load_bytes(&crs_id, &data_type).await.unwrap(),
+            crs_data
+        );
         assert_eq!(
             storage
                 .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type)

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -141,40 +141,32 @@ where
 
 /// Copy private CRS metadata from the legacy flat path to the epoch-aware path.
 ///
-/// Before v0.13, private CRS metadata was stored at `<prefix>/CrsInfo/<crs_id>`, with no epoch
-/// component. The 0.13 migrations moved every other private data type to the epoch-aware layout
-/// `<prefix>/<data_type>/<epoch_id>/<data_id>` but never covered [`PrivDataType::CrsInfo`], so a
-/// storage created before v0.13 keeps a flat CRS entry indefinitely. Without an epoch-scoped copy
-/// the CRS is invisible to the startup loader, which enumerates epochs only, and to
-/// `purge_epoch_material`. Installations created on v0.13 or later are unaffected, because CRS
-/// generation has written epoch-scoped data since then.
+/// Before v0.13, private CRS metadata was stored at `<prefix>/CrsInfo/<crs_id>` with no epoch
+/// component. The 0.13 migrations moved every other private data type to
+/// `<prefix>/<data_type>/<epoch_id>/<data_id>` but never covered [`PrivDataType::CrsInfo`], leaving
+/// pre-0.13 storages with a CRS that the startup loader and `purge_epoch_material` cannot see,
+/// since both enumerate epochs only. Copies go under [`DEFAULT_EPOCH_ID`], where the 0.13
+/// migrations put the FHE key material. Storages created on v0.13 or later have nothing to copy.
 ///
-/// Copies are placed under [`DEFAULT_EPOCH_ID`], which is where the 0.13 migrations put the FHE
-/// key material.
+/// **The legacy entry is deliberately kept**, so the node can be downgraded to a release that
+/// reads the flat path; that release then sees the CRS frozen as of this migration. This is only
+/// safe because `write_all` scopes its duplicate check to the path being written, so the retained
+/// entry does not block later epoch-scoped writes such as resharing.
 ///
-/// **The legacy entry is deliberately kept.** Leaving it in place means the node can still be
-/// downgraded to a release that reads the flat path; that older release then sees the CRS frozen
-/// as of this migration, which is accepted. Retaining it is only safe because `write_all` scopes
-/// its duplicate check to the path being written, so the legacy entry does not block later
-/// epoch-scoped writes such as resharing.
+/// Runs at boot, so it fails loudly rather than leaving the node in an ambiguous state. The copy is
+/// read back byte-for-byte and rolled back if it does not match, since readers resolve CRS metadata
+/// from the epoch-scoped path. An entry already at the target epoch that *differs* from the legacy
+/// one aborts without touching either copy — there is no way to tell which is authoritative. An
+/// identical entry means an earlier run already copied it, and is a no-op.
 ///
-/// The copy is read back byte-for-byte before it is accepted. If the read-back does not match, the
-/// unverified copy is deleted again and the migration fails: leaving it behind would poison the
-/// storage, because readers resolve CRS metadata from the epoch-scoped path.
-///
-/// If an entry already exists at the target epoch and *differs* from the legacy one, the migration
-/// fails without touching either copy. There is no way to tell which is authoritative, and this
-/// runs at boot, so aborting is preferable to starting the node against whichever copy the readers
-/// happen to resolve. An identical entry means an earlier run already copied it, and is a no-op.
-///
-/// Public CRS material ([`kms_grpc::rpc_types::PubDataType::CRS`]) is deliberately left alone:
-/// public data is shared across epochs and is stored flat by design.
+/// Public CRS material ([`kms_grpc::rpc_types::PubDataType::CRS`]) is left alone: public data is
+/// shared across epochs and is stored flat by design.
 ///
 /// # Returns
-/// * `Ok(copied_count)` - Number of CRS entries newly copied to the epoch-aware path. Entries an
-///   earlier run already copied are not counted, so a repeat run on a migrated storage returns 0.
-/// * `Err(...)` - If reading the legacy entry, writing the copy or verifying the copy fails, or if
-///   a conflicting entry exists at the target epoch. The legacy entry is never modified.
+/// * `Ok(copied_count)` - Entries newly copied. Entries an earlier run already copied are not
+///   counted, so a repeat run on a migrated storage returns 0.
+/// * `Err(...)` - Read, write or verification failure, or a conflicting entry at the target epoch.
+///   The legacy entry is never modified.
 async fn migrate_crs_to_0_14_2<PrivS>(priv_storage: &mut PrivS) -> anyhow::Result<usize>
 where
     PrivS: StorageExt + Sync + Send,
@@ -182,8 +174,7 @@ where
     let data_type_str = PrivDataType::CrsInfo.to_string();
     let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
 
-    // Only entries directly under the data type directory are legacy; epoch-scoped entries are
-    // already in the target layout.
+    // Only entries directly under the data type directory are legacy.
     let legacy_crs_ids = priv_storage.all_data_ids(&data_type_str).await?;
 
     if legacy_crs_ids.is_empty() {
@@ -199,25 +190,20 @@ where
     let mut migrated_count = 0;
 
     for crs_id in legacy_crs_ids {
-        // Read raw bytes to avoid type-specific deserialization issues, matching the FHE key
-        // migration above.
+        // Raw bytes, to avoid type-specific deserialization issues, as the FHE key migration does.
         let legacy_data: Vec<u8> = priv_storage.load_bytes(&crs_id, &data_type_str).await?;
 
         if priv_storage
             .data_exists_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
             .await?
         {
-            // Something is already there, e.g. an earlier run of this migration that was
-            // interrupted between the write and the delete. Drop the flat copy only when the two
-            // agree; deleting the flat copy cannot be undone.
+            // An earlier run, or something else, already wrote here.
             let existing_data = priv_storage
                 .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
                 .await?;
             if existing_data != legacy_data {
-                // Two different CRS metadata entries claim the same id and there is no way to tell
-                // which one is authoritative. Abort rather than pick one: this migration runs at
-                // boot, and starting the node would leave it serving whichever copy the readers
-                // happen to resolve. Neither copy is touched, so the operator can inspect both.
+                // No way to tell which is authoritative, so abort instead of picking one and
+                // leave both for the operator to inspect.
                 anyhow::bail!(
                     "Legacy {data_type_str} {crs_id} ({} bytes) differs from the entry already \
 stored at epoch {target_epoch_id} ({} bytes). Refusing to start: this conflict needs manual \
@@ -226,7 +212,6 @@ resolution.",
                     existing_data.len(),
                 );
             }
-            // An earlier run already made the copy and it still matches. Nothing to do.
             tracing::debug!(
                 "{data_type_str} {crs_id} is already present at epoch {target_epoch_id}, nothing to copy"
             );
@@ -237,26 +222,21 @@ resolution.",
             .store_bytes_at_epoch(&legacy_data, &crs_id, &target_epoch_id, &data_type_str)
             .await?;
         if outcome != StoreWriteOutcome::Created {
-            // The store declines to overwrite and reports `SkippedExisting` instead of failing, so
-            // an entry must have appeared between the existence check above and this write. Bail
-            // before the read-back: the rollback below deletes the epoch-scoped entry, and it must
-            // never delete one that this migration did not write.
+            // An entry raced in after the check above. Bail before the read-back: its rollback
+            // must never delete an entry this migration did not write.
             anyhow::bail!(
                 "Storing {data_type_str} {crs_id} at epoch {target_epoch_id} reported {outcome:?} \
 instead of writing the data, so another entry appeared concurrently. Nothing was modified."
             );
         }
 
-        // Verify the copy by reading it back. Guards against a write that reports success without
-        // persisting the expected bytes, which would leave readers resolving corrupt metadata.
+        // Guards against a write that reports success without persisting the expected bytes.
         let written_data = priv_storage
             .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
             .await?;
         if written_data != legacy_data {
-            // Roll the bad copy back. Leaving it in place would poison the storage: readers
-            // resolve CRS metadata from the epoch-scoped path, and every later run of this
-            // migration would classify the pair as a conflict and refuse to start. Abort so the
-            // operator sees the failure on the first attempt.
+            // Leaving the bad copy would poison the storage and make every later run abort on
+            // the conflict branch, so roll it back and fail on this attempt instead.
             priv_storage
                 .delete_data_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
                 .await
@@ -2402,42 +2382,6 @@ mod tests {
         );
     }
 
-    /// An earlier run already made an identical copy at the epoch: nothing is written, nothing is
-    /// counted, and both entries stay in place.
-    pub async fn test_migrate_crs_is_noop_when_identical_copy_exists<
-        S: StorageExt + Sync + Send,
-    >(
-        storage: &mut S,
-    ) {
-        let crs_id = crs_test_id("c4");
-        let data_type = PrivDataType::CrsInfo.to_string();
-        let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
-        let crs_data = vec![4, 2];
-
-        storage
-            .store_bytes(&crs_data, &crs_id, &data_type)
-            .await
-            .unwrap();
-        storage
-            .store_bytes_at_epoch(&crs_data, &crs_id, &target_epoch_id, &data_type)
-            .await
-            .unwrap();
-
-        assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 0);
-
-        assert_eq!(
-            storage.load_bytes(&crs_id, &data_type).await.unwrap(),
-            crs_data
-        );
-        assert_eq!(
-            storage
-                .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type)
-                .await
-                .unwrap(),
-            crs_data
-        );
-    }
-
     /// A *different* entry already sits at the epoch path. The migration must abort so the node
     /// does not boot in an undefined state, and neither copy may be touched.
     pub async fn test_migrate_crs_aborts_on_conflict<S: StorageExt + Sync + Send>(storage: &mut S) {
@@ -2576,11 +2520,6 @@ mod tests {
     #[tokio::test]
     async fn test_migrate_crs_idempotent_ram() {
         test_migrate_crs_idempotent(&mut RamStorage::new()).await;
-    }
-
-    #[tokio::test]
-    async fn test_migrate_crs_is_noop_when_identical_copy_exists_ram() {
-        test_migrate_crs_is_noop_when_identical_copy_exists(&mut RamStorage::new()).await;
     }
 
     #[tokio::test]

--- a/core/service/src/engine/migration.rs
+++ b/core/service/src/engine/migration.rs
@@ -158,8 +158,13 @@ where
 /// byte-for-byte identical, so the metadata is never left without at least one intact copy.
 /// If the read-back does not match, the unverified copy is deleted again and the migration fails:
 /// leaving it behind would poison the storage, because readers resolve CRS metadata from the
-/// epoch-scoped path and a later run of this migration would classify the pair as a conflict and
-/// skip it indefinitely.
+/// epoch-scoped path.
+///
+/// If an entry already exists at the target epoch and *differs* from the flat one, the migration
+/// fails without touching either copy. There is no way to tell which of the two is authoritative,
+/// and this runs at boot, so aborting is preferable to starting the node against whichever copy
+/// the readers happen to resolve. An identical entry is treated as a completed earlier run and the
+/// flat copy is removed.
 ///
 /// Public CRS material ([`kms_grpc::rpc_types::PubDataType::CRS`]) is deliberately left alone:
 /// public data is shared across epochs and is stored flat by design.
@@ -168,7 +173,8 @@ where
 /// * `Ok(migrated_count)` - Number of CRS entries copied to the epoch-aware path and then removed
 ///   from the flat path.
 /// * `Err(...)` - If reading the legacy entry, writing the copy, verifying the copy, or deleting
-///   the flat entry fails. The flat entry is always left intact when this happens.
+///   the flat entry fails, or if a conflicting entry exists at the target epoch. The flat entry is
+///   always left intact when this happens.
 async fn migrate_crs_to_0_14_2<PrivS>(priv_storage: &mut PrivS) -> anyhow::Result<usize>
 where
     PrivS: StorageExt + Sync + Send,
@@ -203,24 +209,28 @@ where
         {
             // Something is already there, e.g. an earlier run of this migration that was
             // interrupted between the write and the delete. Drop the flat copy only when the two
-            // agree; otherwise keep both, because deleting the flat copy cannot be undone.
+            // agree; deleting the flat copy cannot be undone.
             let existing_data = priv_storage
                 .load_bytes_at_epoch(&crs_id, &target_epoch_id, &data_type_str)
                 .await?;
-            if existing_data == legacy_data {
-                // Now that we know it's safe to do so, delete the legacy data      
-                priv_storage.delete_data(&crs_id, &data_type_str).await?;
-                tracing::info!(
-                    "Legacy {data_type_str} {crs_id} was already migrated to epoch {target_epoch_id}, removed the flat copy"
-                );
-            } else {
-                tracing::error!(
+            if existing_data != legacy_data {
+                // Two different CRS metadata entries claim the same id and there is no way to tell
+                // which one is authoritative. Abort rather than pick one: this migration runs at
+                // boot, and starting the node would leave it serving whichever copy the readers
+                // happen to resolve. Neither copy is touched, so the operator can inspect both.
+                anyhow::bail!(
                     "Legacy {data_type_str} {crs_id} ({} bytes) differs from the entry already \
-stored at epoch {target_epoch_id} ({} bytes). Keeping both copies; this needs manual resolution.",
+stored at epoch {target_epoch_id} ({} bytes). Refusing to start: both copies were kept and this \
+conflict needs manual resolution.",
                     legacy_data.len(),
                     existing_data.len(),
                 );
             }
+            // Now that we know it's safe to do so, delete the legacy data
+            priv_storage.delete_data(&crs_id, &data_type_str).await?;
+            tracing::info!(
+                "Legacy {data_type_str} {crs_id} was already migrated to epoch {target_epoch_id}, removed the flat copy"
+            );
             continue;
         }
 
@@ -2406,11 +2416,9 @@ mod tests {
         );
     }
 
-    /// A *different* entry already sits at the epoch path: nothing is overwritten and, crucially,
-    /// the flat copy is kept.
-    pub async fn test_migrate_crs_keeps_both_on_conflict<S: StorageExt + Sync + Send>(
-        storage: &mut S,
-    ) {
+    /// A *different* entry already sits at the epoch path. The migration must abort so the node
+    /// does not boot in an undefined state, and neither copy may be touched.
+    pub async fn test_migrate_crs_aborts_on_conflict<S: StorageExt + Sync + Send>(storage: &mut S) {
         let crs_id = crs_test_id("c5");
         let data_type = PrivDataType::CrsInfo.to_string();
         let target_epoch_id: EpochId = *DEFAULT_EPOCH_ID;
@@ -2426,7 +2434,13 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(migrate_crs_to_0_14_2(storage).await.unwrap(), 0);
+        let err = migrate_crs_to_0_14_2(storage)
+            .await
+            .expect_err("a conflicting epoch entry must abort the migration");
+        assert!(
+            err.to_string().contains("needs manual resolution"),
+            "unexpected error: {err}"
+        );
 
         // Both copies survive untouched so a human can resolve the conflict.
         assert_eq!(
@@ -2539,8 +2553,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_migrate_crs_keeps_both_on_conflict_ram() {
-        test_migrate_crs_keeps_both_on_conflict(&mut RamStorage::new()).await;
+    async fn test_migrate_crs_aborts_on_conflict_ram() {
+        test_migrate_crs_aborts_on_conflict(&mut RamStorage::new()).await;
     }
 
     #[tokio::test]
@@ -2563,10 +2577,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_migrate_crs_keeps_both_on_conflict_file() {
+    async fn test_migrate_crs_aborts_on_conflict_file() {
         let temp_dir = tempfile::tempdir().unwrap();
         let mut storage = FileStorage::new(Some(temp_dir.path()), StorageType::PRIV, None).unwrap();
-        test_migrate_crs_keeps_both_on_conflict(&mut storage).await;
+        test_migrate_crs_aborts_on_conflict(&mut storage).await;
     }
 
     /// The copy must be verified before the flat entry is deleted. A silent short write on the
@@ -2731,13 +2745,13 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_migrate_crs_keeps_both_on_conflict_s3() {
+        async fn test_migrate_crs_aborts_on_conflict_s3() {
             let mut storage = create_s3_storage(
                 StorageType::PRIV,
-                std::stringify!(test_migrate_crs_keeps_both_on_conflict_s3),
+                std::stringify!(test_migrate_crs_aborts_on_conflict_s3),
             )
             .await;
-            test_migrate_crs_keeps_both_on_conflict(&mut storage).await;
+            test_migrate_crs_aborts_on_conflict(&mut storage).await;
         }
 
         #[tokio::test]

--- a/core/service/src/engine/utils.rs
+++ b/core/service/src/engine/utils.rs
@@ -329,9 +329,10 @@ where
             })?,
     };
 
-    // Query CRS IDs
+    // Query CRS IDs. Must span all epochs, like the FHE keys above: CRS metadata is stored
+    // epoch-scoped, and `all_data_ids` deliberately excludes epoch-scoped entries.
     let crs_ids_set = priv_storage
-        .all_data_ids(&PrivDataType::CrsInfo.to_string())
+        .all_data_ids_from_all_epochs(&PrivDataType::CrsInfo.to_string())
         .await
         .map_err(|e| {
             MetricedError::new(
@@ -686,7 +687,7 @@ mod tests {
     use crate::engine::base::KeyGenMetadataInner;
     use crate::engine::centralized::central_kms::gen_centralized_crs;
     use crate::vault::storage::ram::RamStorage;
-    use crate::vault::storage::{delete_at_request_id, store_versioned_at_request_id};
+    use crate::vault::storage::{Storage, delete_at_request_id, store_versioned_at_request_id};
 
     use aes_prng::AesRng;
     use hashing::hash_versioned;
@@ -1440,5 +1441,74 @@ mod tests {
             .unwrap();
 
         (crs, digest)
+    }
+
+    /// CRS metadata is stored epoch-scoped, so the availability query must span all epochs.
+    /// Regression test: querying with `all_data_ids` made migrated CRS entries disappear.
+    #[tokio::test]
+    async fn query_key_material_availability_reports_epoch_scoped_crs() {
+        use crate::consts::DEFAULT_EPOCH_ID;
+        use std::str::FromStr;
+
+        let crs_id = RequestId::from_str(
+            "0x00000000000000000000000000000000000000000000000000000000000005a1",
+        )
+        .unwrap();
+        let key_id = RequestId::from_str(
+            "0x00000000000000000000000000000000000000000000000000000000000004a1",
+        )
+        .unwrap();
+        let epoch_id: EpochId = *DEFAULT_EPOCH_ID;
+
+        let mut storage = RamStorage::new();
+        storage
+            .store_bytes_at_epoch(
+                &[1u8, 2, 3],
+                &crs_id,
+                &epoch_id,
+                &PrivDataType::CrsInfo.to_string(),
+            )
+            .await
+            .unwrap();
+        storage
+            .store_bytes_at_epoch(
+                &[4u8, 5, 6],
+                &key_id,
+                &epoch_id,
+                &PrivDataType::FheKeyInfo.to_string(),
+            )
+            .await
+            .unwrap();
+
+        let response = query_key_material_availability(&storage, KMSType::Threshold, vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(response.crs_ids, vec![crs_id.to_string()]);
+        assert_eq!(response.fhe_key_ids, vec![key_id.to_string()]);
+    }
+
+    /// A pre-migration (flat) CRS entry must still be reported, so availability does not regress
+    /// on a storage that has not been migrated yet.
+    #[tokio::test]
+    async fn query_key_material_availability_reports_flat_crs() {
+        use std::str::FromStr;
+
+        let crs_id = RequestId::from_str(
+            "0x00000000000000000000000000000000000000000000000000000000000005b1",
+        )
+        .unwrap();
+
+        let mut storage = RamStorage::new();
+        storage
+            .store_bytes(&[1u8, 2, 3], &crs_id, &PrivDataType::CrsInfo.to_string())
+            .await
+            .unwrap();
+
+        let response = query_key_material_availability(&storage, KMSType::Threshold, vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(response.crs_ids, vec![crs_id.to_string()]);
     }
 }

--- a/core/service/src/vault/storage/crypto_material/base.rs
+++ b/core/service/src/vault/storage/crypto_material/base.rs
@@ -324,10 +324,9 @@ where
     /// General method for handling the storage of both public and private material along with the backup.
     ///
     /// Existing data is never overwritten: the call returns [`StorageError::Duplicate`] instead.
-    /// Which location is checked depends on `epoch_id`. An epoch-scoped write only conflicts with
-    /// data at that same epoch; a legacy entry at the flat, non-epoch-scoped path does not block
-    /// it, so a storage that keeps its pre-0.13 material for downgrades can still be written to
-    /// under new epochs. A write with no epoch checks the flat path as before.
+    /// The check is scoped to the path being written — an epoch-scoped write only conflicts with
+    /// data at that same epoch, so a legacy entry at the flat path (kept for downgrades) does not
+    /// block it. A write with no epoch checks the flat path as before.
     pub(in crate::vault::storage::crypto_material) async fn write_all<
         'a,
         PubData: Serialize + Versionize + Named + Send + Sync,
@@ -361,9 +360,8 @@ where
         {
             return Err(StorageError::Duplicate);
         }
-        // Only guard the flat path for writes that target it. An epoch-scoped write is already
-        // covered by the epoch-scoped check above, and must not be blocked by a legacy flat entry
-        // that a pre-0.13 storage deliberately retains so it can be downgraded.
+        // Only guard the flat path for writes that target it; epoch-scoped writes are covered
+        // above and must not be blocked by a retained legacy entry.
         if epoch_id.is_none()
             && self
                 .data_exists(req_id, &pub_type, &priv_type)

--- a/core/service/src/vault/storage/crypto_material/base.rs
+++ b/core/service/src/vault/storage/crypto_material/base.rs
@@ -322,6 +322,12 @@ where
     }
 
     /// General method for handling the storage of both public and private material along with the backup.
+    ///
+    /// Existing data is never overwritten: the call returns [`StorageError::Duplicate`] instead.
+    /// Which location is checked depends on `epoch_id`. An epoch-scoped write only conflicts with
+    /// data at that same epoch; a legacy entry at the flat, non-epoch-scoped path does not block
+    /// it, so a storage that keeps its pre-0.13 material for downgrades can still be written to
+    /// under new epochs. A write with no epoch checks the flat path as before.
     pub(in crate::vault::storage::crypto_material) async fn write_all<
         'a,
         PubData: Serialize + Versionize + Named + Send + Sync,
@@ -355,10 +361,14 @@ where
         {
             return Err(StorageError::Duplicate);
         }
-        if self
-            .data_exists(req_id, &pub_type, &priv_type)
-            .await
-            .map_err(|e| StorageError::Other(e.to_string()))?
+        // Only guard the flat path for writes that target it. An epoch-scoped write is already
+        // covered by the epoch-scoped check above, and must not be blocked by a legacy flat entry
+        // that a pre-0.13 storage deliberately retains so it can be downgraded.
+        if epoch_id.is_none()
+            && self
+                .data_exists(req_id, &pub_type, &priv_type)
+                .await
+                .map_err(|e| StorageError::Other(e.to_string()))?
         {
             return Err(StorageError::Duplicate);
         }

--- a/core/service/src/vault/storage/crypto_material/tests.rs
+++ b/core/service/src/vault/storage/crypto_material/tests.rs
@@ -1618,11 +1618,12 @@ async fn refresh_fhe_private_material_paths() {
 /// Regression tests for zama-ai/kms-internal#3204.
 ///
 /// A pre-0.13 deployment keeps its private CRS metadata at the flat, non-epoch-scoped path.
-/// `write_all` rejects a write whose data id exists at the flat path *even when the write targets
-/// an epoch*, so every resharing attempt failed with `StorageError::Duplicate` and rolled the new
-/// epoch back on all nodes. These tests pin the causal chain: the flat entry causes the failure,
-/// and the CRS migration is what clears it.
-mod crs_flat_entry_blocks_resharing {
+/// `write_all` used to reject a write whose data id existed at the flat path *even when the write
+/// targeted an epoch*, so every resharing attempt failed with `StorageError::Duplicate` and rolled
+/// the new epoch back on all nodes. The duplicate check is now scoped to the path being written,
+/// and the migration copies the entry into the epoch-aware layout while leaving the legacy one in
+/// place for downgrades. These tests pin both halves of that.
+mod crs_legacy_entry_and_resharing {
     use super::*;
     use crate::engine::migration::migrate_to_0_14_2;
     use kms_grpc::rpc_types::KMSType;
@@ -1661,10 +1662,11 @@ mod crs_flat_entry_blocks_resharing {
             .expect("a reshared CRS write must succeed on storage with no flat entry");
     }
 
-    /// Reproduces the reported failure: a flat CRS entry makes the epoch-scoped resharing write
-    /// fail with `Duplicate`, which is what aborted every epoch rotation on zws-dev.
+    /// The core of #3204: a legacy flat CRS entry must not block the epoch-scoped resharing write.
+    /// Before the duplicate check was scoped to the path being written, this returned `Duplicate`
+    /// and aborted every epoch rotation on zws-dev.
     #[tokio::test]
-    async fn flat_crs_entry_makes_reshared_write_fail_with_duplicate() {
+    async fn legacy_flat_entry_does_not_block_reshared_write() {
         let storage = ram_threshold_storage(None);
         let (crs_id, crs_meta) = crs_fixture(2);
         let new_epoch: EpochId = *DEFAULT_EPOCH_ID;
@@ -1682,19 +1684,61 @@ mod crs_flat_entry_blocks_resharing {
             .unwrap();
         }
 
-        let err = reshare_crs_write(&storage, &crs_id, &new_epoch, crs_meta)
+        reshare_crs_write(&storage, &crs_id, &new_epoch, crs_meta)
             .await
-            .expect_err("a flat CRS entry must make the epoch-scoped write fail");
+            .expect("a legacy flat CRS entry must not block an epoch-scoped write");
+
+        // The legacy entry is untouched by the write.
+        let priv_s = storage.inner.private_storage.lock().await;
+        assert!(
+            priv_s
+                .data_exists(&crs_id, &PrivDataType::CrsInfo.to_string())
+                .await
+                .unwrap()
+        );
+    }
+
+    /// The duplicate check must still fire for writes that actually target the flat path, so
+    /// scoping it to the epoch has not disabled overwrite protection.
+    #[tokio::test]
+    async fn non_epoch_write_still_rejects_duplicates() {
+        let storage = ram_threshold_storage(None);
+        let (crs_id, crs_meta) = crs_fixture(4);
+
+        {
+            let mut priv_s = storage.inner.private_storage.lock().await;
+            store_versioned_at_request_id(
+                &mut *priv_s,
+                &crs_id,
+                &crs_meta,
+                &PrivDataType::CrsInfo.to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let err = storage
+            .inner
+            .write_all::<CrsGenMetadata, CrsGenMetadata>(
+                &crs_id,
+                None, // no epoch: the flat path is the target
+                None,
+                Some((&crs_meta, PrivDataType::CrsInfo)),
+                false,
+                TEST_METRIC,
+            )
+            .await
+            .expect_err("a non-epoch write over an existing flat entry must be rejected");
         assert!(
             matches!(err, StorageError::Duplicate),
             "expected Duplicate, got {err:?}"
         );
     }
 
-    /// The fix: after the migration moves the flat entry to the epoch-scoped path, the same
-    /// resharing write that previously failed now succeeds.
+    /// The migration copies the legacy entry into the epoch-aware layout, keeps the legacy one,
+    /// and leaves resharing into a further epoch working.
     #[tokio::test]
-    async fn migration_unblocks_reshared_crs_write() {
+    async fn migration_copies_legacy_entry_and_keeps_it() {
         let storage = ram_threshold_storage(None);
         let (crs_id, crs_meta) = crs_fixture(3);
         // Resharing targets a *new* epoch, distinct from the one the migration writes to.
@@ -1712,14 +1756,6 @@ mod crs_flat_entry_blocks_resharing {
             .unwrap();
         }
 
-        // Before the migration the write is rejected.
-        assert!(matches!(
-            reshare_crs_write(&storage, &crs_id, &new_epoch, crs_meta.clone())
-                .await
-                .unwrap_err(),
-            StorageError::Duplicate
-        ));
-
         // Run the real startup migration entry point, as `kms-server` does.
         {
             let mut priv_s = storage.inner.private_storage.lock().await;
@@ -1728,14 +1764,15 @@ mod crs_flat_entry_blocks_resharing {
                 .unwrap();
         }
 
-        // The flat entry is gone and the write now goes through.
+        // The legacy entry is retained and the epoch-scoped copy now exists alongside it.
         {
             let priv_s = storage.inner.private_storage.lock().await;
             assert!(
-                !priv_s
+                priv_s
                     .data_exists(&crs_id, &PrivDataType::CrsInfo.to_string())
                     .await
-                    .unwrap()
+                    .unwrap(),
+                "the legacy entry must be kept so the node stays downgradable"
             );
             assert!(
                 priv_s
@@ -1751,7 +1788,141 @@ mod crs_flat_entry_blocks_resharing {
 
         reshare_crs_write(&storage, &crs_id, &new_epoch, crs_meta)
             .await
-            .expect("after the migration the reshared CRS write must succeed");
+            .expect("resharing into a further epoch must work after the migration");
+    }
+}
+
+/// Behaviour when the legacy flat CRS entry is kept alongside the migrated epoch-scoped one.
+///
+/// The migration copies rather than moves, so a node can be downgraded to a release that reads the
+/// flat path. These tests pin that the retained entry is inert during normal operation.
+mod crs_flat_and_epoch_copies_coexist {
+    use super::*;
+    use crate::vault::storage::{
+        read_all_data_from_all_epochs_versioned, select_data_from_max_epoch,
+    };
+    use std::collections::HashMap;
+
+    fn epoch_from_low_byte(b: u8) -> EpochId {
+        let mut raw = [0u8; 32];
+        raw[0] = 8;
+        raw[31] = b;
+        EpochId::from_bytes(raw)
+    }
+
+    /// Seeds a flat CRS entry plus one epoch-scoped entry per `(epoch, metadata)` pair.
+    async fn seed(
+        storage: &ThresholdCryptoMaterialStorage<RamStorage, RamStorage>,
+        crs_id: &RequestId,
+        flat: &CrsGenMetadata,
+        epoched: &[(EpochId, CrsGenMetadata)],
+    ) {
+        let data_type = PrivDataType::CrsInfo.to_string();
+        let mut priv_s = storage.inner.private_storage.lock().await;
+        store_versioned_at_request_id(&mut *priv_s, crs_id, flat, &data_type)
+            .await
+            .unwrap();
+        for (epoch, meta) in epoched {
+            store_versioned_at_request_and_epoch_id(&mut *priv_s, crs_id, epoch, meta, &data_type)
+                .await
+                .unwrap();
+        }
+    }
+
+    async fn loader_view(
+        storage: &ThresholdCryptoMaterialStorage<RamStorage, RamStorage>,
+    ) -> HashMap<RequestId, CrsGenMetadata> {
+        let priv_s = storage.inner.private_storage.lock().await;
+        select_data_from_max_epoch(
+            read_all_data_from_all_epochs_versioned::<_, CrsGenMetadata>(
+                &*priv_s,
+                &PrivDataType::CrsInfo.to_string(),
+            )
+            .await
+            .unwrap(),
+        )
+    }
+
+    /// The startup loader must ignore the flat copy and serve the epoch-scoped one.
+    #[tokio::test]
+    async fn startup_loader_ignores_flat_copy() {
+        let storage = ram_threshold_storage(None);
+        let crs_id = derive_request_id("coexist_crs_1").unwrap();
+        let flat = dummy_crs_metadata(10);
+        let epoched = dummy_crs_metadata(11);
+
+        seed(
+            &storage,
+            &crs_id,
+            &flat,
+            &[(*DEFAULT_EPOCH_ID, epoched.clone())],
+        )
+        .await;
+
+        let view = loader_view(&storage).await;
+        assert_eq!(view.len(), 1);
+        assert_eq!(
+            view.get(&crs_id),
+            Some(&epoched),
+            "must serve the epoch-scoped copy"
+        );
+        assert_ne!(view.get(&crs_id), Some(&flat));
+    }
+
+    /// With several epochs present the loader must pick the highest one, flat copy notwithstanding.
+    #[tokio::test]
+    async fn startup_loader_picks_latest_epoch() {
+        let storage = ram_threshold_storage(None);
+        let crs_id = derive_request_id("coexist_crs_2").unwrap();
+        let flat = dummy_crs_metadata(20);
+        let older = dummy_crs_metadata(21);
+        let newer = dummy_crs_metadata(22);
+
+        seed(
+            &storage,
+            &crs_id,
+            &flat,
+            &[
+                (epoch_from_low_byte(1), older.clone()),
+                (epoch_from_low_byte(2), newer.clone()),
+            ],
+        )
+        .await;
+
+        let view = loader_view(&storage).await;
+        assert_eq!(
+            view.get(&crs_id),
+            Some(&newer),
+            "must serve the newest epoch"
+        );
+    }
+
+    /// An epoch change must still work with both copies present. This is what makes it safe for
+    /// the migration to keep the legacy entry rather than delete it.
+    #[tokio::test]
+    async fn reshare_into_new_epoch_works_with_flat_copy_present() {
+        let storage = ram_threshold_storage(None);
+        let crs_id = derive_request_id("coexist_crs_3").unwrap();
+        let flat = dummy_crs_metadata(30);
+        let current = dummy_crs_metadata(31);
+        let reshared = dummy_crs_metadata(32);
+
+        seed(
+            &storage,
+            &crs_id,
+            &flat,
+            &[(epoch_from_low_byte(1), current)],
+        )
+        .await;
+
+        storage
+            .resharing_crs_write_no_backup(&crs_id, &epoch_from_low_byte(2), reshared.clone())
+            .await
+            .expect("a retained legacy copy must not block the epoch change");
+
+        // The new epoch now holds the reshared metadata, and the loader serves it.
+        let view = loader_view(&storage).await;
+        assert_eq!(view.get(&crs_id), Some(&reshared));
     }
 }
 

--- a/core/service/src/vault/storage/crypto_material/tests.rs
+++ b/core/service/src/vault/storage/crypto_material/tests.rs
@@ -1615,4 +1615,144 @@ async fn refresh_fhe_private_material_paths() {
     assert!(cache_guard.get(&(miss_req, miss_epoch)).is_none());
 }
 
+/// Regression tests for zama-ai/kms-internal#3204.
+///
+/// A pre-0.13 deployment keeps its private CRS metadata at the flat, non-epoch-scoped path.
+/// `write_all` rejects a write whose data id exists at the flat path *even when the write targets
+/// an epoch*, so every resharing attempt failed with `StorageError::Duplicate` and rolled the new
+/// epoch back on all nodes. These tests pin the causal chain: the flat entry causes the failure,
+/// and the CRS migration is what clears it.
+mod crs_flat_entry_blocks_resharing {
+    use super::*;
+    use crate::engine::migration::migrate_to_0_14_2;
+    use kms_grpc::rpc_types::KMSType;
+
+    /// `dummy_crs_metadata` derives its CRS id from the seed; mirror that here so tests can refer
+    /// to the id without an accessor on `CrsGenMetadata`.
+    fn crs_fixture(seed: u8) -> (RequestId, CrsGenMetadata) {
+        (
+            derive_request_id(&format!("crs_meta_{seed}")).unwrap(),
+            dummy_crs_metadata(seed),
+        )
+    }
+
+    /// Writes `crs_meta` the way resharing does: epoch-scoped, private-only, no backup.
+    async fn reshare_crs_write(
+        storage: &ThresholdCryptoMaterialStorage<RamStorage, RamStorage>,
+        crs_id: &RequestId,
+        epoch_id: &EpochId,
+        crs_meta: CrsGenMetadata,
+    ) -> Result<(), StorageError> {
+        storage
+            .resharing_crs_write_no_backup(crs_id, epoch_id, crs_meta)
+            .await
+    }
+
+    /// Baseline: on a storage that never had a flat CRS entry, the resharing write succeeds.
+    /// This is why the existing fresh-storage tests never reproduced the bug.
+    #[tokio::test]
+    async fn fresh_storage_allows_reshared_crs_write() {
+        let storage = ram_threshold_storage(None);
+        let (crs_id, crs_meta) = crs_fixture(1);
+        let new_epoch: EpochId = *DEFAULT_EPOCH_ID;
+
+        reshare_crs_write(&storage, &crs_id, &new_epoch, crs_meta)
+            .await
+            .expect("a reshared CRS write must succeed on storage with no flat entry");
+    }
+
+    /// Reproduces the reported failure: a flat CRS entry makes the epoch-scoped resharing write
+    /// fail with `Duplicate`, which is what aborted every epoch rotation on zws-dev.
+    #[tokio::test]
+    async fn flat_crs_entry_makes_reshared_write_fail_with_duplicate() {
+        let storage = ram_threshold_storage(None);
+        let (crs_id, crs_meta) = crs_fixture(2);
+        let new_epoch: EpochId = *DEFAULT_EPOCH_ID;
+
+        // Simulate the pre-0.13 layout: CRS metadata directly under the data type, no epoch.
+        {
+            let mut priv_s = storage.inner.private_storage.lock().await;
+            store_versioned_at_request_id(
+                &mut *priv_s,
+                &crs_id,
+                &crs_meta,
+                &PrivDataType::CrsInfo.to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let err = reshare_crs_write(&storage, &crs_id, &new_epoch, crs_meta)
+            .await
+            .expect_err("a flat CRS entry must make the epoch-scoped write fail");
+        assert!(
+            matches!(err, StorageError::Duplicate),
+            "expected Duplicate, got {err:?}"
+        );
+    }
+
+    /// The fix: after the migration moves the flat entry to the epoch-scoped path, the same
+    /// resharing write that previously failed now succeeds.
+    #[tokio::test]
+    async fn migration_unblocks_reshared_crs_write() {
+        let storage = ram_threshold_storage(None);
+        let (crs_id, crs_meta) = crs_fixture(3);
+        // Resharing targets a *new* epoch, distinct from the one the migration writes to.
+        let new_epoch: EpochId = derive_request_id("crs_reshare_new_epoch").unwrap().into();
+
+        {
+            let mut priv_s = storage.inner.private_storage.lock().await;
+            store_versioned_at_request_id(
+                &mut *priv_s,
+                &crs_id,
+                &crs_meta,
+                &PrivDataType::CrsInfo.to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        // Before the migration the write is rejected.
+        assert!(matches!(
+            reshare_crs_write(&storage, &crs_id, &new_epoch, crs_meta.clone())
+                .await
+                .unwrap_err(),
+            StorageError::Duplicate
+        ));
+
+        // Run the real startup migration entry point, as `kms-server` does.
+        {
+            let mut priv_s = storage.inner.private_storage.lock().await;
+            migrate_to_0_14_2(&mut *priv_s, KMSType::Threshold)
+                .await
+                .unwrap();
+        }
+
+        // The flat entry is gone and the write now goes through.
+        {
+            let priv_s = storage.inner.private_storage.lock().await;
+            assert!(
+                !priv_s
+                    .data_exists(&crs_id, &PrivDataType::CrsInfo.to_string())
+                    .await
+                    .unwrap()
+            );
+            assert!(
+                priv_s
+                    .data_exists_at_epoch(
+                        &crs_id,
+                        &DEFAULT_EPOCH_ID,
+                        &PrivDataType::CrsInfo.to_string()
+                    )
+                    .await
+                    .unwrap()
+            );
+        }
+
+        reshare_crs_write(&storage, &crs_id, &new_epoch, crs_meta)
+            .await
+            .expect("after the migration the reshared CRS write must succeed");
+    }
+}
+
 mod migration;

--- a/core/service/src/vault/storage/crypto_material/tests.rs
+++ b/core/service/src/vault/storage/crypto_material/tests.rs
@@ -1618,18 +1618,20 @@ async fn refresh_fhe_private_material_paths() {
 /// Regression tests for zama-ai/kms-internal#3204.
 ///
 /// A pre-0.13 deployment keeps its private CRS metadata at the flat, non-epoch-scoped path.
-/// `write_all` used to reject a write whose data id existed at the flat path *even when the write
-/// targeted an epoch*, so every resharing attempt failed with `StorageError::Duplicate` and rolled
-/// the new epoch back on all nodes. The duplicate check is now scoped to the path being written,
-/// and the migration copies the entry into the epoch-aware layout while leaving the legacy one in
-/// place for downgrades. These tests pin both halves of that.
+/// `write_all` used to reject an epoch-scoped write whose data id existed at that flat path, so
+/// every resharing attempt failed with `Duplicate` and rolled the new epoch back on all nodes.
+/// The duplicate check is now scoped to the path being written, and the migration copies the entry
+/// into the epoch-aware layout while keeping the legacy one so the node stays downgradable.
 mod crs_legacy_entry_and_resharing {
     use super::*;
     use crate::engine::migration::migrate_to_0_14_2;
+    use crate::vault::storage::{
+        read_all_data_from_all_epochs_versioned, select_data_from_max_epoch,
+    };
     use kms_grpc::rpc_types::KMSType;
+    use std::collections::HashMap;
 
-    /// `dummy_crs_metadata` derives its CRS id from the seed; mirror that here so tests can refer
-    /// to the id without an accessor on `CrsGenMetadata`.
+    /// `dummy_crs_metadata` derives its CRS id from the seed; mirror that so tests can name the id.
     fn crs_fixture(seed: u8) -> (RequestId, CrsGenMetadata) {
         (
             derive_request_id(&format!("crs_meta_{seed}")).unwrap(),
@@ -1637,85 +1639,82 @@ mod crs_legacy_entry_and_resharing {
         )
     }
 
-    /// Writes `crs_meta` the way resharing does: epoch-scoped, private-only, no backup.
-    async fn reshare_crs_write(
+    /// Epoch ids ordered by their raw bytes, so `b` orders them predictably against
+    /// `DEFAULT_EPOCH_ID` (`0x08…01`).
+    fn epoch_from_low_byte(b: u8) -> EpochId {
+        let mut raw = [0u8; 32];
+        raw[0] = 8;
+        raw[31] = b;
+        EpochId::from_bytes(raw)
+    }
+
+    async fn store_flat(
         storage: &ThresholdCryptoMaterialStorage<RamStorage, RamStorage>,
         crs_id: &RequestId,
-        epoch_id: &EpochId,
-        crs_meta: CrsGenMetadata,
-    ) -> Result<(), StorageError> {
-        storage
-            .resharing_crs_write_no_backup(crs_id, epoch_id, crs_meta)
-            .await
+        meta: &CrsGenMetadata,
+    ) {
+        let mut priv_s = storage.inner.private_storage.lock().await;
+        store_versioned_at_request_id(
+            &mut *priv_s,
+            crs_id,
+            meta,
+            &PrivDataType::CrsInfo.to_string(),
+        )
+        .await
+        .unwrap();
     }
 
-    /// Baseline: on a storage that never had a flat CRS entry, the resharing write succeeds.
-    /// This is why the existing fresh-storage tests never reproduced the bug.
-    #[tokio::test]
-    async fn fresh_storage_allows_reshared_crs_write() {
-        let storage = ram_threshold_storage(None);
-        let (crs_id, crs_meta) = crs_fixture(1);
-        let new_epoch: EpochId = *DEFAULT_EPOCH_ID;
-
-        reshare_crs_write(&storage, &crs_id, &new_epoch, crs_meta)
+    async fn flat_exists(
+        storage: &ThresholdCryptoMaterialStorage<RamStorage, RamStorage>,
+        crs_id: &RequestId,
+    ) -> bool {
+        let priv_s = storage.inner.private_storage.lock().await;
+        priv_s
+            .data_exists(crs_id, &PrivDataType::CrsInfo.to_string())
             .await
-            .expect("a reshared CRS write must succeed on storage with no flat entry");
+            .unwrap()
     }
 
-    /// The core of #3204: a legacy flat CRS entry must not block the epoch-scoped resharing write.
-    /// Before the duplicate check was scoped to the path being written, this returned `Duplicate`
-    /// and aborted every epoch rotation on zws-dev.
+    /// What the startup loader would see: epoch-scoped entries only, newest epoch per id.
+    async fn loader_view(
+        storage: &ThresholdCryptoMaterialStorage<RamStorage, RamStorage>,
+    ) -> HashMap<RequestId, CrsGenMetadata> {
+        let priv_s = storage.inner.private_storage.lock().await;
+        select_data_from_max_epoch(
+            read_all_data_from_all_epochs_versioned::<_, CrsGenMetadata>(
+                &*priv_s,
+                &PrivDataType::CrsInfo.to_string(),
+            )
+            .await
+            .unwrap(),
+        )
+    }
+
+    /// The core of #3204: a legacy flat entry must not block the epoch-scoped resharing write.
     #[tokio::test]
     async fn legacy_flat_entry_does_not_block_reshared_write() {
         let storage = ram_threshold_storage(None);
         let (crs_id, crs_meta) = crs_fixture(2);
-        let new_epoch: EpochId = *DEFAULT_EPOCH_ID;
 
-        // Simulate the pre-0.13 layout: CRS metadata directly under the data type, no epoch.
-        {
-            let mut priv_s = storage.inner.private_storage.lock().await;
-            store_versioned_at_request_id(
-                &mut *priv_s,
-                &crs_id,
-                &crs_meta,
-                &PrivDataType::CrsInfo.to_string(),
-            )
+        store_flat(&storage, &crs_id, &crs_meta).await;
+
+        storage
+            .resharing_crs_write_no_backup(&crs_id, &epoch_from_low_byte(2), crs_meta)
             .await
-            .unwrap();
-        }
-
-        reshare_crs_write(&storage, &crs_id, &new_epoch, crs_meta)
-            .await
-            .expect("a legacy flat CRS entry must not block an epoch-scoped write");
-
-        // The legacy entry is untouched by the write.
-        let priv_s = storage.inner.private_storage.lock().await;
+            .expect("a legacy flat entry must not block an epoch-scoped write");
         assert!(
-            priv_s
-                .data_exists(&crs_id, &PrivDataType::CrsInfo.to_string())
-                .await
-                .unwrap()
+            flat_exists(&storage, &crs_id).await,
+            "write must not touch the legacy entry"
         );
     }
 
-    /// The duplicate check must still fire for writes that actually target the flat path, so
-    /// scoping it to the epoch has not disabled overwrite protection.
+    /// Scoping the check to the epoch must not disable overwrite protection on the flat path.
     #[tokio::test]
     async fn non_epoch_write_still_rejects_duplicates() {
         let storage = ram_threshold_storage(None);
         let (crs_id, crs_meta) = crs_fixture(4);
 
-        {
-            let mut priv_s = storage.inner.private_storage.lock().await;
-            store_versioned_at_request_id(
-                &mut *priv_s,
-                &crs_id,
-                &crs_meta,
-                &PrivDataType::CrsInfo.to_string(),
-            )
-            .await
-            .unwrap();
-        }
+        store_flat(&storage, &crs_id, &crs_meta).await;
 
         let err = storage
             .inner
@@ -1735,28 +1734,17 @@ mod crs_legacy_entry_and_resharing {
         );
     }
 
-    /// The migration copies the legacy entry into the epoch-aware layout, keeps the legacy one,
-    /// and leaves resharing into a further epoch working.
+    /// End to end: migrate, keep the legacy entry, then reshare into a further epoch and confirm
+    /// the loader serves the reshared metadata.
     #[tokio::test]
-    async fn migration_copies_legacy_entry_and_keeps_it() {
+    async fn migration_copies_legacy_entry_then_resharing_works() {
         let storage = ram_threshold_storage(None);
         let (crs_id, crs_meta) = crs_fixture(3);
-        // Resharing targets a *new* epoch, distinct from the one the migration writes to.
-        let new_epoch: EpochId = derive_request_id("crs_reshare_new_epoch").unwrap().into();
+        let reshared = dummy_crs_metadata(33);
+        let new_epoch = epoch_from_low_byte(2); // orders above DEFAULT_EPOCH_ID
 
-        {
-            let mut priv_s = storage.inner.private_storage.lock().await;
-            store_versioned_at_request_id(
-                &mut *priv_s,
-                &crs_id,
-                &crs_meta,
-                &PrivDataType::CrsInfo.to_string(),
-            )
-            .await
-            .unwrap();
-        }
+        store_flat(&storage, &crs_id, &crs_meta).await;
 
-        // Run the real startup migration entry point, as `kms-server` does.
         {
             let mut priv_s = storage.inner.private_storage.lock().await;
             migrate_to_0_14_2(&mut *priv_s, KMSType::Threshold)
@@ -1764,165 +1752,45 @@ mod crs_legacy_entry_and_resharing {
                 .unwrap();
         }
 
-        // The legacy entry is retained and the epoch-scoped copy now exists alongside it.
-        {
-            let priv_s = storage.inner.private_storage.lock().await;
-            assert!(
-                priv_s
-                    .data_exists(&crs_id, &PrivDataType::CrsInfo.to_string())
-                    .await
-                    .unwrap(),
-                "the legacy entry must be kept so the node stays downgradable"
-            );
-            assert!(
-                priv_s
-                    .data_exists_at_epoch(
-                        &crs_id,
-                        &DEFAULT_EPOCH_ID,
-                        &PrivDataType::CrsInfo.to_string()
-                    )
-                    .await
-                    .unwrap()
-            );
-        }
+        assert!(
+            flat_exists(&storage, &crs_id).await,
+            "the legacy entry must be kept so the node stays downgradable"
+        );
+        assert_eq!(loader_view(&storage).await.get(&crs_id), Some(&crs_meta));
 
-        reshare_crs_write(&storage, &crs_id, &new_epoch, crs_meta)
+        storage
+            .resharing_crs_write_no_backup(&crs_id, &new_epoch, reshared.clone())
             .await
             .expect("resharing into a further epoch must work after the migration");
-    }
-}
-
-/// Behaviour when the legacy flat CRS entry is kept alongside the migrated epoch-scoped one.
-///
-/// The migration copies rather than moves, so a node can be downgraded to a release that reads the
-/// flat path. These tests pin that the retained entry is inert during normal operation.
-mod crs_flat_and_epoch_copies_coexist {
-    use super::*;
-    use crate::vault::storage::{
-        read_all_data_from_all_epochs_versioned, select_data_from_max_epoch,
-    };
-    use std::collections::HashMap;
-
-    fn epoch_from_low_byte(b: u8) -> EpochId {
-        let mut raw = [0u8; 32];
-        raw[0] = 8;
-        raw[31] = b;
-        EpochId::from_bytes(raw)
+        assert_eq!(loader_view(&storage).await.get(&crs_id), Some(&reshared));
     }
 
-    /// Seeds a flat CRS entry plus one epoch-scoped entry per `(epoch, metadata)` pair.
-    async fn seed(
-        storage: &ThresholdCryptoMaterialStorage<RamStorage, RamStorage>,
-        crs_id: &RequestId,
-        flat: &CrsGenMetadata,
-        epoched: &[(EpochId, CrsGenMetadata)],
-    ) {
-        let data_type = PrivDataType::CrsInfo.to_string();
-        let mut priv_s = storage.inner.private_storage.lock().await;
-        store_versioned_at_request_id(&mut *priv_s, crs_id, flat, &data_type)
-            .await
-            .unwrap();
-        for (epoch, meta) in epoched {
-            store_versioned_at_request_and_epoch_id(&mut *priv_s, crs_id, epoch, meta, &data_type)
-                .await
-                .unwrap();
-        }
-    }
-
-    async fn loader_view(
-        storage: &ThresholdCryptoMaterialStorage<RamStorage, RamStorage>,
-    ) -> HashMap<RequestId, CrsGenMetadata> {
-        let priv_s = storage.inner.private_storage.lock().await;
-        select_data_from_max_epoch(
-            read_all_data_from_all_epochs_versioned::<_, CrsGenMetadata>(
-                &*priv_s,
-                &PrivDataType::CrsInfo.to_string(),
-            )
-            .await
-            .unwrap(),
-        )
-    }
-
-    /// The startup loader must ignore the flat copy and serve the epoch-scoped one.
-    #[tokio::test]
-    async fn startup_loader_ignores_flat_copy() {
-        let storage = ram_threshold_storage(None);
-        let crs_id = derive_request_id("coexist_crs_1").unwrap();
-        let flat = dummy_crs_metadata(10);
-        let epoched = dummy_crs_metadata(11);
-
-        seed(
-            &storage,
-            &crs_id,
-            &flat,
-            &[(*DEFAULT_EPOCH_ID, epoched.clone())],
-        )
-        .await;
-
-        let view = loader_view(&storage).await;
-        assert_eq!(view.len(), 1);
-        assert_eq!(
-            view.get(&crs_id),
-            Some(&epoched),
-            "must serve the epoch-scoped copy"
-        );
-        assert_ne!(view.get(&crs_id), Some(&flat));
-    }
-
-    /// With several epochs present the loader must pick the highest one, flat copy notwithstanding.
+    /// With several epochs present the loader picks the highest, legacy entry notwithstanding.
     #[tokio::test]
     async fn startup_loader_picks_latest_epoch() {
         let storage = ram_threshold_storage(None);
         let crs_id = derive_request_id("coexist_crs_2").unwrap();
-        let flat = dummy_crs_metadata(20);
         let older = dummy_crs_metadata(21);
         let newer = dummy_crs_metadata(22);
 
-        seed(
-            &storage,
-            &crs_id,
-            &flat,
-            &[
-                (epoch_from_low_byte(1), older.clone()),
-                (epoch_from_low_byte(2), newer.clone()),
-            ],
-        )
-        .await;
+        store_flat(&storage, &crs_id, &dummy_crs_metadata(20)).await;
+        {
+            let mut priv_s = storage.inner.private_storage.lock().await;
+            let data_type = PrivDataType::CrsInfo.to_string();
+            for (epoch, meta) in [(1u8, &older), (2u8, &newer)] {
+                store_versioned_at_request_and_epoch_id(
+                    &mut *priv_s,
+                    &crs_id,
+                    &epoch_from_low_byte(epoch),
+                    meta,
+                    &data_type,
+                )
+                .await
+                .unwrap();
+            }
+        }
 
-        let view = loader_view(&storage).await;
-        assert_eq!(
-            view.get(&crs_id),
-            Some(&newer),
-            "must serve the newest epoch"
-        );
-    }
-
-    /// An epoch change must still work with both copies present. This is what makes it safe for
-    /// the migration to keep the legacy entry rather than delete it.
-    #[tokio::test]
-    async fn reshare_into_new_epoch_works_with_flat_copy_present() {
-        let storage = ram_threshold_storage(None);
-        let crs_id = derive_request_id("coexist_crs_3").unwrap();
-        let flat = dummy_crs_metadata(30);
-        let current = dummy_crs_metadata(31);
-        let reshared = dummy_crs_metadata(32);
-
-        seed(
-            &storage,
-            &crs_id,
-            &flat,
-            &[(epoch_from_low_byte(1), current)],
-        )
-        .await;
-
-        storage
-            .resharing_crs_write_no_backup(&crs_id, &epoch_from_low_byte(2), reshared.clone())
-            .await
-            .expect("a retained legacy copy must not block the epoch change");
-
-        // The new epoch now holds the reshared metadata, and the loader serves it.
-        let view = loader_view(&storage).await;
-        assert_eq!(view.get(&crs_id), Some(&reshared));
+        assert_eq!(loader_view(&storage).await.get(&crs_id), Some(&newer));
     }
 }
 

--- a/core/service/src/vault/storage/ram.rs
+++ b/core/service/src/vault/storage/ram.rs
@@ -349,16 +349,15 @@ impl FailingRamStorage {
         self.available_epoch_writes = available_epoch_writes
     }
 
-    /// When set, epoch-aware byte writes report success but persist truncated data.
-    /// This models a write that does not persist the bytes it was given while still reporting
-    /// `Created`, which a caller can only detect by reading the data back.
+    /// When set, epoch-aware byte writes report `Created` but persist truncated data — a write
+    /// that loses bytes silently, detectable only by reading it back.
     pub fn set_corrupt_epoch_writes(&mut self, corrupt_epoch_writes: bool) {
         self.corrupt_epoch_writes = corrupt_epoch_writes
     }
 
     /// When set, epoch-aware byte writes persist nothing and report
-    /// [`StoreWriteOutcome::SkippedExisting`]. This models the real backends' refusal to overwrite
-    /// an entry that appeared after the caller's existence check.
+    /// [`StoreWriteOutcome::SkippedExisting`], as the real backends do when an entry appeared
+    /// after the caller's existence check.
     pub fn set_skip_epoch_writes(&mut self, skip_epoch_writes: bool) {
         self.skip_epoch_writes = skip_epoch_writes
     }
@@ -516,8 +515,7 @@ impl StorageExt for FailingRamStorage {
         if self.skip_epoch_writes {
             return Ok(StoreWriteOutcome::SkippedExisting);
         }
-        // Drop the last byte rather than writing nothing, so the corrupted entry is still
-        // discoverable by `data_exists_at_epoch` and only a read-back can tell it apart.
+        // Drop the last byte rather than writing nothing, so only a read-back can tell it apart.
         let to_store = if self.corrupt_epoch_writes {
             &bytes[..bytes.len().saturating_sub(1)]
         } else {

--- a/core/service/src/vault/storage/ram.rs
+++ b/core/service/src/vault/storage/ram.rs
@@ -363,7 +363,8 @@ impl FailingRamStorage {
         self.skip_epoch_writes = skip_epoch_writes
     }
 
-    /// Returns an error and consumes one epoch-write budget unit if the budget is exhausted.
+    /// Consumes one epoch-write budget unit, or returns an error if the budget is exhausted.
+    /// A budget of `None` is unlimited and consumes nothing.
     fn consume_epoch_write(&mut self) -> anyhow::Result<()> {
         if let Some(remaining) = self.available_epoch_writes.as_mut() {
             if *remaining < 1 {

--- a/core/service/src/vault/storage/ram.rs
+++ b/core/service/src/vault/storage/ram.rs
@@ -323,6 +323,7 @@ pub struct FailingRamStorage {
     available_writes: usize,
     available_epoch_writes: Option<usize>,
     corrupt_epoch_writes: bool,
+    skip_epoch_writes: bool,
     inner: RamStorage,
 }
 
@@ -333,6 +334,7 @@ impl FailingRamStorage {
             available_writes: writes_before_failure,
             available_epoch_writes: None,
             corrupt_epoch_writes: false,
+            skip_epoch_writes: false,
             inner: RamStorage::new(),
         }
     }
@@ -348,9 +350,17 @@ impl FailingRamStorage {
     }
 
     /// When set, epoch-aware byte writes report success but persist truncated data.
-    /// This models a silent short write, which a caller can only detect by reading the data back.
+    /// This models a write that does not persist the bytes it was given while still reporting
+    /// `Created`, which a caller can only detect by reading the data back.
     pub fn set_corrupt_epoch_writes(&mut self, corrupt_epoch_writes: bool) {
         self.corrupt_epoch_writes = corrupt_epoch_writes
+    }
+
+    /// When set, epoch-aware byte writes persist nothing and report
+    /// [`StoreWriteOutcome::SkippedExisting`]. This models the real backends' refusal to overwrite
+    /// an entry that appeared after the caller's existence check.
+    pub fn set_skip_epoch_writes(&mut self, skip_epoch_writes: bool) {
+        self.skip_epoch_writes = skip_epoch_writes
     }
 
     /// Returns an error and consumes one epoch-write budget unit if the budget is exhausted.
@@ -502,6 +512,9 @@ impl StorageExt for FailingRamStorage {
         data_type: &str,
     ) -> anyhow::Result<StoreWriteOutcome> {
         self.consume_epoch_write()?;
+        if self.skip_epoch_writes {
+            return Ok(StoreWriteOutcome::SkippedExisting);
+        }
         // Drop the last byte rather than writing nothing, so the corrupted entry is still
         // discoverable by `data_exists_at_epoch` and only a read-back can tell it apart.
         let to_store = if self.corrupt_epoch_writes {

--- a/core/service/src/vault/storage/ram.rs
+++ b/core/service/src/vault/storage/ram.rs
@@ -321,6 +321,8 @@ impl StorageExt for RamStorage {
 #[cfg(test)]
 pub struct FailingRamStorage {
     available_writes: usize,
+    available_epoch_writes: Option<usize>,
+    corrupt_epoch_writes: bool,
     inner: RamStorage,
 }
 
@@ -329,12 +331,37 @@ impl FailingRamStorage {
     pub fn new(writes_before_failure: usize) -> Self {
         Self {
             available_writes: writes_before_failure,
+            available_epoch_writes: None,
+            corrupt_epoch_writes: false,
             inner: RamStorage::new(),
         }
     }
 
     pub fn set_available_writes(&mut self, available_writes: usize) {
         self.available_writes = available_writes
+    }
+
+    /// Limits how many epoch-aware writes succeed before they start returning an error.
+    /// `None` (the default) leaves epoch-aware writes unlimited.
+    pub fn set_available_epoch_writes(&mut self, available_epoch_writes: Option<usize>) {
+        self.available_epoch_writes = available_epoch_writes
+    }
+
+    /// When set, epoch-aware byte writes report success but persist truncated data.
+    /// This models a silent short write, which a caller can only detect by reading the data back.
+    pub fn set_corrupt_epoch_writes(&mut self, corrupt_epoch_writes: bool) {
+        self.corrupt_epoch_writes = corrupt_epoch_writes
+    }
+
+    /// Returns an error and consumes one epoch-write budget unit if the budget is exhausted.
+    fn consume_epoch_write(&mut self) -> anyhow::Result<()> {
+        if let Some(remaining) = self.available_epoch_writes.as_mut() {
+            if *remaining < 1 {
+                anyhow::bail!("epoch storage failed!")
+            }
+            *remaining -= 1;
+        }
+        Ok(())
     }
 }
 
@@ -392,6 +419,110 @@ impl Storage for FailingRamStorage {
 
     async fn delete_data(&mut self, data_id: &RequestId, data_type: &str) -> anyhow::Result<()> {
         self.inner.delete_data(data_id, data_type).await
+    }
+}
+
+#[cfg(test)]
+impl StorageReaderExt for FailingRamStorage {
+    async fn read_data_at_epoch<T: DeserializeOwned + Unversionize + Named + Send>(
+        &self,
+        data_id: &RequestId,
+        epoch_id: &EpochId,
+        data_type: &str,
+    ) -> anyhow::Result<T> {
+        self.inner
+            .read_data_at_epoch(data_id, epoch_id, data_type)
+            .await
+    }
+
+    async fn all_epoch_ids_for_data(&self, data_type: &str) -> anyhow::Result<HashSet<EpochId>> {
+        self.inner.all_epoch_ids_for_data(data_type).await
+    }
+
+    async fn data_exists_at_epoch(
+        &self,
+        data_id: &RequestId,
+        epoch_id: &EpochId,
+        data_type: &str,
+    ) -> anyhow::Result<bool> {
+        self.inner
+            .data_exists_at_epoch(data_id, epoch_id, data_type)
+            .await
+    }
+
+    async fn all_data_ids_at_epoch(
+        &self,
+        epoch_id: &EpochId,
+        data_type: &str,
+    ) -> anyhow::Result<HashSet<RequestId>> {
+        self.inner.all_data_ids_at_epoch(epoch_id, data_type).await
+    }
+
+    async fn all_data_ids_from_all_epochs(
+        &self,
+        data_type: &str,
+    ) -> anyhow::Result<HashSet<RequestId>> {
+        all_data_ids_from_all_epochs_impl(self, data_type)
+            .await
+            .map(|(ids, _)| ids)
+    }
+
+    async fn load_bytes_at_epoch(
+        &self,
+        data_id: &RequestId,
+        epoch_id: &EpochId,
+        data_type: &str,
+    ) -> anyhow::Result<Vec<u8>> {
+        self.inner
+            .load_bytes_at_epoch(data_id, epoch_id, data_type)
+            .await
+    }
+}
+
+#[cfg(test)]
+impl StorageExt for FailingRamStorage {
+    async fn store_data_at_epoch<T: Serialize + Versionize + Named + Send + Sync>(
+        &mut self,
+        data: &T,
+        data_id: &RequestId,
+        epoch_id: &EpochId,
+        data_type: &str,
+    ) -> anyhow::Result<StoreWriteOutcome> {
+        self.consume_epoch_write()?;
+        self.inner
+            .store_data_at_epoch(data, data_id, epoch_id, data_type)
+            .await
+    }
+
+    async fn store_bytes_at_epoch(
+        &mut self,
+        bytes: &[u8],
+        data_id: &RequestId,
+        epoch_id: &EpochId,
+        data_type: &str,
+    ) -> anyhow::Result<StoreWriteOutcome> {
+        self.consume_epoch_write()?;
+        // Drop the last byte rather than writing nothing, so the corrupted entry is still
+        // discoverable by `data_exists_at_epoch` and only a read-back can tell it apart.
+        let to_store = if self.corrupt_epoch_writes {
+            &bytes[..bytes.len().saturating_sub(1)]
+        } else {
+            bytes
+        };
+        self.inner
+            .store_bytes_at_epoch(to_store, data_id, epoch_id, data_type)
+            .await
+    }
+
+    async fn delete_data_at_epoch(
+        &mut self,
+        data_id: &RequestId,
+        epoch_id: &EpochId,
+        data_type: &str,
+    ) -> anyhow::Result<()> {
+        self.inner
+            .delete_data_at_epoch(data_id, epoch_id, data_type)
+            .await
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds a migration for the CRS to v0.14 and puts it under epoch storage.
Before v0.14 the `CrsInfo` was stored in private storage under `CrsInfo/<crs_id>`. We copy this object to `CrsInfo/<DEFAULT_EPOCH_ID>/<crs_id>`, which is the format used for supportting epoch switches.

We retain the old `CrsInfo/<crs_id>` on purpose to be able to roll-back to a previous version and checked that this has no side-effects.

### Related issue(s)
https://github.com/zama-ai/kms-internal/issues/3204

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.

