### PR TITLE
chore: more details in error logs

### DIFF
--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -31,6 +31,14 @@ use tonic::{Code, Request, Response};
 use tracing::Instrument;
 
 /// Implementation of the user_decrypt endpoint
+// `context_id`/`epoch_id` are only known after request validation, so they start empty and are
+// recorded below; the spawned decryption task inherits this span.
+#[tracing::instrument(skip_all, fields(
+    request_id = ?request.get_ref().request_id,
+    operation = "user_decrypt",
+    context_id = tracing::field::Empty,
+    epoch_id = tracing::field::Empty
+))]
 pub async fn user_decrypt_impl<
     PubS: Storage + Sync + Send + 'static,
     PrivS: StorageExt + Sync + Send + 'static,
@@ -62,6 +70,10 @@ pub async fn user_decrypt_impl<
         extra_data,
         signing_schemes,
     ) = validate_user_decrypt_req(&inner)?;
+    // Recorded before the context check so that a rejection there is attributed too.
+    let span = tracing::Span::current();
+    span.record("context_id", tracing::field::display(&context_id));
+    span.record("epoch_id", tracing::field::display(&epoch_id));
     if !service
         .context_manager
         .mpc_context_exists_in_cache(&context_id)
@@ -228,6 +240,14 @@ pub async fn get_user_decryption_result_impl<
 }
 
 /// Implementation of the public_decrypt endpoint
+// `context_id`/`epoch_id` are only known after request validation, so they start empty and are
+// recorded below; the spawned decryption task inherits this span.
+#[tracing::instrument(skip_all, fields(
+    request_id = ?request.get_ref().request_id,
+    operation = "decrypt",
+    context_id = tracing::field::Empty,
+    epoch_id = tracing::field::Empty
+))]
 pub async fn public_decrypt_impl<
     PubS: Storage + Sync + Send + 'static,
     PrivS: StorageExt + Sync + Send + 'static,
@@ -256,6 +276,10 @@ pub async fn public_decrypt_impl<
         extra_data,
         signing_schemes,
     ) = validate_public_decrypt_req(&inner)?;
+    // Recorded before the context check so that a rejection there is attributed too.
+    let span = tracing::Span::current();
+    span.record("context_id", tracing::field::display(&context_id));
+    span.record("epoch_id", tracing::field::display(&epoch_id));
 
     if !service
         .context_manager

--- a/core/service/src/engine/centralized/service/decryption.rs
+++ b/core/service/src/engine/centralized/service/decryption.rs
@@ -5,7 +5,7 @@ use crate::engine::centralized::central_kms::{
     CentralizedKms, async_user_decrypt, central_public_decrypt,
 };
 use crate::engine::traits::{BackupOperator, ContextManager};
-use crate::engine::utils::MetricedError;
+use crate::engine::utils::{MetricedError, format_unvalidated_id};
 use crate::engine::validation::{
     RequestIdParsingErr, parse_grpc_request_id, parse_optional_grpc_request_id,
     validate_public_decrypt_req, validate_user_decrypt_req,
@@ -34,7 +34,7 @@ use tracing::Instrument;
 // `context_id`/`epoch_id` are only known after request validation, so they start empty and are
 // recorded below; the spawned decryption task inherits this span.
 #[tracing::instrument(skip_all, fields(
-    request_id = ?request.get_ref().request_id,
+    request_id = %format_unvalidated_id(&request.get_ref().request_id),
     operation = "user_decrypt",
     context_id = tracing::field::Empty,
     epoch_id = tracing::field::Empty
@@ -243,7 +243,7 @@ pub async fn get_user_decryption_result_impl<
 // `context_id`/`epoch_id` are only known after request validation, so they start empty and are
 // recorded below; the spawned decryption task inherits this span.
 #[tracing::instrument(skip_all, fields(
-    request_id = ?request.get_ref().request_id,
+    request_id = %format_unvalidated_id(&request.get_ref().request_id),
     operation = "decrypt",
     context_id = tracing::field::Empty,
     epoch_id = tracing::field::Empty

--- a/core/service/src/engine/context_manager.rs
+++ b/core/service/src/engine/context_manager.rs
@@ -789,6 +789,15 @@ where
             )
         })?;
 
+        // Context creation is rare and changes which parties we run with, so record the resulting
+        // configuration once.
+        tracing::info!(
+            context_id = %new_context.context_id,
+            num_parties = new_context.mpc_nodes.len(),
+            threshold = new_context.threshold,
+            "Created MPC context"
+        );
+
         Ok(Response::new(Empty {}))
     }
 
@@ -864,7 +873,7 @@ where
                 )
             })?;
 
-        {
+        let remaining_contexts = {
             let mut write_guard = self.cache.write().await;
             let was_present = (*write_guard).remove(&context_id);
             if !was_present {
@@ -873,7 +882,14 @@ where
                     context_id,
                 )
             }
-        }
+            write_guard.len()
+        };
+
+        tracing::info!(
+            context_id = %context_id,
+            remaining_contexts,
+            "Destroyed MPC context"
+        );
 
         Ok(())
     }
