### PR TITLE
fix: restore LTO=thin for 'insecure' Docker images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -390,7 +390,7 @@ jobs:
       packages: write # Required to publish Docker images
       attestations: write # Required to create build attestations
     with:
-      lto-release: ${{ github.event_name == 'release' && 'release' || 'release-lto-off' }}
+      lto-release: ${{ github.event_name == 'release' && 'release' || 'release-lto-thin' }}
       docker-file: './docker/kms-binaries/Dockerfile'
       working-directory: './docker/kms-binaries'
       image-name: 'kms/kms-binaries-insecure'


### PR DESCRIPTION
PR #609 turned LTO off for "insecure" Docker builds, which caused a severe perf regression causing the perf-test suite to fail. This PR restores LTO=thin.
