### PR TITLE
feat: allow multiple trust roots per identity-context

### DIFF
--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -214,8 +214,12 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   `DestroyMpcContext` carries
   the context's epoch IDs and erases their secret shares (cascading to the
   existing per-epoch deletion) before forgetting the context and removing its
-  TLS trust-root references. Trust roots shared with another live context are
-  retained. This ensures retiring a
+  TLS trust-root references. The TLS verifier stores one trust root per context
+  and MPC identity. Different trust roots for one identity coexist while their
+  contexts remain active. Each root is evaluated with only its context's PCR
+  allowlist, and a handshake succeeds when one complete root and PCR check
+  succeeds. Removing a context removes its roots, while another context's copy
+  of the same root remains trusted. This ensures retiring a
   party set leaves no usable key shares behind; the kms-connector is the source
   of truth for which epochs belong to a context. In-memory lifecycle leases
   serialize creation against destruction: `NewMpcEpoch` holds shared leases for

--- a/ai-docs/ARCHITECTURE.md
+++ b/ai-docs/ARCHITECTURE.md
@@ -218,8 +218,9 @@ The primary service is `CoreServiceEndpoint`. Its RPCs group into:
   and MPC identity. Different trust roots for one identity coexist while their
   contexts remain active. Each root is evaluated with only its context's PCR
   allowlist, and a handshake succeeds when one complete root and PCR check
-  succeeds. Removing a context removes its roots, while another context's copy
-  of the same root remains trusted. This ensures retiring a
+  succeeds. The verifier rejects registration for an active context ID instead
+  of replacing its trust roots or PCR values. Removing a context removes its
+  roots, while another context's copy of the same root remains trusted. This ensures retiring a
   party set leaves no usable key shares behind; the kms-connector is the source
   of truth for which epochs belong to a context. In-memory lifecycle leases
   serialize creation against destruction: `NewMpcEpoch` holds shared leases for

--- a/core/service/src/engine/context_manager.rs
+++ b/core/service/src/engine/context_manager.rs
@@ -923,6 +923,8 @@ pub struct ThresholdContextManager<
     inner: SharedContextManager<PubS, PrivS>,
     session_maker: SessionMaker,
     require_pcr_allowlist: bool,
+    /// Serializes context creation across storage and in-memory registration.
+    context_creation_lock: Mutex<()>,
 }
 
 impl<PubS, PrivS> ThresholdContextManager<PubS, PrivS>
@@ -946,6 +948,7 @@ where
             },
             session_maker,
             require_pcr_allowlist,
+            context_creation_lock: Mutex::new(()),
         }
     }
 
@@ -1061,6 +1064,8 @@ where
             .map_err(|e| {
                 MetricedError::new(OP_NEW_MPC_CONTEXT, None, e, tonic::Code::InvalidArgument)
             })?;
+
+        let _creation_guard = self.context_creation_lock.lock().await;
 
         // First check if the context already exists
         if self