@@ -1021,13 +1037,35 @@ async fn atomic_update_context<
 
     match (res1, res2) {
         (Ok(_), Ok(_)) => (),
-        _ => {
+        (storage_res, session_res) => {
+            // Say which half failed and why; both errors are otherwise lost to the rollback.
+            let cause = match (storage_res.err(), session_res.err()) {
+                (Some(e1), Some(e2)) => {
+                    format!("storage write failed ({e1}); session maker update failed ({e2})")
+                }
+                (Some(e1), None) => format!("storage write failed ({e1})"),
+                (None, Some(e2)) => format!("session maker update failed ({e2})"),
+                // Unreachable: the (Ok, Ok) case is handled by the arm above.
+                (None, None) => "no error reported".to_string(),
+            };
+            tracing::error!(
+                context_id = %context_id,
+                "Rolling back context creation: {cause}"
+            );
+
             // Rollback if any operation failed
             // First delete the context from storage.
             {
                 let storage_ref = crypto_storage.private_storage.clone();
                 let mut guarded_priv_storage = storage_ref.lock().await;
-                _ = delete_context_at_id(&mut *guarded_priv_storage, context_id).await;
+                if let Err(e) = delete_context_at_id(&mut *guarded_priv_storage, context_id).await {
+                    // Best-effort: the context may never have reached storage. Worth surfacing
+                    // because it can leave the persisted state ahead of the in-memory state.
+                    tracing::warn!(
+                        context_id = %context_id,
+                        "Could not delete context from storage during rollback: {e}"
+                    );
+                }
             }
 
             // Then remove the context from the session maker and TLS verifier.
@@ -1037,7 +1075,9 @@ async fn atomic_update_context<
                 .map_err(|e| {
                     anyhow::anyhow!("Failed to remove context during atomic update rollback: {e}")
                 })?;
-            return Err(anyhow::anyhow!("Failed to atomically update context"));
+            return Err(anyhow::anyhow!(
+                "Failed to atomically update context {context_id}: {cause}"
+            ));
         }
     }
 
@@ -1096,6 +1136,16 @@ where
                 tonic::Code::Internal,
             )
         })?;
+
+        // Context creation is rare and changes which parties we run with, so record the resulting
+        // configuration once.
+        tracing::info!(
+            context_id = %new_context.context_id,
+            my_role = ?my_role,
+            num_parties = new_context.mpc_nodes.len(),
+            threshold = new_context.threshold,
+            "Created MPC context"
+        );
 
         Ok(Response::new(Empty {}))
     }
@@ -1164,6 +1214,12 @@ where
                     tonic::Code::Internal,
                 )
             })?;
+        let remaining_contexts = self.session_maker.context_count().await;
+        tracing::info!(
+            context_id = %context_id,
+            remaining_contexts,
+            "Destroyed MPC context"
+        );
         Ok(())
     }
 

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -64,6 +64,7 @@ use threshold_types::role::TwoSetsRole;
 use tokio::sync::RwLock;
 use tokio_util::task::TaskTracker;
 use tonic::{Request, Response};
+use tracing::Instrument;
 
 use crate::{
     cryptography::{signatures::PrivateSigKey, signing::SigningSchemeType},
@@ -326,8 +327,13 @@ impl<
         let all_epochs = self.crypto_storage.read_all_epoch_data().await?;
 
         for (epoch_id, prss) in all_epochs {
+            let context_id = prss.context_id;
             self.session_maker.add_epoch(epoch_id, prss).await;
-            tracing::info!("Loaded epoch data from storage for epoch ID {}.", epoch_id);
+            tracing::info!(
+                context_id = %context_id,
+                epoch_id = %epoch_id,
+                "Loaded epoch data from storage"
+            );
         }
         Ok(())
     }
@@ -376,13 +382,14 @@ impl<
             .make_base_session(session_id, *context_id, NetworkMode::Sync)
             .await?;
 
-        tracing::info!("Starting PRSS for identity {}.", own_identity);
         tracing::info!(
-            "Session has {} parties with threshold {}",
-            base_session.parameters.num_parties(),
-            base_session.parameters.threshold()
+            context_id = %context_id,
+            epoch_id = %epoch_id,
+            num_parties = base_session.parameters.num_parties(),
+            threshold = base_session.parameters.threshold(),
+            "Starting PRSS for identity {}", own_identity
         );
-        tracing::info!("Role assignments: {:?}", base_session.parameters.roles());
+        tracing::debug!("Role assignments: {:?}", base_session.parameters.roles());
 
         // It seems we cannot do something like
         // `Init::default().init(&mut base_session).await?;`
@@ -408,9 +415,9 @@ impl<
             .await?;
         session_maker.add_epoch(*epoch_id, epoch_data).await;
         tracing::info!(
-            "PRSS on epoch ID {} completed successfully for identity {}.",
-            epoch_id,
-            own_identity
+            context_id = %context_id,
+            epoch_id = %epoch_id,
+            "PRSS completed successfully for identity {}", own_identity
         );
         Ok(())
     }
@@ -1560,44 +1567,58 @@ impl<
         .await?;
         let session_maker = self.session_maker.clone();
         let crypto_storage = self.crypto_storage.clone();
