### PR TITLE
Add some missing grpc ABI tests

### DIFF
--- a/core/grpc/src/rpc_types.rs
+++ b/core/grpc/src/rpc_types.rs
@@ -1351,6 +1351,64 @@ mod tests {
     }
 
     #[test]
+    fn test_typed_plaintext_byte_length_boundaries() {
+        for (fhe_type, width) in [
+            (FheTypes::Bool, 1),
+            (FheTypes::Uint4, 1),
+            (FheTypes::Uint8, 1),
+            (FheTypes::Uint16, 2),
+            (FheTypes::Uint32, 4),
+            (FheTypes::Uint64, 8),
+            (FheTypes::Uint128, 16),
+            (FheTypes::Uint160, 20),
+            (FheTypes::Uint256, 32),
+            (FheTypes::Uint512, 64),
+            (FheTypes::Uint1024, 128),
+            (FheTypes::Uint2048, 256),
+        ] {
+            for len in [0, width - 1, width, width + 1] {
+                let plaintext = TypedPlaintext {
+                    bytes: vec![0xab; len],
+                    fhe_type: fhe_type as i32,
+                };
+                let result = Vec::<u8>::try_from(plaintext);
+                if len < width {
+                    assert!(result.is_err(), "{fhe_type:?}, length {len}");
+                } else {
+                    let expected = match fhe_type {
+                        FheTypes::Bool => vec![1],
+                        FheTypes::Uint4 => vec![11],
+                        _ => vec![0xab; width],
+                    };
+                    assert_eq!(result.unwrap(), expected, "{fhe_type:?}, length {len}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_abi_encoding_byte_length_boundary() {
+        for len in [31, 32] {
+            let plaintext = TypedPlaintext {
+                bytes: vec![0xab; len],
+                fhe_type: FheTypes::Uint256 as i32,
+            };
+            let mut expected = vec![0; 32 - len];
+            expected.extend(vec![0xab; len]);
+            assert_eq!(
+                abi_encode_plaintexts(&[plaintext]).unwrap().as_ref(),
+                expected
+            );
+        }
+        let oversized = TypedPlaintext {
+            bytes: vec![0xab; 33],
+            fhe_type: FheTypes::Uint256 as i32,
+        };
+        let error = abi_encode_plaintexts(&[oversized]).unwrap_err().to_string();
+        assert!(error.contains("Byte length too large for U256"), "{error}");
+    }
+
+    #[test]
     fn test_request_id() {
         let hex_str = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
         let id = RequestId::from_str(hex_str).unwrap();
@@ -1567,8 +1625,6 @@ mod tests {
 
         let u256_val1 = tfhe::integer::U256::from((1, 256));
         let u256_val2 = tfhe::integer::U256::from((222, 256));
-        let u512_val = tfhe::integer::bigint::U512::from(512_u64);
-        let u2048_val = tfhe::integer::bigint::U2048::from(257_u64);
 
         // a batch of multiple supported plaintexts of different types
         let pts_mix1: Vec<TypedPlaintext> = vec![
@@ -1606,28 +1662,30 @@ mod tests {
         // reference encoding of the same list of plaintexts (pts_mix2).
         let reference_mix2 = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000de000000000000000000000000000000000000000000000000000000000000ea6000000000000000000000000000000000000000000000000000000000000003e7000000000000000000000000000000000000000000000000000000000009fbf10000000000000000000000000000004500000000000000000000000000000007000000000000000000000000000001000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
         assert_eq!(reference_mix2, hexbytes_mix2.as_str());
+    }
 
-        // test that unsupported cause an encoding error
-        let pts_mix3: Vec<TypedPlaintext> = vec![
-            TypedPlaintext::from_u2048(u2048_val),
-            TypedPlaintext::from_u512(u512_val),
-            TypedPlaintext::from_u32(32),
-            TypedPlaintext::from_u512(u512_val),
-        ];
-
-        // encode plaintexts into a list of solidity bytes using `alloy`, this should fail and return an error due to unsupported types
-        let err_msg = super::abi_encode_plaintexts(&pts_mix3)
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err_msg.contains("Received unsupported FHE type for ABI encoding"),
-            "expected unsupported type error: {err_msg}"
-        );
-        // check that we also log an error when trying to encode unsupported types in pts_mix3
-        assert!(
-            err_msg.contains("Error in"),
-            "expected error to be logged (via anyhow_error_and_log): {err_msg}"
-        );
+    #[test]
+    fn test_abi_encoding_rejects_unsupported_types() {
+        for fhe_type in [
+            FheTypes::Uint4,
+            FheTypes::Uint512,
+            FheTypes::Uint1024,
+            FheTypes::Uint2048,
+        ] {
+            let plaintexts = [
+                TypedPlaintext::from_u32(32),
+                TypedPlaintext {
+                    bytes: vec![0],
+                    fhe_type: fhe_type as i32,
+                },
+            ];
+            let error = abi_encode_plaintexts(&plaintexts).unwrap_err().to_string();
+            assert!(
+                error.contains("Received unsupported FHE type for ABI encoding"),
+                "{fhe_type:?}: {error}"
+            );
+            assert!(error.contains("Error in"), "{error}");
+        }
     }
 
     #[test]

--- a/core/service/src/client/tests/threshold/extended_tests.rs
+++ b/core/service/src/client/tests/threshold/extended_tests.rs
@@ -81,46 +81,6 @@ async fn nightly_default_decryption_threshold_with_crash(
 #[cfg(feature = "slow_tests")]
 #[tokio::test(flavor = "multi_thread")]
 #[rstest::rstest]
-#[case(TestingPlaintext::U8(u8::MAX), 1, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
-#[case(TestingPlaintext::Bool(true), 2, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
-#[case(TestingPlaintext::U8(u8::MAX), 1, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
-#[case(TestingPlaintext::U16(u16::MAX), 1, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
-#[case(TestingPlaintext::U32(u32::MAX), 1, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
-#[case(TestingPlaintext::U64(u64::MAX), 1, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
-#[case(TestingPlaintext::U128(u128::MAX), 1, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
-#[case(TestingPlaintext::U160(tfhe::integer::U256::from((u128::MAX, u32::MAX as u128))), 1, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
-#[case(TestingPlaintext::U256(tfhe::integer::U256::from((u128::MAX, u128::MAX))), 1, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
-
-async fn nightly_default_user_decryption_threshold(
-    #[case] msg: TestingPlaintext,
-    #[case] parallelism: usize,
-    #[case] amount_parties: usize,
-    #[case] key_id: &RequestId,
-    #[values(true)] secure: bool,
-) {
-    user_decryption_threshold(
-        DEFAULT_PARAM,
-        key_id,
-        false,
-        msg,
-        EncryptionConfig {
-            compression: true,
-            precompute_sns: true,
-        },
-        parallelism,
-        secure,
-        amount_parties,
-        None,
-        None,
-        None,
-    )
-    .await;
-}
-
-#[cfg(feature = "slow_tests")]
-#[tokio::test(flavor = "multi_thread")]
-#[rstest::rstest]
-#[case(TestingPlaintext::U8(u8::MAX), 1, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
 #[case(TestingPlaintext::Bool(true), 2, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
 #[case(TestingPlaintext::U8(u8::MAX), 1, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]
 #[case(TestingPlaintext::U16(u16::MAX), 1, DEFAULT_AMOUNT_PARTIES, &DEFAULT_THRESHOLD_KEY_ID)]


### PR DESCRIPTION
Add some test coverage in `rpc_types`.
- Complete test coverage of the supported ABI types
- Remove duplicate test

This is the result of https://github.com/zama-ai/kms-internal/issues/2999#issuecomment-5633823128