@@ -1619,6 +1624,69 @@ mod tests {
         });
         context_manager.new_mpc_context(request).await.unwrap();
         assert_eq!(context_manager.session_maker.context_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_duplicate_context_creation_preserves_the_created_context() {
+        let (verification_key, sig_key, crypto_storage) = setup_crypto_storage(false).await;
+        let base_kms = BaseKmsStruct::new(KMSType::Threshold, sig_key).unwrap();
+        let context_id = ContextId::from_bytes([34u8; 32]);
+        let new_context = ContextInfo {
+            mpc_nodes: vec![NodeInfo {
+                mpc_identity: "Node1".to_string(),
+                party_id: 1,
+                external_url: "http://localhost:12345".to_string(),
+                ca_cert: None,
+                public_storage_url: "http://storage".to_string(),
+                public_storage_prefix: None,
+                extra_signer_addresses: vec![],
+                scheme_digests: SchemeDigests::from_ecdsa_verification_key(&verification_key),
+            }],
+            context_id,
+            software_version: SoftwareVersion {
+                major: 0,
+                minor: 1,
+                patch: 0,
+                tag: None,
+            },
+            threshold: 0,
+            pcr_values: vec![],
+        };
+        let session_maker = SessionMaker::empty_dummy_session(base_kms.new_rng().await);
+        let context_manager = ThresholdContextManager::new(
+            base_kms,
+            crypto_storage.clone(),
+            MetaStore::new(100, 10),
+            session_maker,
+            false,
+        );
+        let request_a = Request::new(NewMpcContextRequest {
+            new_context: Some(new_context.clone().try_into().unwrap()),
+        });
+        let request_b = Request::new(NewMpcContextRequest {
+            new_context: Some(new_context.try_into().unwrap()),
+        });
+
+        let (result_a, result_b) = tokio::join!(
+            context_manager.new_mpc_context(request_a),
+            context_manager.new_mpc_context(request_b)
+        );
+        let results = [result_a, result_b];
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        let error = results.into_iter().find_map(Result::err).unwrap();
+        assert_eq!(error.code(), tonic::Code::AlreadyExists);
+        assert_eq!(context_manager.session_maker.context_count().await, 1);
+        assert!(
+            context_manager
+                .session_maker
+                .context_exists(&context_id)
+                .await
+        );
+
+        let guarded_priv_storage = crypto_storage.private_storage.lock().await;
+        read_context_at_id(&*guarded_priv_storage, &context_id)
+            .await
+            .expect("the successful request's context must remain in storage");
     }
 
     #[tokio::test]

--- a/core/service/src/engine/threshold/service/epoch_manager.rs
+++ b/core/service/src/engine/threshold/service/epoch_manager.rs
@@ -5,9 +5,9 @@
 //! __PRSS__
 //!
 //! If the KMS core is started fresh, then the PRSS setups needs to be initialized
-//! via a protocol; this is done via the [`RealThresholdEpochManager::init_prss`] method.
+//! via a protocol; this is done via the [`RealThresholdEpochManager::init_epoch`] method.
 //! If the KMS core restarts, then the PRSS setups are loaded from storage,
-//! this is done via a call to [`RealThresholdEpochManager::init_all_prss_from_storage`];
+//! this is done via a call to [`RealThresholdEpochManager::init_all_epochs_from_storage`].
 //!
 //! __Resharing__
 //!
@@ -321,9 +321,14 @@ impl<
     Reshare: ReshareSecretKeys + Default + 'static,
 > RealThresholdEpochManager<PubS, PrivS, Init, Reshare>
 {
-    /// This will load all epochs from storage into session maker.
-    pub async fn init_all_epochs_from_storage(&self) -> anyhow::Result<()> {
+    /// Loads all stored epochs into the session maker.
+    pub(crate) async fn init_all_epochs_from_storage(&self) -> anyhow::Result<()> {
         let all_epochs = self.crypto_storage.read_all_epoch_data().await?;
+        if all_epochs.is_empty() {
+            tracing::warn!(
+                "No epoch data found in storage. Create an MPC epoch before using threshold operations"
+            );
+        }
 
         for (epoch_id, prss) in all_epochs {
             self.session_maker.add_epoch(epoch_id, prss).await;

--- a/core/service/src/engine/threshold/service/kms_impl.rs
+++ b/core/service/src/engine/threshold/service/kms_impl.rs
@@ -44,7 +44,6 @@ use threshold_networking::{
     tls::AttestedVerifier,
 };
 
-use threshold_types::role::Role;
 use tokio::{
     net::TcpListener,
     sync::{Mutex, RwLock},
@@ -703,7 +702,7 @@ where
 
     // TODO(zama-ai/kms-internal/issues/2758)
     // If we're still using peer config, we need to manually write the default context into storage.
-    // This way we can load it into SessionMaker later when creating the ThresholdContextManager.
+    // This way ThresholdContextManager can load it into SessionMaker.
     ensure_default_threshold_context_in_storage(
         &mut private_storage,
         threshold_config,
@@ -736,18 +735,22 @@ where
         .set_not_serving::<CoreServiceEndpointServer<RealThresholdKms<PubS, PrivS>>>()
         .await;
 
-    let session_maker = SessionMaker::new_initialized(
-        threshold_config.my_id.map(Role::indexed_from_one),
-        &crypto_storage,
-        networking_manager,
-        verifier,
-        base_kms.new_rng().await,
-    )
-    .await?;
-    let immutable_session_maker = session_maker.make_immutable();
+    let session_maker = SessionMaker::new(networking_manager, verifier, base_kms.new_rng().await);
 
     let tracker = Arc::new(TaskTracker::new());
     let rate_limiter = RateLimiter::new(rate_limiter_conf);
+
+    let epoch_manager = RealThresholdEpochManager {
+        crypto_storage: crypto_storage.clone(),
+        session_maker: session_maker.clone(),
+        base_kms: base_kms.new_instance().await,
+        reshare_pubinfo_meta_store: MetaStore::new_unlimited(),
+        tracker: Arc::clone(&tracker),
+        rate_limiter: rate_limiter.clone(),
+        _init: PhantomData,
+        _reshare: PhantomData,
+    };
+    epoch_manager.init_all_epochs_from_storage().await?;
 
     // NOTE: context must be loaded before attempting to automatically start the PRSS
     // since the PRSS requires a context to be present.
@@ -766,16 +769,6 @@ where
         );
     }
 
-    let epoch_manager = RealThresholdEpochManager {
-        crypto_storage: crypto_storage.clone(),
-        session_maker: session_maker.clone(),
-        base_kms: base_kms.new_instance().await,
-        reshare_pubinfo_meta_store: MetaStore::new_unlimited(),
-        tracker: Arc::clone(&tracker),
-        rate_limiter: rate_limiter.clone(),
-        _init: PhantomData,
-        _reshare: PhantomData,
-    };
     if ensure_default_prss {
         let epoch_id_prss = *DEFAULT_EPOCH_ID;
         let default_context_id = *DEFAULT_MPC_CONTEXT;
@@ -794,6 +787,7 @@ where
                 .await?;
         }
     }
+    let immutable_session_maker = session_maker.make_immutable();
 
     let slow_events = Arc::new(Mutex::new(HashMap::new()));
 

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -1116,6 +1116,7 @@ mod tests {
         client::danger::ServerCertVerifier,
         crypto::aws_lc_rs::default_provider,
         pki_types::{ServerName, UnixTime},
+        server::danger::ClientCertVerifier,
     };
 
     /// Sunshine: `epochs_for_context` returns exactly the epochs whose `EpochData` carries the
@@ -1288,8 +1289,7 @@ mod tests {
             .unwrap();
     }
 
-    #[tokio::test]
-    async fn remove_context_updates_attested_verifier_references() {
+    fn session_maker_with_attested_verifier() -> (SessionMaker, Arc<AttestedVerifier>) {
         _ = default_provider().install_default();
         let verifier = Arc::new(
             AttestedVerifier::new(
@@ -1309,20 +1309,29 @@ mod tests {
             AesRng::seed_from_u64(6),
         );
 
-        let identity = "shared.example.com";
+        (session_maker, verifier)
+    }
+
+    fn self_signed_test_certificate(identity: &str) -> rcgen::Certificate {
         let keypair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let (_, certificate, _) =
-            threshold_networking::tls_certs::create_selfsigned_cert_from_keypair(
-                identity, false, false, &keypair,
-            )
-            .unwrap();
-        let certificate_pem = certificate.pem().into_bytes();
-        let make_context = |context_id| ContextInfo {
+        threshold_networking::tls_certs::create_selfsigned_cert_from_keypair(
+            identity, false, false, &keypair,
+        )
+        .unwrap()
+        .1
+    }
+
+    fn context_with_ca(
+        identity: &str,
+        certificate_pem: Vec<u8>,
+        context_id: ContextId,
+    ) -> ContextInfo {
+        ContextInfo {
             mpc_nodes: vec![NodeInfo {
                 mpc_identity: identity.to_string(),
                 party_id: 1,
                 external_url: format!("https://{identity}:8443"),
-                ca_cert: Some(certificate_pem.clone()),
+                ca_cert: Some(certificate_pem),
                 public_storage_url: String::new(),
                 public_storage_prefix: None,
                 extra_signer_addresses: vec![],
@@ -1337,16 +1346,28 @@ mod tests {
             },
             threshold: 0,
             pcr_values: vec![],
-        };
+        }
+    }
+
+    #[tokio::test]
+    async fn remove_context_updates_attested_verifier_references() {
+        let (session_maker, verifier) = session_maker_with_attested_verifier();
+
+        let identity = "shared.example.com";
+        let certificate = self_signed_test_certificate(identity);
+        let certificate_pem = certificate.pem().into_bytes();
         let mut rng = AesRng::seed_from_u64(7);
         let context_a = ContextId::new_random(&mut rng);
         let context_b = ContextId::new_random(&mut rng);
         session_maker
-            .add_context_info(None, &make_context(context_a))
+            .add_context_info(
+                None,
+                &context_with_ca(identity, certificate_pem.clone(), context_a),
+            )
             .await
             .unwrap();
         session_maker
-            .add_context_info(None, &make_context(context_b))
+            .add_context_info(None, &context_with_ca(identity, certificate_pem, context_b))
             .await
             .unwrap();
 
@@ -1369,6 +1390,94 @@ mod tests {
         assert!(
             verify_certificate().is_err(),
             "the trust root must be removed after its last live context is removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_context_removes_only_its_attested_verifier_root() {
+        let (session_maker, verifier) = session_maker_with_attested_verifier();
+        let identity = "rotated.example.com";
+        let certificate_a = self_signed_test_certificate(identity);
+        let certificate_b = self_signed_test_certificate(identity);
+        let mut rng = AesRng::seed_from_u64(10);
+        let context_a = ContextId::new_random(&mut rng);
+        let context_b = ContextId::new_random(&mut rng);
+
+        session_maker
+            .add_context_info(
+                None,
+                &context_with_ca(identity, certificate_a.pem().into_bytes(), context_a),
+            )
+            .await
+            .unwrap();
+        session_maker
+            .add_context_info(
+                None,
+                &context_with_ca(identity, certificate_b.pem().into_bytes(), context_b),
+            )
+            .await
+            .unwrap();
+
+        let server_name = ServerName::try_from(identity).unwrap();
+        let verify_certificate = |certificate: &rcgen::Certificate| {
+            verifier.verify_server_cert(certificate.der(), &[], &server_name, &[], UnixTime::now())
+        };
+        let verify_client_certificate = |certificate: &rcgen::Certificate| {
+            verifier.verify_client_cert(certificate.der(), &[], UnixTime::now())
+        };
+        assert!(verify_certificate(&certificate_a).is_ok());
+        assert!(verify_certificate(&certificate_b).is_ok());
+        assert!(verify_client_certificate(&certificate_a).is_ok());
+        assert!(verify_client_certificate(&certificate_b).is_ok());
+
+        session_maker.remove_context(&context_a).await.unwrap();
+        assert!(verify_certificate(&certificate_a).is_err());
+        assert!(verify_client_certificate(&certificate_a).is_err());
+        assert!(
+            verify_certificate(&certificate_b).is_ok(),
+            "the remaining context's trust root must remain active"
+        );
+        assert!(verify_client_certificate(&certificate_b).is_ok());
+
+        session_maker.remove_context(&context_b).await.unwrap();
+        assert!(verify_certificate(&certificate_b).is_err());
+        assert!(verify_client_certificate(&certificate_b).is_err());
+    }
+
+    #[tokio::test]
+    async fn duplicate_context_replaces_its_attested_verifier_root() {
+        let (session_maker, verifier) = session_maker_with_attested_verifier();
+        let identity = "replaced.example.com";
+        let certificate_a = self_signed_test_certificate(identity);
+        let certificate_b = self_signed_test_certificate(identity);
+        let mut rng = AesRng::seed_from_u64(11);
+        let context_id = ContextId::new_random(&mut rng);
+
+        session_maker
+            .add_context_info(
+                None,
+                &context_with_ca(identity, certificate_a.pem().into_bytes(), context_id),
+            )
+            .await
+            .unwrap();
+        session_maker
+            .add_context_info(
+                None,
+                &context_with_ca(identity, certificate_b.pem().into_bytes(), context_id),
+            )
+            .await
+            .unwrap();
+
+        let server_name = ServerName::try_from(identity).unwrap();
+        assert!(
+            verifier
+                .verify_server_cert(certificate_a.der(), &[], &server_name, &[], UnixTime::now(),)
+                .is_err()
+        );
+        assert!(
+            verifier
+                .verify_server_cert(certificate_b.der(), &[], &server_name, &[], UnixTime::now(),)
+                .is_ok()
         );
     }
 }

--- a/core/service/src/engine/threshold/service/session.rs
+++ b/core/service/src/engine/threshold/service/session.rs
@@ -5,11 +5,8 @@ use std::{
     sync::{Arc, Weak},
 };
 
-use crate::{
-    engine::{
-        context::ContextInfo, threshold::service::epoch_manager::EpochData, utils::MetricedError,
-    },
-    vault::storage::{Storage, StorageExt, crypto_material::ThresholdCryptoMaterialStorage},
+use crate::engine::{
+    context::ContextInfo, threshold::service::epoch_manager::EpochData, utils::MetricedError,
 };
 
 // === External Crates ===
@@ -173,48 +170,7 @@ fn four_party_dummy_role_assignment() -> RoleAssignment<Role> {
 }
 
 impl SessionMaker {
-    pub(crate) async fn new_initialized<
-        PubS: Storage + Sync + Send + 'static,
-        PrivS: StorageExt + Sync + Send + 'static,
-    >(
-        my_id: Option<Role>,
-        crypto_storage: &ThresholdCryptoMaterialStorage<PubS, PrivS>,
-        networking_manager: Arc<RwLock<GrpcNetworkingManager>>,
-        verifier: Option<Arc<AttestedVerifier>>,
-        rng: AesRng,
-    ) -> anyhow::Result<Self> {
-        let session_maker: SessionMaker =
-            Self::new_uninitialized(networking_manager, verifier, rng);
-        let all_epochs = crypto_storage.read_all_epoch_data().await?;
-        if all_epochs.is_empty() {
-            tracing::warn!(
-                "No epoch data found in storage. You may need to call the init end-point later before you can use the KMS server"
-            );
-        }
-        for (epoch_id, prss) in all_epochs {
-            session_maker.add_epoch(epoch_id, prss).await;
-            tracing::info!(
-                "Loaded epoch data from storage for request ID {}.",
-                epoch_id
-            );
-        }
-        let mpc_contexts = crypto_storage.inner.read_all_context_info().await?;
-        if mpc_contexts.is_empty() {
-            tracing::warn!(
-                "No MPC context found in storage! There should at a minimum be a default context!"
-            );
-        }
-        for context_info in mpc_contexts {
-            session_maker.add_context_info(my_id, &context_info).await?;
-            tracing::info!(
-                "Loaded MPC context from storage for context ID {}.",
-                context_info.context_id()
-            );
-        }
-        Ok(session_maker)
-    }
-
-    pub(crate) fn new_uninitialized(
+    pub(crate) fn new(
         networking_manager: Arc<RwLock<GrpcNetworkingManager>>,
         verifier: Option<Arc<AttestedVerifier>>,
         rng: AesRng,
@@ -443,6 +399,7 @@ impl SessionMaker {
         }
     }
 
+    #[cfg(test)]
     async fn add_context(
         &self,
         context_id: ContextId,
@@ -520,15 +477,8 @@ impl SessionMaker {
             inner: role_assignment_map,
         };
 
-        self.add_context(
-            *info.context_id(),
-            my_role,
-            role_assignment,
-            info.threshold as u8,
-        )
-        .await;
-
-        match self.verifier.as_ref() {
+        let context_id = *info.context_id();
+        let verifier_context = match self.verifier.as_ref() {
             Some(verifier) => {
                 let context_id_as_session_id = info.context_id().derive_session_id()?;
                 let release_pcrs = if info.pcr_values.is_empty() {
@@ -540,12 +490,31 @@ impl SessionMaker {
                 } else {
                     Some(info.pcr_values.iter().cloned().collect())
                 };
-                verifier
-                    .add_context(context_id_as_session_id, ca_certs_map, release_pcrs)
-                    .map_err(|e| anyhow::anyhow!("Failed to add context to verifier: {}", e))?;
+                Some((verifier, context_id_as_session_id, release_pcrs))
             }
-            _ => { /* do nothing */ }
+            None => None,
+        };
+
+        let mut context_map = self.context_map.write().await;
+        if context_map.contains_key(&context_id) {
+            tracing::error!("Refusing to replace existing MPC context {context_id}");
+            anyhow::bail!("MPC context {context_id} already exists");
         }
+
+        if let Some((verifier, verifier_context_id, release_pcrs)) = verifier_context {
+            verifier
+                .add_context(verifier_context_id, ca_certs_map, release_pcrs)
+                .map_err(|e| anyhow::anyhow!("Failed to add context to verifier: {e}"))?;
+        }
+
+        context_map.insert(
+            context_id,
+            Context {
+                my_role,
+                role_assignment,
+                threshold: info.threshold as u8,
+            },
+        );
 
         Ok(())
     }
@@ -1303,7 +1272,7 @@ mod tests {
         let networking_manager = Arc::new(RwLock::new(
             GrpcNetworkingManager::new(None, CoreToCoreNetworkConfig::default()).unwrap(),
         ));
-        let session_maker = SessionMaker::new_uninitialized(
+        let session_maker = SessionMaker::new(
             networking_manager,
             Some(Arc::clone(&verifier)),
             AesRng::seed_from_u64(6),
@@ -1445,9 +1414,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn duplicate_context_replaces_its_attested_verifier_root() {
+    async fn duplicate_context_is_rejected_without_replacing_its_verifier_root() {
         let (session_maker, verifier) = session_maker_with_attested_verifier();
-        let identity = "replaced.example.com";
+        let identity = "duplicate.example.com";
         let certificate_a = self_signed_test_certificate(identity);
         let certificate_b = self_signed_test_certificate(identity);
         let mut rng = AesRng::seed_from_u64(11);
@@ -1466,18 +1435,19 @@ mod tests {
                 &context_with_ca(identity, certificate_b.pem().into_bytes(), context_id),
             )
             .await
-            .unwrap();
+            .unwrap_err();
 
         let server_name = ServerName::try_from(identity).unwrap();
         assert!(
             verifier
                 .verify_server_cert(certificate_a.der(), &[], &server_name, &[], UnixTime::now(),)
-                .is_err()
+                .is_ok()
         );
         assert!(
             verifier
                 .verify_server_cert(certificate_b.der(), &[], &server_name, &[], UnixTime::now(),)
-                .is_ok()
+                .is_err()
         );
+        assert_eq!(session_maker.context_count().await, 1);
     }
 }

--- a/core/threshold-networking/src/tls.rs
+++ b/core/threshold-networking/src/tls.rs
@@ -52,21 +52,45 @@ pub struct ReleasePCRValues {
     pub pcr2: Vec<u8>,
 }
 
-pub type TrustRootValue = (
-    Arc<dyn ClientCertVerifier>,
-    Arc<WebPkiServerVerifier>,
-    HashSet<SessionId>,
-);
+#[derive(Clone)]
+struct ContextTrustRoot {
+    client: Arc<dyn ClientCertVerifier>,
+    server: Arc<WebPkiServerVerifier>,
+}
 
 type UserDataVerifier = dyn Fn(ReleasePCRValues, Vec<u8>) -> anyhow::Result<bool> + Send + Sync;
 
-/// The rustls client + server verifiers plus the trusted PCR set selected for a
-/// particular peer certificate, returned by
-/// [`AttestedVerifier::get_verifiers_and_pcrs_for_x509_cert`].
-struct Verifiers {
-    client: Arc<dyn ClientCertVerifier>,
-    server: Arc<dyn ServerCertVerifier>,
+struct VerifierCandidate {
+    context_id: SessionId,
+    trust_root: ContextTrustRoot,
     pcrs: HashSet<ReleasePCRValues>,
+}
+
+/// The active context verifiers for a peer certificate subject.
+struct Verifiers {
+    subject: String,
+    candidates: Vec<VerifierCandidate>,
+}
+
+fn verify_with_any_context<T>(
+    verifiers: &Verifiers,
+    mut verify: impl FnMut(&VerifierCandidate) -> Result<T, Error>,
+) -> Result<T, Error> {
+    let mut last_error = None;
+    for candidate in &verifiers.candidates {
+        match verify(candidate) {
+            Ok(result) => return Ok(result),
+            Err(error) => last_error = Some((candidate.context_id, error)),
+        }
+    }
+
+    Err(Error::General(match last_error {
+        Some((context_id, error)) => format!(
+            "certificate for {} failed validation against all active contexts; last failure was for context {context_id}: {error}",
+            verifiers.subject
+        ),
+        None => format!("no active contexts found for {}", verifiers.subject),
+    }))
 }
 
 /// Our custom verifier for our custom mTLS certificates extended with AWS Nitro
@@ -77,18 +101,13 @@ struct Verifiers {
 /// multiple trust root sets configurable at runtime which is handy when working
 /// with multiple MPC contexts.
 ///
-/// The TLS certificates are expected to embed the context id in their serial
-/// number. Depending on the context id and the certificate subject name, this
-/// verifier will choose a verifier with just one appropriate CA certificate in
-/// the trust root store to actually verify the certificate.
+/// The verifier tries each active context's CA certificate and PCR allowlist for
+/// the certificate subject.
 pub struct AttestedVerifier {
     root_hint_subjects: Vec<DistinguishedName>,
     supported_algs: WebPkiSupportedAlgorithms,
-    // There is one trust root per MPC identity but one MPC identity can belong
-    // to multiple contexts.  SessionId is supposed to be based on RequestId,
-    // and we're representing ContextId as RequestId so far, so let's say it's
-    // all the same for now.
-    trust_roots: RwLock<HashMap<MpcIdentity, TrustRootValue>>,
+    // Each context supplies its own trust root for an MPC identity.
+    trust_roots: RwLock<HashMap<MpcIdentity, HashMap<SessionId, ContextTrustRoot>>>,
     // Each context can specify a list of valid PCR values
     release_pcrs: RwLock<HashMap<SessionId, HashSet<ReleasePCRValues>>>,
     // In addition to the PCR values, the verifier can also check the user data
@@ -161,46 +180,57 @@ Crypto provider should exist at this point"
         ca_certs: HashMap<MpcIdentity, Pem>,
         release_pcrs: Option<HashSet<ReleasePCRValues>>,
     ) -> anyhow::Result<()> {
+        let context_roots = ca_certs
+            .into_iter()
+            .map(|(mpc_identity, ca_cert)| {
+                let mut roots = RootCertStore::empty();
+                roots.add(CertificateDer::from_slice(&ca_cert.contents))?;
+                let roots = Arc::new(roots);
+                let client_verifier = WebPkiClientVerifier::builder(roots.clone()).build()?;
+                let server_verifier = WebPkiServerVerifier::builder(roots).build()?;
+                Ok((
+                    mpc_identity,
+                    ContextTrustRoot {
+                        client: client_verifier,
+                        server: server_verifier,
+                    },
+                ))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
         let mut trust_roots = self
             .trust_roots
             .write()
             .map_err(|e| anyhow::anyhow!("Failed to acquire write lock: {e}"))?;
-        for (mpc_identity, ca_cert) in ca_certs {
-            match trust_roots.get_mut(&mpc_identity) {
-                Some((_, _, contexts)) => {
-                    if !contexts.insert(context_id) {
-                        tracing::warn!(
-                            "MPC identity {mpc_identity} is already present in context {context_id}"
-                        )
-                    }
-                }
-                None => {
-                    let mut roots = RootCertStore::empty();
-                    roots.add(CertificateDer::from_slice(&ca_cert.contents))?;
-                    let roots = Arc::new(roots);
-                    let client_verifier = WebPkiClientVerifier::builder(roots.clone()).build()?;
-                    let server_verifier = WebPkiServerVerifier::builder(roots).build()?;
-                    trust_roots.insert(
-                        mpc_identity,
-                        (
-                            client_verifier,
-                            server_verifier,
-                            HashSet::from([context_id]),
-                        ),
-                    );
-                }
+        let mut release_pcrs_by_context = self
+            .release_pcrs
+            .write()
+            .map_err(|e| anyhow::anyhow!("Failed to acquire write lock: {e}"))?;
+
+        let replaced = trust_roots
+            .values()
+            .any(|roots| roots.contains_key(&context_id))
+            || release_pcrs_by_context.contains_key(&context_id);
+        trust_roots.retain(|_, roots| {
+            roots.remove(&context_id);
+            !roots.is_empty()
+        });
+        for (mpc_identity, trust_root) in context_roots {
+            trust_roots
+                .entry(mpc_identity)
+                .or_default()
+                .insert(context_id, trust_root);
+        }
+        match release_pcrs {
+            Some(release_pcrs) => {
+                release_pcrs_by_context.insert(context_id, release_pcrs);
+            }
+            None => {
+                release_pcrs_by_context.remove(&context_id);
             }
         }
-        if let Some(new_release_pcrs) = release_pcrs {
-            let mut release_pcrs = self
-                .release_pcrs
-                .write()
-                .map_err(|e| anyhow::anyhow!("Failed to acquire write lock: {e}"))?;
-            if let std::collections::hash_map::Entry::Vacant(e) = release_pcrs.entry(context_id) {
-                e.insert(new_release_pcrs);
-            } else {
-                tracing::warn!("PCR values already defined in context {context_id}")
-            }
+        if replaced {
+            tracing::warn!("Replaced TLS trust roots and PCR values for context {context_id}");
         }
         Ok(())
     }
@@ -210,14 +240,14 @@ Crypto provider should exist at this point"
             .trust_roots
             .write()
             .map_err(|e| anyhow::anyhow!("Failed to acquire write lock: {e}"))?;
-        trust_roots.retain(|_, (_, _, contexts)| {
-            contexts.remove(&context_id);
-            !contexts.is_empty()
-        });
         let mut release_pcrs = self
             .release_pcrs
             .write()
             .map_err(|e| anyhow::anyhow!("Failed to acquire write lock: {e}"))?;
+        trust_roots.retain(|_, context_roots| {
+            context_roots.remove(&context_id);
+            !context_roots.is_empty()
+        });
         release_pcrs.remove(&context_id);
         Ok(())
     }
@@ -233,9 +263,8 @@ Crypto provider should exist at this point"
             .trust_roots
             .read()
             .map_err(|e| Error::General(format!("Failed to acquire read lock: {e}")))?;
-        let (client_verifier, server_verifier, contexts) = trust_roots
+        let context_roots = trust_roots
             .get(&MpcIdentity(subject.clone()))
-            .cloned()
             .ok_or_else(|| {
                 let e = Error::General(format!("{subject} is not a trust anchor"));
                 tracing::error!("{e}");
@@ -245,17 +274,16 @@ Crypto provider should exist at this point"
             .release_pcrs
             .read()
             .map_err(|e| Error::General(format!("Failed to acquire read lock: {e}")))?;
-        let pcrs_for_mpc_identity = contexts
-            .iter()
-            .filter_map(|context_id| release_pcrs.get(context_id))
-            .flatten()
-            .cloned()
-            .collect::<HashSet<_>>();
-
         Ok(Verifiers {
-            client: client_verifier,
-            server: server_verifier,
-            pcrs: pcrs_for_mpc_identity,
+            subject,
+            candidates: context_roots
+                .iter()
+                .map(|(context_id, trust_root)| VerifierCandidate {
+                    context_id: *context_id,
+                    trust_root: trust_root.clone(),
+                    pcrs: release_pcrs.get(context_id).cloned().unwrap_or_default(),
+                })
+                .collect(),
         })
     }
 
@@ -282,49 +310,49 @@ impl ServerCertVerifier for AttestedVerifier {
     ) -> Result<ServerCertVerified, Error> {
         let (_, cert) = parse_x509_certificate(end_entity.as_ref())
             .map_err(|e| Error::General(e.to_string()))?;
-        let Verifiers {
-            server: server_verifier,
-            pcrs: release_pcrs,
-            ..
-        } = self.get_verifiers_and_pcrs_for_x509_cert(&cert)?;
-        let subject =
-            extract_subject_from_cert(&cert).map_err(|e| Error::General(e.to_string()))?;
+        let verifiers = self.get_verifiers_and_pcrs_for_x509_cert(&cert)?;
         // check the enclave-generated certificate used for the TLS session as
         // usual (however, we expect it to be self-signed)
         tracing::debug!("Verifying certificate for server {:?}", server_name,);
-        server_verifier
-            .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
-            .inspect_err(|e| {
-                tracing::error!(
-                    "server verifier validation error: {}, supported algorithms: {:?}",
-                    e,
-                    &self.supported_algs
-                );
-            })?;
         // check the bundled attestation document and EIF signing certificate
         #[cfg(feature = "testing")]
         let do_validation = !&self.mock_enclave;
         #[cfg(not(feature = "testing"))]
         let do_validation = true;
 
-        if do_validation && !release_pcrs.is_empty() {
-            validate_wrapped_cert(
-                &cert,
-                release_pcrs,
-                self.user_data_verifier.as_ref().map(Arc::clone),
-                self.pcr8_expected,
-                CertVerifier::Server(server_verifier.clone(), server_name, ocsp_response),
+        verify_with_any_context(&verifiers, |candidate| {
+            candidate.trust_root.server.verify_server_cert(
+                end_entity,
                 intermediates,
+                server_name,
+                ocsp_response,
                 now,
-            )
-            .map_err(|e| {
-                tracing::error!(
-                    "bundled attestation document validation error for party {subject}: {e}"
-                );
-                Error::General(e.to_string())
-            })?;
-        }
-        Ok(ServerCertVerified::assertion())
+            )?;
+            if do_validation && !candidate.pcrs.is_empty() {
+                validate_wrapped_cert(
+                    &cert,
+                    candidate.pcrs.clone(),
+                    self.user_data_verifier.as_ref().map(Arc::clone),
+                    self.pcr8_expected,
+                    CertVerifier::Server(
+                        candidate.trust_root.server.clone(),
+                        server_name,
+                        ocsp_response,
+                    ),
+                    intermediates,
+                    now,
+                )
+                .map_err(|e| Error::General(e.to_string()))?;
+            }
+            Ok(ServerCertVerified::assertion())
+        })
+        .inspect_err(|e| {
+            tracing::error!(
+                "server certificate validation error for party {}: {e}, supported algorithms: {:?}",
+                verifiers.subject,
+                &self.supported_algs
+            );
+        })
     }
 
     fn verify_tls12_signature(
@@ -333,9 +361,13 @@ impl ServerCertVerifier for AttestedVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, Error> {
-        self.get_verifiers_and_pcrs_for_cert_der(cert)?
-            .server
-            .verify_tls12_signature(message, cert, dss)
+        let verifiers = self.get_verifiers_and_pcrs_for_cert_der(cert)?;
+        verify_with_any_context(&verifiers, |candidate| {
+            candidate
+                .trust_root
+                .server
+                .verify_tls12_signature(message, cert, dss)
+        })
     }
 
     fn verify_tls13_signature(
@@ -344,9 +376,13 @@ impl ServerCertVerifier for AttestedVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, Error> {
-        self.get_verifiers_and_pcrs_for_cert_der(cert)?
-            .server
-            .verify_tls13_signature(message, cert, dss)
+        let verifiers = self.get_verifiers_and_pcrs_for_cert_der(cert)?;
+        verify_with_any_context(&verifiers, |candidate| {
+            candidate
+                .trust_root
+                .server
+                .verify_tls13_signature(message, cert, dss)
+        })
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
@@ -384,24 +420,7 @@ impl ClientCertVerifier for AttestedVerifier {
             .map_err(|e| Error::General(e.to_string()))?;
         // if none of the trust roots has a subject name matching the client
         // subject name, verification will fail
-        let Verifiers {
-            client: client_verifier,
-            pcrs: release_pcrs,
-            ..
-        } = self.get_verifiers_and_pcrs_for_x509_cert(&cert)?;
-        let subject =
-            extract_subject_from_cert(&cert).map_err(|e| Error::General(e.to_string()))?;
-        // check the enclave-generated certificate used for the TLS session as
-        // usual
-        client_verifier
-            .verify_client_cert(end_entity, intermediates, now)
-            .inspect_err(|e| {
-                tracing::error!(
-                    "client verifier validation error: {}, supported algorithms: {:?}",
-                    e,
-                    &self.supported_algs
-                );
-            })?;
+        let verifiers = self.get_verifiers_and_pcrs_for_x509_cert(&cert)?;
 
         // check the bundled attestation document and EIF signing certificate
         #[cfg(feature = "testing")]
@@ -409,31 +428,39 @@ impl ClientCertVerifier for AttestedVerifier {
         #[cfg(not(feature = "testing"))]
         let do_validation = true;
 
-        if do_validation && !release_pcrs.is_empty() {
-            validate_wrapped_cert(
-                &cert,
-                release_pcrs,
-                self.user_data_verifier.as_ref().map(Arc::clone),
-                self.pcr8_expected,
-                CertVerifier::Client(client_verifier.clone()),
-                intermediates,
-                now,
-            )
-            .map_err(|e| {
-                tracing::error!(
-                    "bundled attestation document validation error for party {subject}: {e}"
+        verify_with_any_context(&verifiers, |candidate| {
+            candidate
+                .trust_root
+                .client
+                .verify_client_cert(end_entity, intermediates, now)?;
+            if do_validation && !candidate.pcrs.is_empty() {
+                validate_wrapped_cert(
+                    &cert,
+                    candidate.pcrs.clone(),
+                    self.user_data_verifier.as_ref().map(Arc::clone),
+                    self.pcr8_expected,
+                    CertVerifier::Client(candidate.trust_root.client.clone()),
+                    intermediates,
+                    now,
+                )
+                .map_err(|e| Error::General(e.to_string()))?;
+            } else {
+                tracing::warn!(
+                    "Skipping attestation document validation for context {} because do_validation={}, release_pcrs.is_empty={}",
+                    candidate.context_id,
+                    do_validation,
+                    candidate.pcrs.is_empty()
                 );
-                Error::General(e.to_string())
-            })?;
-        } else {
-            tracing::warn!(
-                "Skipping attestation document validation because do_validation={}, release_pcrs.is_empty={}",
-                do_validation,
-                release_pcrs.is_empty()
+            }
+            Ok(ClientCertVerified::assertion())
+        })
+        .inspect_err(|e| {
+            tracing::error!(
+                "client certificate validation error for party {}: {e}, supported algorithms: {:?}",
+                verifiers.subject,
+                &self.supported_algs
             );
-        }
-
-        Ok(ClientCertVerified::assertion())
+        })
     }
 
     fn verify_tls12_signature(
@@ -442,9 +469,13 @@ impl ClientCertVerifier for AttestedVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, Error> {
-        self.get_verifiers_and_pcrs_for_cert_der(cert)?
-            .client
-            .verify_tls12_signature(message, cert, dss)
+        let verifiers = self.get_verifiers_and_pcrs_for_cert_der(cert)?;
+        verify_with_any_context(&verifiers, |candidate| {
+            candidate
+                .trust_root
+                .client
+                .verify_tls12_signature(message, cert, dss)
+        })
     }
 
     fn verify_tls13_signature(
@@ -453,9 +484,13 @@ impl ClientCertVerifier for AttestedVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, Error> {
-        self.get_verifiers_and_pcrs_for_cert_der(cert)?
-            .client
-            .verify_tls13_signature(message, cert, dss)
+        let verifiers = self.get_verifiers_and_pcrs_for_cert_der(cert)?;
+        verify_with_any_context(&verifiers, |candidate| {
+            candidate
+                .trust_root
+                .client
+                .verify_tls13_signature(message, cert, dss)
+        })
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
@@ -663,4 +698,83 @@ pub fn build_ca_certs_map<I: Iterator<Item = Pem>>(
                 })
         })
         .collect::<Result<HashMap<MpcIdentity, Pem>, _>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rcgen::{KeyPair, PKCS_ECDSA_P256_SHA256};
+    use tokio_rustls::rustls::crypto::aws_lc_rs::default_provider;
+
+    fn test_ca(identity: &str) -> (rcgen::Certificate, Pem) {
+        let keypair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let certificate =
+            crate::tls_certs::create_selfsigned_cert_from_keypair(identity, false, false, &keypair)
+                .unwrap()
+                .1;
+        let pem = x509_parser::pem::parse_x509_pem(certificate.pem().as_bytes())
+            .unwrap()
+            .1;
+        (certificate, pem)
+    }
+
+    fn test_pcr(value: u8) -> ReleasePCRValues {
+        ReleasePCRValues {
+            pcr0: vec![value],
+            pcr1: vec![value],
+            pcr2: vec![value],
+        }
+    }
+
+    #[test]
+    fn pcrs_are_scoped_to_context_candidates() {
+        _ = default_provider().install_default();
+        let verifier = AttestedVerifier::new(
+            None,
+            false,
+            #[cfg(feature = "testing")]
+            true,
+        )
+        .unwrap();
+        let identity = "scoped-pcr.example.com";
+        let (certificate_a, ca_a) = test_ca(identity);
+        let (_, ca_b) = test_ca(identity);
+        let context_a = SessionId::from(1u128);
+        let context_b = SessionId::from(2u128);
+        let pcr_a = test_pcr(1);
+        let pcr_b = test_pcr(2);
+
+        verifier
+            .add_context(
+                context_a,
+                HashMap::from([(MpcIdentity(identity.to_string()), ca_a)]),
+                Some(HashSet::from([pcr_a.clone()])),
+            )
+            .unwrap();
+        verifier
+            .add_context(
+                context_b,
+                HashMap::from([(MpcIdentity(identity.to_string()), ca_b)]),
+                Some(HashSet::from([pcr_b.clone()])),
+            )
+            .unwrap();
+
+        let (_, certificate_a) = parse_x509_certificate(certificate_a.der()).unwrap();
+        let verifiers = verifier
+            .get_verifiers_and_pcrs_for_x509_cert(&certificate_a)
+            .unwrap();
+        assert_eq!(verifiers.candidates.len(), 2);
+        let candidate_a = verifiers
+            .candidates
+            .iter()
+            .find(|candidate| candidate.context_id == context_a)
+            .unwrap();
+        let candidate_b = verifiers
+            .candidates
+            .iter()
+            .find(|candidate| candidate.context_id == context_b)
+            .unwrap();
+        assert_eq!(candidate_a.pcrs, HashSet::from([pcr_a]));
+        assert_eq!(candidate_b.pcrs, HashSet::from([pcr_b]));
+    }
 }

--- a/core/threshold-networking/src/tls.rs
+++ b/core/threshold-networking/src/tls.rs
@@ -207,31 +207,24 @@ Crypto provider should exist at this point"
             .write()
             .map_err(|e| anyhow::anyhow!("Failed to acquire write lock: {e}"))?;
 
-        let replaced = trust_roots
+        if trust_roots
             .values()
             .any(|roots| roots.contains_key(&context_id))
-            || release_pcrs_by_context.contains_key(&context_id);
-        trust_roots.retain(|_, roots| {
-            roots.remove(&context_id);
-            !roots.is_empty()
-        });
+            || release_pcrs_by_context.contains_key(&context_id)
+        {
+            tracing::error!(
+                "Refusing to replace TLS trust roots and PCR values for existing context {context_id}"
+            );
+            anyhow::bail!("TLS verifier context {context_id} already exists");
+        }
+
         for (mpc_identity, trust_root) in context_roots {
             trust_roots
                 .entry(mpc_identity)
                 .or_default()
                 .insert(context_id, trust_root);
         }
-        match release_pcrs {
-            Some(release_pcrs) => {
-                release_pcrs_by_context.insert(context_id, release_pcrs);
-            }
-            None => {
-                release_pcrs_by_context.remove(&context_id);
-            }
-        }
-        if replaced {
-            tracing::warn!("Replaced TLS trust roots and PCR values for context {context_id}");
-        }
+        release_pcrs_by_context.insert(context_id, release_pcrs.unwrap_or_default());
         Ok(())
     }
 
@@ -776,5 +769,83 @@ mod tests {
             .unwrap();
         assert_eq!(candidate_a.pcrs, HashSet::from([pcr_a]));
         assert_eq!(candidate_b.pcrs, HashSet::from([pcr_b]));
+    }
+
+    #[test]
+    fn duplicate_context_is_rejected_without_replacing_verifier_state() {
+        _ = default_provider().install_default();
+        let verifier = AttestedVerifier::new(
+            None,
+            false,
+            #[cfg(feature = "testing")]
+            true,
+        )
+        .unwrap();
+        let identity = "duplicate.example.com";
+        let (certificate_a, ca_a) = test_ca(identity);
+        let (certificate_b, ca_b) = test_ca(identity);
+        let context_id = SessionId::from(3u128);
+        let pcr_a = test_pcr(3);
+
+        verifier
+            .add_context(
+                context_id,
+                HashMap::from([(MpcIdentity(identity.to_string()), ca_a)]),
+                Some(HashSet::from([pcr_a.clone()])),
+            )
+            .unwrap();
+        let error = verifier
+            .add_context(
+                context_id,
+                HashMap::from([(MpcIdentity(identity.to_string()), ca_b)]),
+                Some(HashSet::from([test_pcr(4)])),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("already exists"));
+
+        let (_, parsed_certificate) = parse_x509_certificate(certificate_a.der()).unwrap();
+        let verifiers = verifier
+            .get_verifiers_and_pcrs_for_x509_cert(&parsed_certificate)
+            .unwrap();
+        assert_eq!(verifiers.candidates.len(), 1);
+        assert_eq!(verifiers.candidates[0].pcrs, HashSet::from([pcr_a]));
+
+        let server_name = ServerName::try_from(identity).unwrap();
+        assert!(
+            verifiers.candidates[0]
+                .trust_root
+                .server
+                .verify_server_cert(certificate_a.der(), &[], &server_name, &[], UnixTime::now(),)
+                .is_ok()
+        );
+        assert!(
+            verifiers.candidates[0]
+                .trust_root
+                .server
+                .verify_server_cert(certificate_b.der(), &[], &server_name, &[], UnixTime::now(),)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn duplicate_context_without_ca_or_pcrs_is_rejected() {
+        _ = default_provider().install_default();
+        let verifier = AttestedVerifier::new(
+            None,
+            false,
+            #[cfg(feature = "testing")]
+            true,
+        )
+        .unwrap();
+        let context_id = SessionId::from(4u128);
+
+        verifier
+            .add_context(context_id, HashMap::new(), None)
+            .unwrap();
+        let error = verifier
+            .add_context(context_id, HashMap::new(), None)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("already exists"));
     }
 }


### PR DESCRIPTION
## Description
Currently, we don't update the CA certificate for a party when adding a new context if an existing context already had a party with the same `MpcIdentity`. This means that changing the certificate requires deleting that party and readding it again, which might be inconvenient. This PR permits storing and verifying against different CA certificates for the same party in different co-existing contexts.

### Related issue(s)
Might fix https://github.com/zama-ai/kms-internal/issues/3142

## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [x] Title follows conventional commits (e.g. `chore: ...`).
- [x] Tests added for every new `pub` item and test coverage has not decreased.
- [x] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [x] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [x] No dependency version changes OR (if changed) only minimal required fixes.
- [x] No architectural protocol changes OR linked spec PR/issue provided.
- [x] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [x] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [x] No modifications to existing versionized structs OR backward compatibility tests updated.
- [x] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [x] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [x] No new public storage data OR data is verifiable (signature / digest).
- [x] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [x] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [x] Self-review completed.