-        self.tracker.spawn(async move {
-            let _creation_lease = creation_lease;
-            let _rate_limiter_permit = rate_limiter_permit;
-            let crypto_storage = crypto_storage;
-            let context_id = context_id;
-            let epoch_id = epoch_id;
-            let meta_store = meta_store;
-            if do_prss
-                && let Err(e) = Self::internal_init_epoch(
-                    session_maker,
-                    &crypto_storage,
-                    &context_id,
-                    &epoch_id,
-                )
-                .await
-            {
-                let err = format!("PRSS initialization failed during epoch creation: {e:?}");
-                let _ =
-                    update_err_req_in_meta_store(&meta_store, meta_permit, err, OP_NEW_EPOCH).await;
-                return;
-            }
-            // Either reshare and commit the resulting EpochOutput, or commit
-            // PRSSInitOnly. Either way, the permit is consumed exactly once.
-            let result: Result<EpochOutput, String> = if let Some(resharing_task) = resharing_task {
-                resharing_task
+        // The epoch change runs detached, so give it its own span: PRSS init and resharing then log
+        // under the context and epoch they belong to without each line repeating them.
+        let epoch_span = tracing::info_span!(
+            "new_epoch",
+            context_id = %context_id,
+            epoch_id = %epoch_id,
+            resharing = resharing_task.is_some(),
+            prss = do_prss
+        );
+        self.tracker.spawn(
+            async move {
+                let _creation_lease = creation_lease;
+                let _rate_limiter_permit = rate_limiter_permit;
+                let crypto_storage = crypto_storage;
+                let context_id = context_id;
+                let epoch_id = epoch_id;
+                let meta_store = meta_store;
+                if do_prss
+                    && let Err(e) = Self::internal_init_epoch(
+                        session_maker,
+                        &crypto_storage,
+                        &context_id,
+                        &epoch_id,
+                    )
                     .await
-                    .map_err(|e| format!("Resharing failed during epoch creation: {e:?}"))
-            } else {
-                Ok(EpochOutput::PRSSInitOnly)
-            };
-            let _ = update_req_in_meta_store::<_, String>(
-                &meta_store,
-                meta_permit,
-                result,
-                OP_NEW_EPOCH,
-            )
-            .await;
-        });
+                {
+                    let err = format!("PRSS initialization failed during epoch creation: {e:?}");
+                    let _ =
+                        update_err_req_in_meta_store(&meta_store, meta_permit, err, OP_NEW_EPOCH)
+                            .await;
+                    return;
+                }
+                // Either reshare and commit the resulting EpochOutput, or commit
+                // PRSSInitOnly. Either way, the permit is consumed exactly once.
+                let result: Result<EpochOutput, String> =
+                    if let Some(resharing_task) = resharing_task {
+                        resharing_task
+                            .await
+                            .map_err(|e| format!("Resharing failed during epoch creation: {e:?}"))
+                    } else {
+                        Ok(EpochOutput::PRSSInitOnly)
+                    };
+                let _ = update_req_in_meta_store::<_, String>(
+                    &meta_store,
+                    meta_permit,
+                    result,
+                    OP_NEW_EPOCH,
+                )
+                .await;
+            }
+            .instrument(epoch_span),
+        );
 
         Ok(Response::new(Empty {}))
     }

--- a/core/service/src/engine/threshold/service/public_decryptor.rs
+++ b/core/service/src/engine/threshold/service/public_decryptor.rs
@@ -167,13 +167,6 @@ impl<
         T: tfhe::integer::block_decomposition::Recomposable
             + tfhe::core_crypto::commons::traits::CastFrom<u128>,
     {
-        let my_identity = session_maker.my_identity(&context_id).await?;
-        tracing::info!(
-            "{:?} started inner_decrypt with mode {:?} with session ID {session_id} and context ID {context_id}",
-            my_identity,
-            dec_mode
-        );
-
         let keys = fhe_keys;
         // Only the SmallCompressed format needs the decompression key to deserialize.
         // Fetching it would lazily decompress the (multi-GiB) keyset, so avoid it for
@@ -194,7 +187,7 @@ impl<
                     .await
                     .map_err(|e| {
                         anyhow::anyhow!(
-                            "Could not prepare ddec data for noiseflood decryption: {e}",
+                            "Could not prepare ddec data for noiseflood decryption in sid {session_id}: {e}",
                         )
                     })?;
                 let mut noiseflood_session = SmallOfflineNoiseFloodSession::new(session);
@@ -242,8 +235,7 @@ impl<
                     }
                 };
                 tracing::info!(
-                    "Public decryption in session {session_id} completed on {:?}. Inner thread took {:?} ms",
-                    my_identity,
+                    "Public decryption in session {session_id} completed. Inner thread took {:?} ms",
                     time.as_millis()
                 );
                 raw_decryption
@@ -266,9 +258,14 @@ impl<
         > + 'static,
 > PublicDecryptor for RealPublicDecryptor<PubS, PrivS, Dec>
 {
+    // `context_id`/`epoch_id` are only known after request validation, so they start empty and are
+    // recorded below. Every event and error in this request — including the ones emitted by the
+    // spawned decryption task, which inherits this span — then carries both without extra log lines.
     #[tracing::instrument(skip_all, fields(
         request_id = ?request.get_ref().request_id,
-        operation = "decrypt"
+        operation = "decrypt",
+        context_id = tracing::field::Empty,
+        epoch_id = tracing::field::Empty
     ))]
     async fn public_decrypt(
         &self,
@@ -285,7 +282,6 @@ impl<
             .start();
 
         let inner = Arc::new(request.into_inner());
-        tracing::info!("{}", format_public_request(&inner));
 
         // Check and extract the parameters from the request in a separate thread
         let (
@@ -297,7 +293,17 @@ impl<
             eip712_domain,
             extra_data,
             signing_schemes,
-        ) = validate_public_decrypt_req(&inner)?;
+        ) = validate_public_decrypt_req(&inner).inspect_err(|_| {
+            // The unvalidated ids are worth logging only when validation rejects the request: they
+            // are then the sole record of what the caller actually sent. On success the span fields
+            // recorded below carry the parsed ids, and `unpack_public_decrypt_req` has already
+            // logged the request's arrival.
+            tracing::warn!("Rejected {}", format_public_request(&inner));
+        })?;
+        // Recorded before the context/epoch check so that a rejection there is attributed too.
+        let span = tracing::Span::current();
+        span.record("context_id", tracing::field::display(&context_id));
+        span.record("epoch_id", tracing::field::display(&epoch_id));
         let my_role = validate_context_and_epoch(
             OP_PUBLIC_DECRYPT_REQUEST,
             &self.session_maker,
@@ -316,17 +322,25 @@ impl<
         ];
         timer.tags(metric_tags.clone());
 
