### PR TITLE
fix(network): do not evict active network sessions

### DIFF
--- a/core/threshold-networking/src/constants.rs
+++ b/core/threshold-networking/src/constants.rs
@@ -20,7 +20,7 @@ pub(crate) const SESSION_STATUS_UPDATE_INTERVAL_SECS: u64 = 60;
 // The default time interval after which we completely forget about completed sessions
 pub(crate) const SESSION_CLEANUP_INTERVAL_SECS: u64 = 86400; // 24 hours
 
-// The default time interval after which we discard inactive sessions, or active sessions that have not seen any activity
+// The default time interval after which we discard inactive sessions
 pub(crate) const DISCARD_INACTIVE_SESSION_INTERVAL_SECS: u64 = 15 * 60;
 
 // The default maximum waiting time we wait for trying to push or fetch a message in the send/rec queue

--- a/core/threshold-networking/src/grpc/manager.rs
+++ b/core/threshold-networking/src/grpc/manager.rs
@@ -112,16 +112,7 @@ impl GrpcNetworkingManager {
                             }
                         }
                         SessionStatus::Active(session) => match session.upgrade() {
-                            Some(network_session) => {
-                                let time_since_last_rec =
-                                    network_session.last_rec_activity_time.load().elapsed();
-                                if time_since_last_rec > discard_inactive_interval {
-                                    metrics::METRICS.increment_network_event(
-                                        NetworkDebugEvent::SessionActiveDiscarded,
-                                    );
-                                    to_remove.push(*session_id);
-                                    continue;
-                                }
+                            Some(_) => {
                                 internal_active_sessions_count += 1;
                             }
                             None => {
@@ -342,17 +333,25 @@ mod tests {
     use threshold_types::party::Identity;
     use threshold_types::role::Role;
 
-    /// The cleanup task discards an *active* session that received no message for
-    /// `discard_inactive_sessions_interval`, whatever its round clock says. A
-    /// session that was advanced many rounds ahead (its deadline is far in the
-    /// future) is discarded all the same while its owner idles, which destroys
-    /// the routing entry for messages that arrive later. A party that holds a
-    /// session while it waits for a slower phase is therefore only safe when that
-    /// phase is shorter than the discard interval.
+    /// Name of a session store entry's status, for assertion messages.
+    fn status_name(status: Option<&SessionStatus>) -> &'static str {
+        match status {
+            Some(SessionStatus::Active(_)) => "active",
+            Some(SessionStatus::Inactive(_)) => "inactive",
+            Some(SessionStatus::Completed(_)) => "completed",
+            None => "absent",
+        }
+    }
+
+    /// Regression test: the task used to discard an active session that had not
+    /// received anything for `discard_inactive_sessions_interval`. Sessions that
+    /// legitimately idle would thus be discarded, which turned out to be an issue..
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_idle_active_session_is_discarded_regardless_of_round_clock() {
+    async fn test_active_session_is_never_discarded() {
         let conf = CoreToCoreNetworkConfig {
+            network_timeout: Some(1),
             session_update_interval_secs: Some(1),
+            session_cleanup_interval_secs: Some(1),
             discard_inactive_sessions_interval: Some(1),
             ..Default::default()
         };
@@ -364,39 +363,65 @@ mod tests {
         role_assignment.insert(role_1, Identity::new("127.0.0.1".to_string(), 1, None));
         role_assignment.insert(role_2, Identity::new("127.0.0.1".to_string(), 2, None));
 
-        let session_id = SessionId::from(7);
-        let session = manager
-            .make_network_session(session_id, &role_assignment, role_1, NetworkMode::Sync)
+        // An idle session at round 0, whose 1s round deadline passes right away.
+        let idle_id = SessionId::from(7);
+        let idle = manager
+            .make_network_session(idle_id, &role_assignment, role_1, NetworkMode::Sync)
             .await
             .unwrap();
-
-        // Budget the session for many rounds, so that its deadline lies far beyond
-        // the discard interval.
+        // A session budgeted 20 rounds ahead, whose deadline outlasts the test.
+        let ahead_id = SessionId::from(8);
+        let ahead = manager
+            .make_network_session(ahead_id, &role_assignment, role_1, NetworkMode::Sync)
+            .await
+            .unwrap();
         let advance = 20;
         for _ in 0..advance {
-            session.increase_round_counter().await;
+            ahead.increase_round_counter().await;
         }
-        let budget_left = session
-            .get_timeout_current_round()
-            .await
-            .saturating_duration_since(std::time::Instant::now());
-        assert!(
-            budget_left > Duration::from_secs(60),
-            "the round clock must leave a budget far beyond the discard interval, got {budget_left:?}"
-        );
-        assert!(matches!(
-            manager.session_store.get(&session_id).as_deref(),
-            Some(SessionStatus::Active(_))
-        ));
 
-        // Two sweeps of the cleanup task at a 1s update interval.
-        tokio::time::sleep(Duration::from_millis(2500)).await;
+        // Several sweeps of the cleanup task at a 1s update interval, well past the
+        // 1s discard and cleanup intervals and past the idle session's deadline.
+        tokio::time::sleep(Duration::from_millis(3500)).await;
 
         assert!(
-            manager.session_store.get(&session_id).is_none(),
-            "an active session without received messages is discarded after the discard interval"
+            idle.get_timeout_current_round().await < std::time::Instant::now(),
+            "the idle session must be past its own round deadline for the test to be meaningful"
         );
-        // Only the routing entry is gone: the handle held by the protocol is untouched.
-        assert_eq!(session.get_current_round().await, advance);
+        for (id, session) in [(idle_id, &idle), (ahead_id, &ahead)] {
+            let entry = manager.session_store.get(&id);
+            match entry.as_deref() {
+                Some(SessionStatus::Active(weak)) => {
+                    let routed = weak.upgrade().unwrap_or_else(|| {
+                        panic!("the entry of session {id} must point at a live session")
+                    });
+                    assert_eq!(
+                        Arc::as_ptr(&routed) as *const (),
+                        Arc::as_ptr(session) as *const (),
+                        "the entry of session {id} must still route to the protocol's session"
+                    );
+                }
+                other => panic!(
+                    "session {id} must still be active while the protocol holds it, got {}",
+                    status_name(other)
+                ),
+            }
+        }
+        assert_eq!(manager.active_session_count().await, 2);
+        assert_eq!(ahead.get_current_round().await, advance);
+
+        // Dropping the handles is the only way out of `Active`: the next sweep marks
+        // the entries completed and the cleanup interval then removes them.
+        drop(idle);
+        drop(ahead);
+        tokio::time::sleep(Duration::from_millis(3500)).await;
+        for id in [idle_id, ahead_id] {
+            assert!(
+                manager.session_store.get(&id).is_none(),
+                "session {id} must be removed once dropped and past the cleanup interval, got {}",
+                status_name(manager.session_store.get(&id).as_deref())
+            );
+        }
+        assert_eq!(manager.active_session_count().await, 0);
     }
 }

--- a/core/threshold-networking/src/grpc/manager.rs
+++ b/core/threshold-networking/src/grpc/manager.rs
@@ -345,7 +345,7 @@ mod tests {
 
     /// Regression test: the task used to discard an active session that had not
     /// received anything for `discard_inactive_sessions_interval`. Sessions that
-    /// legitimately idle would thus be discarded, which turned out to be an issue..
+    /// legitimately idle would thus be discarded, which turned out to be an issue.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_active_session_is_never_discarded() {
         let conf = CoreToCoreNetworkConfig {

--- a/core/threshold-networking/src/sending_service/session.rs
+++ b/core/threshold-networking/src/sending_service/session.rs
@@ -363,8 +363,8 @@ impl NetworkSession {
     /// [`GrpcNetworkingManager::make_network_session`](crate::grpc::GrpcNetworkingManager)
     /// (the inactive→active and vacant branches), which previously duplicated this
     /// 14-field literal and had to be kept in lock-step by hand. All the
-    /// round-independent fields (round counter, timers, byte counter, activity
-    /// time) are initialised here; callers supply only what actually differs.
+    /// round-independent fields (round counter, timers, byte counter)
+    /// are initialised here; callers supply only what actually differs.
     pub(crate) fn new(
         owner: Identity,
         session_id: SessionId,

--- a/core/threshold-networking/src/sending_service/session.rs
+++ b/core/threshold-networking/src/sending_service/session.rs
@@ -54,12 +54,7 @@ pub struct NetworkSession {
     /// (an [`AtomicInstant`]) so `synchronize_from` can overwrite it from `&self`,
     /// like the other atomic time fields below.
     pub(crate) init_time: AtomicInstant,
-    /// When the last message was received, or when the session was made active if
-    /// no message has been received yet. Used to discard inactive sessions. Stored
-    /// lock-free (an [`AtomicInstant`]) so it can be read and written without
-    /// awaiting — in particular from the session cleanup task while it holds a
-    /// `DashMap` shard guard.
-    pub(crate) last_rec_activity_time: AtomicInstant,
+
     /// Current round's network timeout. Backed by an [`AtomicDuration`] rather
     /// than a lock so the round-transition update in
     /// [`Networking::increase_round_counter`] only needs to hold the
@@ -173,7 +168,6 @@ impl<R: RoleTrait> Networking<R> for NetworkSession {
         // on `ReceiverState` (see `take_current`) so the buffer discipline stays
         // unit-testable without a running session.
         if let Some(value) = state.take_current(network_round) {
-            self.last_rec_activity_time.store(Instant::now());
             return Ok(value);
         }
 
@@ -208,8 +202,6 @@ impl<R: RoleTrait> Networking<R> for NetworkSession {
                     )));
                 }
             };
-            // Update the time we received a message
-            self.last_rec_activity_time.store(Instant::now());
 
             // Classify the packet against the current round. The round counter
             // is peer-controlled and unauthenticated, so a packet is only
@@ -398,7 +390,6 @@ impl NetworkSession {
             network_mode,
             conf,
             init_time: AtomicInstant::now(),
-            last_rec_activity_time: AtomicInstant::now(),
             current_network_timeout: AtomicDuration::new(timeout),
             next_network_timeout: AtomicDuration::new(timeout),
             max_elapsed_time: AtomicDuration::new(Duration::ZERO),
@@ -753,7 +744,6 @@ mod tests {
             network_mode: NetworkMode::Async,
             conf: CoreToCoreNetworkConfig::default(),
             init_time: AtomicInstant::now(),
-            last_rec_activity_time: AtomicInstant::now(),
             current_network_timeout: AtomicDuration::new(Duration::from_secs(10)),
             next_network_timeout: AtomicDuration::new(Duration::from_secs(10)),
             max_elapsed_time: AtomicDuration::new(Duration::ZERO),
@@ -899,7 +889,6 @@ mod tests {
             network_mode: NetworkMode::Async,
             conf,
             init_time: AtomicInstant::now(),
-            last_rec_activity_time: AtomicInstant::now(),
             current_network_timeout: AtomicDuration::new(Duration::from_secs(10)),
             next_network_timeout: AtomicDuration::new(Duration::from_secs(10)),
             max_elapsed_time: AtomicDuration::new(Duration::ZERO),
@@ -1511,7 +1500,6 @@ mod tests {
             network_mode: NetworkMode::Async,
             conf: test_config(1),
             init_time: AtomicInstant::now(),
-            last_rec_activity_time: AtomicInstant::now(),
             current_network_timeout: AtomicDuration::new(wait),
             next_network_timeout: AtomicDuration::new(wait),
             max_elapsed_time: AtomicDuration::new(Duration::ZERO),

--- a/observability/src/metrics.rs
+++ b/observability/src/metrics.rs
@@ -118,8 +118,6 @@ pub enum NetworkDebugEvent {
     SessionCompleted,
     /// An inbound-only session expired before it was started locally.
     SessionInactiveDiscarded,
-    /// An active session was discarded after its receive activity timed out.
-    SessionActiveDiscarded,
     /// A completed session was removed after its grace period expired.
     SessionCompletedRemoved,
     /// An inbound peer message was added to its session queue.
@@ -151,14 +149,13 @@ pub enum NetworkDebugEvent {
 }
 
 impl NetworkDebugEvent {
-    const COUNT: usize = 20;
+    const COUNT: usize = 19;
     const LABELS: [&'static str; Self::COUNT] = [
         "session_inactive_created",
         "session_activated",
         "session_active_created",
         "session_completed",
         "session_inactive_discarded",
-        "session_active_discarded",
         "session_completed_removed",
         "message_enqueued",
         "message_to_inactive",


### PR DESCRIPTION
## Description
<!-- Explain what changed and why. -->
Stop evicting active network sessions because they haven't seen a message in a while.
This was harmful because timeout can accumulate past the eviction deadline, and not very useful because only a weak reference is stored in the map that was mutated.
### Related issue(s)
<!-- Reference the issue fixed if available (e.g. "Closes #1234"). -->
Part 2 of https://github.com/zama-ai/kms-internal/issues/3202
## PR Checklist
Tick all that apply — by ticking I attest the item holds; justify any deviation in the description above.
- [ ] Title follows conventional commits (e.g. `chore: ...`).
- [ ] Tests added for every new `pub` item and test coverage has not decreased.
- [ ] Public APIs and non-obvious logic documented; unfinished work marked `TODO(#issue)`.
- [ ] `unwrap`/`expect`/`panic` only in tests or for invariant bugs (documented if present).
- [ ] No dependency version changes OR (if changed) only minimal required fixes.
- [ ] No architectural protocol changes OR linked spec PR/issue provided.
- [ ] No breaking deployment config / Helm chart / telemetry changes OR `devops` label + infra notified + review requested.
- [ ] No breaking gRPC / serialized data changes OR commit marked with `!` and affected teams notified.
- [ ] No modifications to existing versionized structs OR backward compatibility tests updated.
- [ ] No critical business logic / crypto changes OR ≥2 reviewers assigned.
- [ ] No new sensitive data fields OR `Zeroize` + `ZeroizeOnDrop` implemented.
- [ ] No new public storage data OR data is verifiable (signature / digest).
- [ ] No `unsafe`; if unavoidable: minimal, justified, documented, and test/fuzz covered.
- [ ] Strongly typed boundaries: typed inputs validated at the edge; no untyped values or errors cross modules.
- [ ] Self-review completed.

### Dependency Update Questionnaire (only if deps changed or added)
<!-- Answer next to the dependency in `Cargo.toml`, or here: -->
1. Ownership changes or suspicious concentration?
2. Low popularity?
3. Unusual version jump?
4. Lacking documentation?
5. Missing CI?
6. No security / disclosure policy?
7. Significant size increase?

More details in [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md).