-        tracing::debug!(
-            request_id = ?req_id,
-            key_id = ?key_id,
-            ciphertexts_count = ciphertexts.len(),
-            "Starting decryption process"
-        );
-
         let ext_handles_bytes = ciphertexts
             .iter()
             .map(|c| c.external_handle.to_owned())
             .collect::<Vec<_>>();
+
+        // The external handles are how the caller refers to these ciphertexts, so they are the join
+        // key between a KMS log and a gateway request. Logged once per request, in batch order, so
+        // the `ctr` reported by a failing inner decryption below identifies the handle.
+        let ext_handles_hex = ext_handles_bytes
+            .iter()
+            .map(hex::encode)
+            .collect::<Vec<_>>();
+        tracing::debug!(
+            request_id = ?req_id,
+            key_id = ?key_id,
+            ciphertexts_count = ciphertexts.len(),
+            handles = ?ext_handles_hex,
+            "Starting decryption process"
+        );
 
         let meta_store = Arc::clone(&self.pub_dec_meta_store);
         let sigkey = self.base_kms.sig_key().map_err(|e| {
@@ -386,12 +400,15 @@ impl<
             let fhe_keys_rlock_clone = fhe_keys_rlock.clone();
             let decrypt_future = || async move {
                 let internal_sid = req_id.derive_session_id_with_counter(ctr as u64)?;
+                // Taken before `typed_ciphertext` is partially moved below, so that every failure
+                // in this task can name the handle the caller asked about.
+                let external_handle = hex::encode(&typed_ciphertext.external_handle);
                 let fhe_type_string = typed_ciphertext.fhe_type_string();
                 let fhe_type = if let Ok(f) = typed_ciphertext.fhe_type() {
                     f
                 } else {
                     return Err(anyhow::anyhow!(format!(
-                        "Threshold decryption failed due to wrong fhe type: {}",
+                        "Threshold decryption failed for handle {external_handle} due to wrong fhe type: {}",
                         typed_ciphertext.fhe_type
                     )));
                 };
@@ -538,7 +555,9 @@ impl<
                 // so we only update it once even if there are multiple decryption task that fail
                 match res_plaintext {
                     Ok(plaintext) => Ok((ctr, plaintext)),
-                    Result::Err(e) => Err(anyhow::anyhow!("Threshold decryption failed: {e}")),
+                    Result::Err(e) => Err(anyhow::anyhow!(
+                        "Threshold decryption failed for ciphertext #{ctr} (handle {external_handle}): {e}"
+                    )),
                 }
             };
             dec_tasks.push(

--- a/core/service/src/engine/threshold/service/public_decryptor.rs
+++ b/core/service/src/engine/threshold/service/public_decryptor.rs
@@ -55,7 +55,7 @@ use crate::{
             service::session::{ImmutableSessionMaker, validate_context_and_epoch},
             traits::PublicDecryptor,
         },
-        utils::MetricedError,
+        utils::{MetricedError, format_handle, format_unvalidated_id},
         validation::{
             RequestIdParsingErr, parse_grpc_request_id, parse_optional_grpc_request_id,
             validate_public_decrypt_req,
@@ -261,8 +261,11 @@ impl<
     // `context_id`/`epoch_id` are only known after request validation, so they start empty and are
     // recorded below. Every event and error in this request — including the ones emitted by the
     // spawned decryption task, which inherits this span — then carries both without extra log lines.
+    // `request_id` is still unvalidated when the span is created, so it is size-bounded: a span
+    // field is repeated on every event in the request, so an unbounded one is worse than a single
+    // oversized line.
     #[tracing::instrument(skip_all, fields(
-        request_id = ?request.get_ref().request_id,
+        request_id = %format_unvalidated_id(&request.get_ref().request_id),
         operation = "decrypt",
         context_id = tracing::field::Empty,
         epoch_id = tracing::field::Empty
@@ -322,25 +325,24 @@ impl<
         ];
         timer.tags(metric_tags.clone());
 
-        let ext_handles_bytes = ciphertexts
-            .iter()
-            .map(|c| c.external_handle.to_owned())
-            .collect::<Vec<_>>();
-
         // The external handles are how the caller refers to these ciphertexts, so they are the join
-        // key between a KMS log and a gateway request. Logged once per request, in batch order, so
-        // the `ctr` reported by a failing inner decryption below identifies the handle.
-        let ext_handles_hex = ext_handles_bytes
-            .iter()
-            .map(hex::encode)
-            .collect::<Vec<_>>();
+        // key between a KMS log and a gateway request. Logged in batch order, so the `ctr` reported
+        // by a failing inner decryption below identifies the handle. Bounded in both handle size
+        // and count because handles are unvalidated and the batch is only bounded by the gRPC
+        // message limit; `ciphertexts_count` still reports the true total. Called from inside the
+        // macro so nothing is formatted while debug logging is off.
         tracing::debug!(
             request_id = ?req_id,
             key_id = ?key_id,
             ciphertexts_count = ciphertexts.len(),
-            handles = ?ext_handles_hex,
+            handles = ?format_logged_handles(&ciphertexts),
             "Starting decryption process"
         );
+
+        let ext_handles_bytes = ciphertexts
+            .iter()
+            .map(|c| c.external_handle.to_owned())
+            .collect::<Vec<_>>();
 
         let meta_store = Arc::clone(&self.pub_dec_meta_store);
         let sigkey = self.base_kms.sig_key().map_err(|e| {
@@ -401,8 +403,9 @@ impl<
             let decrypt_future = || async move {
                 let internal_sid = req_id.derive_session_id_with_counter(ctr as u64)?;
                 // Taken before `typed_ciphertext` is partially moved below, so that every failure
-                // in this task can name the handle the caller asked about.
-                let external_handle = hex::encode(&typed_ciphertext.external_handle);
+                // in this task can name the handle the caller asked about. Bounded: the handle is
+                // caller-supplied and this runs for every ciphertext, error or not.
+                let external_handle = format_handle(&typed_ciphertext.external_handle);
                 let fhe_type_string = typed_ciphertext.fhe_type_string();
                 let fhe_type = if let Ok(f) = typed_ciphertext.fhe_type() {
                     f
@@ -737,14 +740,28 @@ impl<
     }
 }
 
-// We want most of the metadata but not the actual ciphertexts
+/// Number of handles from a batch that are logged. The count of a well-formed batch is bounded by
+/// how many ciphertexts fit in a gRPC message, which is not a bound worth writing to a log line.
+const MAX_LOGGED_HANDLES: usize = 16;
+
+/// Bounded, hex-encoded prefix of the batch's external handles, for a single log line per request.
+fn format_logged_handles(ciphertexts: &[v1::TypedCiphertext]) -> Vec<String> {
+    ciphertexts
+        .iter()
+        .take(MAX_LOGGED_HANDLES)
+        .map(|c| format_handle(&c.external_handle))
+        .collect()
+}
+
+// We want most of the metadata but not the actual ciphertexts. The IDs are unvalidated when this
+// runs, so they go through `format_unvalidated_id` rather than being printed verbatim.
 fn format_public_request(request: &PublicDecryptionRequest) -> String {
     format!(
-        "PublicDecryptionRequest {{ request_id: {:?}, key_id: {:?}, context_id: {:?}, epoch_id: {:?}, ciphertext_count: {:?} }}",
-        request.request_id,
-        request.key_id,
-        request.context_id,
-        request.epoch_id,
+        "PublicDecryptionRequest {{ request_id: {}, key_id: {}, context_id: {}, epoch_id: {}, ciphertext_count: {} }}",
+        format_unvalidated_id(&request.request_id),
+        format_unvalidated_id(&request.key_id),
+        format_unvalidated_id(&request.context_id),
+        format_unvalidated_id(&request.epoch_id),
         request.ciphertexts.len()
     )
 }

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -965,6 +965,10 @@ impl ImmutableSessionMaker {
         self.inner.epoch_exists(epoch_id).await
     }
 
+    pub(crate) async fn epochs_for_context(&self, context_id: &ContextId) -> Vec<EpochId> {
+        self.inner.epochs_for_context(context_id).await
+    }
+
     pub(crate) async fn make_base_session(
         &self,
         session_id: SessionId,
@@ -1094,10 +1098,22 @@ pub(crate) async fn validate_context_and_epoch(
         .map_err(|e| MetricedError::new(op_tag, req_id, e, Code::NotFound))?;
 
     if !session_maker.epoch_exists(epoch_id).await {
+        // Name the epochs this context does have: the usual cause is a request still pointing at an
+        // epoch that a completed epoch change replaced. `EpochId`'s `Debug` is the raw byte array,
+        // so format through `Display` to keep the list readable.
+        let known_epochs = session_maker
+            .epochs_for_context(context_id)
+            .await
+            .iter()
+            .map(|epoch| epoch.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
         return Err(MetricedError::new(
             op_tag,
             req_id,
-            anyhow::anyhow!("Epoch {epoch_id} not found"),
+            anyhow::anyhow!(
+                "Epoch {epoch_id} not found for context {context_id}, which currently has epochs [{known_epochs}]"
+            ),
             Code::NotFound,
         ));
     }

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -68,7 +68,7 @@ use crate::{
             service::session::{ImmutableSessionMaker, validate_context_and_epoch},
             traits::UserDecryptor,
         },
-        utils::MetricedError,
+        utils::{MetricedError, format_handle, format_unvalidated_id},
         validation::{
             DSEP_USER_DECRYPTION, RequestIdParsingErr, parse_grpc_request_id,
             parse_optional_grpc_request_id, validate_user_decrypt_req,
@@ -224,7 +224,7 @@ impl<
                 request_id = hex_req_id,
                 request_id_decimal = decimal_req_id,
                 "User Decrypt Request: Decrypting ciphertext #{ctr}. sid: {session_id}, handle: {}",
-                hex::encode(&typed_ciphertext.external_handle)
+                format_handle(&typed_ciphertext.external_handle)
             );
 
             // Only the SmallCompressed format needs the decompression key to deserialize.
@@ -481,7 +481,7 @@ impl<
     // validation, so they start empty and are recorded below. The spawned decryption task inherits
     // this span, so its events carry both without extra log lines.
     #[tracing::instrument(skip_all, fields(
-        request_id = ?request.get_ref().request_id,
+        request_id = %format_unvalidated_id(&request.get_ref().request_id),
         operation = "user_decrypt",
         context_id = tracing::field::Empty,
         epoch_id = tracing::field::Empty
@@ -519,12 +519,13 @@ impl<
         ) = validate_user_decrypt_req(inner.as_ref()).inspect_err(|_| {
             // As in public decryption: the unvalidated ids are the only record of what the caller
             // sent once validation rejects the request, and nothing else logs them on that path.
+            // The IDs are unvalidated here, so they are size-bounded rather than printed verbatim.
             tracing::warn!(
-                "Rejected UserDecryptionRequest {{ request_id: {:?}, key_id: {:?}, context_id: {:?}, epoch_id: {:?}, ciphertext_count: {} }}",
-                inner.request_id,
-                inner.key_id,
-                inner.context_id,
-                inner.epoch_id,
+                "Rejected UserDecryptionRequest {{ request_id: {}, key_id: {}, context_id: {}, epoch_id: {}, ciphertext_count: {} }}",
+                format_unvalidated_id(&inner.request_id),
+                format_unvalidated_id(&inner.key_id),
+                format_unvalidated_id(&inner.context_id),
+                format_unvalidated_id(&inner.epoch_id),
                 inner.typed_ciphertexts.len()
             );
         })?;

--- a/core/service/src/engine/threshold/service/user_decryptor.rs
+++ b/core/service/src/engine/threshold/service/user_decryptor.rs
@@ -219,10 +219,11 @@ impl<
             let decimal_req_id = U256::try_from_be_slice(req_id.as_bytes())
                 .unwrap_or(U256::ZERO)
                 .to_string();
+            // The context and epoch come from the request span; only the per-value session ID is new here.
             tracing::debug!(
                 request_id = hex_req_id,
                 request_id_decimal = decimal_req_id,
-                "User Decrypt Request: Decrypting ciphertext #{ctr} with internal session ID: {session_id} and context ID: {context_id}. Handle: {}",
+                "User Decrypt Request: Decrypting ciphertext #{ctr}. sid: {session_id}, handle: {}",
                 hex::encode(&typed_ciphertext.external_handle)
             );
 
@@ -476,6 +477,15 @@ impl<
         > + 'static,
 > UserDecryptor for RealUserDecryptor<PubS, PrivS, Dec>
 {
+    // Mirrors the public decryption span: `context_id`/`epoch_id` are only known after request
+    // validation, so they start empty and are recorded below. The spawned decryption task inherits
+    // this span, so its events carry both without extra log lines.
+    #[tracing::instrument(skip_all, fields(
+        request_id = ?request.get_ref().request_id,
+        operation = "user_decrypt",
+        context_id = tracing::field::Empty,
+        epoch_id = tracing::field::Empty
+    ))]
     async fn user_decrypt(
         &self,
         request: Request<UserDecryptionRequest>,
@@ -506,7 +516,22 @@ impl<
             domain,
             extra_data,
             signing_schemes,
-        ) = validate_user_decrypt_req(inner.as_ref())?;
+        ) = validate_user_decrypt_req(inner.as_ref()).inspect_err(|_| {
+            // As in public decryption: the unvalidated ids are the only record of what the caller
+            // sent once validation rejects the request, and nothing else logs them on that path.
+            tracing::warn!(
+                "Rejected UserDecryptionRequest {{ request_id: {:?}, key_id: {:?}, context_id: {:?}, epoch_id: {:?}, ciphertext_count: {} }}",
+                inner.request_id,
+                inner.key_id,
+                inner.context_id,
+                inner.epoch_id,
+                inner.typed_ciphertexts.len()
+            );
+        })?;
+        // Recorded before the context/epoch check so that a rejection there is attributed too.
+        let span = tracing::Span::current();
+        span.record("context_id", tracing::field::display(&context_id));
+        span.record("epoch_id", tracing::field::display(&epoch_id));
         let my_role = validate_context_and_epoch(
             OP_USER_DECRYPT_REQUEST,
             &self.session_maker,

--- a/core/service/src/engine/utils.rs
+++ b/core/service/src/engine/utils.rs
@@ -16,6 +16,50 @@ use std::fmt::Display;
 use tfhe::safe_serialization::{safe_deserialize, safe_serialize};
 use tonic::Status;
 
+/// Characters kept from a caller-supplied identifier when logging it. A well-formed request, key,
+/// context, or epoch ID is 64 hex characters, so every valid ID survives intact.
+const MAX_LOGGED_ID_CHARS: usize = 64;
+
+/// Leading bytes kept from a caller-supplied external handle when logging it. Handles are 32-byte
+/// identifiers in practice, so a valid handle survives intact.
+const MAX_LOGGED_HANDLE_BYTES: usize = 32;
+
+/// Format an identifier taken straight off the wire for logging.
+///
+/// Before validation an ID is an arbitrary string, bounded only by the gRPC message size limit, so
+/// logging it verbatim lets one malformed request write that much into persistent logs. Keep a
+/// bounded prefix and report the original size instead.
+///
+/// Truncation counts `chars`, not bytes: `String::truncate` would panic on a caller-chosen
+/// multi-byte sequence straddling the cut.
+pub(crate) fn format_unvalidated_id(id: &Option<kms_grpc::kms::v1::RequestId>) -> String {
+    let Some(id) = id else {
+        return "<missing>".to_string();
+    };
+    let kept: String = id.request_id.chars().take(MAX_LOGGED_ID_CHARS).collect();
+    if kept.len() == id.request_id.len() {
+        kept
+    } else {
+        format!("{kept}...(truncated from {} bytes)", id.request_id.len())
+    }
+}
+
+/// Hex-encode an external ciphertext handle for logging, bounded in size.
+///
+/// Handles are caller-supplied and unvalidated, so hex-encoding one in full can allocate twice the
+/// gRPC message limit. A prefix is enough to correlate a KMS log line with a gateway request.
+pub(crate) fn format_handle(handle: &[u8]) -> String {
+    if handle.len() <= MAX_LOGGED_HANDLE_BYTES {
+        hex::encode(handle)
+    } else {
+        format!(
+            "{}...(+{} bytes)",
+            hex::encode(&handle[..MAX_LOGGED_HANDLE_BYTES]),
+            handle.len() - MAX_LOGGED_HANDLE_BYTES
+        )
+    }
+}
+
 /// Query key material availability from private storage
 ///
 /// This shared utility function queries FHE keys, CRS keys, and optionally preprocessing keys

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -44,16 +44,16 @@ pub trait MemoizedExceptionals: Sized + Clone + 'static {
                         lock_exceptional_set_store.insert((index, degree), powers.clone());
                         Ok(powers)
                     } else {
-                        Err(anyhow_error_and_log(
-                            "Error writing exceptional store 64".to_string(),
-                        ))
+                        Err(anyhow_error_and_log(format!(
+                            "Error writing exceptional store for index {index}, degree {degree}"
+                        )))
                     }
                 }
             }
         } else {
-            Err(anyhow_error_and_log(
-                "Error reading exceptional store".to_string(),
-            ))
+            Err(anyhow_error_and_log(format!(
+                "Error reading exceptional store for index {index}, degree {degree}"
+            )))
         }
     }
 }

--- a/core/threshold-algebra/src/error_correction.rs
+++ b/core/threshold-algebra/src/error_correction.rs
@@ -256,7 +256,10 @@ where
 
             // Log at most once, when the share becomes invalid
             if !*is_valid {
-                tracing::warn!("Share at index {j} is invalid after iteration {bit_idx}");
+                tracing::warn!(
+                    "Share of party {} (at index {j}) is invalid after iteration {bit_idx}",
+                    share.owner()
+                );
                 evicted.push(share.owner());
             }
         }

--- a/core/threshold-algebra/src/poly.rs
+++ b/core/threshold-algebra/src/poly.rs
@@ -706,10 +706,11 @@ pub fn lagrange_interpolation_with_polys<F: Field>(
 ) -> anyhow::Result<Poly<F>> {
     let lagrange_polys = lagrange_polys.as_ref();
     if lagrange_polys.len() != values.len() {
-        return Err(anyhow_error_and_log(
-            "Lagrange interpolation failure: mismatch between number of points and values"
-                .to_string(),
-        ));
+        return Err(anyhow_error_and_log(format!(
+            "Lagrange interpolation failure: mismatch between number of points ({}) and values ({})",
+            lagrange_polys.len(),
+            values.len()
+        )));
     }
 
     // res = Σ_i lagrange_polys[i] * values[i], accumulated coefficient-wise into a single buffer. This function runs
@@ -769,16 +770,19 @@ fn gao_decoding_common<F: Field>(
     g: &Poly<F>,
 ) -> anyhow::Result<Poly<F>> {
     // d = n - k + 1
-    let d = (n + 1)
-        .checked_sub(k)
-        .ok_or_else(|| anyhow_error_and_log("Gao decoding failure: overflow computing d"))?;
+    let d = (n + 1).checked_sub(k).ok_or_else(|| {
+        anyhow_error_and_log(format!(
+            "Gao decoding failure: overflow computing d with n={n} points and dimension k={k}"
+        ))
+    })?;
 
     // We are expecting to correct more than what can be done:
     // Gao can only correct up to (d-1)/2 errors
     if 2 * max_errors >= d {
-        return Err(anyhow_error_and_log(
-            "Gao decoding failure: expected max number of errors is too large for given code parameters".to_string(),
-        ));
+        return Err(anyhow_error_and_log(format!(
+            "Gao decoding failure: expected max number of errors ({max_errors}) is too large for given code parameters n={n}, k={k}, d={d}: can correct at most {} errors",
+            d.saturating_sub(1) / 2
+        )));
     }
 
     // apply EEA to compute q0, q1 such that
@@ -861,9 +865,10 @@ pub fn gao_decoding<F: Field>(
 
     // sanity check for parameter sizes
     if values.len() != points.len() {
-        return Err(anyhow_error_and_log(
-            "Gao decoding failure: mismatch between number of values and points".to_string(),
-        ));
+        return Err(anyhow_error_and_log(format!(
+            "Gao decoding failure: mismatch between number of values ({}) and points ({n})",
+            values.len()
+        )));
     }
 
     // R \in F[X] such that R(xi) = yi. Called g_1(x) in the Gao paper.
@@ -892,9 +897,10 @@ pub fn gao_decoding_with_field_hints<F: Field>(
     let n = points.len();
 
     if values.len() != points.len() {
-        return Err(anyhow_error_and_log(
-            "Gao decoding failure: mismatch between number of values and points".to_string(),
-        ));
+        return Err(anyhow_error_and_log(format!(
+            "Gao decoding failure: mismatch between number of values ({}) and points ({n})",
+            values.len()
+        )));
     }
 
     // R = interpolation polynomial through (points, values), using the precomputed Lagrange basis.

--- a/core/threshold-execution/src/large_execution/double_sharing.rs
+++ b/core/threshold-execution/src/large_execution/double_sharing.rs
@@ -249,11 +249,10 @@ fn format_for_next<Z: Ring>(
         let mut deg_t = Vec::with_capacity(num_parties);
         let mut deg_2t = Vec::with_capacity(num_parties);
         for party_idx in 0..num_parties {
-            let double_share_j = local_double_shares
-                .get(&Role::indexed_from_zero(party_idx))
-                .ok_or_else(|| {
-                    anyhow_error_and_log(format!("Can not find shares for Party {}", party_idx + 1))
-                })?;
+            let role = Role::indexed_from_zero(party_idx);
+            let double_share_j = local_double_shares.get(&role).ok_or_else(|| {
+                anyhow_error_and_log(format!("Can not find shares for Party {role}"))
+            })?;
             deg_t.push(double_share_j.share_t[i]);
             deg_2t.push(double_share_j.share_2t[i]);
         }

--- a/core/threshold-execution/src/large_execution/single_sharing.rs
+++ b/core/threshold-execution/src/large_execution/single_sharing.rs
@@ -199,15 +199,11 @@ fn format_for_next<Z: Ring>(
     for i in 0..l {
         let mut vec = Vec::with_capacity(num_parties);
         for party_idx in 0..num_parties {
+            let role = Role::indexed_from_zero(party_idx);
             vec.push(
-                local_single_shares
-                    .get(&Role::indexed_from_zero(party_idx))
-                    .ok_or_else(|| {
-                        anyhow_error_and_log(format!(
-                            "Can not find shares for Party {}",
-                            party_idx + 1
-                        ))
-                    })?[i],
+                local_single_shares.get(&role).ok_or_else(|| {
+                    anyhow_error_and_log(format!("Can not find shares for Party {role}"))
+                })?[i],
             );
         }
         res.push(vec);

--- a/core/threshold-execution/src/online/reshare.rs
+++ b/core/threshold-execution/src/online/reshare.rs
@@ -923,7 +923,10 @@ where
             } else {
                 // Any other variant is malicious behavior
                 // since it's broadcast we can add it to malicious parties
-                session.add_corrupt(role);
+                session.add_corrupt_with_reason(
+                    role,
+                    "broadcast a value that was neither a RingVector nor Bot during resharing",
+                );
                 tracing::error!(
                     "During resharing, unexpected broadcast. Adding {} to corrupt parties",
                     role
@@ -1046,7 +1049,10 @@ fn take_majority_vote_on_broadcasts<
             tracing::warn!(
                 "During resharing, unexpected broadcast. Adding party {sender_in_s2:?} to corrupt parties"
             );
-            my_set_session.add_corrupt(sender_in_s2);
+            my_set_session.add_corrupt_with_reason(
+                sender_in_s2,
+                "broadcast an unexpected value type while resharing to set 1",
+            );
         }
     }
 

--- a/core/threshold-execution/src/small_execution/offline.rs
+++ b/core/threshold-execution/src/small_execution/offline.rs
@@ -252,11 +252,18 @@ where
             BroadcastValue::RingVector(cur_values) => {
                 if cur_values.len() != amount {
                     tracing::warn!(
-                        "I am party {:?} and party {:?} did not broadcast the correct amount of shares and is thus malicious",
+                        "I am party {:?} and party {:?} did not broadcast the correct amount of shares ({} instead of {amount}) and is thus malicious",
                         session.my_role().one_based(),
-                        cur_role.one_based()
+                        cur_role.one_based(),
+                        cur_values.len()
                     );
-                    session.add_corrupt(cur_role);
+                    session.add_corrupt_with_reason(
+                        cur_role,
+                        &format!(
+                            "broadcast {} shares instead of {amount} during PRSS-init check",
+                            cur_values.len()
+                        ),
+                    );
                     continue;
                 }
                 party_vectors.push((cur_role, cur_values));
@@ -266,7 +273,10 @@ where
                     "Party {:?} did not broadcast the correct type and is thus malicious",
                     cur_role.one_based()
                 );
-                session.add_corrupt(cur_role);
+                session.add_corrupt_with_reason(
+                    cur_role,
+                    "did not broadcast a RingVector during PRSS-init check",
+                );
                 continue;
             }
         };
@@ -403,7 +413,10 @@ async fn check_d<Z: Ring, Ses: SmallSessionHandles<Z>>(
                 "Party {cur_role} did not send correct values during PRSS-init and
                 has been added to the list of corrupt parties"
             );
-            session.add_corrupt(cur_role);
+            session.add_corrupt_with_reason(
+                cur_role,
+                "sent a d share inconsistent with x*y+v during PRSS-init",
+            );
         }
     }
     Ok(())


### PR DESCRIPTION
## Description
This PR 
- adds more details to error logs, that should help in debugging issues we encounter
- improves existing logging for decryption (removing unnecessary logs and adding more details where useful)
- Plenty of details around the KMS context and epoch management so we can track these events better
- Also add sanitization for logging potentially large user inputs and bounding their size. 

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
